### PR TITLE
Add Rust action to `actions.lua`

### DIFF
--- a/lua/codecompanion/actions.lua
+++ b/lua/codecompanion/actions.lua
@@ -257,6 +257,35 @@ M.static.actions = {
             },
           },
         },
+        {
+          name = "Rust",
+          strategy = "chat",
+          description = "Chat as a senior Rust developer",
+          type = "rust",
+          prompts = {
+            {
+              role = "system",
+              content = expert("Rust"),
+            },
+            {
+              role = "user",
+              contains_code = true,
+              condition = function(context)
+                return context.is_visual
+              end,
+              content = function(context)
+                return send_code(context)
+              end,
+            },
+            {
+              role = "user",
+              condition = function(context)
+                return not context.is_visual
+              end,
+              content = "\n \n",
+            },
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
Hi Oli,

I'm a big fan of `onedarkpro.nvim` and I'm excited about this project and the level of polish to it.

This PR is a small tweak to extend the `Chat as` actions. I hope it might provide some value. I understand your involvement in further development may be minimal, but if your circumstances permit, I'm looking forward to making more meaningful contributions as I integrate this plugin into my work and personal workflow.

Thanks,
Yomi
