### PR TITLE
feat(config): Allow specifying adapters by string

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ You only need to the call the `setup` function if you wish to change any of the 
 ```lua
 require("codecompanion").setup({
   adapters = {
-    chat = require("codecompanion.adapters").use("openai"),
-    inline = require("codecompanion.adapters").use("openai"),
+    chat = "openai",
+    inline = "openai",
   },
   saved_chats = {
     save_dir = vim.fn.stdpath("data") .. "/codecompanion/saved_chats", -- Path to save chats to

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -92,6 +92,15 @@ M.setup = function(opts)
   }
   vim.diagnostic.config(diagnostic_config, M.INFO_NS)
   vim.diagnostic.config(diagnostic_config, M.ERROR_NS)
+
+  local chat_adapter = vim.tbl_get(M.options, "adapters", "chat")
+  if type(chat_adapter) == "string" then
+    M.options.adapters.chat = require("codecompanion.adapters").use(chat_adapter)
+  end
+  local inline_adapter = vim.tbl_get(M.options, "adapters", "inline")
+  if type(inline_adapter) == "string" then
+    M.options.adapters.inline = require("codecompanion.adapters").use(inline_adapter)
+  end
 end
 
 return M


### PR DESCRIPTION
Allows using lazy.nvim `opts` (declarative) instead of having to use a `config` function (imperative)