### PR TITLE
Add support for a shell command in place of environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ require("codecompanion").setup({
     chat = require("codecompanion.adapters").use("openai", {
       env = {
         api_key = "DIFFERENT_OPENAI_KEY",
-        -- To execute a shell command, prefix it with `cmd:`.
+        -- To execute a shell command, prefix it with "cmd:"
         -- api_key = "cmd:gpg --decrypt ~/.openai-api-key.gpg 2>/dev/null",
       },
     }),

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ require("codecompanion").setup({
     chat = require("codecompanion.adapters").use("openai", {
       env = {
         api_key = "DIFFERENT_OPENAI_KEY",
+        -- To execute a shell command, prefix it with `cmd:`.
+        -- api_key = "cmd:gpg --decrypt ~/.openai-api-key.gpg 2>/dev/null",
       },
     }),
   },

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -164,7 +164,7 @@ passing in a table to the `use` method:
         chat = require("codecompanion.adapters").use("openai", {
           env = {
             api_key = "DIFFERENT_OPENAI_KEY",
-            -- To execute a shell command, prefix it with `cmd:`.
+            -- To execute a shell command, prefix it with "cmd:"
             -- api_key = "cmd:gpg --decrypt ~/.openai-api-key.gpg 2>/dev/null",
           },
         }),

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -164,6 +164,8 @@ passing in a table to the `use` method:
         chat = require("codecompanion.adapters").use("openai", {
           env = {
             api_key = "DIFFERENT_OPENAI_KEY",
+            -- To execute a shell command, prefix it with `cmd:`.
+            -- api_key = "cmd:gpg --decrypt ~/.openai-api-key.gpg 2>/dev/null",
           },
         }),
       },

--- a/lua/codecompanion/utils/util.lua
+++ b/lua/codecompanion/utils/util.lua
@@ -148,4 +148,11 @@ function M.replace_vars(msg, vars, mapping)
   return string.format(msg, unpack(replacements))
 end
 
+---Check if value starts with "cmd:"
+---@param value string
+---@return boolean
+function M.is_cmd_var(value)
+  return value:match("^cmd:")
+end
+
 return M


### PR DESCRIPTION
Having the API key in environment variables is not always safe, as any application or program can read it.

> I also had a situation where a program didn't load the project specific `.env` file but used the main key from the user profile - although, this case can be rectified with the recent pattern using a different variable name.

This PR allows for this:
```lua
chat = require("codecompanion.adapters").use("openai", {
  env = {
    api_key = "cmd:gpg --decrypt ~/.openai-api-key.gpg 2>/dev/null",
  },
}),
```

I'm happy to make further changes; this change breaks assumptions about what the config should be.