### PR TITLE
Fix: Include base model name for entries in ollama

### DIFF
--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -9,7 +9,13 @@ local function get_ollama_choices()
     for line in handle:lines() do
       local first_word = line:match("%S+")
       if first_word ~= nil and first_word ~= "NAME" then
-        table.insert(result, first_word)
+        table.insert(result, first_word)  -- Insert the full name
+        if first_word:find(":latest$") then  -- Check if it ends with :latest
+          local base_name = first_word:match("([^:]+)")  -- Extract the base name
+          if base_name then
+            table.insert(result, base_name)  -- Insert the base name
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This is a fix for https://github.com/olimorris/codecompanion.nvim/issues/67.

If a user has a `:latest` model installed on their system it should also add the model without a tag. Generally I just use `llama3` in my config file and this was throwing a validation as I *technically* have `llama3:latest` on my system.