### PR TITLE
feat(agent): support multi-agent return and add command_runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- panvimdoc-ignore-start -->rem
+<!-- panvimdoc-ignore-start -->
 
 <p align="center">
 <img src="https://github.com/olimorris/codecompanion.nvim/assets/9512444/e54f98b6-8bfd-465a-85b6-73ab6bb274fa" alt="CodeCompanion.nvim" />
@@ -95,7 +95,7 @@ You only need to the call the `setup` function if you wish to change any of the 
 <details>
   <summary>Click to see the default configuration</summary>
 
-````lua
+```lua
 require("codecompanion").setup({
   adapters = {
     anthropic = "anthropic",
@@ -441,7 +441,7 @@ When informed by the user of an available agent, pay attention to the schema tha
     ),
   },
 })
-````
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- panvimdoc-ignore-start -->
+<!-- panvimdoc-ignore-start -->rem
 
 <p align="center">
 <img src="https://github.com/olimorris/codecompanion.nvim/assets/9512444/e54f98b6-8bfd-465a-85b6-73ab6bb274fa" alt="CodeCompanion.nvim" />
@@ -95,7 +95,7 @@ You only need to the call the `setup` function if you wish to change any of the 
 <details>
   <summary>Click to see the default configuration</summary>
 
-```lua
+````lua
 require("codecompanion").setup({
   adapters = {
     anthropic = "anthropic",
@@ -441,7 +441,7 @@ When informed by the user of an available agent, pay attention to the schema tha
     ),
   },
 })
-```
+````
 
 </details>
 
@@ -612,6 +612,7 @@ Below is the full list of commands that are available in the plugin:
 - `CodeCompanionChat <adapter>` - To open up a new chat buffer with a specific adapter
 - `CodeCompanionToggle` - To toggle a chat buffer
 - `CodeCompanionAdd` - To add visually selected chat to the current chat buffer
+- `CodeCompanionAddLSPDiagnostics` - To add the current LSP diagnostics to a chat buffer
 
 **Suggested workflow**
 
@@ -623,6 +624,7 @@ vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap
 vim.api.nvim_set_keymap("n", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "ga", "<cmd>CodeCompanionAdd<cr>", { noremap = true, silent = true })
+vim.api.nvim_set_keymap("n", "gl", "<cmd>CodeCompanionAddLSPDiagnostics<cr>", { noremap = true, silent = true })
 
 -- Expand 'cc' into 'CodeCompanion' in the command line
 vim.cmd([[cab cc CodeCompanion]])

--- a/lua/codecompanion/agents.lua
+++ b/lua/codecompanion/agents.lua
@@ -55,6 +55,7 @@ local function set_autocmds(chat, agent)
 
       log:trace("Agent finished event: %s", request)
       if request.data.status == "started" then
+        vim.g.codecompanion_agent_running = true
         ui.set_virtual_text(chat.bufnr, ns_id, "Agent processing ...", { hl_group = "CodeCompanionVirtualTextAgents" })
         return
       end
@@ -63,6 +64,7 @@ local function set_autocmds(chat, agent)
 
       -- If the agent is still in progress, we need check stream_output and put it in to chat buffer
       if request.data.status == "progress" then
+        vim.g.codecompanion_agent_running = true
         if request.data.stream_output then
           chat:add_message({
             role = "user",
@@ -73,6 +75,7 @@ local function set_autocmds(chat, agent)
       end
 
       if request.data.status == "error" then
+        vim.g.codecompanion_agent_running = false
         if request.data.error then
           chat:add_message({
             role = "user",
@@ -86,6 +89,7 @@ local function set_autocmds(chat, agent)
       end
 
       if request.data.status == "success" then
+        vim.g.codecompanion_agent_running = false
         local output
         -- Sometimes, the output from a command will get sent to stderr instead
         -- of stdout. We can do a check and redirect the output accordingly

--- a/lua/codecompanion/agents.lua
+++ b/lua/codecompanion/agents.lua
@@ -153,9 +153,7 @@ end
 function M.run(chat, ts, opts)
   local ok, xml = pcall(parse_xml, ts)
   if not ok then
-    -- format str
-    local err = string.format("Error parsing XML: %s", xml)
-    log:info(err)
+    log:info("Error parsing XML: %s", xml)
     return
   end
 

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -427,7 +427,7 @@ M.output_error_prompt = function(error)
 end
 
 M.output_prompt = function(output)
-  return "After the buffer_editor completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```"
+  return "After the buffer_editor completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```\n"
 end
 
 return M

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -22,8 +22,6 @@ M.prompts = {
     content = function(schema)
       return [[To aid you further, I'm giving you access to a Buffer Editor which can modify existing code within a buffer or create a new buffer to write code. 
 
-When you use this agent, you do not need to output the code in a single code block.
-
 To use the block editor, you need to return an XML markdown code block (with backticks) which follows the below schema:
 ```xml
 ]] .. xml2lua.toXml(schema, "agent") .. [[
@@ -425,11 +423,11 @@ end
 
 -- The prompt to share with the LLM if an error is encountered
 M.output_error_prompt = function(error)
-  return "After the buffer_editor completed, there was an error:" .. "\n```\n" .. table.concat(error, "\n") .. "\n```\n"
+  return "After the buffer_editor completed, there was an error:" .. "\n```\n" .. table.concat(error, "\n") .. "\n```"
 end
 
 M.output_prompt = function(output)
-  return "After the buffer_editor completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```\n"
+  return "After the buffer_editor completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```"
 end
 
 return M

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -40,21 +40,36 @@ file_path
 >>>>>>> REPLACE
 ]] .. "]]>" .. [[></content>
 
-IMPORTANT RULES:
-1. The SEARCH section must EXACTLY match the existing code, including all whitespace, comments, and indentation.
-2. Do not include any explanations or additional text outside the XML and SEARCH/REPLACE blocks.
-3. The REPLACE section should contain the new or modified code.
-4. You can include multiple SEARCH/REPLACE blocks for different files or different parts of the same file within the same CDATA section.
-5. Always wrap your entire response in a code block with XML syntax highlighting.
-6. Always use CDATA to wrap the content to avoid XML parsing issues with special characters in the code.
-7. DO NOT include line numbers in either the SEARCH or REPLACE sections. Line numbers are provided for your reference only and should not be part of the actual code blocks.
-8. For empty lines in the SEARCH section, do not include any whitespace characters. Just use a blank line.
-9. In the REPLACE section, maintain the same indentation as the original code for consistency.
-10. Each SEARCH/REPLACE should contain as few modifications as possible
-11. Please use tabs instead of spaces for indentation
-12. When you want to create a new file, please use an SEARCH block which contain blank line.
+*SEARCH/REPLACE block* Rules:
+
+Every *SEARCH/REPLACE block* must use this format:
+1. The file path alone on a line, verbatim. No bold asterisks, no quotes around it, no escaping of characters, etc.
+2. The start of search block: <<<<<<< SEARCH
+3. A contiguous chunk of lines to search for in the existing source code
+4. The dividing line: =======
+5. The lines to replace into the source code
+6. The end of the replace block: >>>>>>> REPLACE
+
+Every *SEARCH* section must *EXACTLY MATCH* the existing source code, character for character, including all comments, docstrings, etc.
+
+*SEARCH/REPLACE* blocks will replace *all* matching occurrences.
+Include enough lines to make the SEARCH blocks uniquely match the lines to change.
+
+Keep *SEARCH/REPLACE* blocks concise.
+Break large *SEARCH/REPLACE* blocks into a series of smaller blocks that each change a small portion of the file.
+Include just the changing lines, and a few surrounding lines if needed for uniqueness.
+Do not include long runs of unchanging lines in *SEARCH/REPLACE* blocks.
+
+To move code within a file, use 2 *SEARCH/REPLACE* blocks: 1 to delete it from its current location, 1 to insert it in the new location.
+
+If you want to put code in a new file, use a *SEARCH/REPLACE block* with:
+- A new file path, including dir name if needed
+- An empty `SEARCH` section
+- The new file's contents in the `REPLACE` section
 
 Be extremely careful and precise when creating these blocks. If the SEARCH section doesn't match exactly, the edit will fail.
+
+ONLY EVER RETURN CODE IN A *SEARCH/REPLACE BLOCK*!
 
 Here's an example of how to use the buffer_editor agent:
 

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -21,7 +21,7 @@ M.prompts = {
     role = "system",
     content = function(schema)
       return [[To aid you further, I'm giving you access to a Buffer Editor which can modify existing code within a buffer or create a new buffer to write code. 
-
+When using this agent, do not output the code to be edited in a Markdown code block. Instead, use the buffer_editor agent directly to modify or create the code.
 To use the block editor, you need to return an XML markdown code block (with backticks) which follows the below schema:
 ```xml
 ]] .. xml2lua.toXml(schema, "agent") .. [[

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -1,13 +1,16 @@
 local log = require("codecompanion.utils.log")
 local config = require("codecompanion").config
 local xml2lua = require("codecompanion.utils.xml.xml2lua")
+local api = vim.api
+local util = require("codecompanion.utils.agent")
 
+---@type CodeCompanion.Agent
 local M = {}
 
 M.schema = {
   parameters = {
     inputs = {
-      content = "string containing file paths and SEARCH/REPLACE blocks",
+      content = "<![CDATA[string containing file paths and SEARCH/REPLACE blocks]]>",
     },
   },
   name = "buffer_editor",
@@ -17,13 +20,9 @@ M.prompts = {
   {
     role = "system",
     content = function(schema)
-      return [[You are an expert in writing and reviewing code. Always use best practices when coding. If the user request is ambiguous, ask questions. Always reply to the user in the same language they are using.
+      return [[To aid you further, I'm giving you access to a Buffer Editor which can modify existing code within a buffer or create a new buffer to write code. 
 
-Once you understand the request you MUST:
-1. Decide if you need to use block editor to edits any files that haven't been added to the chat. You can create new files without asking.  You can keep asking if you then decide you need to edit more files.
-2. Think step-by-step and explain the needed changes with a numbered list of short sentences.
-
-To aid you further, I'm giving you access to a block editor that can make changes to the code in the current buffer. This enables you to propose edits, trigger their execution, and immediately see the results of your efforts.
+When you use this agent, you do not need to output the code in a single code block.
 
 To use the block editor, you need to return an XML markdown code block (with backticks) which follows the below schema:
 ```xml
@@ -53,6 +52,7 @@ IMPORTANT RULES:
 9. In the REPLACE section, maintain the same indentation as the original code for consistency.
 10. Each SEARCH/REPLACE should contain as few modifications as possible
 11. Please use tabs instead of spaces for indentation
+12. When you want to create a new file, please use an SEARCH block which contain blank line.
 
 Be extremely careful and precise when creating these blocks. If the SEARCH section doesn't match exactly, the edit will fail.
 
@@ -78,13 +78,22 @@ func main() {
 
 /Users/user/projects/myproject/config.go
 <<<<<<< SEARCH
-// package main
+package main
+
 import "fmt"
 
 =======
-// package main
+package main
+
 // Importing the fmt package
 import "fmt"
+
+>>>>>>> REPLACE
+
+/Users/user/projects/myproject/config_test.go
+<<<<<<< SEARCH
+=======
+package main
 
 >>>>>>> REPLACE
 ]] .. "]]>" .. [[</content>
@@ -93,18 +102,17 @@ import "fmt"
 </agent>
 ```
 
-This example demonstrates how to add comments to the main.go and config.go files. Note how each SEARCH/REPLACE block starts with the file path, and how the SEARCH section exactly matches the existing code. Also, notice that the entire content is wrapped in a CDATA section to prevent XML parsing issues with special characters in the code.]]
+This example demonstrates how to add comments to the main.go and config.go files and creat a new file config_test.go. Note how each SEARCH/REPLACE block starts with the file path, and how the SEARCH section exactly matches the existing code. Also, notice that the entire content is wrapped in a CDATA section to prevent XML parsing issues with special characters in the code.]]
     end,
   },
   {
     role = "user",
     ---@param context CodeCompanion.Context
     content = function(context)
-      return [[Here are the code files you need to focus on and edit, these codes are always in the most up-to-date state
+      return [[Here are the code files you need to focus, these codes are always in the most up-to-date state
 
 @buffers
 
-I need you
 ]]
     end,
   },
@@ -133,109 +141,167 @@ local function find_blocks(content)
   local current_block = {}
   local current_file = nil
   local in_block = false
+  local block_type = nil
   local lines = vim.split(content, "\n", { plain = true })
 
   for _, line in ipairs(lines) do
     if line:match("^<<<<<<<%s*SEARCH%s*$") then
       in_block = true
-      current_block = { search = {}, replace = {} }
+      block_type = "search"
+      current_block = { search = {}, replace = {}, is_new_file = false }
+    elseif line:match("^<<<<<<<%s*REPLACE%s*$") then
+      in_block = true
+      block_type = "replace"
+      current_block = { search = {}, replace = {}, is_new_file = true }
     elseif line:match("^=======%s*$") and in_block then
-      current_block.current = "replace"
+      block_type = "replace"
     elseif line:match("^>>>>>>>%s*REPLACE%s*$") and in_block then
       in_block = false
-      if current_file and #current_block.search > 0 then
+      if current_file then
         log:trace("Found block for file: %s", current_file)
         log:trace("Search: %s", vim.inspect(current_block.search))
         log:trace("Replace: %s", vim.inspect(current_block.replace))
+        log:trace("Is new file: %s", tostring(current_block.is_new_file))
         table.insert(blocks, { file = current_file, block = current_block })
       end
+      current_block = {}
+      block_type = nil
     elseif in_block then
-      table.insert(current_block[current_block.current or "search"], line)
+      table.insert(current_block[block_type], line)
     elseif not in_block and line ~= "" then
       current_file = line
     end
   end
+
   return blocks
 end
 
-local function apply_edit(bufnr, search_lines, replace_lines)
+local function apply_edit(bufnr, search_lines, replace_lines, is_new_file)
   local content = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
-  local search = table.concat(search_lines, "\n")
-  local replace = table.concat(replace_lines, "\n")
 
-  log:debug("Content length: %d", #content)
-  log:debug("Search length: %d", #search)
-  log:debug("Replace length: %d", #replace)
+  if is_new_file then
+    -- if it is a new file, directly set the entire content of the buffer
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, replace_lines)
+    return true, "New file content set"
+  elseif #search_lines == 0 then
+    -- if the search line is empty, but it is not a new file, we add new content at the end of the file
+    local new_content = content .. "\n" .. table.concat(replace_lines, "\n")
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(new_content, "\n"))
+    return true, "New content added to existing file"
+  else
+    local search = table.concat(search_lines, "\n")
+    local replace = table.concat(replace_lines, "\n")
+
+    log:debug("Content length: %d", #content)
+    log:debug("Search length: %d", #search)
+    log:debug("Replace length: %d", #replace)
   -- stylua: ignore
   log:trace("Content (hex):\n%s", content:gsub(".", function(c) return string.format("%02X ", string.byte(c)) end))
   -- stylua: ignore
   log:trace("Search (hex):\n%s", search:gsub(".", function(c) return string.format("%02X ", string.byte(c)) end))
 
-  local function find_fuzzy(text, pattern)
-    pattern = pattern:gsub("%s+", "%%s*")
-    pattern = pattern:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1") -- 转义特殊字符
-    return text:match("()" .. pattern)
-  end
-
-  local start_pos = content:find(search, 1, true)
-  if not start_pos then
-    log:debug("Exact match failed, trying fuzzy match")
-    start_pos = find_fuzzy(content, search)
-    if not start_pos then
-      log:error("Could not find the search block in the buffer, even with fuzzy matching")
-      return false, "Could not find the search block in the buffer"
+    local function find_fuzzy(text, pattern)
+      pattern = pattern:gsub("%s+", "%%s*")
+      pattern = pattern:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1") -- 转义特殊字符
+      return text:match("()" .. pattern)
     end
+
+    local start_pos = content:find(search, 1, true)
+    if not start_pos then
+      log:debug("Exact match failed, trying fuzzy match")
+      start_pos = find_fuzzy(content, search)
+      if not start_pos then
+        log:error("Could not find the search block in the buffer, even with fuzzy matching")
+        return false, "Could not find the search block in the buffer"
+      end
+    end
+
+    local end_pos = start_pos + #search - 1
+    local start_line = select(2, content:sub(1, start_pos):gsub("\n", "")) + 1
+    local end_line = select(2, content:sub(1, end_pos):gsub("\n", "")) + 1
+
+    log:debug("Match found at position %d-%d (lines %d-%d)", start_pos, end_pos, start_line, end_line)
+
+    api.nvim_buf_set_lines(bufnr, start_line - 1, end_line, false, vim.split(replace, "\n"))
+    return true, string.format("Edit applied successfully at lines %d-%d", start_line, end_line)
   end
-
-  local end_pos = start_pos + #search - 1
-  local start_line = select(2, content:sub(1, start_pos):gsub("\n", "")) + 1
-  local end_line = select(2, content:sub(1, end_pos):gsub("\n", "")) + 1
-
-  log:debug("Match found at position %d-%d (lines %d-%d)", start_pos, end_pos, start_line, end_line)
-
-  vim.api.nvim_buf_set_lines(bufnr, start_line - 1, end_line, false, vim.split(replace, "\n"))
-  return true, string.format("Edit applied successfully at lines %d-%d", start_line, end_line)
 end
 
 local function create_rollback_point(bufnr)
   return {
     bufnr = bufnr,
-    lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false),
+    lines = api.nvim_buf_get_lines(bufnr, 0, -1, false),
     view = vim.fn.winsaveview(),
   }
 end
 
 local function rollback(rollback_point)
   if rollback_point then
-    vim.api.nvim_buf_set_lines(rollback_point.bufnr, 0, -1, false, rollback_point.lines)
+    api.nvim_buf_set_lines(rollback_point.bufnr, 0, -1, false, rollback_point.lines)
     vim.fn.winrestview(rollback_point.view)
     return true, "Changes rolled back successfully"
   end
   return false, "No rollback point available"
 end
 
--- New function to handle the actual execution
+--- Finds an appropriate window to open a file or creates a new left split window if no suitable window is found.
+---@param file_path string: The path of the file to be opened.
+---@return integer: Window ID of the found or newly created window.
+local function find_or_create_appropriate_window(file_path)
+  local chat_bufnr = api.nvim_get_current_buf()
+  local target_filetype = vim.fn.fnamemodify(file_path, ":e")
+
+  -- find the non-chat buffer window on the left
+  for _, win in ipairs(api.nvim_list_wins()) do
+    local buf = api.nvim_win_get_buf(win)
+    if buf ~= chat_bufnr and api.nvim_win_get_config(win).relative == "" then
+      local win_file_type = vim.bo[buf].filetype
+      if win_file_type == target_filetype or win_file_type == "" then
+        return win
+      end
+    end
+  end
+
+  -- if no suitable window is found, create a new left split
+  vim.cmd("leftabove vnew")
+  return api.nvim_get_current_win()
+end
+
+-- Edits the specified blocks in the content of the buffers.
+---@param params table: A table containing the fields needed for the edits.
+---@return table: A table containing the results of each edit operation including success status and messages.
+---@return table: A table that maps modified file paths to their respective edits.
+---@return table: A table containing rollback points for the buffers that were modified.
 local function perform_edits(params)
   local blocks = find_blocks(params.content)
   local results = {}
   local modified_files = {}
   local rollback_points = {}
+  local new_buffers = {}
+  local chat_win = api.nvim_get_current_win()
 
   for _, item in ipairs(blocks) do
     local file_path = item.file
     local block = item.block
-
     local bufnr = vim.fn.bufnr(file_path)
+    local is_new_buffer = false
+
+    log:trace("Buffer number for file: %s is %d", file_path, bufnr)
+
+    -- if bufnr is -1, the buffer does not exist, so create it
     if bufnr == -1 then
       bufnr = vim.fn.bufadd(file_path)
       vim.fn.bufload(bufnr)
+      is_new_buffer = true
+      table.insert(new_buffers, bufnr)
+      log:trace("Created new buffer for file: %s with number %d", file_path, bufnr)
     end
 
-    if vim.api.nvim_buf_is_valid(bufnr) then
+    if api.nvim_buf_is_valid(bufnr) then
       local rollback_point = create_rollback_point(bufnr)
       table.insert(rollback_points, rollback_point)
 
-      local success, result = apply_edit(bufnr, block.search, block.replace)
+      local success, result = apply_edit(bufnr, block.search, block.replace, block.is_new_file)
 
       table.insert(results, {
         success = success,
@@ -253,32 +319,61 @@ local function perform_edits(params)
           search = table.concat(block.search, "\n"),
           replace = table.concat(block.replace, "\n"),
         })
+
+        -- Save the buffer to disk if auto_submit_success is enabled
+        if config.strategies.agent.agents.opts.auto_submit_success then
+          local save_success, save_error = pcall(function()
+            vim.api.nvim_buf_call(bufnr, function()
+              vim.cmd("silent! write")
+            end)
+          end)
+
+          if not save_success then
+            log:error("Failed to save file: " .. file_path .. ". Error: " .. save_error)
+            table.insert(results, {
+              success = false,
+              message = "Failed to save file: " .. file_path .. ". Error: " .. save_error,
+              file = file_path,
+            })
+          else
+            log:info("Successfully saved file: " .. file_path)
+            table.insert(results, {
+              success = true,
+              message = "Successfully saved file: " .. file_path,
+              file = file_path,
+            })
+          end
+        end
+      end
+
+      -- if the buffer is newly created, set some options
+      if is_new_buffer then
+        local target_win = find_or_create_appropriate_window(file_path)
+        api.nvim_win_set_buf(target_win, bufnr)
+        api.nvim_set_option_value("buflisted", true, { buf = bufnr })
+        api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+        api.nvim_set_option_value("modified", false, { buf = bufnr })
       end
     else
       table.insert(results, { success = false, message = "Invalid buffer for file: " .. file_path })
     end
   end
 
+  -- return focus to the chat buffer
+  api.nvim_set_current_win(chat_win)
+
   return results, modified_files, rollback_points
 end
 
--- Executes code modifications and handles the results.
---
----@param chat CodeCompanion.Chat The chat object containing buffer information.
----@param params table Parameters for the code modifications.
---
----@return CodeCompanion.AgentExecuteResult
-function M.execute(chat, params)
+function M.execute(chat, params, last_execute)
   local bufnr = chat.bufnr
 
   -- Announce start
-  vim.api.nvim_exec_autocmds("User", {
-    pattern = "CodeCompanionAgent",
-    data = { bufnr = bufnr, status = "started" },
-  })
+  util.announce_start(bufnr)
 
   -- Perform edits
   local results, modified_files, rollback_points = perform_edits(params)
+  log:trace("result: %s", results)
 
   -- Process results
   local overall_success = vim.tbl_count(vim.tbl_filter(function(r)
@@ -290,7 +385,7 @@ function M.execute(chat, params)
 
   for file_path, _ in pairs(modified_files) do
     local file_bufnr = vim.fn.bufnr(file_path)
-    modified_files[file_path].content = table.concat(vim.api.nvim_buf_get_lines(file_bufnr, 0, -1, false), "\n")
+    modified_files[file_path].content = table.concat(api.nvim_buf_get_lines(file_bufnr, 0, -1, false), "\n")
   end
 
   -- Handle rollback if necessary
@@ -304,41 +399,22 @@ function M.execute(chat, params)
     modified_files = {}
   end
 
-  -- Prepare final result
-  local result = {
-    success = overall_success,
-    message = table.concat(messages, "\n"),
-    modified_files = modified_files,
-    details = results,
-  }
-
-  -- Announce end
-  vim.api.nvim_exec_autocmds("User", {
-    pattern = "CodeCompanionAgent",
-    data = {
-      bufnr = bufnr,
-      status = overall_success and "success" or "error",
-      error = not overall_success and result.message or nil,
-      output = overall_success and result.message or nil,
-    },
-  })
-
-  return result
+  util.announce_end(
+    bufnr,
+    overall_success and "success" or "error",
+    not overall_success and messages or {},
+    overall_success and messages or {},
+    last_execute
+  )
 end
 
 -- The prompt to share with the LLM if an error is encountered
 M.output_error_prompt = function(error)
-  return "The buffer editor encountered an error: " .. error .. "\n\nCan you fix this issue?"
+  return "After the buffer_editor completed, there was an error:" .. "\n```\n" .. table.concat(error, "\n") .. "\n```\n"
 end
 
 M.output_prompt = function(output)
-  if config.strategies.agent.agents.opts.auto_submit_success then
-    return "The buffer editor completed successfully with the following output:\n\n"
-      .. output
-      .. "\nWhat do you want to do next?"
-  else
-    return "The buffer editor completed successfully with the following output:\n\n" .. output .. "\nNow I need you "
-  end
+  return "After the buffer_editor completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```\n"
 end
 
 return M

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -42,7 +42,7 @@ file_path
 
 Every *SEARCH/REPLACE block* must use this format:
 1. The file path alone on a line, verbatim. No bold asterisks, no quotes around it, no escaping of characters, etc.
-2. The start of search block: <<<<<<< SEARCH
+2. The start of search block: <<<<<<< SEARCH even if there is no content needed to search for.
 3. A contiguous chunk of lines to search for in the existing source code. **DO NOT** include line numbers.
 4. The dividing line: =======
 5. The lines to replace into the source code
@@ -67,9 +67,18 @@ If you want to put code in a new file, use a *SEARCH/REPLACE block* with:
 
 Be extremely careful and precise when creating these blocks. If the SEARCH section doesn't match exactly, the edit will fail.
 
-ONLY EVER RETURN CODE IN A *SEARCH/REPLACE BLOCK*!
+ONLY EVER RETURN CODE IN A *SEARCH/REPLACE BLOCK*!]] .. [[
 
-Here's an example of how to use the buffer_editor agent:
+## Example conversations:
+
+### USER: Change get_factorial() to use math.factorial
+### ASSISTANT: To make this change we need to modify `mathweb/flask/app.py` to:
+
+1. Import the math package.
+2. Remove the existing factorial() function.
+3. Update get_factorial() to call math.factorial instead.
+
+Here are the *SEARCH/REPLACE* blocks:
 
 ```xml
 <agent>
@@ -77,45 +86,76 @@ Here's an example of how to use the buffer_editor agent:
   <parameters>
     <inputs>
       <content><![CDATA[
-/Users/user/projects/myproject/main.go
+mathweb/flask/app.py
 <<<<<<< SEARCH
-func main() {
-    fmt.Println("Hello, world!")
-}
+from flask import Flask
 =======
-func main() {
-    // Starting the main function
-    fmt.Println("Hello, world!") // Printing Hello, world! to the console
-}
+import math
+from flask import Flask
 >>>>>>> REPLACE
 
-/Users/user/projects/myproject/config.go
+mathweb/flask/app.py
 <<<<<<< SEARCH
-package main
+def factorial(n):
+    "compute factorial"
 
-import "fmt"
+    if n == 0:
+        return 1
+    else:
+        return n * factorial(n-1)
 
 =======
-package main
-
-// Importing the fmt package
-import "fmt"
-
 >>>>>>> REPLACE
 
-/Users/user/projects/myproject/config_test.go
+mathweb/flask/app.py
 <<<<<<< SEARCH
+    return str(factorial(n))
 =======
-package main
-
->>>>>>> REPLACE
-]] .. "]]>" .. [[</content>
+    return str(math.factorial(n))
+>>>>>>> REPLACE]] .. "]]>" .. [[</content>
     </inputs>
   </parameters>
 </agent>
 ```
 
-This example demonstrates how to add comments to the main.go and config.go files and creat a new file config_test.go. Note how each SEARCH/REPLACE block starts with the file path, and how the SEARCH section exactly matches the existing code. Also, notice that the entire content is wrapped in a CDATA section to prevent XML parsing issues with special characters in the code.]]
+### USER: Refactor hello() into its own file.
+### ASSISTANT: To make this change we need to modify `main.py` and make a new file `hello.py`:
+
+1. Make a new hello.py file with hello() in it.
+2. Remove hello() from main.py and replace it with an import.
+
+Here are the *SEARCH/REPLACE* blocks:
+
+```xml
+<agent>
+  <name>buffer_editor</name>
+  <parameters>
+    <inputs>
+      <content><![CDATA[
+hello.py
+<<<<<<< SEARCH
+=======
+def hello():
+    "print a greeting"
+
+    print("hello")
+>>>>>>> REPLACE
+
+main.py
+<<<<<<< SEARCH
+def hello():
+    "print a greeting"
+
+    print("hello")
+=======
+from hello import hello
+>>>>>>> REPLACE
+
+]] .. "]]>" .. [[</content>
+    </inputs>
+  </parameters>
+</agent>
+```]]
     end,
   },
   {

--- a/lua/codecompanion/agents/buffer_editor.lua
+++ b/lua/codecompanion/agents/buffer_editor.lua
@@ -43,7 +43,7 @@ file_path
 Every *SEARCH/REPLACE block* must use this format:
 1. The file path alone on a line, verbatim. No bold asterisks, no quotes around it, no escaping of characters, etc.
 2. The start of search block: <<<<<<< SEARCH
-3. A contiguous chunk of lines to search for in the existing source code
+3. A contiguous chunk of lines to search for in the existing source code. **DO NOT** include line numbers.
 4. The dividing line: =======
 5. The lines to replace into the source code
 6. The end of the replace block: >>>>>>> REPLACE

--- a/lua/codecompanion/agents/code_runner.lua
+++ b/lua/codecompanion/agents/code_runner.lua
@@ -38,7 +38,7 @@ return {
     {
       role = "user",
       content = function()
-        return "Using the agent, "
+        return ""
       end,
     },
   },
@@ -70,21 +70,13 @@ return {
     if type(error) == "table" then
       error = table.concat(error, "\n")
     end
-    return "After the agent completed, there was an error:"
-      .. "\n\n```\n"
-      .. error
-      .. "\n```\n\n"
-      .. "Can you attempt to fix this?"
+    return "After the code_runner completed, there was an error:" .. "\n```\n" .. error .. "\n```\n"
   end,
   output_prompt = function(output)
     if type(output) == "table" then
       output = table.concat(output, "\n")
     end
 
-    return "After the agent completed the output was:"
-      .. "\n\n```\n"
-      .. output
-      .. "\n```\n\n"
-      .. "Is that what you expected? If it is, just reply with a confirmation. Don't reply with any code. If not, say so and I can plan our next step."
+    return "After the code_runner completed the output was:" .. "\n```\n" .. output .. "\n```\n"
   end,
 }

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -73,13 +73,18 @@ function M.execute(chat, params, last_execute)
 
   local status = "success"
   local stderr = {}
+  local args = type(params.arg) == "table" and params.arg or { type(params.arg) == "string" and params.arg or "" }
 
   local job = Job:new({
     command = params.cmd,
-    args = type(params.arg) == "table" and params.arg or { type(params.arg) == "string" and params.arg or "" },
+    args = args,
     on_start = function()
       log:trace("Command Runner: Starting command: %s", cmd)
-      util.announce_progress(chat.bufnr, "progress", "Command executed successfully. output: \n ```\n")
+      util.announce_progress(
+        chat.bufnr,
+        "progress",
+        "Command `" .. params.cmd .. table.concat(params.arg, " ") .. "`. output: \n ```\n"
+      )
     end,
     on_exit = function(_, exit_code)
       vim.schedule(function()

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -81,7 +81,7 @@ function M.execute(chat, params, last_execute)
       log:trace("Command Runner: Starting command: %s", cmd)
       util.announce_progress(chat.bufnr, "progress", "Command executed successfully. output: \n ```\n")
     end,
-    on_exit = function(j, exit_code)
+    on_exit = function(_, exit_code)
       vim.schedule(function()
         log:trace("Command Runner: Command exited with code: %s", exit_code)
         util.announce_progress(chat.bufnr, "progress", "\n```\n")
@@ -94,8 +94,7 @@ function M.execute(chat, params, last_execute)
           status = "error"
           log:info("Command failed: %s", stderr)
         end
-        log:trace("Command Runner: Command output: %s", j:result())
-        return util.announce_end(chat.bufnr, status, stderr, j:result(), last_execute)
+        return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
       end)
     end,
     on_stdout = vim.schedule_wrap(function(_, data)

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -87,23 +87,23 @@ function M.execute(chat, params, last_execute)
           .. params.cmd
           .. " "
           .. table.concat(params.arg, " ")
-          .. "\n```. output: \n ```\n"
+          .. "\n```\nExecute command output: \n```bash\n"
       )
     end,
     on_exit = function(_, exit_code)
       vim.schedule(function()
-        log:trace("Command Runner: Command exited with code: %s", exit_code)
         util.announce_progress(chat.bufnr, "progress", "\n```\n")
+
+        log:trace("Command Runner: Command exited with code: %s", exit_code)
+        if exit_code ~= 0 then
+          status = "error"
+          log:info("Command failed: %s", stderr)
+          return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
+        end
 
         if _G.codecompanion_cancel_agent then
           return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
         end
-
-        if exit_code ~= 0 then
-          status = "error"
-          log:info("Command failed: %s", stderr)
-        end
-        return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
       end)
     end,
     on_stdout = vim.schedule_wrap(function(_, data)

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -21,7 +21,9 @@ M.prompts = {
     role = "system",
     content = function(schema)
       return "To aid you further, I'm giving you access to Command Runner which can run command in user's terminal."
-        .. [[Please be very cautious when suggesting commands, as they will be executed on the user's system. If the command may have destructive effects, please inform the user as first.
+        .. [[
+Be aware that each command does not share environment variables with others. The order of the command_runner agent calls determines the execution order. Plan your commands accordingly, and if you need to use variables across commands, consider using a single command with appropriate shell syntax.
+Please be very cautious when suggesting commands, as they will be executed on the user's system. If the command may have destructive effects, please inform the user as first.
 ]]
         .. "To use Command Runner, provide a command in the following format:\n\n"
         .. "```xml\n"

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -92,18 +92,19 @@ function M.execute(chat, params, last_execute)
     end,
     on_exit = function(_, exit_code)
       vim.schedule(function()
-        util.announce_progress(chat.bufnr, "progress", "\n```\n")
+        util.announce_progress(chat.bufnr, "progress", "\n```")
 
         log:trace("Command Runner: Command exited with code: %s", exit_code)
         if exit_code ~= 0 then
           status = "error"
           log:info("Command failed: %s", stderr)
-          return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
+
+          if vim.tbl_isempty(stderr) then
+            stderr = nil
+          end
         end
 
-        if _G.codecompanion_cancel_agent then
-          return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
-        end
+        return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
       end)
     end,
     on_stdout = vim.schedule_wrap(function(_, data)
@@ -125,14 +126,11 @@ function M.execute(chat, params, last_execute)
 end
 
 M.output_error_prompt = function(error)
-  return "After the command_runner completed, there was an error:"
-    .. "\n```\n"
-    .. table.concat(error, "\n")
-    .. "\n```\n"
+  return "After the command_runner completed, there was an error:" .. "\n```\n" .. table.concat(error, "\n") .. "\n```"
 end
 
 M.output_prompt = function(output)
-  return "After the command_runner completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```\n"
+  return "After the command_runner completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```"
 end
 
 return M

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -1,8 +1,6 @@
 local Job = require("plenary.job")
-local config = require("codecompanion").config
-local util = require("codecompanion.utils.agent")
-local api = vim.api
 local log = require("codecompanion.utils.log")
+local util = require("codecompanion.utils.agent")
 local xml2lua = require("codecompanion.utils.xml.xml2lua")
 
 ---@type CodeCompanion.Agent
@@ -13,9 +11,6 @@ M.schema = {
   parameters = {
     inputs = {
       cmd = "The command to execute",
-      -- args = {
-      --   arg = "The arguments to pass to the command",
-      -- },
       arg = "The arguments to pass to the command",
     },
   },
@@ -92,7 +87,11 @@ function M.execute(chat, params, last_execute)
     end,
     on_exit = function(_, exit_code)
       vim.schedule(function()
-        util.announce_progress(chat.bufnr, "progress", "\n```")
+        util.announce_progress(chat.bufnr, "progress", "\n```\n")
+
+        if _G.codecompanion_cancel_agent then
+          return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
+        end
 
         log:trace("Command Runner: Command exited with code: %s", exit_code)
         if exit_code ~= 0 then
@@ -115,7 +114,6 @@ function M.execute(chat, params, last_execute)
     end),
     on_stderr = function(_, data)
       if data then
-        log:trace("command runner stderr: %s", data)
         table.insert(stderr, data)
       end
     end,

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -83,7 +83,11 @@ function M.execute(chat, params, last_execute)
       util.announce_progress(
         chat.bufnr,
         "progress",
-        "Command `" .. params.cmd .. table.concat(params.arg, " ") .. "`. output: \n ```\n"
+        "Execute command below \n```bash\n"
+          .. params.cmd
+          .. " "
+          .. table.concat(params.arg, " ")
+          .. "\n```. output: \n ```\n"
       )
     end,
     on_exit = function(_, exit_code)

--- a/lua/codecompanion/agents/command_runner.lua
+++ b/lua/codecompanion/agents/command_runner.lua
@@ -1,0 +1,130 @@
+local Job = require("plenary.job")
+local config = require("codecompanion").config
+local util = require("codecompanion.utils.agent")
+local api = vim.api
+local log = require("codecompanion.utils.log")
+local xml2lua = require("codecompanion.utils.xml.xml2lua")
+
+---@type CodeCompanion.Agent
+local M = {}
+
+M.schema = {
+  name = "command_runner",
+  parameters = {
+    inputs = {
+      cmd = "The command to execute",
+      -- args = {
+      --   arg = "The arguments to pass to the command",
+      -- },
+      arg = "The arguments to pass to the command",
+    },
+  },
+}
+
+M.prompts = {
+  {
+    role = "system",
+    content = function(schema)
+      return "To aid you further, I'm giving you access to Command Runner which can run command in user's terminal."
+        .. [[Please be very cautious when suggesting commands, as they will be executed on the user's system. If the command may have destructive effects, please inform the user as first.
+]]
+        .. "To use Command Runner, provide a command in the following format:\n\n"
+        .. "```xml\n"
+        .. xml2lua.toXml(schema, "agent")
+        .. [[
+
+```
+
+Here's an example of how to use the Command Runner agent:
+
+```xml
+<agent>
+  <name>command_runner</name>
+  <parameters>
+    <inputs>
+      <cmd>ls</cmd>
+      <arg>-l</arg>
+      <arg>-a</arg>
+    </inputs>
+  </parameters>
+</agent>
+```
+
+This example demonstrates how to list all files in the current directory, including hidden files, with detailed information. Always ensure the command is safe and appropriate for the user's needs. After executing a command, I will provide you with the output, which you should interpret and use to inform your next actions or responses.]]
+    end,
+  },
+  {
+    role = "user",
+    content = function(context)
+      return ""
+    end,
+  },
+}
+
+function M.execute(chat, params, last_execute)
+  local cmd = params.cmd
+  log:trace("command Runner: Executing command: %s", cmd)
+  log:trace("command Runner: Executing command: %s", params.arg)
+  if not cmd then
+    log:error("command is required")
+    util.announce_end(chat.bufnr, "error", { "Command is required" }, {}, last_execute)
+    return
+  end
+
+  local status = "success"
+  local stderr = {}
+
+  local job = Job:new({
+    command = params.cmd,
+    args = type(params.arg) == "table" and params.arg or { type(params.arg) == "string" and params.arg or "" },
+    on_start = function()
+      log:trace("Command Runner: Starting command: %s", cmd)
+      util.announce_progress(chat.bufnr, "progress", "Command executed successfully. output: \n ```\n")
+    end,
+    on_exit = function(j, exit_code)
+      vim.schedule(function()
+        log:trace("Command Runner: Command exited with code: %s", exit_code)
+        util.announce_progress(chat.bufnr, "progress", "\n```\n")
+
+        if _G.codecompanion_cancel_agent then
+          return util.announce_end(chat.bufnr, status, stderr, nil, last_execute)
+        end
+
+        if exit_code ~= 0 then
+          status = "error"
+          log:info("Command failed: %s", stderr)
+        end
+        log:trace("Command Runner: Command output: %s", j:result())
+        return util.announce_end(chat.bufnr, status, stderr, j:result(), last_execute)
+      end)
+    end,
+    on_stdout = vim.schedule_wrap(function(_, data)
+      if data then
+        log:trace("command runner stdout: %s", data)
+        util.announce_progress(chat.bufnr, "progress", data)
+      end
+    end),
+    on_stderr = function(_, data)
+      if data then
+        log:trace("command runner stderr: %s", data)
+        table.insert(stderr, data)
+      end
+    end,
+  })
+
+  chat.current_agent = job
+  job:start()
+end
+
+M.output_error_prompt = function(error)
+  return "After the command_runner completed, there was an error:"
+    .. "\n```\n"
+    .. table.concat(error, "\n")
+    .. "\n```\n"
+end
+
+M.output_prompt = function(output)
+  return "After the command_runner completed the output was:" .. "\n```\n" .. table.concat(output, "\n") .. "\n```\n"
+end
+
+return M

--- a/lua/codecompanion/agents/rag.lua
+++ b/lua/codecompanion/agents/rag.lua
@@ -50,7 +50,7 @@ return {
     {
       role = "user",
       content = function()
-        return "Using the rag agent, can you "
+        return ""
       end,
     },
   },
@@ -58,7 +58,7 @@ return {
     if type(error) == "table" then
       error = table.concat(error, "\n")
     end
-    return "After the agent completed, there was an error:" .. "\n\n```\n" .. error .. "\n```\n\n"
+    return "After the agent completed, there was an error:" .. "\n```\n" .. error .. "\n```\n\n"
   end,
   output_prompt = function(output)
     if type(output) == "table" then
@@ -67,7 +67,7 @@ return {
 
     return "After browsing the internet, this is what the rag agent found:"
       .. "\n\n## agent"
-      .. "\n\n```\n"
+      .. "\n```\n"
       .. rag.strip_markdown(output)
       .. "\n```\n"
   end,

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -86,4 +86,11 @@ return {
     end,
     opts = { desc = "Add the current selection to a chat buffer", range = true },
   },
+  {
+    cmd = "CodeCompanionAddLSPDiagnostics",
+    callback = function(opts)
+      codecompanion.add_lsp_diagnostics(opts)
+    end,
+    opts = { desc = "Add the current LSP diagnostics to a chat buffer", range = true },
+  },
 }

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -326,31 +326,67 @@ return {
     use_default_actions = true,
     use_default_prompts = true,
     system_prompt = string.format(
-      [[You are an AI programming assistant named "CodeCompanion" that's inbuilt into the Neovim text editor. Follow the user's requirements carefully and to the letter. Keep your answers short and impersonal.
+      [[# CodeCompanion AI Assistant
 
-You can answer general programming questions and perform the following tasks:
-- Ask questions about the files in your current workspace
-- Explain how the selected code works
-- Generate unit tests for the selected code
-- Propose a fix for problems in the selected code
-- Scaffold code for a new feature
-- Ask questions about Neovim
-- Ask how to do something in the terminal
+You are an AI programming assistant named "CodeCompanion" integrated into the Neovim text editor. Follow user requirements carefully and precisely. Keep answers concise and professional.
 
-First, think step-by-step and describe your plan in pseudocode, written out in great detail. Then, output the code in a single code block. Minimize any other prose. Use Markdown formatting in your answers, and include the programming language name at the start of the Markdown code blocks. Avoid wrapping the whole response in triple backticks. The user works in a text editor called Neovim and the version is %d.%d.%d. Neovim has concepts for editors with open files, integrated unit test support, an output pane for running code, and an integrated terminal. The active document is the source code the user is looking at right now. You can only give one reply for each conversation turn.
+## General Information
 
-You may also have access to agents that you can use to initiate actions on the user's machine:
-- code_runner: To run any code that you've generated and receive the output
-- rag: To supplement your responses with real-time information and insight
-- buffer_editor: Able to modify existing code within a buffer or create a new buffer to write code. When you use buffer_editor you do not need to output the code in a single code block.
-- command_runner: Able to execute terminal commands and provide the output. 
+- You can answer general programming questions.
+- The user works in Neovim version %d.%d.%d.
+- Neovim has concepts for editors with open files, integrated unit test support, an output pane for running code, and an integrated terminal.
+- The active document is the source code the user is currently viewing.
+- You can only give one reply for each conversation turn.
+- Use Markdown formatting in your answers, including the programming language name at the start of code blocks.
+- Do not wrap the whole response in triple backticks.
 
-When informed by the user of an available agent, pay attention to the schema that the user provides in order to execute the agent. When you want to use a agent you need think step-by-step and explain you plan with a numbered list of short sentences at first then write agent xml.
+## Task Types
 
-You can return multiple agent XMLs each time, but each XML must be properly short explained beforehand.
+### RESPONSE TASKS
 
-Carefully determine whether the user's intention is to have their questions answered or to use a agent to solve therir problem or request, and choose an appropriate response strategy.
-]],
+These tasks involve direct responses to user queries without executing actions on the user's machine.
+
+Available RESPONSE TASKS:
+1. Answer questions about files in the current workspace
+2. Explain how selected code works
+3. Generate unit tests for selected code
+4. Propose fixes for problems in selected code
+5. Scaffold code for new features
+6. Answer questions about Neovim
+7. Explain how to perform terminal actions
+
+For RESPONSE TASKS:
+1. Think step-by-step and describe your plan in detailed pseudocode.
+2. Output the final code in a single code block.
+3. Minimize additional prose.
+
+### COOPERATE TASKS
+
+These tasks involve using agents to perform actions on the user's machine. 
+
+IMPORTANT: Agents are not available by default. You can only use an agent if the user explicitly mentions that it has been granted to you. Do not assume you have access to any agent unless specifically told so.
+
+Potential agents for COOPERATE TASKS (if granted):
+1. code_runner: Runs generated code and returns output
+2. rag: Supplements responses with real-time information
+3. buffer_editor: Modifies existing code or creates new buffers
+4. command_runner: Executes terminal commands and provides output
+
+For COOPERATE TASKS (when agents are available):
+1. Confirm which agents you have been granted access to.
+2. Briefly describe your plan in pseudocode.
+3. Write the appropriate agent XML for the available agents.
+4. You can return multiple agent XMLs, but explain each one briefly.
+
+## Decision Logic
+
+To determine the appropriate task type:
+1. Analyze the user's input carefully.
+2. If the user is asking for information, explanations, or code generation without mentioning specific agents or machine actions, treat it as a RESPONSE TASK.
+3. If the user explicitly mentions granting access to an agent or requires actions to be performed on their machine, treat it as a COOPERATE TASK. Only use the agents that have been explicitly granted.
+4. If unclear or no agents have been granted, default to a RESPONSE TASK. You may suggest the use of agents if you think they would be helpful, but do not attempt to use them unless the user confirms access.
+
+Always ensure you're using the correct response strategy for the identified task type and only use agents when explicitly granted access.]],
       vim.version().major,
       vim.version().minor,
       vim.version().patch

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -71,6 +71,11 @@ return {
           description = "Edit code by searching and replacing blocks",
           enabled = true,
         },
+        ["command_runner"] = {
+          name = "Command Runner",
+          description = "Run shell commands on the user's system",
+          enabled = true,
+        },
         opts = {
           auto_submit_errors = false,
           auto_submit_success = false,
@@ -335,10 +340,16 @@ You can answer general programming questions and perform the following tasks:
 First, think step-by-step and describe your plan in pseudocode, written out in great detail. Then, output the code in a single code block. Minimize any other prose. Use Markdown formatting in your answers, and include the programming language name at the start of the Markdown code blocks. Avoid wrapping the whole response in triple backticks. The user works in a text editor called Neovim and the version is %d.%d.%d. Neovim has concepts for editors with open files, integrated unit test support, an output pane for running code, and an integrated terminal. The active document is the source code the user is looking at right now. You can only give one reply for each conversation turn.
 
 You may also have access to agents that you can use to initiate actions on the user's machine:
-- Code Runner: To run any code that you've generated and receive the output
-- RAG: To supplement your responses with real-time information and insight
+- code_runner: To run any code that you've generated and receive the output
+- rag: To supplement your responses with real-time information and insight
+- buffer_editor: Able to modify existing code within a buffer or create a new buffer to write code
+- command_runner: Able to execute terminal commands and provide the output
 
-When informed by the user of an available agent, pay attention to the schema that the user provides in order to execute the agent.]],
+When informed by the user of an available agent, pay attention to the schema that the user provides in order to execute the agent. When you want to use a agent you need think step-by-step and explain you plan with a numbered list of short sentences at first then write agent xml.
+you can return multi agent XMLs at once but each XML must be **separated** by a blank line.
+
+Carefully determine whether the user's intention is to have their questions answered or to use a agent to solve therir problem or request, and choose an appropriate response strategy.
+]],
       vim.version().major,
       vim.version().minor,
       vim.version().patch

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -326,9 +326,7 @@ return {
     use_default_actions = true,
     use_default_prompts = true,
     system_prompt = string.format(
-      [[# CodeCompanion AI Assistant
-
-You are an AI programming assistant named "CodeCompanion" integrated into the Neovim text editor. Follow user requirements carefully and precisely. Keep answers concise and professional.
+      [[You are an AI programming assistant named "CodeCompanion" integrated into the Neovim text editor. Follow user requirements carefully and precisely. Keep answers concise and professional.
 
 ## General Information
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -346,7 +346,8 @@ You may also have access to agents that you can use to initiate actions on the u
 - command_runner: Able to execute terminal commands and provide the output
 
 When informed by the user of an available agent, pay attention to the schema that the user provides in order to execute the agent. When you want to use a agent you need think step-by-step and explain you plan with a numbered list of short sentences at first then write agent xml.
-you can return multi agent XMLs at once but each XML must be **separated** by a blank line.
+
+You can return multiple agent XMLs each time, but each XML must be properly short explained beforehand.
 
 Carefully determine whether the user's intention is to have their questions answered or to use a agent to solve therir problem or request, and choose an appropriate response strategy.
 ]],

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -342,8 +342,8 @@ First, think step-by-step and describe your plan in pseudocode, written out in g
 You may also have access to agents that you can use to initiate actions on the user's machine:
 - code_runner: To run any code that you've generated and receive the output
 - rag: To supplement your responses with real-time information and insight
-- buffer_editor: Able to modify existing code within a buffer or create a new buffer to write code
-- command_runner: Able to execute terminal commands and provide the output
+- buffer_editor: Able to modify existing code within a buffer or create a new buffer to write code. When you use buffer_editor you do not need to output the code in a single code block.
+- command_runner: Able to execute terminal commands and provide the output. 
 
 When informed by the user of an available agent, pay attention to the schema that the user provides in order to execute the agent. When you want to use a agent you need think step-by-step and explain you plan with a numbered list of short sentences at first then write agent xml.
 

--- a/lua/codecompanion/helpers/buffers.lua
+++ b/lua/codecompanion/helpers/buffers.lua
@@ -71,8 +71,7 @@ function M.get_open_buffers(ft, bufs)
   for _, buf in ipairs(buffers) do
     if api.nvim_buf_is_valid(buf) and vim.bo[buf].filetype == ft then
       local filename = api.nvim_buf_get_name(buf)
-      local name = filename:match("^.+/(.+)$")
-      content[name] = get_content(buf)
+      content[filename] = get_content(buf)
     end
   end
 

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -278,4 +278,41 @@ M.setup = function(opts)
   vim.treesitter.language.register("markdown", "codecompanion")
 end
 
+---Add current buffer lsp diagnostics to current chat buffer
+---@param opts table
+---@return nil
+M.add_lsp_diagnostics = function(opts)
+  local chat = _G.codecompanion_last_chat_buffer
+  if not chat then
+    return vim.notify("[CodeCompanion.nvim]\nNo chat buffer found", vim.log.levels.WARN)
+  end
+
+  local context = util.get_context(api.nvim_get_current_buf(), args)
+  local diagnostics =
+    require("codecompanion.helpers.lsp").get_diagnostics(context.start_line, context.end_line, context.bufnr)
+
+  chat:append({
+    role = "user",
+    content = "The programming language is " .. context.filetype .. ". This is a list of the diagnostic messages:\n\n",
+  })
+
+  for i, diagnostic in ipairs(diagnostics) do
+    chat:append({
+      role = "user",
+      content = i
+        .. ". Issue "
+        .. i
+        .. "\n  - File Name: "
+        .. context.filename
+        .. "\n  - Location: Line "
+        .. diagnostic.line_number
+        .. "\n  - Severity: "
+        .. diagnostic.severity
+        .. "\n  - Message: "
+        .. diagnostic.message
+        .. "\n",
+    })
+  end
+end
+
 return M

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -281,7 +281,7 @@ end
 ---Add current buffer lsp diagnostics to current chat buffer
 ---@param opts table
 ---@return nil
-M.add_lsp_diagnostics = function(opts)
+M.add_lsp_diagnostics = function(args)
   local chat = _G.codecompanion_last_chat_buffer
   if not chat then
     return vim.notify("[CodeCompanion.nvim]\nNo chat buffer found", vim.log.levels.WARN)

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -288,12 +288,21 @@ M.add_lsp_diagnostics = function(opts)
   end
 
   local context = util.get_context(api.nvim_get_current_buf(), args)
+
+  if context.start_line == context.end_line then
+    context.end_line = vim.api.nvim_buf_line_count(context.bufnr)
+  end
+
   local diagnostics =
     require("codecompanion.helpers.lsp").get_diagnostics(context.start_line, context.end_line, context.bufnr)
 
   chat:append({
     role = "user",
-    content = "The programming language is " .. context.filetype .. ". This is a list of the diagnostic messages:\n\n",
+    content = "The programming language is "
+      .. context.filetype
+      .. ". This is a list of the diagnostic in file:"
+      .. context.filename
+      .. "\n\n",
   })
 
   for i, diagnostic in ipairs(diagnostics) do
@@ -302,8 +311,6 @@ M.add_lsp_diagnostics = function(opts)
       content = i
         .. ". Issue "
         .. i
-        .. "\n  - File Name: "
-        .. context.filename
         .. "\n  - Location: Line "
         .. diagnostic.line_number
         .. "\n  - Severity: "

--- a/lua/codecompanion/keymaps.lua
+++ b/lua/codecompanion/keymaps.lua
@@ -181,6 +181,10 @@ M.add_agent = {
               notify = "The Code Runner agent was added to the chat buffer",
             })
           else
+            if content == "" then
+              return
+            end
+
             chat:append({
               role = prompt.role,
               content = content,

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -175,21 +175,19 @@ local function parse_helpers(chat, messages)
     return nil
   end
 
-  -- resolve all messages
-  for i, message in pairs(messages) do
-    local helper = find(message.content, config.strategies.chat.helpers)
-    if helper then
-      local content = resolve(config.strategies.chat.helpers[helper].callback)
+  -- Only parse the last message
+  local message = messages[#messages]
+  local helper = find(message.content, config.strategies.chat.helpers)
+  if helper then
+    local content = resolve(config.strategies.chat.helpers[helper].callback)
 
-      if content then
-        log:debug("Parsed helper in chat buffer")
-        log:trace("parse_helper content: %s", content)
-        log:info("parse_helper content: %s", content)
-        chat.buffers = {
-          index = i,
-          content = content,
-        }
-      end
+    if content then
+      log:debug("Parsed helper in chat buffer at message index %d", #messages)
+      log:trace("parse_helper content: %s", content)
+      chat.buffers = {
+        index = #messages,
+        content = content,
+      }
     end
   end
 end

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -700,6 +700,11 @@ function Chat:submit()
     end
 
     if done then
+      -- if find unclosed markdown code block close it
+      if table.concat(api.nvim_buf_get_lines(self.bufnr, 0, -1, false), "\n"):match("```[^`]*$") then
+        self:append({ role = "assistant", content = "\n```" })
+      end
+
       self:append({ role = "user", content = "" })
       self:display_tokens()
       if self.status ~= CONSTANTS.STATUS_ERROR then

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -175,20 +175,19 @@ local function parse_helpers(chat, messages)
     return nil
   end
 
-  -- resolve all messages
-  for i, message in pairs(messages) do
-    local helper = find(message.content, config.strategies.chat.helpers)
-    if helper then
-      local content = resolve(config.strategies.chat.helpers[helper].callback)
+  -- Only parse the last message
+  local message = messages[#messages]
+  local helper = find(message.content, config.strategies.chat.helpers)
+  if helper then
+    local content = resolve(config.strategies.chat.helpers[helper].callback)
 
-      if content then
-        log:debug("Parsed helper in chat buffer")
-        log:trace("parse_helper content: %s", content)
-        chat.buffers = {
-          index = i,
-          content = content,
-        }
-      end
+    if content then
+      log:debug("Parsed helper in chat buffer at message index %d", #messages)
+      log:trace("parse_helper content: %s", content)
+      chat.buffers = {
+        index = #messages,
+        content = content,
+      }
     end
   end
 end

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -1,4 +1,3 @@
-local Job = require("plenary.job")
 local client = require("codecompanion.client")
 local config = require("codecompanion").config
 local keymaps = require("codecompanion.utils.keymaps")
@@ -167,6 +166,7 @@ local function parse_helpers(chat, messages)
   ---@param helpers table
   ---@return string|nil
   local function find(message, helpers)
+    log:info("parse_helper message: %s", message)
     for helper, _ in pairs(helpers) do
       if message:match("%f[%w@]" .. "@" .. helper .. "%f[%W]") then
         return helper
@@ -175,19 +175,21 @@ local function parse_helpers(chat, messages)
     return nil
   end
 
-  -- Only parse the last message
-  local message = messages[#messages]
-  local helper = find(message.content, config.strategies.chat.helpers)
-  if helper then
-    local content = resolve(config.strategies.chat.helpers[helper].callback)
+  -- resolve all messages
+  for i, message in pairs(messages) do
+    local helper = find(message.content, config.strategies.chat.helpers)
+    if helper then
+      local content = resolve(config.strategies.chat.helpers[helper].callback)
 
-    if content then
-      log:debug("Parsed helper in chat buffer at message index %d", #messages)
-      log:trace("parse_helper content: %s", content)
-      chat.buffers = {
-        index = #messages,
-        content = content,
-      }
+      if content then
+        log:debug("Parsed helper in chat buffer")
+        log:trace("parse_helper content: %s", content)
+        log:info("parse_helper content: %s", content)
+        chat.buffers = {
+          index = i,
+          content = content,
+        }
+      end
     end
   end
 end

--- a/lua/codecompanion/utils/agent.lua
+++ b/lua/codecompanion/utils/agent.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+---@alias status
+---| "started" # The process has started.
+---| "progress" # The process is in progress.
+---| "success" # The process has completed successfully.
+---| "error" # The process has completed with an error.
+
+--- Announces the start of an operation to the "CodeCompanionAgent" by executing a custom autocmd.
+---@param bufnr number: The buffer number associated with the operation.
+function M.announce_start(bufnr)
+  vim.api.nvim_exec_autocmds("User", { pattern = "CodeCompanionAgent", data = { bufnr = bufnr, status = "started" } })
+end
+
+-- Announces the progress of an operation by triggering a custom Vim autocommand.
+---@param bufnr number The buffer number where the operation is taking place.
+---@param status status The current status of the operation.
+---@param stream_output string stream output produced by the operation.
+function M.announce_progress(bufnr, status, stream_output)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "CodeCompanionAgent",
+    data = {
+      bufnr = bufnr,
+      status = status,
+      error = nil,
+      output = nil,
+      stream_output = stream_output,
+      last_execute = false,
+    },
+  })
+end
+
+--- Announces the end of a process by triggering a custom "User" autocommand event with relevant data.
+--- output will append to last use block
+---@param bufnr number: The buffer number.
+---@param status status: The status of the process.
+---@param error table|nil: Any error message if available.
+---@param output table|nil: The output of the agent.
+---@param last_execute boolean: Is this the last agent in the conversation turn?
+function M.announce_end(bufnr, status, error, output, last_execute)
+  vim.api.nvim_exec_autocmds("User", {
+    pattern = "CodeCompanionAgent",
+    data = { bufnr = bufnr, status = status, error = error, output = output, last_execute = last_execute },
+  })
+end
+
+return M

--- a/lua/codecompanion/utils/util.lua
+++ b/lua/codecompanion/utils/util.lua
@@ -160,7 +160,6 @@ function M.get_context(bufnr, args)
     start_col = start_col,
     end_line = end_line,
     end_col = end_col,
-    active_buffers = get_active_buffers(),
   }
 end
 


### PR DESCRIPTION
- Refactor agent execute flow which support mutli agents at once and trigger chat:submit() when last agent return.
- Improve default system prompt to make the LLM more reliable for multi-agent return. Currently, the best performing LLM is 'claude-3-5-sonnet'.
- Refactor `buffer_editor`. remove `AgentExecuteResult` and use util.announce_start util.announce_progress util.announce_end to send stream output or final output to chat buffer.
- Implement new buffer and save handling in `buffer_editor.lua`.
- Refactor `code_runner.lua`, `job_runner.lua`, and `rag.lua` to improve prompt formatting.
- Add new `Command Runner` agent in `config.lua` which support execute command on user`s machine and stream output to chat buffer.
- Fixed some bugs, such as multiple requests being sent at once when pressing <c-s>, resulting in the chat buffer content looking strange. Removed some agent user prompts to make `gt` add agent work properly.

This is a commit with quite significant changes, need to review carefully.

![CleanShot 2024-07-16 at 15 13 47](https://github.com/user-attachments/assets/487f8a57-8fc0-4ae9-b90b-ae66af30d9de)

The following LLMs can achieve the best usage effect.
1. anthropic
- `claude-3-5-sonnet`
2. deepseek
- `deepseek-coder`
- 
Strangely, openai's `gpt4-o` often does not follow the instructions correctly in this set of prompt schemes to use buffer_editor and command_runner to complete tasks.
