### PR TITLE
Fixed the Num_Predict default value

### DIFF
--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -254,8 +254,8 @@ return {
       mapping = "parameters.options",
       type = "number",
       optional = true,
-      default = 128,
-      desc = "Maximum number of tokens to predict when generating text. (Default: 128, -1 = infinite generation, -2 = fill context)",
+      default = -1,
+      desc = "Maximum number of tokens to predict when generating text. (Default: -1, -1 = infinite generation, -2 = fill context)",
       validate = function(n)
         return n >= -2, "Must be -2 or greater"
       end,


### PR DESCRIPTION
As @davidgumberg mentioned here: https://github.com/olimorris/codecompanion.nvim/pull/61#issuecomment-2237751169

`num_predict` is incorrectly documented on Ollama's docs, we should adjust the default value of `num_predict` to reflect this.

Also, I agree with @davidgumberg's point that we should probably nil out the values that ollama states as we should grab this from the modelfile, but ideally we should try find a way to do this so that the values are being shown to the user. I am investigating this at the moment. This fix is just a temporary measure to fix what is an incorrect value.