### PR TITLE
Set the default Ollama Schema from the Modelfile

### DIFF
--- a/lua/codecompanion/adapters.lua
+++ b/lua/codecompanion/adapters.lua
@@ -23,10 +23,14 @@ local Adapter = {}
 ---@field callbacks.chat_output fun(data: table): table|nil
 ---@field callbacks.inline_output fun(data: table, context: table): table|nil
 ---@field schema table Set of parameters for the generative AI service that the user can customise in the chat buffer
+---@field init? function Function to call during intialisation of the object, useful if you want to modify the schema using values from the schema
 
 ---@param args CodeCompanion.AdapterArgs
 ---@return CodeCompanion.Adapter
 function Adapter.new(args)
+  if args.init then
+    args = args.init(args)
+  end
   return setmetatable({ args = args }, { __index = Adapter })
 end
 


### PR DESCRIPTION
This PR is to address https://github.com/olimorris/codecompanion.nvim/pull/61#issuecomment-2241827860

I ran into a bit of a snag as I couldn't actually fetch the current model the user had specified from the Schema in the Adapter itself. As such, I added an `init` function that you can declare, to effectively run some extra code with the user's options pre-populated in case you want to modify them after Initializing the adapter

But as this is quite a change on the general Adapter side, I wanted to get some confirmation from @olimorris that this is the right approach to take before proceeding too far (Still not quite confident on Lua best practice haha)

As of current, this PR does fetch the new values from the Modelfile (Even if they aren't currently existing in the schema) as well as using any new defaults the modelfile provides:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/14c89c0b-a25c-4431-9285-895930164509">

However, currently it is bugged for a few reasons:
 - [ ] The Completions don't currently work at all
 - [ ] Some parameters that can have multiple values, such as `stop` will just take the last value.
 
If we decide to go ahead I will fix these up and finalise the PR