### PR TITLE
Fix last instance of `get_code` being called from `codecompanion.helpers.code`

### DIFF
--- a/doc/RECIPES.md
+++ b/doc/RECIPES.md
@@ -124,7 +124,7 @@ require("codecompanion").setup({
           role = "user",
           contains_code = true,
           content = function(context)
-            local text = require("codecompanion.helpers.code").get_code(context.start_line, context.end_line)
+            local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
 
             return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
           end,
@@ -170,7 +170,7 @@ prompts = {
     role = "user",
     contains_code = true,
     content = function(context)
-      local text = require("codecompanion.helpers.code").get_code(context.start_line, context.end_line)
+      local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
 
       return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
     end,
@@ -220,7 +220,7 @@ Lets now take a look at the second prompt:
   role = "user",
   contains_code = true,
   content = function(context)
-    local text = require("codecompanion.helpers.code").get_code(context.start_line, context.end_line)
+    local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
 
     return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
   end,

--- a/lua/codecompanion/actions.lua
+++ b/lua/codecompanion/actions.lua
@@ -6,7 +6,7 @@ local M = {}
 M.static = {}
 
 local send_code = function(context)
-  local text = require("codecompanion.helpers.code").get_code(context.start_line, context.end_line)
+  local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
 
   return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
 end


### PR DESCRIPTION
https://github.com/olimorris/codecompanion.nvim/commit/e4466f8242821da4b784df88a604bad13b8e9b52 moved the `get_code` function to `codecompanion.helpers.actions`, but the send_code action still tries to call it from helpers.code, resulting in a crash.