### PR TITLE
feat(copilot) impl copilot (preview agent impl)

### DIFF
--- a/lua/codecompanion/actions.lua
+++ b/lua/codecompanion/actions.lua
@@ -65,6 +65,29 @@ M.static.actions = {
     },
   },
   {
+    name = "Copilot",
+    strategy = "copilot",
+    description = "Open a chat buffer with powerful tools to converse with an LLM",
+    type = nil,
+    opts = {
+      stop_context_insertion = true,
+    },
+    prompts = {
+      n = function()
+        return require("codecompanion").copilot()
+      end,
+      v = {
+        {
+          role = "user",
+          contains_code = true,
+          content = function(context)
+            return send_code(context)
+          end,
+        },
+      },
+    },
+  },
+  {
     name = "Prompts ...",
     strategy = " ",
     description = "Pre-defined prompts to help you code",

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -303,4 +303,31 @@ M.setup = function(opts)
   vim.treesitter.language.register("markdown", "codecompanion")
 end
 
+M.copilot = function(args)
+  local adapter
+  local context = util.get_context(api.nvim_get_current_buf(), args)
+
+  if args and args.fargs then
+    adapter = M.config.adapters[args.fargs[1]]
+  end
+
+  local chat = require("codecompanion.strategies.copilot").new({
+    context = context,
+    adapter = adapter,
+    tools = M.config.strategies.copilot.tools,
+    messages = {
+      {
+        role = "user",
+        content = "#buffers\n\n",
+      },
+    },
+  })
+
+  if not chat then
+    return vim.notify("[CodeCompanion.nvim]\nNo chat strategy found", vim.log.levels.WARN)
+  end
+
+  ui.scroll_to_end(0)
+end
+
 return M

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -18,6 +18,7 @@ local CONSTANTS = {
   AU_USER_EVENT = "CodeCompanionChat",
 
   STATUS_ERROR = "error",
+  STATUS_RUNNING = "running",
   STATUS_SUCCESS = "success",
   STATUS_FINISHED = "finished",
 }
@@ -241,7 +242,7 @@ local Chat = {}
 
 ---@class CodeCompanion.ChatArgs
 ---@field context? table
----@field adapter? CodeCompanion.Adapter
+---@field adapter? CodeCompanion.Adapter|string
 ---@field messages? table
 ---@field auto_submit? boolean
 ---@field stop_context_insertion? boolean
@@ -252,6 +253,7 @@ local Chat = {}
 ---@field last_role? string
 
 ---@param args CodeCompanion.ChatArgs
+---@return CodeCompanion.Chat
 function Chat.new(args)
   local id = math.random(10000000)
 
@@ -493,7 +495,11 @@ function Chat:set_autocmds()
     desc = "Submit the CodeCompanion chat buffer",
     callback = function()
       self:save_chat()
-      self:submit()
+
+      --- prevent send twice or more req at same time
+      if self.status == "" then
+        self:submit()
+      end
     end,
   })
 

--- a/lua/codecompanion/strategies/copilot.lua
+++ b/lua/codecompanion/strategies/copilot.lua
@@ -1,0 +1,341 @@
+local client = require("codecompanion.client")
+local config = require("codecompanion").config
+local log = require("codecompanion.utils.log")
+local n = require("nui-components")
+local yaml = require("codecompanion.utils.yaml")
+
+local api = vim.api
+
+local Chat = require("codecompanion.strategies.chat")
+local ToolManager = require("codecompanion.tools.tool_manager")
+
+local CONSTANTS = {
+  AU_USER_EVENT = "CodeCompanionChat",
+  STATUS_ERROR = "error",
+  STATUS_SUCCESS = "success",
+  STATUS_FINISHED = "finished",
+}
+
+local chat_query = [[
+(
+  atx_heading
+  (atx_h1_marker)
+  heading_content: (_) @role
+)
+(
+  section
+  [(paragraph) (section) (fenced_code_block) (list)] @text
+)
+]]
+
+local _cached_settings = {}
+
+---@param adapter? CodeCompanion.Adapter|string|function
+---@return CodeCompanion.Adapter
+local function resolve_adapter(adapter)
+  adapter = adapter or config.adapters[config.strategies.copilot.adapter]
+
+  if type(adapter) == "string" then
+    return require("codecompanion.adapters").use(adapter)
+  elseif type(adapter) == "function" then
+    return adapter()
+  end
+
+  return adapter
+end
+
+---@param bufnr integer
+---@param adapter? CodeCompanion.Adapter
+---@param ts_query? string
+---@return table
+local function parse_settings(bufnr, adapter, ts_query)
+  if _cached_settings[bufnr] then
+    return _cached_settings[bufnr]
+  end
+
+  -- If the user has disabled settings in the chat buffer, use the default settings
+  if not config.display.chat.show_settings then
+    if adapter then
+      _cached_settings[bufnr] = adapter:get_default_settings()
+
+      return _cached_settings[bufnr]
+    end
+  end
+
+  ts_query = ts_query or [[
+    ((block_mapping (_)) @block)
+  ]]
+
+  local settings = {}
+  local parser = vim.treesitter.get_parser(bufnr, "yaml", { ignore_injections = false })
+  local query = vim.treesitter.query.parse("yaml", ts_query)
+  local root = parser:parse()[1]:root()
+
+  for _, match in query:iter_matches(root, bufnr) do
+    local value = vim.treesitter.get_node_text(match[1], bufnr)
+
+    settings = yaml.decode(value)
+    break
+  end
+
+  if not settings then
+    log:error("Failed to parse settings in chat buffer")
+    return {}
+  end
+
+  return settings
+end
+
+---@param bufnr integer
+---@return table
+local function parse_messages(bufnr)
+  local output = {}
+
+  local parser = vim.treesitter.get_parser(bufnr, "markdown")
+  local query = vim.treesitter.query.parse("markdown", chat_query)
+  local root = parser:parse()[1]:root()
+
+  local captures = {}
+  for k, v in pairs(query.captures) do
+    captures[v] = k
+  end
+
+  local message = {}
+  for _, match in query:iter_matches(root, bufnr) do
+    if match[captures.role] then
+      if not vim.tbl_isempty(message) then
+        table.insert(output, message)
+        message = { role = "", content = "" }
+      end
+      message.role = vim.trim(vim.treesitter.get_node_text(match[captures.role], bufnr):lower())
+    elseif match[captures.text] then
+      local text = vim.trim(vim.treesitter.get_node_text(match[captures.text], bufnr))
+      if message.content then
+        message.content = message.content .. "\n\n" .. text
+      else
+        message.content = text
+      end
+      if not message.role then
+        message.role = "user"
+      end
+    end
+  end
+
+  if not vim.tbl_isempty(message) then
+    table.insert(output, message)
+  end
+
+  return output
+end
+
+---parse the tool call from the response
+---@param content string
+---@return string|nil, string|nil
+local function parse_tool_call(content)
+  local tool_name, args = content:match("%(([^%)]+)%)%s*\n```\n(.-)\n```")
+  -- local tool_name, args = content:match("%(([^%)]+)%)%s*\n%-%-%-\n(.-)\n%-%-%-")
+  log:info("parse_tool_call: %s, %s", tool_name, args)
+  if not tool_name or not args then
+    return nil, nil
+  end
+  return tool_name, args:gsub("^%s*(.-)%s*$", "%1") -- Trim whitespace
+end
+
+---@class CodeCompanion.CopilotArgs : CodeCompanion.ChatArgs
+---@field tools? CodeCompanion.CopilotTool[]
+
+---@class CodeCompanion.Copilot : CodeCompanion.Chat
+---@field current_tool? CodeCompanion.CopilotTool current running tool
+---@field tool_manager? CodeCompanion.ToolManager tool manager
+---@field current_assistant_response string current assistant response
+local Copilot = setmetatable({}, { __index = Chat })
+Copilot.__index = Copilot
+
+---@param args CodeCompanion.CopilotArgs
+function Copilot.new(args)
+  local auto_submit = args.auto_submit
+  local saved_chat = args.saved_chat
+
+  args.auto_submit = false
+  args.saved_chat = ""
+
+  -- resolve adapter before new chat
+  -- make sure the settings are set and rendered
+  args.adapter = resolve_adapter(args.adapter)
+
+  -- set stop sequences
+  if args.adapter.args.schema.stop then
+    log:info("set stop sequences")
+    --- openai api stop
+    args.adapter.args.schema.stop.default = {
+      "output:==",
+    }
+  elseif args.adapter.args.schema.stop_sequences then
+    log:info("set stop sequences")
+    --- anthropic api stop
+    args.adapter.args.schema.stop_sequences.default = {
+      "output:==",
+    }
+  end
+
+  local self = setmetatable(Chat.new(args), Copilot)
+
+  args.auto_submit = auto_submit
+  args.saved_chat = saved_chat
+
+  self.current_assistant_response = ""
+  self.tool_manager = ToolManager.new()
+
+  -- register tools
+  if args.tools then
+    for _, t in ipairs(args.tools) do
+      ---@type CodeCompanion.CopilotTool
+      local tool = t.new(self)
+      self.tool_manager:register_tool(tool.name, tool.new(self))
+    end
+  end
+
+  if args.saved_chat then
+    self:display_tokens()
+  end
+
+  if args.auto_submit then
+    self:submit()
+  end
+
+  return self
+end
+
+---Submit the chat buffer's contents to the LLM
+---@return nil
+function Copilot:submit()
+  local bufnr = self.bufnr
+  local settings, messages = parse_settings(bufnr, self.adapter), parse_messages(bufnr)
+  if not messages or #messages == 0 or (not messages[#messages].content or messages[#messages].content == "") then
+    return
+  end
+
+  if config.strategies.copilot.system_prompt then
+    table.insert(messages, 1, {
+      role = "system",
+      content = config.strategies.copilot.system_prompt(self),
+    })
+  end
+
+  -- Detect if the user has called any variables in their latest message
+  local vars = self.variables:parse(self, messages[#messages].content, #messages)
+  if vars then
+    -- For the message that includes the variable, remove it from the content
+    -- so we don't confuse the LLM. We don't need to remove the variable in
+    -- future replies as the LLM has already processed it.
+    messages[#messages].content = self.variables:replace(messages[#messages].content, vars)
+    table.insert(self.variable_output, vars)
+  end
+
+  -- Always add the variables to the same place in the message stack
+  if self.variable_output then
+    for i, var in ipairs(self.variable_output) do
+      table.insert(messages, var.index, {
+        role = "user",
+        content = var.content,
+      })
+
+      if i == 1 then
+        -- Insert workspace_prompt before the variable content
+        table.insert(messages, var.index, {
+          role = "user",
+          content = config.strategies.copilot.workspace_prompt(self),
+        })
+      end
+    end
+
+    -- remove all history variable output
+    self.variable_output = {}
+  end
+
+  vim.bo[bufnr].modified = false
+  vim.bo[bufnr].modifiable = false
+
+  self.current_assistant_response = ""
+
+  self.current_request = client.new():stream(self.adapter:set_params(settings), messages, function(err, data, done)
+    if err then
+      vim.notify("Error: " .. err, vim.log.levels.ERROR)
+      return self:reset()
+    end
+
+    -- With some adapters, the tokens come as part of the regular response so
+    -- we need to account for that here before the client is terminated
+    if data then
+      self:get_tokens(data)
+    end
+
+    if done then
+      local content = self.current_assistant_response
+      log:info("current_assistant_response: %s", content)
+      self.current_assistant_response = ""
+
+      local tool_name, args = parse_tool_call(content)
+
+      if tool_name then
+        return self:execute_tool(tool_name, args)
+      else
+        self:append({ role = "user", content = "#buffers \n\n" })
+
+        self:display_tokens()
+        api.nvim_exec_autocmds(
+          "User",
+          { pattern = CONSTANTS.AU_USER_EVENT, data = { status = CONSTANTS.STATUS_FINISHED } }
+        )
+        return self:reset()
+      end
+    end
+
+    if data and data ~= "data: [DONE]" then
+      local result = self.adapter.args.callbacks.chat_output(data)
+      if result and result.status == CONSTANTS.STATUS_SUCCESS then
+        self.current_assistant_response = self.current_assistant_response .. (result.output.content or "")
+        self:append(result.output)
+      elseif result and result.status == CONSTANTS.STATUS_ERROR then
+        self.status = CONSTANTS.STATUS_ERROR
+        self:stop()
+        vim.notify("Error: " .. result.output, vim.log.levels.ERROR)
+      end
+    end
+  end, function()
+    self.current_request = nil
+  end)
+end
+
+---execute tool
+---@param tool_name string
+---@param args string|nil
+function Copilot:execute_tool(tool_name, args)
+  local tool = self.tool_manager:get_tool(tool_name)
+
+  if not tool then
+    log:error("Tool '%s' not found", tool_name)
+    return self:reset()
+  end
+
+  require("codecompanion.tools.autocmd").set_autocmd(self, tool)
+  tool:run(args)
+end
+
+---When a request has finished, reset the chat buffer
+---@return nil
+function Copilot:reset()
+  --- call parent reset
+  self.current_tool = nil
+  Chat.reset(self)
+end
+
+function Copilot:get_tool_descriptions()
+  return self.tool_manager:get_tool_descriptions()
+end
+
+function Copilot:get_tool_examples()
+  return self.tool_manager:get_tool_examples()
+end
+
+return Copilot

--- a/lua/codecompanion/tools/autocmd.lua
+++ b/lua/codecompanion/tools/autocmd.lua
@@ -1,0 +1,86 @@
+local api = vim.api
+local log = require("codecompanion.utils.log")
+local ui = require("codecompanion.utils.ui")
+
+local M = {}
+
+---@enum CodeCompanion.CopilotToolStatus
+M.TOOL_STATUS = {
+  start = "start",
+  progress = "progress",
+  final = "final",
+  error = "error",
+}
+
+---Set the autocmds for the copilot
+---@param copilot CodeCompanion.Copilot
+---@param tool CodeCompanion.CopilotTool
+M.set_autocmd = function(copilot, tool)
+  local ns_id = api.nvim_create_namespace("CodeCompanionCopilotVirtualText")
+  local group = "CodeCompanionCopilot_" .. copilot.bufnr
+
+  api.nvim_create_augroup(group, { clear = true })
+
+  return api.nvim_create_autocmd("User", {
+    desc = "Handle responses from any copilot tools",
+    group = group,
+    pattern = "CodeCompanionCopilot",
+    callback = function(request)
+      ---@type CodeCompanion.CopilotToolChunkResp
+      local tool_resp = request.data
+
+      if tool_resp.bufnr ~= copilot.bufnr then
+        return
+      end
+
+      log:info("copilot tool event: %s", tool_resp)
+
+      if tool_resp.status == M.TOOL_STATUS.start then
+        copilot.current_tool = tool
+
+        ui.set_virtual_text(
+          copilot.bufnr,
+          ns_id,
+          "Copilot Tool processing ...",
+          --- TODO: add hl group
+          { hl_group = "CodeCompanionVirtualTextAgents" }
+        )
+        return
+      end
+
+      if tool_resp.status == M.TOOL_STATUS.progress then
+        copilot:add_message({
+          role = "assistant",
+          content = tool_resp.stream_output,
+        })
+        return
+      end
+
+      api.nvim_buf_clear_namespace(copilot.bufnr, ns_id, 0, -1)
+
+      if tool_resp.status == M.TOOL_STATUS.error then
+        copilot:add_message({
+          role = "assistant",
+          content = tool_resp.error,
+        })
+
+        copilot:reset()
+        copilot:submit()
+      end
+
+      if tool_resp.status == M.TOOL_STATUS.final then
+        copilot:add_message({
+          role = "assistant",
+          content = tool_resp.final_output,
+        })
+
+        copilot:reset()
+        copilot:submit()
+      end
+
+      api.nvim_clear_autocmds({ group = group })
+    end,
+  })
+end
+
+return M

--- a/lua/codecompanion/tools/base_tool.lua
+++ b/lua/codecompanion/tools/base_tool.lua
@@ -1,0 +1,103 @@
+local api = vim.api
+local TOOL_STATUS = require("codecompanion.tools.autocmd").TOOL_STATUS
+local ctcr = require("codecompanion.tools.chunk")
+local log = require("codecompanion.utils.log")
+
+---@enum EXECUTE_TYPE
+CODECOMPANION_COPILOT_TOOL_EXECUTE_TYPE = {
+  sync = 0,
+  stream = 1,
+}
+
+---@class CodeCompanion.CopilotTool
+---@field name string
+---@field copilot CodeCompanion.Copilot
+local BaseTool = { name = "base_tool" }
+BaseTool.__index = BaseTool
+
+---@param chat CodeCompanion.Chat
+function BaseTool.new(chat)
+  local self = setmetatable({ copilot = chat }, BaseTool)
+  return self
+end
+
+---@param chunk CodeCompanion.CopilotToolChunkResp
+function BaseTool:send(chunk)
+  chunk.bufnr = self.copilot.bufnr
+  api.nvim_exec_autocmds("User", { pattern = "CodeCompanionCopilot", data = chunk })
+end
+
+--- Executes the tool's operation with the provided arguments.
+--- Sends a start and progress response to the copilot buffer,
+--- and handles the execution asynchronously.
+---
+--- @param args string|nil The arguments needed to execute the tool's operation.
+--- @return nil
+function BaseTool:run(args)
+  self:send(ctcr.new_start(self.copilot.bufnr))
+
+  --- some api like deepseek will return stop words so when the last line is stop words
+  --- we do not need send "output:==" to chat buffer
+  local ll, _, _ = self.copilot:last()
+  local last_line = api.nvim_buf_get_lines(self.copilot.bufnr, ll, ll + 1, false)
+
+  if last_line and #last_line > 0 and last_line[1]:match("*output*") then
+    self:send(ctcr.new_progress(self.copilot.bufnr, "\n```\n"))
+  else
+    self:send(ctcr.new_progress(self.copilot.bufnr, "\noutput:==\n```\n"))
+  end
+
+  vim.schedule(function()
+    ---@param chunk CodeCompanion.CopilotToolChunkResp
+    self:execute(args, function(chunk)
+      if chunk.status == TOOL_STATUS.final then
+        -- when subclass tool send a final chunk
+        -- we should close the code block and send the final chunk
+        if chunk.final_output == nil then
+          chunk.final_output = "\n```\n"
+        else
+          chunk.final_output = chunk.final_output .. "\n```\n"
+        end
+      end
+
+      if chunk.status == TOOL_STATUS.error then
+        -- when subclass tool send a final chunk
+        -- we should close the code block and send the final chunk
+        if chunk.error == nil then
+          chunk.error = "\n```\n"
+        else
+          chunk.error = chunk.error .. "\n```\n"
+        end
+      end
+
+      self:send(chunk)
+    end)
+  end)
+end
+
+-- Executes the tool's functionality with the given arguments.
+-- This method must be implemented by subclasses of BaseTool.
+--
+---@param args string|nil A table containing the arguments necessary for execution.
+---@param callback fun(response: CodeCompanion.CopilotToolChunkResp)
+function BaseTool:execute(args, callback)
+  error("execute method must be implemented by sync tool subclass")
+end
+
+function BaseTool:description()
+  error("description method must be implemented by subclass")
+end
+
+function BaseTool:input_format()
+  error("input_format method must be implemented by subclass")
+end
+
+function BaseTool:output_format()
+  error("output_format method must be implemented by subclass")
+end
+
+function BaseTool:example()
+  error("example method must be implemented by subclass")
+end
+
+return BaseTool

--- a/lua/codecompanion/tools/buffer_editor.lua
+++ b/lua/codecompanion/tools/buffer_editor.lua
@@ -1,0 +1,438 @@
+local BaseTool = require("codecompanion.tools.base_tool")
+local ctcr = require("codecompanion.tools.chunk")
+local log = require("codecompanion.utils.log")
+local api = vim.api
+
+local function create_rollback_point(bufnr)
+  return {
+    bufnr = bufnr,
+    lines = api.nvim_buf_get_lines(bufnr, 0, -1, false),
+    view = vim.fn.winsaveview(),
+  }
+end
+
+local function apply_edit(bufnr, search_lines, replace_lines, is_new_file)
+  local content = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+
+  if is_new_file then
+    -- if it is a new file, directly set the entire content of the buffer
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, replace_lines)
+    return true, "New file content set"
+  elseif #search_lines == 0 then
+    -- if the search line is empty, but it is not a new file, we add new content at the end of the file
+    local new_content = content .. "\n" .. table.concat(replace_lines, "\n")
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(new_content, "\n"))
+    return true, "New content added to existing file"
+  else
+    local search = table.concat(search_lines, "\n")
+    local replace = table.concat(replace_lines, "\n")
+
+    log:debug("Content length: %d", #content)
+    log:debug("Search length: %d", #search)
+    log:debug("Replace length: %d", #replace)
+  -- stylua: ignore
+  log:trace("Content (hex):\n%s", content:gsub(".", function(c) return string.format("%02X ", string.byte(c)) end))
+  -- stylua: ignore
+  log:trace("Search (hex):\n%s", search:gsub(".", function(c) return string.format("%02X ", string.byte(c)) end))
+
+    local function find_fuzzy(text, pattern)
+      pattern = pattern:gsub("%s+", "%%s*")
+      pattern = pattern:gsub("([%(%)%.%%%+%-%*%?%[%]%^%$])", "%%%1") -- 转义特殊字符
+      return text:match("()" .. pattern)
+    end
+
+    local start_pos = content:find(search, 1, true)
+    if not start_pos then
+      log:debug("Exact match failed, trying fuzzy match")
+      start_pos = find_fuzzy(content, search)
+      if not start_pos then
+        log:error("Could not find the search block in the buffer, even with fuzzy matching")
+        return false, "Could not find the search block in the buffer"
+      end
+    end
+
+    local end_pos = start_pos + #search - 1
+    local start_line = select(2, content:sub(1, start_pos):gsub("\n", "")) + 1
+    local end_line = select(2, content:sub(1, end_pos):gsub("\n", "")) + 1
+
+    log:debug("Match found at position %d-%d (lines %d-%d)", start_pos, end_pos, start_line, end_line)
+
+    api.nvim_buf_set_lines(bufnr, start_line - 1, end_line, false, vim.split(replace, "\n"))
+    return true, string.format("Edit applied successfully at lines %d-%d", start_line, end_line)
+  end
+end
+
+--- Finds an appropriate window to open a file or creates a new left split window if no suitable window is found.
+---@param file_path string: The path of the file to be opened.
+---@return integer: Window ID of the found or newly created window.
+local function find_or_create_appropriate_window(file_path)
+  local chat_bufnr = api.nvim_get_current_buf()
+  local target_filetype = vim.fn.fnamemodify(file_path, ":e")
+
+  -- find the non-chat buffer window on the left
+  for _, win in ipairs(api.nvim_list_wins()) do
+    local buf = api.nvim_win_get_buf(win)
+    if buf ~= chat_bufnr and api.nvim_win_get_config(win).relative == "" then
+      local win_file_type = vim.bo[buf].filetype
+      if win_file_type == target_filetype or win_file_type == "" then
+        return win
+      end
+    end
+  end
+
+  -- if no suitable window is found, create a new left split
+  vim.cmd("leftabove vnew")
+  return api.nvim_get_current_win()
+end
+
+---@class CodeCompanion.BufferEditorTool : CodeCompanion.CopilotTool
+local BufferEditorTool = setmetatable({}, { __index = BaseTool })
+BufferEditorTool.__index = BufferEditorTool
+
+---@param copilot CodeCompanion.Copilot
+function BufferEditorTool.new(copilot)
+  local self = setmetatable(BaseTool.new(copilot), BufferEditorTool)
+  self.name = "buffer_editor"
+  return self
+end
+
+-- Executes the buffer editing tool with the provided arguments.
+--
+---@param args string A table containing the arguments necessary for execution.
+---@param callback fun(response: CodeCompanion.CopilotToolChunkResp)
+function BufferEditorTool:execute(args, callback)
+  -- Implementation remains largely the same, but now works directly with 'args'
+  local blocks = self:find_blocks(args)
+  local results, _, _ = self:perform_edits(blocks)
+
+  callback(ctcr.new_final(self.copilot.bufnr, self:format_results(results)))
+end
+
+---returns the result of the tool execution
+---@param results table
+---@private
+function BufferEditorTool:format_results(results)
+  local messages = vim.tbl_map(function(r)
+    return string.format("%s: %s", r.file, r.message)
+  end, results)
+
+  return table.concat(messages, "\n")
+end
+
+---@private
+function BufferEditorTool:find_blocks(content)
+  local blocks = {}
+  local current_block = {}
+  local current_file = nil
+  local in_block = false
+  local block_type = nil
+  local lines = vim.split(content, "\n", { plain = true })
+
+  for _, line in ipairs(lines) do
+    if line:match("^<<<<<<<%s*SEARCH%s*$") then
+      in_block = true
+      block_type = "search"
+      current_block = { search = {}, replace = {}, is_new_file = false }
+    elseif line:match("^<<<<<<<%s*REPLACE%s*$") then
+      in_block = true
+      block_type = "replace"
+      current_block = { search = {}, replace = {}, is_new_file = true }
+    elseif line:match("^=======%s*$") and in_block then
+      block_type = "replace"
+    elseif line:match("^>>>>>>>%s*REPLACE%s*$") and in_block then
+      in_block = false
+      if current_file then
+        log:trace("Found block for file: %s", current_file)
+        log:trace("Search: %s", vim.inspect(current_block.search))
+        log:trace("Replace: %s", vim.inspect(current_block.replace))
+        log:trace("Is new file: %s", tostring(current_block.is_new_file))
+        table.insert(blocks, { file = current_file, block = current_block })
+      end
+      current_block = {}
+      block_type = nil
+    elseif in_block then
+      table.insert(current_block[block_type], line)
+    elseif not in_block and line ~= "" then
+      current_file = line
+    end
+  end
+
+  return blocks
+end
+
+---@private
+function BufferEditorTool:perform_edits(blocks)
+  local results = {}
+  local modified_files = {}
+  local rollback_points = {}
+  local new_buffers = {}
+  local chat_win = api.nvim_get_current_win()
+
+  for _, item in ipairs(blocks) do
+    local file_path = item.file
+    local block = item.block
+    local bufnr = vim.fn.bufnr(file_path)
+    local is_new_buffer = false
+
+    log:trace("Buffer number for file: %s is %d", file_path, bufnr)
+
+    -- if bufnr is -1, the buffer does not exist, so create it
+    if bufnr == -1 then
+      bufnr = vim.fn.bufadd(file_path)
+      vim.fn.bufload(bufnr)
+      is_new_buffer = true
+      table.insert(new_buffers, bufnr)
+      log:trace("Created new buffer for file: %s with number %d", file_path, bufnr)
+    end
+
+    if api.nvim_buf_is_valid(bufnr) then
+      local rollback_point = create_rollback_point(bufnr)
+      table.insert(rollback_points, rollback_point)
+
+      local success, result = apply_edit(bufnr, block.search, block.replace, block.is_new_file)
+
+      table.insert(results, {
+        success = success,
+        message = result,
+        file = file_path,
+        search = table.concat(block.search, "\n"),
+        replace = table.concat(block.replace, "\n"),
+      })
+
+      if success then
+        if not modified_files[file_path] then
+          modified_files[file_path] = {}
+        end
+        table.insert(modified_files[file_path], {
+          search = table.concat(block.search, "\n"),
+          replace = table.concat(block.replace, "\n"),
+        })
+
+        -- Save the buffer to disk if auto_submit_success is enabled
+        local save_success, save_error = pcall(function()
+          vim.api.nvim_buf_call(bufnr, function()
+            vim.cmd("silent! write")
+          end)
+        end)
+
+        if not save_success then
+          log:error("Failed to save file: " .. file_path .. ". Error: " .. save_error)
+          table.insert(results, {
+            success = false,
+            message = "Failed to save file: " .. file_path .. ". Error: " .. save_error,
+            file = file_path,
+          })
+        else
+          log:info("Successfully saved file: " .. file_path)
+          table.insert(results, {
+            success = true,
+            message = "Successfully saved file: " .. file_path,
+            file = file_path,
+          })
+        end
+      end
+
+      -- if the buffer is newly created, set some options
+      if is_new_buffer then
+        local target_win = find_or_create_appropriate_window(file_path)
+        api.nvim_win_set_buf(target_win, bufnr)
+        api.nvim_set_option_value("buflisted", true, { buf = bufnr })
+        api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+        api.nvim_set_option_value("modified", false, { buf = bufnr })
+      end
+    else
+      table.insert(results, { success = false, message = "Invalid buffer for file: " .. file_path })
+    end
+  end
+
+  -- return focus to the chat buffer
+  api.nvim_set_current_win(chat_win)
+
+  return results, modified_files, rollback_points
+end
+
+function BufferEditorTool:description()
+  return "Performs complex buffer editing operations across multiple files, including search, replace, and block manipulations."
+end
+
+function BufferEditorTool:input_format()
+  return [[
+Input should contain a series of *SEARCH/REPLACE* blocks, each block representing a file edit operation.:
+
+file_path1
+<<<<<<< SEARCH
+[exact lines to search for]
+=======
+[lines to replace with]
+>>>>>>> REPLACE
+
+file_path2
+<<<<<<< SEARCH
+[another block to search for]
+=======
+[lines to replace with]
+>>>>>>> REPLACE
+
+
+*SEARCH/REPLACE block* Rules:
+
+Every *SEARCH/REPLACE block* must use this format:
+1. The file path alone on a line, verbatim. No bold asterisks, no quotes around it, no escaping of characters, etc. note user code file path.
+2. The start of search block: <<<<<<< SEARCH even if there is no content needed to search for. 注意请忽视掉给你的代码中每行最前面的行号,行号只是给你参考位置的
+3. A contiguous chunk of lines to search for in the existing source code.
+4. The dividing line: =======
+5. The lines to replace into the source code
+6. The end of the replace block: >>>>>>> REPLACE
+
+Every *SEARCH* section must *EXACTLY MATCH* the existing source code, character for character, including all comments, docstrings, etc.
+
+*SEARCH/REPLACE* blocks will replace *all* matching occurrences.
+Include enough lines to make the SEARCH blocks uniquely match the lines to change.
+
+Keep *SEARCH/REPLACE* blocks concise.
+Break large *SEARCH/REPLACE* blocks into a series of smaller blocks that each change a small portion of the file.
+Include just the changing lines, and a few surrounding lines if needed for uniqueness.
+Do not include long runs of unchanging lines in *SEARCH/REPLACE* blocks.
+
+To move code within a file, use 2 *SEARCH/REPLACE* blocks: 1 to delete it from its current location, 1 to insert it in the new location.
+
+Be extremely careful and precise when creating these blocks dot not forget code indentation same as the workspace code content. If the SEARCH section doesn't match exactly, the edit will fail.
+
+ONLY EVER RETURN CODE IN A *SEARCH/REPLACE BLOCK*! USE TAB FOR INDENTATION.
+
+CRITICAL INDENTATION RULES:
+1. ALWAYS preserve the exact indentation of the original code in the SEARCH block.
+2. In the REPLACE block, use the SAME TYPE of indentation (tabs or spaces) as in the SEARCH block.
+3. Do NOT convert tabs to spaces or vice versa. Use whatever indentation type is present in the original code.
+4. Pay close attention to the indentation in the workspace content provided to you. Mirror this indentation precisely in your SEARCH and REPLACE blocks.
+5. If you're unsure about the indentation, examine the provided workspace content carefully to determine whether tabs or spaces are being used.
+
+Remember: Incorrect indentation can cause the edit to fail or introduce bugs. Be extremely precise with indentation in both SEARCH and REPLACE blocks.
+  ]]
+end
+
+function BufferEditorTool:example()
+  return [[
+When using the buffer_editor tool to add or modify file content:
+
+1. For files not in the workspace yet:
+   - First, ask the user whether to create a new file directly or to have the user add the file to the workspace, in order to prevent buffer_editor from directly modifying a file that exists but is not in the workspace. 
+   - Use a SEARCH/REPLACE block with:
+     - A new file path, including directory name if needed
+     - An empty `SEARCH` section
+     - The new file's contents in the `REPLACE` section
+
+2. For files already in the workspace:
+   - Use a SEARCH/REPLACE block with:
+     - The existing file path
+     - An empty `SEARCH` section if you want to append content to the end of the file
+     - The content to be added in the `REPLACE` section
+
+Important notes:
+- If the specified file already exists and you use an empty `SEARCH` section, the content in the `REPLACE` section will be appended to the end of the existing file.
+- To replace the entire content of an existing file, include the entire current file content in the `SEARCH` section and the new content in the `REPLACE` section.
+- Always verify the current content of files in the workspace before making modifications to avoid unintended changes.
+- If you're unsure about the current state of a file, use the command_runner tool to check its content before using the buffer_editor tool.
+
+Example for appending to an existing file:
+```
+existing_file.txt
+<<<<<<< SEARCH
+=======
+This content will be appended to the end of the existing file.
+>>>>>>> REPLACE
+```
+
+Remember: The workspace contents are continuously updated, so always base your actions on the most recent information provided about the files in the workspace.
+
+Some Example conversations:
+
+### USER: Change get_factorial() to use math.factorial
+### ASSISTANT: To make this change we need to modify `mathweb/flask/app.py` to:
+
+1. Import the math package.
+2. Remove the existing factorial() function.
+3. Update get_factorial() to call math.factorial instead.
+
+(buffer_editor)
+```
+main.py
+<<<<<<< SEARCH
+def hello():
+    print("Hello, World!")
+=======
+def greet(name):
+    print(f"Hello, {name}!")
+>>>>>>> REPLACE
+
+mathweb/flask/app.py
+<<<<<<< SEARCH
+from flask import Flask
+=======
+import math
+from flask import Flask
+>>>>>>> REPLACE
+
+mathweb/flask/app.py
+<<<<<<< SEARCH
+def factorial(n):
+    "compute factorial"
+
+    if n == 0:
+        return 1
+    else:
+        return n * factorial(n-1)
+
+=======
+>>>>>>> REPLACE
+
+mathweb/flask/app.py
+<<<<<<< SEARCH
+    return str(factorial(n))
+=======
+    return str(math.factorial(n))
+>>>>>>> REPLACE
+```
+output:==
+```
+
+
+### USER: Refactor hello() into its own file.
+### ASSISTANT: To make this change we need to modify `main.py` and make a new file `hello.py`:
+
+1. Make a new hello.py file with hello() in it.
+2. Remove hello() from main.py and replace it with an import.
+
+
+(buffer_editor)
+```
+hello.py
+<<<<<<< SEARCH
+=======
+def hello():
+    "print a greeting"
+
+    print("hello")
+>>>>>>> REPLACE
+
+main.py
+<<<<<<< SEARCH
+def hello():
+    "print a greeting"
+
+    print("hello")
+=======
+from hello import hello
+>>>>>>> REPLACE
+```
+output:==
+```
+
+]]
+end
+
+function BufferEditorTool:output_format()
+  return "A list of messages indicating the success or failure of the buffer editing operations."
+end
+
+return BufferEditorTool

--- a/lua/codecompanion/tools/chunk.lua
+++ b/lua/codecompanion/tools/chunk.lua
@@ -1,0 +1,44 @@
+local TOOL_STATUS = require("codecompanion.tools.autocmd").TOOL_STATUS
+
+---@class CodeCompanion.CopilotToolChunkResp
+---@field bufnr number the buffer number
+---@field status CodeCompanion.CopilotToolStatus status of the tool
+---@field stream_output string when status is progress
+---@field final_output string when status is success
+---@field error string when status is error
+local CopilotToolChunkResp = {}
+
+---new start when you impl your own tool run method, you should send this chunk first
+---@param bufnr number chat buffer number
+function CopilotToolChunkResp.new_start(bufnr)
+  local self = setmetatable({ bufnr = bufnr, status = TOOL_STATUS.start }, CopilotToolChunkResp)
+  return self
+end
+
+--- new progress chunk which is used to show the stream output of a running tool
+---@param bufnr number chat buffer number
+---@param stream_output string
+function CopilotToolChunkResp.new_progress(bufnr, stream_output)
+  local self =
+    setmetatable({ bufnr = bufnr, stream_output = stream_output, status = TOOL_STATUS.progress }, CopilotToolChunkResp)
+  return self
+end
+
+--- new final chunk which is used to show the final output of a tool
+---@param bufnr number chat buffer number
+---@param final_output? string
+function CopilotToolChunkResp.new_final(bufnr, final_output)
+  local self =
+    setmetatable({ bufnr = bufnr, final_output = final_output, status = TOOL_STATUS.final }, CopilotToolChunkResp)
+  return self
+end
+
+--- new error chunk which is used to show the error output of a tool
+---@param bufnr number chat buffer number
+---@param error string
+function CopilotToolChunkResp.new_error(bufnr, error)
+  local self = setmetatable({ bufnr = bufnr, error = error, status = TOOL_STATUS.error }, CopilotToolChunkResp)
+  return self
+end
+
+return CopilotToolChunkResp

--- a/lua/codecompanion/tools/command_runner.lua
+++ b/lua/codecompanion/tools/command_runner.lua
@@ -1,0 +1,99 @@
+local BaseTool = require("codecompanion.tools.base_tool")
+local ctcr = require("codecompanion.tools.chunk")
+local log = require("codecompanion.utils.log")
+
+---@class CodeCompanion.CommandRunnerTool : CodeCompanion.CopilotTool
+local CommandRunnerTool = setmetatable({}, { __index = BaseTool })
+CommandRunnerTool.__index = CommandRunnerTool
+
+---@param copilot CodeCompanion.Copilot
+function CommandRunnerTool.new(copilot)
+  local self = setmetatable(BaseTool.new(copilot), CommandRunnerTool)
+  self.name = "command_runner"
+  return self
+end
+
+---@param args string A table containing the arguments necessary for execution.
+---@param callback fun(chunk: CodeCompanion.CopilotToolChunkResp)
+function CommandRunnerTool:execute(args, callback)
+  local shell_command = string.format("sh -c '%s'", args:gsub("'", "'\\''"))
+  local handle, err = io.popen(shell_command .. " 2>&1", "r")
+  if not handle then
+    callback(ctcr.new_error(self.copilot.bufnr, "\nError opening command: " .. err))
+    return
+  end
+
+  local code
+  local function close_handle()
+    if handle then
+      _, err, code = handle:close()
+      handle = nil
+    end
+  end
+
+  local ok, _ = pcall(function()
+    for line in handle:lines() do
+      callback(ctcr.new_progress(self.copilot.bufnr, line .. "\n"))
+    end
+  end)
+
+  close_handle()
+
+  if not ok then
+    callback(ctcr.new_error(self.copilot.bufnr, "\nError during command execution: " .. tostring(err)))
+  elseif code and code ~= 0 then
+    callback(ctcr.new_final(self.copilot.bufnr, "\nCommand exited with code " .. tostring(code)))
+  else
+    callback(ctcr.new_final(self.copilot.bufnr, "\nCommand executed successfully."))
+  end
+end
+
+function CommandRunnerTool:description()
+  return "Executes shell commands and streams the output."
+end
+
+function CommandRunnerTool:input_format()
+  return "A string containing the shell command to be executed."
+end
+
+function CommandRunnerTool:output_format()
+  return "The output of the command."
+end
+
+function CommandRunnerTool:example()
+  return [[
+For the command_runner tool, you can execute shell commands to perform various operations. Here are several examples showcasing its usage:
+
+1. List files in the current directory:
+(command_runner)
+```
+ls -la
+```
+output:==
+```
+
+2. Search for a specific file pattern:
+(command_runner)
+```
+find . -name "*.lua"
+```
+output:==
+```
+
+Important guidelines when using the command_runner tool:
+
+1. Security: Never execute commands that could harm the user's system or expose sensitive information. Avoid commands that modify system settings or delete files unless explicitly requested and confirmed by the user.
+2. File paths: When operating on files, prefer using relative paths from the current working directory. If absolute paths are necessary, ensure they are within the user's project directory.
+3. Error handling: Be prepared to interpret and explain any error messages that may be returned by the command.
+4. OS compatibility: Consider that commands may behave differently on various operating systems (Windows, macOS, Linux). When possible, use commands that are cross-platform compatible.
+5. Permissions: Be aware that some commands may require elevated permissions. Inform the user if a command might need to be run with sudo or as an administrator.
+6. Resource usage: For commands that might take a long time or use significant system resources, warn the user beforehand.
+7. Output interpretation: After running a command, be prepared to explain its output to the user if it's not self-explanatory.
+8. Chaining commands: You can use shell operators to chain multiple commands if necessary, e.g., "command1 && command2" to run command2 only if command1 succeeds.
+Remember, the output of the command will be returned automatically. Do not attempt to fabricate or write the output yourself. Always wait for the actual result of the command execution before proceeding with your response.
+
+Adjust the commands according to the specific task at hand and the user's needs. Always prioritize safety and explain the purpose of the command before executing it.
+  ]]
+end
+
+return CommandRunnerTool

--- a/lua/codecompanion/tools/rag.lua
+++ b/lua/codecompanion/tools/rag.lua
@@ -1,0 +1,129 @@
+local BaseTool = require("codecompanion.tools.base_tool")
+local ctcr = require("codecompanion.tools.chunk")
+local log = require("codecompanion.utils.log")
+local rag = require("codecompanion.utils.rag")
+
+---@class CodeCompanion.RagTool : CodeCompanion.CopilotTool
+local RagTool = setmetatable({}, { __index = BaseTool })
+RagTool.__index = RagTool
+
+---@param copilot CodeCompanion.Copilot
+function RagTool.new(copilot)
+  local self = setmetatable(BaseTool.new(copilot), RagTool)
+  self.name = "rag"
+  return self
+end
+
+---@param args string table containing the arguments necessary for execution.
+---@param callback fun(response: CodeCompanion.CopilotToolChunkResp)
+-- function RagTool:execute(args, callback)
+--   local address
+--   local cmd = [[curl -X GET -H  "Accept: text/event-stream" ]]
+--
+--   -- Determine if it's a search or read query
+--   if args:sub(1, 5) == "read:" then
+--     address = "https://r.jina.ai/"
+--     cmd = cmd .. address .. rag.encode(args:sub(6)) -- Remove "read:" from the query
+--   else
+--     address = "https://s.jina.ai/"
+--     cmd = cmd .. address .. rag.encode(args) -- Default to search
+--   end
+--
+--   log:info("Executing RAG command: %s", cmd)
+--
+--   -- Execute command and capture output
+--   local output = io.popen(cmd .. " 2>&1"):read("*a")
+--   log:info("Command output: %s", output)
+--
+--   callback(ctcr.new_final(self.copilot.bufnr, output))
+-- end
+local Job = require("plenary.job")
+
+function RagTool:execute(args, callback)
+  local query, address
+  local stdout, stderr = {}, {}
+
+  -- Determine if it's a search or read query
+  if args:sub(1, 5) == "read:" then
+    -- Remove "read:" from the query
+    address = "https://r.jina.ai/"
+    query = args:sub(6)
+    --- trim whitespace
+    query = query:gsub("^%s*(.-)%s*$", "%1")
+  else
+    -- Default to search
+    address = "https://s.jina.ai/"
+    query = rag.encode(args)
+  end
+
+  if query == "" then
+    callback(ctcr.new_error(self.copilot.bufnr, "Invalid query"))
+    return
+  end
+
+  log:info("query:%s", query)
+  log:info("Executing RAG command: %s", address .. query)
+  Job:new({
+    command = "curl",
+    args = { "-N", "-H", "Accept: text/event-stream", address .. query },
+    on_exit = function(j, exit_code)
+      vim.schedule(function()
+        -- Process any remaining data in the buffer
+        log:info("rag final result: %s", j:result())
+        log:info("rag exited with code: %s", exit_code)
+        log:info("rag error: %s", table.concat(stderr, "\n"))
+
+        if #stderr > 0 then
+          callback(ctcr.new_error(self.copilot.bufnr, "Command failed with exit code: " .. tostring(exit_code)))
+        else
+          callback(ctcr.new_final(self.copilot.bufnr))
+        end
+      end)
+    end,
+    on_stdout = function(_, chunk)
+      vim.schedule(function()
+        if not chunk or chunk == "" then
+          return
+        end
+
+        callback(ctcr.new_progress(self.copilot.bufnr, chunk))
+      end)
+    end,
+    on_stderr = function(_, data)
+      table.insert(stderr, data)
+    end,
+  }):start()
+end
+
+function RagTool:description()
+  return "Retrieval Augmented Generation tool for executing searches and reads."
+end
+
+function RagTool:input_format()
+  return "A query to search for or the URL to browse. Use 'query' to search and 'read: query' to read."
+end
+
+function RagTool:output_format()
+  return "The output of the RAG execution."
+end
+
+function RagTool:example()
+  return [[
+  1. search today in history
+(rag)
+```
+today in history
+```
+output:==
+```
+
+2. read https://jina.ai/
+(rag)
+```
+read: https://jina.ai/
+```
+output:==
+    ]]
+end
+
+return RagTool

--- a/lua/codecompanion/tools/tool_manager.lua
+++ b/lua/codecompanion/tools/tool_manager.lua
@@ -1,0 +1,40 @@
+---@class CodeCompanion.ToolManager
+---@field tools CodeCompanion.CopilotTool[]
+local ToolManager = {}
+ToolManager.__index = ToolManager
+
+function ToolManager.new()
+  local self = setmetatable({}, ToolManager)
+  self.tools = {}
+  return self
+end
+
+function ToolManager:register_tool(name, tool)
+  self.tools[name] = tool
+end
+
+function ToolManager:get_tool(name)
+  return self.tools[name]
+end
+
+function ToolManager:get_tool_descriptions()
+  local descriptions = {}
+  for name, tool in pairs(self.tools) do
+    descriptions[name] = {
+      description = tool:description(),
+      input_format = tool:input_format(),
+      output_format = tool:output_format(),
+    }
+  end
+  return descriptions
+end
+
+function ToolManager:get_tool_examples()
+  local examples = {}
+  for name, tool in pairs(self.tools) do
+    examples[name] = tool:example()
+  end
+  return examples
+end
+
+return ToolManager

--- a/lua/codecompanion/utils/yaml.lua
+++ b/lua/codecompanion/utils/yaml.lua
@@ -26,11 +26,19 @@ M.encode = function(data)
     local lines = {}
     if islist(data) then
       if vim.tbl_isempty(data) then
-        return "[]"
+        return "{}"
       else
-        for _, v in ipairs(data) do
-          table.insert(lines, string.format("- %s", M.encode(v)))
+        local value = "["
+        -- table.insert(lines, string.format("%s", M.encode(data)))
+        for i, v in ipairs(data) do
+          value = value .. string.format("'%s'", M.encode(v))
+          if i < #data then
+            value = value .. ", "
+          else
+            value = value .. "]"
+          end
         end
+        table.insert(lines, value)
       end
     else
       if vim.tbl_isempty(data) then
@@ -41,7 +49,7 @@ M.encode = function(data)
         end
       end
     end
-    return table.concat(lines, "\n")
+    return table.concat(lines, " ")
   else
     error(string.format("Cannot encode type '%s' to yaml", dt))
   end


### PR DESCRIPTION
This is a brand new agent implementation (preview version). Considering its current capabilities, I'm calling it copilot. It's implemented by inheriting from strategy chat and overriding the submit function. The effect is as shown in the gif.

1. add comment then write test then run test

![CleanShot 2024-07-24 at 23 39 03](https://github.com/user-attachments/assets/b5760d42-956c-4575-bda1-5d5a759f190c)

2. read web page then write comment 
![CleanShot 2024-07-24 at 23 47 18](https://github.com/user-attachments/assets/0968663e-a0f9-498f-9465-4846c18db69f)

3. fix lsp error
![CleanShot 2024-07-24 at 23 49 06](https://github.com/user-attachments/assets/30c54564-8a9a-4b55-89da-96c3b9d35566)

Current known drawbacks and todos:

1. It's extremely token-consuming. This implementation can only run for extended periods on high-performance-to-price ratio models like gpt-4o-mini, claude-3-haiku, and Dee-seek. For models with lower IQ like gpt-4o-mini and claude-3-haiku, it's actually unable to achieve the best results.
2. The current prompts still need more fine-tuning. I haven't had time to optimize the previous prompts based on the current implementation yet.
3. The command_runner tool hasn't been rewritten for asynchronous execution.
4. The rag tool in search mode returns a large amount of string data, which easily causes Neovim to get stuck.
5. Write test code.