### PR TITLE
feat: better workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ When in the chat buffer, there are number of keymaps available to you:
 - `gc` - Clear the buffer's contents
 - `ga` - Add a codeblock
 - `gs` - Save the chat to disk
+- `}` - Move to the next chat
+- `{` - Move to the previous chat
 - `[` - Move to the next header
 - `]` - Move to the previous header
 

--- a/lua/codecompanion/actions.lua
+++ b/lua/codecompanion/actions.lua
@@ -76,28 +76,27 @@ M.static.actions = {
       stop_context_insertion = true,
     },
     condition = function()
-      return _G.codecompanion_chats and utils.count(_G.codecompanion_chats) > 0
+      return #require("codecompanion").buf_get_chat() > 0
     end,
     picker = {
       prompt = "Select a chat",
       items = function()
-        local ui = require("codecompanion.utils.ui")
-        local chats = {}
+        local loaded_chats = require("codecompanion").buf_get_chat()
+        local open_chats = {}
 
-        for bufnr, chat in pairs(_G.codecompanion_chats) do
-          table.insert(chats, {
-            name = chat.name,
+        for _, data in ipairs(loaded_chats) do
+          table.insert(open_chats, {
+            name = data.name,
             strategy = "chat",
-            description = chat.description,
+            description = data.description,
             callback = function()
-              _G.codecompanion_chats[bufnr] = nil
-              chat.chat:open()
-              ui.buf_scroll_to_end(bufnr)
+              require("codecompanion").close_last_chat()
+              data.chat:open()
             end,
           })
         end
 
-        return chats
+        return open_chats
       end,
     },
   },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -86,14 +86,6 @@ return {
           callback = "keymaps.clear",
           description = "Clear Chat",
         },
-        hide = {
-          modes = {
-            n = "gh",
-          },
-          index = 5,
-          callback = "keymaps.hide",
-          description = "Hide Chat",
-        },
         codeblock = {
           modes = {
             n = "ga",

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -86,11 +86,19 @@ return {
           callback = "keymaps.clear",
           description = "Clear Chat",
         },
+        hide = {
+          modes = {
+            n = "gh",
+          },
+          index = 5,
+          callback = "keymaps.hide",
+          description = "Hide Chat",
+        },
         codeblock = {
           modes = {
             n = "ga",
           },
-          index = 5,
+          index = 6,
           callback = "keymaps.codeblock",
           description = "Insert Codeblock",
         },
@@ -98,24 +106,40 @@ return {
           modes = {
             n = "gs",
           },
-          index = 6,
+          index = 7,
           callback = "keymaps.save_chat",
           description = "Save Chat",
         },
-        next = {
+        next_chat = {
+          modes = {
+            n = "}",
+          },
+          index = 8,
+          callback = "keymaps.next_chat",
+          description = "Next Chat",
+        },
+        previous_chat = {
+          modes = {
+            n = "{",
+          },
+          index = 9,
+          callback = "keymaps.previous_chat",
+          description = "Previous Chat",
+        },
+        next_header = {
           modes = {
             n = "]",
           },
-          index = 7,
-          callback = "keymaps.next",
+          index = 10,
+          callback = "keymaps.next_header",
           description = "Next Header",
         },
-        previous = {
+        previous_header = {
           modes = {
             n = "[",
           },
-          index = 8,
-          callback = "keymaps.previous",
+          index = 11,
+          callback = "keymaps.previous_header",
           description = "Previous Header",
         },
       },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -499,9 +499,9 @@ Use Markdown formatting and include the programming language name at the start o
       intro_message = "Welcome to CodeCompanion ✨! Press ? for help",
 
       messages_separator = "─", -- The separator between the different messages in the chat buffer
-      show_separator = true, -- Show a separator between LLM responses
-      show_settings = false, -- Show LLM settings at the top of the chat buffer
-      show_token_count = true, -- Show the token count for each response
+      show_separator = true, -- Show a separator between LLM responses?
+      show_settings = false, -- Show LLM settings at the top of the chat buffer?
+      show_token_count = true, -- Show the token count for each response?
     },
     inline = {
       layout = "vertical", -- vertical|horizontal|buffer
@@ -516,7 +516,7 @@ Use Markdown formatting and include the programming language name at the start o
   },
   -- GENERAL OPTIONS ----------------------------------------------------------
   opts = {
-    log_level = "ERROR",
+    log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
     auto_save_chats = true, -- If a chat has already been saved or loaded then autosave it after every prompt
     saved_chats_dir = vim.fn.stdpath("data") .. "/codecompanion/saved_chats",
 

--- a/lua/codecompanion/keymaps.lua
+++ b/lua/codecompanion/keymaps.lua
@@ -144,6 +144,12 @@ M.send = {
 M.close = {
   callback = function(chat)
     chat:close()
+
+    local chats = require("codecompanion").buf_get_chat()
+    if #chats == 0 then
+      return
+    end
+    chats[1].chat:open()
   end,
 }
 

--- a/lua/codecompanion/keymaps.lua
+++ b/lua/codecompanion/keymaps.lua
@@ -1,6 +1,7 @@
 local config = require("codecompanion").config
 
 local ts = require("codecompanion.utils.treesitter")
+local utils = require("codecompanion.utils.util")
 
 local api = vim.api
 
@@ -160,6 +161,12 @@ M.clear = {
   end,
 }
 
+M.hide = {
+  callback = function(chat)
+    chat:hide()
+  end,
+}
+
 M.save_chat = {
   desc = "Save the current chat",
   callback = function(chat)
@@ -206,14 +213,52 @@ M.codeblock = {
   end,
 }
 
-M.next = {
+M.next_chat = {
+  desc = "Move to the next chat",
+  callback = function(chat)
+    local chats = require("codecompanion").buf_get_chat()
+    if #chats == 1 then
+      return
+    end
+
+    local index = utils.find_key(chats, "bufnr", chat.bufnr)
+    local next = index + 1
+    if next > #chats then
+      next = 1
+    end
+
+    chats[index].chat:hide()
+    chats[next].chat:open()
+  end,
+}
+
+M.previous_chat = {
+  desc = "Move to the previous chat",
+  callback = function(chat)
+    local chats = require("codecompanion").buf_get_chat()
+    if #chats == 1 then
+      return
+    end
+
+    local index = utils.find_key(chats, "bufnr", chat.bufnr)
+    local previous = index - 1
+    if previous < 1 then
+      previous = #chats
+    end
+
+    chats[index].chat:hide()
+    chats[previous].chat:open()
+  end,
+}
+
+M.next_header = {
   desc = "Go to the next message",
   callback = function()
     ts.goto_heading("next", 1)
   end,
 }
 
-M.previous = {
+M.previous_header = {
   desc = "Go to the previous message",
   callback = function()
     ts.goto_heading("prev", 1)

--- a/lua/codecompanion/keymaps.lua
+++ b/lua/codecompanion/keymaps.lua
@@ -161,12 +161,6 @@ M.clear = {
   end,
 }
 
-M.hide = {
-  callback = function(chat)
-    chat:hide()
-  end,
-}
-
 M.save_chat = {
   desc = "Save the current chat",
   callback = function(chat)

--- a/lua/codecompanion/prompts.lua
+++ b/lua/codecompanion/prompts.lua
@@ -1,5 +1,5 @@
 local Strategy = require("codecompanion.strategies")
-local util = require("codecompanion.utils.context")
+local context_utils = require("codecompanion.utils.context")
 local api = vim.api
 
 ---@param desc table
@@ -19,7 +19,7 @@ end
 local function map(config, mode)
   return api.nvim_set_keymap(mode, config.opts.mapping, "", {
     callback = function()
-      local context = util.get_context(api.nvim_get_current_buf())
+      local context = context_utils.get(api.nvim_get_current_buf())
 
       return Strategy.new({
         context = context,

--- a/lua/codecompanion/strategies.lua
+++ b/lua/codecompanion/strategies.lua
@@ -129,29 +129,4 @@ function Strategies:inline()
     :start()
 end
 
----@return nil|CodeCompanion.Chat
-function Strategies:agent()
-  local messages = self:evaluate_prompts(self.selected.prompts)
-
-  local adapter = config.adapters[config.strategies.agent.adapter]
-
-  if type(adapter) == "string" then
-    adapter = require("codecompanion.adapters").use(adapter)
-  elseif type(adapter) == "function" then
-    adapter = adapter()
-  end
-
-  if not adapter then
-    return nil
-  end
-
-  log:trace("Strategy: Agent")
-  return require("codecompanion.strategies.chat").new({
-    adapter = adapter,
-    type = self.selected.type,
-    messages = messages,
-    context = self.context,
-  })
-end
-
 return Strategies

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -869,9 +869,11 @@ function Chat:close()
 
   local index = util.find_key(chatmap, "bufnr", self.bufnr)
   if index then
-    chatmap[index] = nil
+    table.remove(chatmap, index)
   end
+
   api.nvim_buf_delete(self.bufnr, { force = true })
+  self = nil
 end
 
 ---Determine if the chat buffer is visible
@@ -1105,7 +1107,6 @@ function Chat.buf_get_chat(bufnr)
   if bufnr == 0 then
     bufnr = api.nvim_get_current_buf()
   end
-
   return chatmap[util.find_key(chatmap, "bufnr", bufnr)].chat
 end
 

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -366,8 +366,6 @@ function Chat:open()
   ui.buf_scroll_to_end(self.bufnr)
   keymaps.set(config.strategies.chat.keymaps, self.bufnr, self)
 
-  log:debug("Opening %s", self.bufnr)
-
   return self
 end
 
@@ -852,8 +850,6 @@ function Chat:hide()
   else
     vim.cmd("buffer " .. vim.fn.bufnr("#"))
   end
-
-  log:debug("Hiding %s", self.bufnr)
 end
 
 ---Close the current chat buffer

--- a/lua/codecompanion/strategies/saved_chats.lua
+++ b/lua/codecompanion/strategies/saved_chats.lua
@@ -1,7 +1,7 @@
 local Chat = require("codecompanion.strategies.chat")
 local config = require("codecompanion").config
 
-local context = require("codecompanion.utils.context")
+local context_utils = require("codecompanion.utils.context")
 local log = require("codecompanion.utils.log")
 
 local api = vim.api
@@ -155,7 +155,7 @@ function SavedChat:load(opts)
     messages = content.messages,
     hidden_msgs = content.hidden_msgs,
     adapter = config.adapters[content.adapter],
-    context = context.get_context(api.nvim_get_current_buf()),
+    context = context_utils.get(api.nvim_get_current_buf()),
     tokens = content.meta.tokens,
   })
 

--- a/lua/codecompanion/utils/context.lua
+++ b/lua/codecompanion/utils/context.lua
@@ -66,7 +66,7 @@ end
 ---@param bufnr? integer
 ---@param args? table
 ---@return table
-function M.get_context(bufnr, args)
+function M.get(bufnr, args)
   bufnr = bufnr or api.nvim_get_current_buf()
   local winnr = api.nvim_get_current_win()
   local mode = vim.fn.mode()

--- a/lua/codecompanion/utils/util.lua
+++ b/lua/codecompanion/utils/util.lua
@@ -20,6 +20,40 @@ M.count = function(table)
   return count
 end
 
+---Check if a table is empty
+---@param tbl? table
+---@return boolean
+M.is_empty = function(tbl)
+  if tbl == nil then
+    return true
+  end
+
+  return next(tbl) == nil
+end
+
+---Find a nested key in a table and return the index
+---@param tbl table
+---@param key any
+---@param val any
+---@return integer|nil
+function M.find_key(tbl, key, val)
+  for k, v in pairs(tbl) do
+    if type(v) == "table" then
+      if v[key] == val then
+        return k
+      else
+        local result = M.find_key(v, key, val)
+        if result then
+          return k
+        end
+      end
+    elseif k == key and v == val then
+      return k
+    end
+  end
+  return nil
+end
+
 ---@param table table
 ---@param value string
 ---@return boolean

--- a/lua/codecompanion/workflow.lua
+++ b/lua/codecompanion/workflow.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion").config
 local log = require("codecompanion.utils.log")
+
 local api = vim.api
 
 ---@class CodeCompanion.Workflow


### PR DESCRIPTION
Users can now move between open chat buffers with `}` and `{`. There is prevention built into the plugin to stop multiple chat buffers being open at the same time. Global variables have also been reduced.