### PR TITLE
fix(adapters): re-import config to fetch latest variables for chat fu…

### DIFF
--- a/lua/codecompanion/adapters.lua
+++ b/lua/codecompanion/adapters.lua
@@ -171,6 +171,7 @@ end
 ---@param adapter? string|function|CodeCompanion.Adapter
 ---@return CodeCompanion.Adapter
 function Adapter.resolve(adapter)
+  config = require("codecompanion").config
   adapter = adapter or config.adapters[config.strategies.chat.adapter]
 
   if type(adapter) == "string" then


### PR DESCRIPTION
…nctionality

Previously, the chat functionality was unable to access the latest configuration variables due to stale imports. This commit addresses the issue by re-importing the config module at the resolve function, ensuring that the most up-to-date configuration is used.


