### PR TITLE
feat(inline): support stop_context_insertion  logic in inline strategy

### DIFF
--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -90,7 +90,7 @@ local build_prompt = function(inline, user_input)
 
   -- Send the visual selection
   if config.opts.send_code then
-    if inline.context.is_visual then
+    if inline.context.is_visual and not inline.opts.stop_context_insertion then
       log:trace("Sending visual selection")
       table.insert(output, {
         role = user_role,


### PR DESCRIPTION
support stop_context_insertion  logic in inline strategy

Sometimes we need modify the visual selected code sended to model.