### PR TITLE
fix(inline): Add safe_undojoin function and integrate into inline str…

### DIFF
--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -1,6 +1,7 @@
 local adapters = require("codecompanion.adapters")
 local client = require("codecompanion.client")
 local config = require("codecompanion").config
+local util = require("codecompanion.utils.util")
 
 local hl = require("codecompanion.utils.highlights")
 local keymaps = require("codecompanion.utils.keymaps")
@@ -476,7 +477,7 @@ function Inline:submit()
         local content = self.adapter.args.callbacks.inline_output(data, self.context)
 
         if content then
-          vim.cmd.undojoin()
+          util.safe_undojoin()
           stream_text_to_buffer(classified.pos, bufnr, content)
           -- self:diff_added(updated_pos.line)
           if classified.placement == "new" then

--- a/lua/codecompanion/utils/util.lua
+++ b/lua/codecompanion/utils/util.lua
@@ -117,4 +117,13 @@ function M.replace_vars(msg, vars, mapping)
   return string.format(msg, unpack(replacements))
 end
 
+---Safely join the current change with the previous change in the undo history.
+---@return nil
+function M.safe_undojoin()
+  local tree = vim.fn.undotree()
+  if tree.seq_cur == tree.seq_last then
+    vim.cmd.undojoin()
+  end
+end
+
 return M


### PR DESCRIPTION
<img width="1430" alt="Snipaste_2024-08-18_00-15-19" src="https://github.com/user-attachments/assets/38f2a6d7-2c18-4f40-bfd0-eba2e2e4175b">


I still don't know how this bug is triggered. Currently, I suspect it's caused by the custom cmp configuration. However, the fix should be effective.

```lua
-- This is a better implementation of `cmp.confirm`:
--  * check if the completion menu is visible without waiting for running sources
--  * create an undo point before confirming
-- This function is both faster and more reliable.
---@param opts? {select: boolean, behavior: cmp.ConfirmBehavior}
function M.confirm(opts)
  local cmp = require "cmp"
  opts = vim.tbl_extend("force", {
    select = true,
    behavior = cmp.ConfirmBehavior.Insert,
  }, opts or {})
  return function(fallback)
    if cmp.core.view:visible() or vim.fn.pumvisible() == 1 then
      utils.create_undo()
      if cmp.confirm(opts) then
        return
      end
    end
    return fallback()
  end
end
```