### PR TITLE
feat: Impl slash command like zed

### DIFF
--- a/lua/cmp_codecompanion/slash_command.lua
+++ b/lua/cmp_codecompanion/slash_command.lua
@@ -1,0 +1,101 @@
+local source = {}
+
+function source.new()
+  return setmetatable({}, { __index = source })
+end
+
+function source:is_available()
+  local chat = require("codecompanion.strategies.chat").last_chat()
+  return vim.bo.filetype == "codecompanion" and chat ~= nil and chat.bufnr == vim.api.nvim_get_current_buf()
+end
+
+source.get_position_encoding_kind = function()
+  return "utf-8"
+end
+
+function source:get_trigger_characters()
+  return { "/", " " }
+end
+
+---@param params cmp.SourceCompletionApiParams
+---@param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+function source:complete(params, callback)
+  local input = params.context.cursor_before_line
+  local chat = require("codecompanion.strategies.chat").last_chat()
+
+  if not chat or not chat.slash_command_manager then
+    return callback()
+  end
+
+  local command = input:match("/(%w+)")
+  local cmd = chat.slash_command_manager:get(command)
+
+  if command and cmd then
+    if input:match("/" .. command .. "%s$") then
+      if cmd and cmd.complete then
+        return cmd:complete(params, callback)
+      end
+    end
+
+    return callback()
+  else
+    local items = {}
+
+    for name, c in pairs(chat.slash_command_manager.commands) do
+      local item = {
+        label = name,
+        kind = require("cmp").lsp.CompletionItemKind.Function,
+        documentation = c.description,
+        -- Because when executing source:execute, the corresponding command needs to be obtained through slash_command_name
+        -- For the 'now' and 'terminal' commands, since they are executed directly, slash_command_name needs to be set
+        -- Ensure that the corresponding command:execute is called
+        slash_command_name = (name == "now" or name == "terminal") and name or nil,
+      }
+
+      table.insert(items, item)
+    end
+
+    return callback({ items = items, isIncomplete = false })
+  end
+end
+
+---Executed after the item was selected.
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+function source:execute(completion_item, callback)
+  local chat = require("codecompanion.strategies.chat").last_chat()
+  if not chat or not chat.slash_command_manager then
+    return callback()
+  end
+
+  local cmd = chat.slash_command_manager:get(completion_item.slash_command_name)
+
+  if cmd and completion_item then
+    -- remove current line
+    vim.api.nvim_set_current_line("")
+
+    return cmd:execute(completion_item, callback)
+  end
+
+  return callback()
+end
+
+---Resolve completion item (optional). This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+function source:resolve(completion_item, callback)
+  local chat = require("codecompanion.strategies.chat").last_chat()
+  if not chat or not chat.slash_command_manager then
+    return callback()
+  end
+
+  local cmd = chat.slash_command_manager:get(completion_item.slash_command_name)
+  if cmd then
+    return cmd:resolve(completion_item, callback)
+  end
+
+  return callback()
+end
+
+return source

--- a/lua/cmp_codecompanion/slash_command.lua
+++ b/lua/cmp_codecompanion/slash_command.lua
@@ -53,7 +53,7 @@ function source:complete(params, callback)
         -- Because when executing source:execute, the corresponding command needs to be obtained through slash_command_name
         -- For the 'now' and 'terminal' commands, since they are executed directly, slash_command_name needs to be set
         -- Ensure that the corresponding command:execute is called
-        slash_command_name = (name == "now" or name == "terminal") and name or nil,
+        slash_command_name = (name == "now") and name or nil,
       }
 
       table.insert(items, item)

--- a/lua/cmp_codecompanion/slash_command.lua
+++ b/lua/cmp_codecompanion/slash_command.lua
@@ -27,6 +27,10 @@ function source:complete(params, callback)
     return callback()
   end
 
+  if not input:match("^/") then
+    return callback()
+  end
+
   local command = input:match("/(%w+)")
   local cmd = chat.slash_command_manager:get(command)
 

--- a/lua/cmp_codecompanion/slash_command.lua
+++ b/lua/cmp_codecompanion/slash_command.lua
@@ -74,7 +74,7 @@ function source:execute(completion_item, callback)
 
   local cmd = chat.slash_command_manager:get(completion_item.slash_command_name)
 
-  if cmd and completion_item then
+  if cmd then
     -- remove current line
     vim.api.nvim_set_current_line("")
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -564,7 +564,7 @@ Use Markdown formatting and include the programming language name at the start o
   },
   slash_commands = {
     prompts = {
-      ["example_prompt"] = "This is an example prompt.",
+      -- ["example_prompt"] = "This is an example prompt.",
     },
   },
   -- GENERAL OPTIONS ----------------------------------------------------------

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -562,6 +562,11 @@ Use Markdown formatting and include the programming language name at the start o
       },
     },
   },
+  slash_commands = {
+    prompts = {
+      ["example_prompt"] = "This is an example prompt.",
+    },
+  },
   -- GENERAL OPTIONS ----------------------------------------------------------
   opts = {
     log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO

--- a/lua/codecompanion/slash_commands/diagnostics.lua
+++ b/lua/codecompanion/slash_commands/diagnostics.lua
@@ -1,8 +1,6 @@
 local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
-local ui = require("codecompanion.utils.ui")
 local api = vim.api
 local fn = vim.fn
-local cmp = require("cmp")
 
 --- DiagnosticsCommand class for inserting diagnostic information with context.
 --- @class CodeCompanion.DiagnosticsCommand : CodeCompanion.BaseSlashCommand
@@ -59,10 +57,10 @@ function DiagnosticsCommand:complete(params, callback)
     ---@type CodeCompanion.SlashCommandCompletionItem
     local item = {
       label = diagnostic_info,
-      kind = cmp.lsp.CompletionItemKind.Text,
+      kind = require("cmp").lsp.CompletionItemKind.Text,
       slash_command_name = self.name,
       documentation = {
-        kind = cmp.lsp.MarkupKind.Markdown,
+        kind = require("cmp").lsp.MarkupKind.Markdown,
         value = string.format("```diagnostics %s\n%s\nContext:\n%s\n```", filepath, diagnostic_info, context_info),
       },
     }
@@ -74,10 +72,10 @@ function DiagnosticsCommand:complete(params, callback)
   if #diagnostics > 0 then
     table.insert(items, 1, {
       label = "All diagnostics",
-      kind = cmp.lsp.CompletionItemKind.Text,
+      kind = require("cmp").lsp.CompletionItemKind.Text,
       slash_command_name = self.name,
       documentation = {
-        kind = cmp.lsp.MarkupKind.Markdown,
+        kind = require("cmp").lsp.MarkupKind.Markdown,
         value = string.format("```diagnostics %s\n%s\n```", filepath, table.concat(formatted_diagnostics, "\n\n")),
       },
     })

--- a/lua/codecompanion/slash_commands/diagnostics.lua
+++ b/lua/codecompanion/slash_commands/diagnostics.lua
@@ -37,7 +37,12 @@ end
 --- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
 ---@diagnostic disable-next-line: unused-local
 function DiagnosticsCommand:complete(params, callback)
-  local bufnr = self.chat.focus_bufnr
+  local chat = self.get_chat()
+  if not chat then
+    return callback()
+  end
+
+  local bufnr = chat.focus_bufnr
   local filepath = vim.fn.fnamemodify(api.nvim_buf_get_name(bufnr), ":.")
   local diagnostics = vim.diagnostic.get(bufnr)
   local formatted_diagnostics = {}

--- a/lua/codecompanion/slash_commands/diagnostics.lua
+++ b/lua/codecompanion/slash_commands/diagnostics.lua
@@ -1,0 +1,92 @@
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+local ui = require("codecompanion.utils.ui")
+local api = vim.api
+local fn = vim.fn
+local cmp = require("cmp")
+
+--- DiagnosticsCommand class for inserting diagnostic information with context.
+--- @class CodeCompanion.DiagnosticsCommand : CodeCompanion.BaseSlashCommand
+local DiagnosticsCommand = BaseSlashCommand:extend()
+
+function DiagnosticsCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+
+  self.name = "diagnostics"
+  self.description = "Insert diagnostic information with context"
+end
+
+--- Get context lines around a specific line
+--- @param bufnr number The buffer number
+--- @param lnum number The line number
+--- @param context number The number of context lines
+--- @return table
+local function get_context_lines(bufnr, lnum, context)
+  local start_line = math.max(0, lnum - context)
+  local end_line = lnum + context
+  local lines = api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)
+  local result = {}
+  for i, line in ipairs(lines) do
+    table.insert(result, string.format("%d: %s", start_line + i, line))
+  end
+  return result
+end
+
+--- Complete file paths for the command.
+--- @param params cmp.SourceCompletionApiParams
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+---@diagnostic disable-next-line: unused-local
+function DiagnosticsCommand:complete(params, callback)
+  local bufnr = self.chat.focus_bufnr
+  local filepath = vim.fn.fnamemodify(api.nvim_buf_get_name(bufnr), ":.")
+  local diagnostics = vim.diagnostic.get(bufnr)
+  local formatted_diagnostics = {}
+
+  ---@type CodeCompanion.SlashCommandCompletionResponse
+  local items = {}
+
+  for _, d in ipairs(diagnostics) do
+    local context_lines = get_context_lines(bufnr, d.lnum, 5)
+    local diagnostic_info = string.format("%s:%d:%d - %s", d.source, d.lnum, d.col, d.message)
+    local context_info = table.concat(context_lines, "\n")
+    table.insert(formatted_diagnostics, string.format("%s\nContext:\n%s", diagnostic_info, context_info))
+
+    ---@type CodeCompanion.SlashCommandCompletionItem
+    local item = {
+      label = diagnostic_info,
+      kind = cmp.lsp.CompletionItemKind.Text,
+      slash_command_name = self.name,
+      documentation = {
+        kind = cmp.lsp.MarkupKind.Markdown,
+        value = string.format("```diagnostics %s\n%s\nContext:\n%s\n```", filepath, diagnostic_info, context_info),
+      },
+    }
+
+    table.insert(items, item)
+  end
+
+  -- insert a all diagnostics option at the top
+  if #diagnostics > 0 then
+    table.insert(items, 1, {
+      label = "All diagnostics",
+      kind = cmp.lsp.CompletionItemKind.Text,
+      slash_command_name = self.name,
+      documentation = {
+        kind = cmp.lsp.MarkupKind.Markdown,
+        value = string.format("```diagnostics %s\n%s\n```", filepath, table.concat(formatted_diagnostics, "\n\n")),
+      },
+    })
+
+    -- vim.notify(vim.inspect(items))
+
+    return callback({ items = items, isIncomplete = false })
+  end
+
+  return callback()
+end
+
+function DiagnosticsCommand:get_fold_text()
+  return fn.expand("%:.")
+end
+
+return DiagnosticsCommand

--- a/lua/codecompanion/slash_commands/file.lua
+++ b/lua/codecompanion/slash_commands/file.lua
@@ -178,19 +178,17 @@ function FileCommand:complete(params, callback)
     dir = self:_parse_input(Path:new(input):absolute())
   end
 
+  local args = {
+    "--files",
+    "--hidden",
+    "-g",
+    "!.git",
+    dir:absolute(),
+  }
+
   Job:new({
-    command = "fd",
-    args = {
-      "--max-depth",
-      max_depth,
-      self.config.show_hidden_files and "--hidden" or "",
-      "--type",
-      "d",
-      "--type",
-      "f",
-      ".",
-      dir:absolute(),
-    },
+    command = "rg",
+    args = args,
     on_exit = vim.schedule_wrap(function(j, return_val)
       if return_val ~= 0 then
         callback()

--- a/lua/codecompanion/slash_commands/file.lua
+++ b/lua/codecompanion/slash_commands/file.lua
@@ -1,0 +1,285 @@
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+local Job = require("plenary.job")
+local Path = require("plenary.path")
+local async = require("plenary.async")
+local cmp = require("cmp")
+local scan = require("plenary.scandir")
+
+--- FileCommand class for inserting file or directory contents into the chat.
+--- @class CodeCompanion.FileCommand: CodeCompanion.BaseSlashCommand
+--- @field config table Configuration options for the command.
+local FileCommand = BaseSlashCommand:extend()
+
+function FileCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+  self.name = "file"
+  self.description = "Insert content of a file or directory"
+  self.config = {
+    show_hidden_files = false,
+    max_items = 100,
+    sort_order = "name", -- "name" or "modified"
+    trailing_slash = true,
+    max_file_size = 1024 * 1024, -- 1MB
+    max_depth = 3, -- Maximum depth for directory recursion
+    doc_preview_lines = 20, -- Number of lines to preview in documentation
+  }
+end
+
+--- Execute the diagnostics command with the provided chat context and arguments.
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+---@diagnostic disable-next-line: unused-local
+function FileCommand:execute(completion_item, callback)
+  local file = self:_parse_input(completion_item.slash_command_args)
+
+  if file:is_dir() then
+    self:_insert_directory_content(file)
+  else
+    self:_insert_file_content(file)
+  end
+
+  return callback()
+end
+
+--- Parse the input path and resolve it to an absolute Path object.
+--- @param input string The input path to parse.
+--- @return Path The resolved absolute Path object.
+function FileCommand:_parse_input(input)
+  if input:match("^~/") then
+    return Path:new(vim.fn.expand(input))
+  end
+
+  local p = Path:new(input)
+  if p:is_absolute() then
+    return p
+  else
+    return Path:new(vim.fn.getcwd(), input)
+  end
+end
+
+--- Insert the contents of a file into the chat buffer.
+--- @param file Path The file to insert.
+function FileCommand:_insert_file_content(file)
+  local chat = self.chat
+  async.run(function()
+    if not file:exists() then
+      vim.schedule(function()
+        vim.notify("File does not exist: " .. file:absolute(), vim.log.levels.ERROR)
+      end)
+      return
+    end
+
+    if file:_stat().size > self.config.max_file_size then
+      vim.schedule(function()
+        vim.notify("File is too large to insert: " .. file:absolute(), vim.log.levels.WARN)
+      end)
+      return
+    end
+
+    local content = file:read()
+    if not content then
+      vim.schedule(function()
+        vim.notify("Failed to read file: " .. file:absolute(), vim.log.levels.ERROR)
+      end)
+      return
+    end
+
+    vim.schedule(function()
+      local filetype = vim.fn.fnamemodify(file:absolute(), ":e")
+      local formatted_content = string.format("```%s %s\n%s\n```", filetype, file:absolute(), content)
+      local start_line = vim.api.nvim_buf_line_count(chat.bufnr)
+      chat:append({ content = formatted_content })
+      local end_line = vim.api.nvim_buf_line_count(chat.bufnr)
+
+      -- Create fold
+      vim.api.nvim_buf_set_option(chat.bufnr, "foldmethod", "manual")
+      vim.cmd(string.format("%d,%dfold", start_line, end_line))
+
+      -- Add virtual text
+      local relative_path = file:make_relative(vim.fn.getcwd())
+      vim.api.nvim_buf_set_extmark(chat.bufnr, chat.namespace, start_line, 0, {
+        virt_text = { { relative_path, "CodeCompanionVirtualText" } },
+        virt_text_pos = "eol",
+      })
+    end)
+  end, function() end)
+end
+
+--- Insert the contents of a directory into the chat buffer.
+--- @param dir Path The directory to insert.
+--- @param depth? number The current depth of recursion.
+function FileCommand:_insert_directory_content(dir, depth)
+  local chat = self.chat
+  depth = depth or 0
+  if depth > self.config.max_depth then
+    return
+  end
+
+  async.run(function()
+    local entries = scan.scan_dir(dir:absolute(), {
+      hidden = self.config.show_hidden_files,
+      add_dirs = true,
+      depth = 1,
+    })
+
+    local content = depth == 0 and "Directory contents of " .. dir:absolute() .. ":\n\n" or ""
+    local indent = string.rep("  ", depth)
+
+    for _, entry in ipairs(entries) do
+      local entry_path = Path:new(entry)
+      local is_dir = entry_path:is_dir()
+      content = content .. indent .. entry_path:filename() .. (is_dir and "/" or "") .. "\n"
+      if is_dir then
+        self:_insert_directory_content(entry_path, depth + 1)
+      end
+    end
+
+    vim.schedule(function()
+      local start_line = vim.api.nvim_buf_line_count(chat.bufnr)
+      chat:append({ content = content })
+      local end_line = vim.api.nvim_buf_line_count(chat.bufnr)
+
+      if depth == 0 then
+        -- Create fold
+        vim.api.nvim_buf_set_option(chat.bufnr, "foldmethod", "manual")
+        vim.cmd(string.format("%d,%dfold", start_line, end_line))
+
+        -- Add virtual text
+        local relative_path = dir:make_relative(vim.fn.getcwd())
+        vim.api.nvim_buf_set_extmark(chat.bufnr, chat.namespace, start_line, 0, {
+          virt_text = { { relative_path, "Comment" } },
+          virt_text_pos = "eol",
+        })
+      end
+    end)
+  end, function() end)
+end
+
+--- Complete file paths for the command.
+--- @param params cmp.SourceCompletionApiParams
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+function FileCommand:complete(params, callback)
+  local input = params.context.cursor_before_line:match("/file%s*(.*)$") or ""
+  local dir = self:_parse_input(Path:new(input):parent():absolute())
+  local max_depth = self.config.max_depth
+
+  if not input or input == "" then
+    input = vim.fn.getcwd()
+    dir = self:_parse_input(Path:new(input):absolute())
+  end
+
+  Job:new({
+    command = "fd",
+    args = {
+      "--max-depth",
+      max_depth,
+      self.config.show_hidden_files and "--hidden" or "",
+      "--type",
+      "d",
+      "--type",
+      "f",
+      ".",
+      dir:absolute(),
+    },
+    on_exit = vim.schedule_wrap(function(j, return_val)
+      if return_val ~= 0 then
+        callback()
+        return
+      end
+
+      local items = {}
+      for _, file in ipairs(j:result()) do
+        local item = self:_create_completion_item(file, dir:absolute())
+        table.insert(items, item)
+      end
+
+      items = self:_filter_and_sort(items)
+      callback(items)
+    end),
+  }):start()
+end
+
+--- Create a completion item for a file or directory.
+--- @param file string The file or directory path.
+--- @param base_path string The base path for relative paths.
+--- @return table The completion item.
+function FileCommand:_create_completion_item(file, base_path)
+  local p = Path:new(file)
+  local relative_path = p:make_relative(base_path)
+  local is_dir = p:is_dir()
+
+  ---@type CodeCompanion.SlashCommandCompletionItem
+  local item = {
+    label = relative_path,
+    kind = is_dir and cmp.lsp.CompletionItemKind.Folder or cmp.lsp.CompletionItemKind.File,
+    slash_command_name = self.name,
+    slash_command_args = file,
+  }
+
+  if is_dir and self.config.trailing_slash then
+    item.label = item.label .. "/"
+  end
+
+  return item
+end
+
+---Resolve completion item (optional). This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+function FileCommand:resolve(completion_item, callback)
+  if completion_item.slash_command_name == "" or completion_item.slash_command_args == "" then
+    return callback()
+  end
+
+  if completion_item.documentation then
+    return callback(completion_item)
+  else
+    Job:new({
+      command = "head",
+      args = {
+        "-n",
+        string.format("%d", self.config.doc_preview_lines),
+        completion_item.slash_command_args,
+      },
+      on_exit = vim.schedule_wrap(function(j, return_val)
+        if return_val ~= 0 then
+          callback(completion_item)
+          return
+        end
+
+        local content = j:result()
+        completion_item.documentation = {
+          kind = cmp.lsp.MarkupKind.Markdown,
+          value = string.format(
+            "```%s\n%s\n```",
+            vim.fn.fnamemodify(completion_item.slash_command_args, ":e"),
+            table.concat(content, "\n")
+          ),
+        }
+
+        callback(completion_item)
+      end),
+    }):start()
+  end
+end
+
+--- Filter and sort completion items.
+--- @param items table The items to filter and sort.
+--- @return table The filtered and sorted items.
+function FileCommand:_filter_and_sort(items)
+  if self.config.sort_order == "modified" then
+    table.sort(items, function(a, b)
+      return a.documentation > b.documentation
+    end)
+  else
+    table.sort(items, function(a, b)
+      return a.label < b.label
+    end)
+  end
+
+  return vim.list_slice(items, 1, self.config.max_items)
+end
+
+return FileCommand

--- a/lua/codecompanion/slash_commands/file.lua
+++ b/lua/codecompanion/slash_commands/file.lua
@@ -89,7 +89,7 @@ function FileCommand:_insert_file_content(file)
       local filetype = vim.fn.fnamemodify(file:absolute(), ":e")
       local formatted_content = string.format("```%s %s\n%s\n```", filetype, file:absolute(), content)
       local start_line = vim.api.nvim_buf_line_count(chat.bufnr)
-      chat:append({ content = formatted_content })
+      chat:append_to_buf({ content = formatted_content })
       local end_line = vim.api.nvim_buf_line_count(chat.bufnr)
 
       -- Create fold
@@ -137,7 +137,7 @@ function FileCommand:_insert_directory_content(dir, depth)
 
     vim.schedule(function()
       local start_line = vim.api.nvim_buf_line_count(chat.bufnr)
-      chat:append({ content = content })
+      chat:append_to_buf({ content = content })
       local end_line = vim.api.nvim_buf_line_count(chat.bufnr)
 
       if depth == 0 then

--- a/lua/codecompanion/slash_commands/file.lua
+++ b/lua/codecompanion/slash_commands/file.lua
@@ -61,7 +61,12 @@ end
 --- Insert the contents of a file into the chat buffer.
 --- @param file Path The file to insert.
 function FileCommand:_insert_file_content(file)
-  local chat = self.chat
+  local chat = self.get_chat()
+  if not chat then
+    return callback()
+  end
+
+  local bufnr = chat.focus_bufnr
   async.run(function()
     if not file:exists() then
       vim.schedule(function()
@@ -110,7 +115,12 @@ end
 --- @param dir Path The directory to insert.
 --- @param depth? number The current depth of recursion.
 function FileCommand:_insert_directory_content(dir, depth)
-  local chat = self.chat
+  local chat = self.get_chat()
+  if not chat then
+    return callback()
+  end
+
+  local bufnr = chat.focus_bufnr
   depth = depth or 0
   if depth > self.config.max_depth then
     return

--- a/lua/codecompanion/slash_commands/file.lua
+++ b/lua/codecompanion/slash_commands/file.lua
@@ -2,7 +2,6 @@ local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashComman
 local Job = require("plenary.job")
 local Path = require("plenary.path")
 local async = require("plenary.async")
-local cmp = require("cmp")
 local scan = require("plenary.scandir")
 
 --- FileCommand class for inserting file or directory contents into the chat.
@@ -222,7 +221,7 @@ function FileCommand:_create_completion_item(file, base_path)
   ---@type CodeCompanion.SlashCommandCompletionItem
   local item = {
     label = relative_path,
-    kind = is_dir and cmp.lsp.CompletionItemKind.Folder or cmp.lsp.CompletionItemKind.File,
+    kind = is_dir and require("cmp").lsp.CompletionItemKind.Folder or require("cmp").lsp.CompletionItemKind.File,
     slash_command_name = self.name,
     slash_command_args = file,
   }
@@ -261,7 +260,7 @@ function FileCommand:resolve(completion_item, callback)
 
         local content = j:result()
         completion_item.documentation = {
-          kind = cmp.lsp.MarkupKind.Markdown,
+          kind = require("cmp").lsp.MarkupKind.Markdown,
           value = string.format(
             "Content of %s\n```%s\n%s\n```",
             completion_item.slash_command_args,

--- a/lua/codecompanion/slash_commands/file.lua
+++ b/lua/codecompanion/slash_commands/file.lua
@@ -263,7 +263,8 @@ function FileCommand:resolve(completion_item, callback)
         completion_item.documentation = {
           kind = cmp.lsp.MarkupKind.Markdown,
           value = string.format(
-            "```%s\n%s\n```",
+            "Content of %s\n```%s\n%s\n```",
+            completion_item.slash_command_args,
             vim.fn.fnamemodify(completion_item.slash_command_args, ":e"),
             table.concat(content, "\n")
           ),

--- a/lua/codecompanion/slash_commands/init.lua
+++ b/lua/codecompanion/slash_commands/init.lua
@@ -1,0 +1,184 @@
+local api = vim.api
+local ui = require("codecompanion.utils.ui")
+
+--- Represents a completion item for a slash command in the LSP (Language Server Protocol) context.
+---
+--- This class extends the lsp.CompletionItem with additional fields specific to slash commands.
+---@class CodeCompanion.SlashCommandCompletionItem: lsp.CompletionItem
+---@field public slash_command_name? string The name of the command.
+---@field public slash_command_args? any The arguments for the command. When the command does not have arguments, this field is nil. and slash_command_not_has_args is true.
+
+--- Represents the response for slash command completion.
+---
+--- This class encapsulates the completion items for slash commands within
+--- the Language Server Protocol, indicating whether the completion is
+--- complete and providing a list of available completion items.
+---
+---@class CodeCompanion.SlashCommandCompletionResponse
+---@field public isIncomplete? boolean
+---@field public items? CodeCompanion.SlashCommandCompletionItem[]
+
+---@class CodeCompanion.BaseSlashCommand
+---
+--- This class serves as the base for all slash commands, providing a structure for
+--- defining command names, descriptions, execution functions, completion functions,
+--- and functions to get fold text representations. It can be extended to create
+--- specific commands with additional functionalities.
+---@field public name string The name of the command.
+---@field public description string A brief description of the command.
+---@field public chat CodeCompanion.Chat The chat context in which the command is executed.
+local BaseSlashCommand = {}
+BaseSlashCommand.__index = BaseSlashCommand
+
+--- Creates a new instance of the BaseSlashCommand.
+---
+--- This function initializes a new slash command with the given options, which can include
+--- a name, description, an execution function, a completion function, and a function to
+--- get the fold text representation. If any option is not provided, default values will
+--- be used.
+---
+--- @param opts table A table containing optional parameters:
+---    - name: string The name of the command.
+---    - description: string A brief description of the command.
+---    - execute: function The function to execute when the command is called.
+---    - complete: function A function that returns completion items for the command.
+---    - get_fold_text: function A function that returns a string for the fold text.
+--- @return CodeCompanion.BaseSlashCommand A new instance of CodeCompanion.BaseSlashCommand with the provided options.
+function BaseSlashCommand.new(opts)
+  local self = setmetatable({}, BaseSlashCommand)
+  self:init(opts)
+  return self
+end
+
+--- Initializes the BaseSlashCommand instance with the provided options.
+---
+--- This function sets up the command's name, description, execution function,
+--- completion function, and function to retrieve fold text. Default values
+--- are assigned if any of the options are not provided.
+---
+--- @param opts table A table containing optional parameters for initialization:
+---    - name: string The name of the command.
+---    - description: string A brief description of the command.
+--- @return nil
+function BaseSlashCommand:init(opts)
+  opts = opts or {}
+  self.name = opts.name
+  self.description = opts.description
+  self.chat = opts.chat
+end
+
+--- Extends the BaseSlashCommand to create a new child command class.
+---
+--- This function sets up a new table that inherits from BaseSlashCommand, enabling
+--- the creation of derived command classes with their own specific behaviors.
+--- The new class can be instantiated with its own parameters, which will be
+--- initialized using the inherited initialization method.
+---
+--- @return table A new command class that extends BaseSlashCommand.
+function BaseSlashCommand:extend()
+  local child = {}
+  child.__index = child
+  setmetatable(child, {
+    __index = self,
+    __call = function(cls, ...)
+      local instance = setmetatable({}, cls)
+      instance:init(...)
+      return instance
+    end,
+  })
+  return child
+end
+
+--- Executes the slash command with the provided chat context and arguments.
+--- This function is meant to be overridden by derived classes to provide
+--- specific functionality for each command.
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+---@diagnostic disable-next-line: unused-local
+function BaseSlashCommand:execute(completion_item, callback)
+  local chat = self.chat
+  local doc = type(completion_item.documentation) == "table" and completion_item.documentation.value
+    or string.format("%s", completion_item.documentation)
+
+  local start_line = api.nvim_buf_line_count(chat.bufnr)
+  chat:append({ content = doc })
+  local end_line = api.nvim_buf_line_count(chat.bufnr)
+
+  ---@diagnostic disable-next-line: deprecated
+  api.nvim_buf_set_option(chat.bufnr, "foldmethod", "manual")
+  api.nvim_buf_call(chat.bufnr, function()
+    vim.fn.setpos(".", { chat.bufnr, start_line, 0, 0 })
+    vim.cmd("normal! zf" .. end_line .. "G")
+  end)
+  ui.buf_scroll_to_end(chat.bufnr)
+
+  return callback()
+end
+
+--- Completes the command based on the provided input.
+--- This function is meant to be overridden by derived classes to provide
+--- specific completion functionality for each command.
+--- @param params cmp.SourceCompletionApiParams The completion parameters.
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil) The callback function to return the completion response.
+--- @return nil
+---@diagnostic disable-next-line: unused-local
+function BaseSlashCommand:complete(params, callback) end
+
+---Resolve completion item (optional). This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+function BaseSlashCommand:resolve(completion_item, callback)
+  callback(completion_item)
+end
+
+---@class CodeCompanion.SlashCommandManager
+---
+--- This class manages a collection of slash commands, providing functionalities
+--- to register new commands, execute commands, and provide command completions.
+--- It serves as a central hub for handling all slash commands within the system.
+---@field public commands CodeCompanion.BaseSlashCommand[] A table mapping command names to their respective BaseSlashCommand instances.
+---@field public chat CodeCompanion.Chat The chat context in which the commands are executed.
+local SlashCommandManager = {}
+
+---@param chat CodeCompanion.Chat The chat context in which the command is executed.
+function SlashCommandManager.new(chat)
+  local self = setmetatable({}, { __index = SlashCommandManager })
+  self.commands = {}
+  self.chat = chat
+  return self
+end
+
+--- Registers a new slash command in the command manager.
+---
+--- This function maps the command's name to its corresponding
+--- BaseSlashCommand instance, allowing for later execution and
+--- completion functionality.
+---
+--- @param command CodeCompanion.BaseSlashCommand The command instance to register.
+function SlashCommandManager:register(command)
+  if not command or not command.name then
+    return
+  end
+
+  self.commands[command.name] = command
+end
+
+--- Retrieves a registered slash command by its name.
+---
+--- This function checks if a command exists in the command manager's
+--- collection. If found, it returns the corresponding
+--- BaseSlashCommand instance.
+---
+--- @param command string The name of the command to retrieve.
+--- @return CodeCompanion.BaseSlashCommand|nil The command instance if found, or nil if not.
+function SlashCommandManager:get(command)
+  if self.commands[command] then
+    return self.commands[command]
+  end
+end
+
+return {
+  BaseSlashCommand = BaseSlashCommand,
+  SlashCommandManager = SlashCommandManager,
+}

--- a/lua/codecompanion/slash_commands/init.lua
+++ b/lua/codecompanion/slash_commands/init.lua
@@ -101,7 +101,7 @@ function BaseSlashCommand:execute(completion_item, callback)
     or string.format("%s", completion_item.documentation)
 
   local start_line = api.nvim_buf_line_count(chat.bufnr)
-  chat:append({ content = doc })
+  chat:append_to_buf({ content = doc })
   local end_line = api.nvim_buf_line_count(chat.bufnr)
 
   ---@diagnostic disable-next-line: deprecated

--- a/lua/codecompanion/slash_commands/now.lua
+++ b/lua/codecompanion/slash_commands/now.lua
@@ -17,10 +17,15 @@ end
 ---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
 ---@diagnostic disable-next-line: unused-local
 function NowCommand:execute(completion_item, callback)
+  local chat = self.get_chat()
+  if not chat then
+    return callback()
+  end
+
   local datetime = os.date("%a, %d %b %Y %H:%M:%S %z")
   local formatted_content = string.format("Current date and time: %s", datetime)
-  self.chat:append_to_buf({ content = formatted_content })
-  ui.buf_scroll_to_end(self.chat.bufnr)
+  chat:append_to_buf({ content = formatted_content })
+  ui.buf_scroll_to_end(chat.bufnr)
 
   return callback()
 end

--- a/lua/codecompanion/slash_commands/now.lua
+++ b/lua/codecompanion/slash_commands/now.lua
@@ -19,7 +19,7 @@ end
 function NowCommand:execute(completion_item, callback)
   local datetime = os.date("%a, %d %b %Y %H:%M:%S %z")
   local formatted_content = string.format("Current date and time: %s", datetime)
-  self.chat:append({ content = formatted_content })
+  self.chat:append_to_buf({ content = formatted_content })
   ui.buf_scroll_to_end(self.chat.bufnr)
 
   return callback()

--- a/lua/codecompanion/slash_commands/now.lua
+++ b/lua/codecompanion/slash_commands/now.lua
@@ -1,0 +1,35 @@
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+local ui = require("codecompanion.utils.ui")
+
+--- NowCommand class for inserting current date and time.
+--- @class CodeCompanion.NowCommand: CodeCompanion.BaseSlashCommand
+local NowCommand = BaseSlashCommand:extend()
+
+function NowCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+  self.name = "now"
+  self.description = "Insert current date and time"
+end
+
+--- Execute the diagnostics command with the provided chat context and arguments.
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+---@diagnostic disable-next-line: unused-local
+function NowCommand:execute(completion_item, callback)
+  local datetime = os.date("%a, %d %b %Y %H:%M:%S %z")
+  local formatted_content = string.format("Current date and time: %s", datetime)
+  self.chat:append({ content = formatted_content })
+  ui.buf_scroll_to_end(self.chat.bufnr)
+
+  return callback()
+end
+
+---@param params cmp.SourceCompletionApiParams
+---@param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+---@diagnostic disable-next-line: unused-local
+function NowCommand:complete(params, callback)
+  return callback()
+end
+
+return NowCommand

--- a/lua/codecompanion/slash_commands/prompt.lua
+++ b/lua/codecompanion/slash_commands/prompt.lua
@@ -1,0 +1,39 @@
+local config = require("codecompanion").config
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+
+local PromptCommand = BaseSlashCommand:extend()
+
+function PromptCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+
+  self.name = "prompt"
+  self.description = "Insert a predefined prompt"
+  self.prompts = config.slash_commands.prompts
+  vim.notify(vim.inspect(opts.prompts))
+end
+
+--- Complete file paths for the command.
+--- @param params cmp.SourceCompletionApiParams
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+---@diagnostic disable-next-line: unused-local
+function PromptCommand:complete(params, callback)
+  ---@type CodeCompanion.SlashCommandCompletionItem
+  local items = {}
+
+  for name, content in pairs(self.prompts) do
+    table.insert(items, {
+      label = name,
+      kind = require("cmp").lsp.CompletionItemKind.Text,
+      slash_command_name = self.name,
+      documentation = {
+        kind = require("cmp").lsp.MarkupKind.Markdown,
+        value = content,
+      },
+    })
+  end
+
+  return callback({ items = items, isIncomplete = false })
+end
+
+return PromptCommand

--- a/lua/codecompanion/slash_commands/prompt.lua
+++ b/lua/codecompanion/slash_commands/prompt.lua
@@ -10,7 +10,6 @@ function PromptCommand:init(opts)
   self.name = "prompt"
   self.description = "Insert a predefined prompt"
   self.prompts = config.slash_commands.prompts
-  vim.notify(vim.inspect(opts.prompts))
 end
 
 --- Complete file paths for the command.

--- a/lua/codecompanion/slash_commands/prompt.lua
+++ b/lua/codecompanion/slash_commands/prompt.lua
@@ -19,8 +19,15 @@ end
 function PromptCommand:complete(params, callback)
   ---@type CodeCompanion.SlashCommandCompletionItem
   local items = {}
+  ---@type CodeCompanion.Chat
+  local chat = self.get_chat()
 
-  for name, content in pairs(self.prompts) do
+  for name, prompt in pairs(self.prompts) do
+    local content = prompt
+    if type(content) == "function" then
+      content = prompt(chat.context)
+    end
+
     table.insert(items, {
       label = name,
       kind = require("cmp").lsp.CompletionItemKind.Text,

--- a/lua/codecompanion/slash_commands/symbols.lua
+++ b/lua/codecompanion/slash_commands/symbols.lua
@@ -127,7 +127,12 @@ local important_symbol_kinds = {
 --- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
 ---@diagnostic disable-next-line: unused-local
 function SymbolsCommand:complete(params, callback)
-  local bufnr = self.chat.focus_bufnr
+  local chat = self.get_chat()
+  if not chat then
+    return callback()
+  end
+
+  local bufnr = chat.focus_bufnr
   local filepath = vim.fn.fnamemodify(api.nvim_buf_get_name(bufnr), ":.")
 
   vim.lsp.buf_request(
@@ -188,13 +193,18 @@ end
 ---@param completion_item CodeCompanion.SlashCommandCompletionItem
 ---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
 function SymbolsCommand:resolve(completion_item, callback)
+  local chat = self.get_chat()
+  if not chat then
+    return callback()
+  end
+
   local symbol = completion_item.slash_command_args.symbol
   local filepath = completion_item.slash_command_args.filepath
   local range = completion_item.slash_command_args.range
   local kind_name = vim.lsp.protocol.SymbolKind[symbol.kind] or "Unknown"
 
   if range then
-    local bufnr = self.chat.focus_bufnr
+    local bufnr = chat.focus_bufnr
 
     local start_line = range.start.line
     local end_line = range["end"].line

--- a/lua/codecompanion/slash_commands/symbols.lua
+++ b/lua/codecompanion/slash_commands/symbols.lua
@@ -1,9 +1,7 @@
 ---@diagnostic disable: undefined-field
 local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
 local api = vim.api
-local cmp = require("cmp")
 local log = require("codecompanion.utils.log")
-local ui = require("codecompanion.utils.ui")
 
 local SymbolsCommand = BaseSlashCommand:extend()
 
@@ -157,7 +155,7 @@ function SymbolsCommand:complete(params, callback)
           local kind_name = vim.lsp.protocol.SymbolKind[symbol.kind] or "Unknown"
           local item = {
             label = full_name,
-            kind = cmp.lsp.CompletionItemKind[kind_name] or cmp.lsp.CompletionItemKind.Text,
+            kind = require("cmp").lsp.CompletionItemKind[kind_name] or require("cmp").lsp.CompletionItemKind.Text,
             slash_command_name = self.name,
             slash_command_args = {
               symbol = symbol,

--- a/lua/codecompanion/slash_commands/symbols.lua
+++ b/lua/codecompanion/slash_commands/symbols.lua
@@ -1,0 +1,224 @@
+---@diagnostic disable: undefined-field
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+local api = vim.api
+local cmp = require("cmp")
+local log = require("codecompanion.utils.log")
+local ui = require("codecompanion.utils.ui")
+
+local SymbolsCommand = BaseSlashCommand:extend()
+
+function SymbolsCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+  self.name = "symbols"
+  self.description = "Insert current file symbols"
+end
+
+local function get_node_range(_, node)
+  local start_row, start_col, end_row, end_col = node:range()
+  return {
+    start = { line = start_row, character = start_col },
+    ["end"] = { line = end_row, character = end_col },
+  }
+end
+
+local language_queries = {
+  python = [[
+    (function_definition name: (_) @func_name) @function
+    (class_definition name: (_) @class_name) @class
+    (module) @module
+    ((identifier) @variable (#is-not? local))
+  ]],
+  lua = [[
+    (function_declaration name: (_) @func_name) @function
+    (function_definition name: (_) @func_name) @function
+    (local_function name: (_) @func_name) @function
+    (variable_declaration name: (_) @variable)
+  ]],
+  javascript = [[
+    (function_declaration name: (_) @func_name) @function
+    (class_declaration name: (_) @class_name) @class
+    (method_definition name: (_) @method_name) @method
+    (variable_declaration) @variable
+  ]],
+  go = [[
+    (function_declaration name: (identifier) @func_name) @function
+    (method_declaration name: (field_identifier) @method_name) @method
+    (type_declaration
+      (type_spec name: (type_identifier) @type_name) @type
+    )
+    (struct_type_declaration
+      name: (type_identifier) @struct_name
+    ) @struct
+    (interface_type_declaration
+      name: (type_identifier) @interface_name
+    ) @interface
+    (const_declaration
+      (const_spec name: (identifier) @const_name)
+    ) @const
+    (var_declaration
+      (var_spec name: (identifier) @var_name)
+    ) @var
+  ]],
+  -- 添加更多语言的查询...
+}
+
+local function find_symbol_node(bufnr, symbol_name, start_line)
+  local parser = vim.treesitter.get_parser(bufnr)
+  local tree = parser:parse()[1]
+  local root = tree:root()
+
+  local lang = vim.bo[bufnr].filetype
+  local query_string = language_queries[lang]
+    or [[
+    (function) @function
+    (class) @class
+    (variable) @variable
+  ]]
+
+  local query = vim.treesitter.query.parse(lang, query_string)
+
+  for id, node in query:iter_captures(root, bufnr, start_line, -1) do
+    local name = query.captures[id]
+    if name:match("_name$") then
+      if vim.treesitter.get_node_text(node, bufnr) == symbol_name then
+        return node:parent()
+      end
+    elseif name == "variable" or name == "module" then
+      if vim.treesitter.get_node_text(node, bufnr):match(symbol_name) then
+        return node
+      end
+    end
+  end
+  return nil
+end
+
+local function get_symbol_range(bufnr, symbol)
+  if symbol.range.start.line ~= symbol.range["end"].line then
+    -- LSP provided a multi-line range, use it
+    return symbol.range
+  else
+    -- LSP provided a single-line range, use Treesitter to find the full range
+    local node = find_symbol_node(bufnr, symbol.name, symbol.range.start.line)
+    if node then
+      return get_node_range(bufnr, node)
+    else
+      -- Fallback to LSP range if Treesitter fails
+      return symbol.range
+    end
+  end
+end
+
+local important_symbol_kinds = {
+  [vim.lsp.protocol.SymbolKind.Class] = true,
+  [vim.lsp.protocol.SymbolKind.Method] = true,
+  [vim.lsp.protocol.SymbolKind.Constructor] = true,
+  [vim.lsp.protocol.SymbolKind.Enum] = true,
+  [vim.lsp.protocol.SymbolKind.Interface] = true,
+  [vim.lsp.protocol.SymbolKind.Function] = true,
+  [vim.lsp.protocol.SymbolKind.Constant] = true,
+  [vim.lsp.protocol.SymbolKind.Object] = true,
+  [vim.lsp.protocol.SymbolKind.Struct] = true,
+  [vim.lsp.protocol.SymbolKind.Event] = true,
+}
+
+--- Complete file paths for the command.
+--- @param params cmp.SourceCompletionApiParams
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+---@diagnostic disable-next-line: unused-local
+function SymbolsCommand:complete(params, callback)
+  local bufnr = self.chat.focus_bufnr
+  local filepath = vim.fn.fnamemodify(api.nvim_buf_get_name(bufnr), ":.")
+
+  vim.lsp.buf_request(
+    bufnr,
+    "textDocument/documentSymbol",
+    { textDocument = vim.lsp.util.make_text_document_params(bufnr) },
+    function(err, results, _, _)
+      if err then
+        log:warn("Error when requesting document symbols: %s", err)
+        return callback()
+      end
+
+      local items = {}
+
+      local function process_symbols(symbols, prefix)
+        for _, symbol in ipairs(symbols) do
+          if not important_symbol_kinds[symbol.kind] then
+            goto continue
+          end
+
+          local full_name = prefix and (prefix .. "." .. symbol.name) or symbol.name
+          local kind_name = vim.lsp.protocol.SymbolKind[symbol.kind] or "Unknown"
+          local item = {
+            label = full_name,
+            kind = cmp.lsp.CompletionItemKind[kind_name] or cmp.lsp.CompletionItemKind.Text,
+            slash_command_name = self.name,
+            slash_command_args = {
+              symbol = symbol,
+              filepath = filepath,
+              range = nil,
+            },
+          }
+
+          local ok, range = pcall(get_symbol_range, bufnr, symbol)
+          if ok then
+            item.slash_command_args.range = range
+          end
+
+          table.insert(items, item)
+
+          if symbol.children then
+            process_symbols(symbol.children, full_name)
+          end
+
+          ::continue::
+        end
+      end
+
+      process_symbols(results)
+
+      return callback({ items = items, isIncomplete = false })
+    end
+  )
+end
+
+---Resolve completion item (optional). This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+function SymbolsCommand:resolve(completion_item, callback)
+  local symbol = completion_item.slash_command_args.symbol
+  local filepath = completion_item.slash_command_args.filepath
+  local range = completion_item.slash_command_args.range
+  local kind_name = vim.lsp.protocol.SymbolKind[symbol.kind] or "Unknown"
+
+  if range then
+    local bufnr = self.chat.focus_bufnr
+
+    local start_line = range.start.line
+    local end_line = range["end"].line
+    local lines = vim.api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)
+    local symbol_content = table.concat(lines, "\n")
+
+    completion_item.documentation = {
+      kind = require("cmp").lsp.MarkupKind.Markdown,
+      value = string.format(
+        "Symbols for %s:\n%s\nkind: %s - name: %s",
+        filepath,
+        symbol_content,
+        kind_name,
+        symbol.name
+      ),
+    }
+  else
+    completion_item.documentation = {
+      kind = require("cmp").lsp.MarkupKind.Markdown,
+      value = string.format("Symbols for %s:\n%s\nkind: %s - name: %s", filepath, "", kind_name, symbol.name),
+    }
+  end
+
+  callback(completion_item)
+end
+
+return SymbolsCommand

--- a/lua/codecompanion/slash_commands/tab.lua
+++ b/lua/codecompanion/slash_commands/tab.lua
@@ -1,0 +1,65 @@
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+local api = vim.api
+local fn = vim.fn
+
+---@class TabCommand: CodeCompanion.BaseSlashCommand
+local TabCommand = BaseSlashCommand:extend()
+
+function TabCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+end
+
+--- Complete file paths for the command.
+--- @param params cmp.SourceCompletionApiParams
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+---@diagnostic disable-next-line: unused-local
+function TabCommand:complete(params, callback)
+  local bufs = api.nvim_list_bufs()
+  ---@type CodeCompanion.SlashCommandCompletionItem[]
+  local items = {}
+
+  for _, buf in ipairs(bufs) do
+    if api.nvim_buf_is_loaded(buf) then
+      local name = api.nvim_buf_get_name(buf)
+      ---@diagnostic disable-next-line: undefined-field
+      if name == "" or name:match("*[CodeCompanion]*") then
+        goto continue
+      end
+
+      table.insert(items, {
+        label = name,
+        kind = require("cmp").lsp.CompletionItemKind.File,
+        slash_command_name = self.name,
+        slash_command_args = {
+          bufnr = buf,
+        },
+      })
+
+      ::continue::
+    end
+  end
+
+  return items
+end
+
+---Resolve completion item (optional). This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+function TabCommand:resolve(completion_item, callback)
+  local bufnr = completion_item.slash_command_args.bufnr
+  local full_path = api.nvim_buf_get_name(bufnr)
+  local cwd_relative_path = fn.fnamemodify(full_path, ":.")
+  local lines = api.nvim_buf_get_lines(bufnr, 0, 1, false)
+
+  local item = {
+    label = full_path,
+    kind = require("cmp").lsp.CompletionItemKind.File,
+    documentation = string.format("```%s\n%s\n```", cwd_relative_path, table.concat(lines, "\n")),
+  }
+
+  return callback(item)
+end
+
+return TabCommand

--- a/lua/codecompanion/slash_commands/tab.lua
+++ b/lua/codecompanion/slash_commands/tab.lua
@@ -25,12 +25,13 @@ function TabCommand:complete(params, callback)
     if api.nvim_buf_is_loaded(buf) then
       local name = api.nvim_buf_get_name(buf)
       ---@diagnostic disable-next-line: undefined-field
-      if name == "" or name:match("*[CodeCompanion]*") then
+      -- if name contain CodeCompanion continue
+      if name:find("CodeCompanion") or name:find("term") then
         goto continue
       end
 
       table.insert(items, {
-        label = name,
+        label = vim.fn.fnamemodify(name, ":t"),
         kind = require("cmp").lsp.CompletionItemKind.File,
         slash_command_name = self.name,
         slash_command_args = {

--- a/lua/codecompanion/slash_commands/tab.lua
+++ b/lua/codecompanion/slash_commands/tab.lua
@@ -53,7 +53,7 @@ end
 function TabCommand:resolve(completion_item, callback)
   local bufnr = completion_item.slash_command_args.bufnr
   local full_path = api.nvim_buf_get_name(bufnr)
-  local file_type = fn.fnamemodify(full_path, ":e")
+  local file_type = fn.fnamemodify(full_path, ":t")
   local cwd_relative_path = fn.fnamemodify(full_path, ":.")
   local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
 

--- a/lua/codecompanion/slash_commands/tab.lua
+++ b/lua/codecompanion/slash_commands/tab.lua
@@ -8,6 +8,8 @@ local TabCommand = BaseSlashCommand:extend()
 function TabCommand:init(opts)
   opts = opts or {}
   BaseSlashCommand.init(self, opts)
+  self.name = "tab"
+  self.description = "Insert a open buffer"
 end
 
 --- Complete file paths for the command.
@@ -40,7 +42,7 @@ function TabCommand:complete(params, callback)
     end
   end
 
-  return items
+  return callback({ items = items, isIncomplete = false })
 end
 
 ---Resolve completion item (optional). This is called right before the completion is about to be displayed.
@@ -50,13 +52,19 @@ end
 function TabCommand:resolve(completion_item, callback)
   local bufnr = completion_item.slash_command_args.bufnr
   local full_path = api.nvim_buf_get_name(bufnr)
+  local file_type = fn.fnamemodify(full_path, ":e")
   local cwd_relative_path = fn.fnamemodify(full_path, ":.")
-  local lines = api.nvim_buf_get_lines(bufnr, 0, 1, false)
+  local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
   local item = {
     label = full_path,
     kind = require("cmp").lsp.CompletionItemKind.File,
-    documentation = string.format("```%s\n%s\n```", cwd_relative_path, table.concat(lines, "\n")),
+    documentation = string.format(
+      "Content of %s\n```%s\n %s\n```",
+      file_type,
+      cwd_relative_path,
+      table.concat(lines, "\n")
+    ),
   }
 
   return callback(item)

--- a/lua/codecompanion/slash_commands/terminal.lua
+++ b/lua/codecompanion/slash_commands/terminal.lua
@@ -1,0 +1,31 @@
+local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+
+local TerminalCommand = BaseSlashCommand:extend()
+
+function TerminalCommand:init(opts)
+  opts = opts or {}
+  BaseSlashCommand.init(self, opts)
+  self.name = "terminal"
+  self.description = "Insert terminal output"
+end
+
+--- Complete file paths for the command.
+--- @param params cmp.SourceCompletionApiParams
+--- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
+---@diagnostic disable-next-line: unused-local
+function TerminalCommand:execute(params, callback)
+  --TODO: Implement terminal command
+  return callback()
+end
+
+---Resolve completion item (optional). This is called right before the completion is about to be displayed.
+---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
+---@param completion_item CodeCompanion.SlashCommandCompletionItem
+---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
+---@diagnostic disable-next-line: unused-local
+function TerminalCommand:complete(completion_item, callback)
+  --TODO: Implement terminal command
+  return callback()
+end
+
+return TerminalCommand

--- a/lua/codecompanion/slash_commands/terminal.lua
+++ b/lua/codecompanion/slash_commands/terminal.lua
@@ -1,5 +1,8 @@
 local BaseSlashCommand = require("codecompanion.slash_commands").BaseSlashCommand
+local api = vim.api
+local fn = vim.fn
 
+---@class TerminalCommand: CodeCompanion.BaseSlashCommand
 local TerminalCommand = BaseSlashCommand:extend()
 
 function TerminalCommand:init(opts)
@@ -13,19 +16,55 @@ end
 --- @param params cmp.SourceCompletionApiParams
 --- @param callback fun(response: CodeCompanion.SlashCommandCompletionResponse|nil)
 ---@diagnostic disable-next-line: unused-local
-function TerminalCommand:execute(params, callback)
-  --TODO: Implement terminal command
-  return callback()
+function TerminalCommand:complete(params, callback)
+  local bufs = api.nvim_list_bufs()
+  ---@type CodeCompanion.SlashCommandCompletionItem[]
+  local items = {}
+
+  for _, buf in ipairs(bufs) do
+    if api.nvim_buf_is_loaded(buf) then
+      local name = api.nvim_buf_get_name(buf)
+      ---@diagnostic disable-next-line: undefined-field
+      -- if name contain CodeCompanion continue
+      if name:find("term") then
+        table.insert(items, {
+          label = vim.fn.fnamemodify(name, ":t"),
+          kind = require("cmp").lsp.CompletionItemKind.File,
+          slash_command_name = self.name,
+          slash_command_args = {
+            bufnr = buf,
+          },
+        })
+      end
+    end
+  end
+
+  return callback({ items = items, isIncomplete = false })
 end
 
 ---Resolve completion item (optional). This is called right before the completion is about to be displayed.
 ---Useful for setting the text shown in the documentation window (`completion_item.documentation`).
 ---@param completion_item CodeCompanion.SlashCommandCompletionItem
 ---@param callback fun(completion_item: CodeCompanion.SlashCommandCompletionItem|nil)
----@diagnostic disable-next-line: unused-local
-function TerminalCommand:complete(completion_item, callback)
-  --TODO: Implement terminal command
-  return callback()
+function TerminalCommand:resolve(completion_item, callback)
+  local bufnr = completion_item.slash_command_args.bufnr
+  local full_path = api.nvim_buf_get_name(bufnr)
+  local file_type = fn.fnamemodify(full_path, ":e")
+  local cwd_relative_path = fn.fnamemodify(full_path, ":.")
+  local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+  local item = {
+    label = full_path,
+    kind = require("cmp").lsp.CompletionItemKind.File,
+    documentation = string.format(
+      "Content of %s\n```%s\n %s\n```",
+      file_type,
+      cwd_relative_path,
+      table.concat(lines, "\n")
+    ),
+  }
+
+  return callback(item)
 end
 
 return TerminalCommand

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -308,7 +308,7 @@ function Chat.new(args)
     context = args.context,
     header_ns = api.nvim_create_namespace(CONSTANTS.NS_HEADER),
     id = id,
-    last_role = args.last_role,
+    last_role = args.last_role or CONSTANTS.USER_ROLE,
     messages = args.messages or {},
     status = "",
     tokens = args.tokens,

--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -67,7 +67,7 @@ local function build_prompt(inline, user_input)
   if inline.opts.append_last_chat then
     local last_chat = require("codecompanion.strategies.chat").last_chat()
     if last_chat and last_chat ~= {} then
-      local messages = last_chat:messages()
+      local messages = last_chat.messages
 
       if messages then
         for index, message in ipairs(messages) do


### PR DESCRIPTION
Please note that this is only a demonstration pull request. It is not intended to be merged into this codebase, but rather to provide a possible approach, as I am not certain of the best way to implement this feature.

## Description

Impl slash command like zed

## Screenshots

### now

![CleanShot 2024-08-25 at 23 15 05](https://github.com/user-attachments/assets/012bd00c-77e1-422d-9f2c-f30c2a6bf2f8)


### file

![CleanShot 2024-08-25 at 23 16 37](https://github.com/user-attachments/assets/02aab527-f6a2-4ad6-a0c2-543605ce3424)


### diagnostics

![CleanShot 2024-08-25 at 23 18 14](https://github.com/user-attachments/assets/f0d01fb2-fea7-4141-b2b5-e34b1996b961)


### prompt

![CleanShot 2024-08-25 at 23 22 02](https://github.com/user-attachments/assets/f226908d-f6b7-4c54-857f-f3fc755eca3a)

### terminal

Not impl yet


## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
