### PR TITLE
fix: Prevent nil error

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -242,6 +242,8 @@ end
 M.setup = function(opts)
   if
     opts
+    and opts.strategies
+    and opts.strategies.chat
     and opts.strategies.chat.callbacks
     and (opts.strategies.chat.callbacks.on_submit or opts.strategies.chat.callbacks.on_complete)
   then


### PR DESCRIPTION
I have encountered this error when not having `strategies` set in the configuration.

```
attempt to index field 'strategies' (a nil value)
```

This commit adds a check to prevent this error.
