### PR TITLE
feat: send keymap use submit function instead of writing buffer

### DIFF
--- a/lua/codecompanion/keymaps.lua
+++ b/lua/codecompanion/keymaps.lua
@@ -161,8 +161,8 @@ M.options = {
 }
 
 M.send = {
-  callback = function()
-    vim.cmd("w")
+  callback = function(chat)
+    chat:submit()
   end,
 }
 


### PR DESCRIPTION
## Description

related discussion: #147

The buffer sending on write is nice and convenient, but forcing all implementations of send to use this mechanism can be limiting.

Implementing send using the `submit` function on the Chat object makes it possible to set `buftype=nofile` which greatly improves the experience for users of the `hidden` setting

Currently, with `set hidden`, when the chat window is toggled off after being modified, quitting neovim will be blocked by the `No write since last change` error which is very annoying, as the user must now force quit, or re-open the chat buffer and close it definitively (e.g. using `<C-c>`)

With this change, my toggle keymap looks like this and I get no issues when closing neovim:
```lua
vim.keymap.set("n", "<leader>gpt", function()
    codecompanion.toggle()
    local current_buffer = vim.api.nvim_get_current_buf()
    local buffer_name = vim.api.nvim_buf_get_name(current_buffer)
    if string.find(buffer_name, "%[CodeCompanion%]") then
        vim.api.nvim_buf_set_option(0, "buftype", "nofile")
    end
end)
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
