### PR TITLE
fix(keymaps): update next and previous header keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ require("codecompanion").setup({
         },
         next_header = {
           modes = {
-            n = "]",
+            n = "]]",
           },
           index = 10,
           callback = "keymaps.next_header",
@@ -265,7 +265,7 @@ require("codecompanion").setup({
         },
         previous_header = {
           modes = {
-            n = "[",
+            n = "[[",
           },
           index = 11,
           callback = "keymaps.previous_header",

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -126,7 +126,7 @@ return {
         },
         next_header = {
           modes = {
-            n = "]",
+            n = "]]",
           },
           index = 9,
           callback = "keymaps.next_header",
@@ -134,7 +134,7 @@ return {
         },
         previous_header = {
           modes = {
-            n = "[",
+            n = "[[",
           },
           index = 10,
           callback = "keymaps.previous_header",


### PR DESCRIPTION
## Description

Updated the keybindings for navigating to the next and previous headers from `]` to `]]` and from `[` to `[[` respectively in both the README and configuration files.

It's pretty common to use `[` and `]` as first char in Vim/Neovim motion keymaps. So the editor usually pause for a couple of milliseconds before process `[` and `]` as standalone motion.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
