### PR TITLE
fix(inline): last_chat maybe nil, e.g. on first usage

### DIFF
--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -165,7 +165,7 @@ function Inline.new(args)
 
   if not args.chat_context then
     local last_chat = require("codecompanion").last_chat()
-    if util.count(last_chat) > 0 then
+    if last_chat ~= nil and util.count(last_chat) > 0 then
       args.chat_context = last_chat:get_messages()
     end
   end


### PR DESCRIPTION
## Description

Run `:codecompanion hello` after installation got following error:

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
```
Error executing Lua callback: ...ects/codecompanion.nvim/lua/codecompanion/utils/util.lua:24: bad argument #1 to 'pairs' (table expect
ed, got nil)
stack traceback:
        [C]: in function 'pairs'
        ...ects/codecompanion.nvim/lua/codecompanion/utils/util.lua:24: in function 'count'
        ...decompanion.nvim/lua/codecompanion/strategies/inline.lua:168: in function 'new'
        ...i/projects/codecompanion.nvim/lua/codecompanion/init.lua:21: in function 'inline'
        ...ojects/codecompanion.nvim/lua/codecompanion/commands.lua:55: in function <...ojects/codecompanion.nvim/lua/codecompanion/co
mmands.lua:21>
```
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
