### PR TITLE
Adding mini.pick as an alternative to telescope for /file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ require("codecompanion").setup({
           opts = {
             contains_code = true,
             max_lines = 1000,
-            provider = "telescope", -- telescope
+            provider = "telescope", -- telescope | or: mini_pick
           },
         },
       },

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -66,6 +66,27 @@ local Providers = {
       end,
     })
   end,
+
+  ---The mini.pick provider
+  ---@param SlashCommand CodeCompanion.SlashCommandFile
+  ---@return nil
+  mini_pick = function(SlashCommand)
+    local ok, mini_pick = pcall(require, "mini.pick")
+    if not ok then
+      return log:error("mini.pick is not installed")
+    end
+    local selected = mini_pick.builtin.files({}, {
+      source = {
+        name = CONSTANTS.PROMPT,
+        choose = function(path)
+          output(SlashCommand, { path = path, [1] = path })
+        end,
+      },
+    })
+    if not selected then
+      log:info("No file selected")
+    end
+  end,
 }
 
 ---@class CodeCompanion.SlashCommandFile
@@ -95,7 +116,18 @@ function SlashCommandFile:execute()
     end
     provider(self)
   else
-    Providers.telescope(self)
+    -- Try Telescope first, then fall back to mini.pick
+    local telescope_ok, _ = pcall(require, "telescope.builtin")
+    if telescope_ok then
+      Providers.telescope(self)
+    else
+      local mini_pick_ok, _ = pcall(require, "mini.pick")
+      if mini_pick_ok then
+        Providers.mini_pick(self)
+      else
+        return log:error("Neither Telescope nor mini.pick is installed")
+      end
+    end
   end
 end
 

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -116,18 +116,7 @@ function SlashCommandFile:execute()
     end
     provider(self)
   else
-    -- Try Telescope first, then fall back to mini.pick
-    local telescope_ok, _ = pcall(require, "telescope.builtin")
-    if telescope_ok then
-      Providers.telescope(self)
-    else
-      local mini_pick_ok, _ = pcall(require, "mini.pick")
-      if mini_pick_ok then
-        Providers.mini_pick(self)
-      else
-        return log:error("Neither Telescope nor mini.pick is installed")
-      end
-    end
+    Providers.telescope(self)
   end
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
related to #166
This PR introduces support for the mini.pick plugin as an alternative file selector for the `/file` command. It allows users to use mini.pick for file selection when Telescope isn’t available, offering greater flexibility and compatibility with various Neovim setups.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
I haven’t used Telescope in a long time, and since the slash /file command requires the Telescope plugin, it’s a feature I haven’t really been able to use.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
screenshot for mini.pick
<img width="1665" alt="Screenshot 2024-09-04 at 10 34 59 PM" src="https://github.com/user-attachments/assets/b5ae9231-7c6f-402c-9a59-b7db7baf09bd">

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
