### PR TITLE
Accommodate mini.pick to with with relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ require("codecompanion").setup({
           opts = {
             contains_code = true,
             max_lines = 1000,
-            provider = "telescope", -- telescope
+            provider = "telescope", -- telescope | or: mini_pick
           },
         },
       },

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -66,6 +66,27 @@ local Providers = {
       end,
     })
   end,
+
+  ---The mini.pick provider
+  ---@param SlashCommand CodeCompanion.SlashCommandFile
+  ---@return nil
+  mini_pick = function(SlashCommand)
+    local ok, mini_pick = pcall(require, "mini.pick")
+    if not ok then
+      return log:error("mini.pick is not installed")
+    end
+    local selected = mini_pick.builtin.files({}, {
+      source = {
+        name = CONSTANTS.PROMPT,
+        choose = function(path)
+          output(SlashCommand, { path = path, [1] = path })
+        end,
+      },
+    })
+    if not selected then
+      log:info("No file selected")
+    end
+  end,
 }
 
 ---@class CodeCompanion.SlashCommandFile
@@ -95,7 +116,18 @@ function SlashCommandFile:execute()
     end
     provider(self)
   else
-    Providers.telescope(self)
+    -- Try Telescope first, then fall back to mini.pick
+    local telescope_ok, _ = pcall(require, "telescope.builtin")
+    if telescope_ok then
+      Providers.telescope(self)
+    else
+      local mini_pick_ok, _ = pcall(require, "mini.pick")
+      if mini_pick_ok then
+        Providers.mini_pick(self)
+      else
+        return log:error("Neither Telescope nor mini.pick is installed")
+      end
+    end
   end
 end
 

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -73,7 +73,7 @@ local Providers = {
       source = {
         name = CONSTANTS.PROMPT,
         choose = function(path)
-          output(SlashCommand, { path = path, [1] = path })
+          output(SlashCommand, { path = path, relative_path = vim.fn.fnamemodify(path, ":~:.") })
         end,
       },
     })

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -25,7 +25,8 @@ local function output(SlashCommand, selected)
   end
 
   local Chat = SlashCommand.Chat
-  Chat:append_to_buf({ content = "[!" .. CONSTANTS.NAME .. ": `" .. selected.relative_path .. "`]\n" })
+  local relative_path = selected.relative_path or selected[1] or selected.path
+  Chat:append_to_buf({ content = "[!" .. CONSTANTS.NAME .. ": `" .. relative_path .. "`]\n" })
   Chat:append_to_buf({ content = "```" .. ft .. "\n" .. content .. "```" })
   Chat:fold_code()
 end

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -116,18 +116,7 @@ function SlashCommandFile:execute()
     end
     provider(self)
   else
-    -- Try Telescope first, then fall back to mini.pick
-    local telescope_ok, _ = pcall(require, "telescope.builtin")
-    if telescope_ok then
-      Providers.telescope(self)
-    else
-      local mini_pick_ok, _ = pcall(require, "mini.pick")
-      if mini_pick_ok then
-        Providers.mini_pick(self)
-      else
-        return log:error("Neither Telescope nor mini.pick is installed")
-      end
-    end
+    Providers.telescope(self)
   end
 end
 


### PR DESCRIPTION
## Description

After the last refactor of file.lua, `mini.pick` stopped working. with error:
```lua
 ...n.nvim/lua/codecompanion/helpers/slash_commands/file.lua:21: attempt to index global 'file' (a nil value)
```
so it's just a small modification to allow it to work.

## Related Issue(s)

#169

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.

Thank you