### PR TITLE
fix: properly closing Mini.pick after choosing file/buffer

### DIFF
--- a/lua/codecompanion/helpers/slash_commands/buffer.lua
+++ b/lua/codecompanion/helpers/slash_commands/buffer.lua
@@ -101,13 +101,16 @@ local Providers = {
       source = {
         name = CONSTANTS.PROMPT,
         choose = function(selection)
-          local _, _ = pcall(function()
+          local success, _ = pcall(function()
             output(SlashCommand, {
               bufnr = selection.bufnr,
               name = selection.text,
               path = selection.text,
             })
           end)
+          if success then
+            return nil
+          end
         end,
       },
     })

--- a/lua/codecompanion/helpers/slash_commands/buffer.lua
+++ b/lua/codecompanion/helpers/slash_commands/buffer.lua
@@ -97,18 +97,17 @@ local Providers = {
       return log:error("mini.pick is not installed")
     end
 
-    local picker = mini_pick.builtin.buffers({ include_current = false }, {
+    mini_pick.builtin.buffers({ include_current = false }, {
       source = {
         name = CONSTANTS.PROMPT,
         choose = function(selection)
-          if selection then
-            api.nvim_win_close(0, false)
+          local _, _ = pcall(function()
             output(SlashCommand, {
               bufnr = selection.bufnr,
               name = selection.text,
               path = selection.text,
             })
-          end
+          end)
         end,
       },
     })

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -69,18 +69,16 @@ local Providers = {
     if not ok then
       return log:error("mini.pick is not installed")
     end
-    local selected = mini_pick.builtin.files({}, {
+    mini_pick.builtin.files({}, {
       source = {
         name = CONSTANTS.PROMPT,
         choose = function(path)
-          vim.api.nvim_win_close(0, false)
-          output(SlashCommand, { path = path, relative_path = vim.fn.fnamemodify(path, ":~:.") })
+          local _, _ = pcall(function()
+            output(SlashCommand, { path = path })
+          end)
         end,
       },
     })
-    if not selected then
-      return
-    end
   end,
 
   ---The fzf-lua provider

--- a/lua/codecompanion/helpers/slash_commands/file.lua
+++ b/lua/codecompanion/helpers/slash_commands/file.lua
@@ -73,9 +73,12 @@ local Providers = {
       source = {
         name = CONSTANTS.PROMPT,
         choose = function(path)
-          local _, _ = pcall(function()
+          local success, _ = pcall(function()
             output(SlashCommand, { path = path })
           end)
+          if success then
+            return nil
+          end
         end,
       },
     })


### PR DESCRIPTION
## Description

I noticed that mini.pick wasn’t closing properly but didn’t have the time to fix it, so thank you for addressing that. This PR simply ensures the window closes correctly as outlined in the `mini.pick` documentation.

## Related Issue(s)

After the latest update, I noticed some flickering in mini.pick. I believe this PR should fully resolve the issue by always passing `nil` after selecting a file or buffer.

thank you

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.