### PR TITLE
ensure callback execution in source:execute

### DIFF
--- a/lua/cmp_codecompanion/slash_commands.lua
+++ b/lua/cmp_codecompanion/slash_commands.lua
@@ -54,6 +54,9 @@ end
 ---@return nil
 function source:execute(item, callback)
   vim.api.nvim_set_current_line("")
+  if callback then
+	  callback()
+  end
   return SlashCommands:execute(item)
 end
 


### PR DESCRIPTION
## Description

Callback execution in source.execute() for slash commands so that cmp ends correctly.

## Related Issue(s)

#197 

## Screenshots

![image](https://github.com/user-attachments/assets/46eb9dca-0cd0-45d1-b6fc-8153619f9336)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
