### PR TITLE
feat: add /help slash-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ _Slash commands_, accessed via `/`, run commands to insert additional context in
 - `/file` - Insert a file
 - `/now` - Insert the current date and time
 - `/symbols` - Insert symbols for the active buffer
+- `/help` - Insert content from help tags
 
 _Tools_, accessed via `@`, allow the LLM to function as an agent and carry out actions:
 
@@ -322,6 +323,13 @@ require("codecompanion").setup({
         ["symbols"] = {
           callback = "helpers.slash_commands.symbols",
           description = "Insert symbols for the active buffer",
+          opts = {
+            contains_code = true,
+          },
+        },
+        ["help"] = {
+          callback = "helpers.slash_commands.help",
+          description = "Insert content from help tags",
           opts = {
             contains_code = true,
           },

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -122,6 +122,7 @@ into the chat buffer:
 - `/file` - Insert a file
 - `/now` - Insert the current date and time
 - `/symbols` - Insert symbols for the active buffer
+- `/help` - Insert content from help tags
 
 _Tools_, accessed via `@`, allow the LLM to function as an agent and carry out
 actions:

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -74,6 +74,13 @@ return {
             contains_code = true,
           },
         },
+        ["help"] = {
+          callback = "helpers.slash_commands.help",
+          description = "Insert content from help tags",
+          opts = {
+            contains_code = true,
+          },
+        },
       },
       keymaps = {
         options = {

--- a/lua/codecompanion/helpers/slash_commands/help.lua
+++ b/lua/codecompanion/helpers/slash_commands/help.lua
@@ -1,0 +1,98 @@
+local config = require("codecompanion").config
+
+local file_utils = require("codecompanion.utils.files")
+local log = require("codecompanion.utils.log")
+
+CONSTANTS = {
+  NAME = "Help",
+  PROMPT = "Select a help tag",
+}
+
+---Output from the slash command in the chat buffer
+---@param SlashCommand CodeCompanion.SlashCommandHelp
+---@param selected table The selected item from the provider { relative_path = string, path = string }
+---@return nil
+local function output(SlashCommand, selected)
+  if not config.opts.send_code and (SlashCommand.config.opts and SlashCommand.config.opts.contains_code) then
+    return log:warn("Sending of code has been disabled")
+  end
+
+  local ft = "help"
+  local content = file_utils.read(selected.path)
+
+  if content == "" then
+    return log:warn("Could not read the file: %s", selected.path)
+  end
+
+  local Chat = SlashCommand.Chat
+  Chat:append_to_buf({ content = "[!" .. CONSTANTS.NAME .. ": `" .. selected.tag .. "`]\n" })
+  Chat:append_to_buf({ content = "```" .. ft .. "\n" .. content .. "```" })
+  Chat:fold_code()
+end
+
+local Providers = {
+  ---The Telescope provider
+  ---@param SlashCommand CodeCompanion.SlashCommandHelp
+  ---@return nil
+  telescope = function(SlashCommand)
+    local ok, telescope = pcall(require, "telescope.builtin")
+    if not ok then
+      return log:error("Telescope is not installed")
+    end
+
+    telescope.help_tags({
+      prompt_title = CONSTANTS.PROMPT,
+      attach_mappings = function(prompt_bufnr, map)
+        local actions = require("telescope.actions")
+        local action_state = require("telescope.actions.state")
+
+        actions.select_default:replace(function()
+          local selection = action_state.get_selected_entry()
+          actions.close(prompt_bufnr)
+          if selection then
+            selection = { path = selection.filename, tag = selection.display }
+            output(SlashCommand, selection)
+          end
+        end)
+
+        return true
+      end,
+    })
+  end,
+
+  ---TODO: Add the mini.pick provider
+  ---TODO: The fzf-lua provider
+}
+
+---@class CodeCompanion.SlashCommandHelp
+local SlashCommandHelp = {}
+
+---@class CodeCompanion.SlashCommandHelp
+---@field Chat CodeCompanion.Chat The chat buffer
+---@field config table The config of the slash command
+---@field context table The context of the chat buffer from the completion menu
+function SlashCommandHelp.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommandHelp })
+
+  return self
+end
+
+---Execute the slash command
+---@return nil
+function SlashCommandHelp:execute()
+  if self.config.opts and self.config.opts.provider then
+    local provider = Providers[self.config.opts.provider]
+    if not provider then
+      return log:error("Provider for the help slash command could not found: %s", self.config.opts.provider)
+    end
+    provider(self)
+  else
+    Providers.telescope(self)
+  end
+end
+
+return SlashCommandHelp


### PR DESCRIPTION
## Description

I've start to work on implementing the simple version of the `/help` slash command as described in discussion https://github.com/olimorris/codecompanion.nvim/discussions/207.

This is the simple version (not the rag version), that simply use tags to select the docs file.

Some doc/*.txt can be quite long so I'd like to select only a couple of subsetion of the whole file (e.g. the first section and the tag's section). 

I'm thinking about filtering using regex or make use of treesitter. Feedbacks?

## Demo


https://github.com/user-attachments/assets/7bcd4c62-52c9-494e-bbf1-51b7db1d3129


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.