### PR TITLE
Fix duplicate tags in help

### DIFF
--- a/doc/codecompanion-tools.txt
+++ b/doc/codecompanion-tools.txt
@@ -1,12 +1,12 @@
-*codecompanion.txt*       For NVIM v0.9.2       Last change: 2024 September 16
+*codecompanion-tools.txt*    For NVIM v0.9.2    Last change: 2024 September 16
 
 ==============================================================================
-Table of Contents                            *codecompanion-table-of-contents*
+Table of Contents                      *codecompanion-tools-table-of-contents*
 
 1. Tools                                                 |codecompanion-tools|
-  - Introduction                                  |codecompanion-introduction|
-  - Tool Types                                      |codecompanion-tool-types|
-  - The Interface                                |codecompanion-the-interface|
+  - Introduction                            |codecompanion-tools-introduction|
+  - Tool Types                                |codecompanion-tools-tool-types|
+  - The Interface                          |codecompanion-tools-the-interface|
 
 ==============================================================================
 1. Tools                                                 *codecompanion-tools*
@@ -16,7 +16,7 @@ act as an Agent. Tools are added to chat buffers as participants. This guide
 walks you through the implementation of tools, enabling you to create your own.
 
 
-INTRODUCTION                                      *codecompanion-introduction*
+INTRODUCTION                                *codecompanion-tools-introduction*
 
 In the plugin, tools work by sharing a system prompt with an LLM. This
 instructs them how to produce an XML markdown code block which can, in turn, be
@@ -28,7 +28,7 @@ tools is orchestrated by the `CodeCompanion.Chat` class which parses an LLM’s
 response and looks to identify the XML code block.
 
 
-TOOL TYPES                                          *codecompanion-tool-types*
+TOOL TYPES                                    *codecompanion-tools-tool-types*
 
 There are two types of tools within the plugin:
 
@@ -43,7 +43,7 @@ directly in Neovim within the main process.
 
 
 
-THE INTERFACE                                    *codecompanion-the-interface*
+THE INTERFACE                              *codecompanion-tools-the-interface*
 
 Tools must implement the following interface:
 


### PR DESCRIPTION
## Description

This PR fixes the naming in the documentation which leads to duplicate tags (if you build it with nix). Hopefully I renamed and formatted everything correct again 😄 

## Related Issue(s)

Its only a small fix for the documentation which occurs for example if you try to build the plugin with nix:

```
> E154: Duplicate tag "codecompanion-table-of-contents" in file /nix/store/yqpyyaqmabfv3r4ik3yxfr3mkvkaqx9g-vimplugin-codecompanion.nvim-2024-09-16/./doc/codecompanion.txt
       > E154: Duplicate tag "codecompanion.txt" in file /nix/store/yqpyyaqmabfv3r4ik3yxfr3mkvkaqx9g-vimplugin-codecompanion.nvim-2024-09-16/./doc/codecompanion.txtFailed to build help tags!
       For full logs, run 'nix log /nix/store/i52zgxq9irxx7hwriwzc0vp5i2yz16ha-vimplugin-codecompanion.nvim-2024-09-16.drv'.
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
