### PR TITLE
Allow to customize prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,9 @@ Use Markdown formatting and include the programming language name at the start o
   opts = {
     log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
 
+    -- Prompt used for interactive LLM calls
+    command_prompt_prefix = "Prompt ",
+
     diff = {
       enabled = true,
       close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...

--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Use Markdown formatting and include the programming language name at the start o
     action_palette = {
       width = 95,
       height = 10,
-      command = "Prompt ", -- Prompt used for interactive LLM calls
+      prompt = "Prompt ", -- Prompt used for interactive LLM calls
     },
     chat = {
       window = {

--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ Use Markdown formatting and include the programming language name at the start o
     action_palette = {
       width = 95,
       height = 10,
+      command = "Prompt ", -- Prompt used for interactive LLM calls
     },
     chat = {
       window = {
@@ -876,9 +877,6 @@ Use Markdown formatting and include the programming language name at the start o
   -- GENERAL OPTIONS ----------------------------------------------------------
   opts = {
     log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
-
-    -- Prompt used for interactive LLM calls
-    command_prompt_prefix = "Prompt ",
 
     diff = {
       enabled = true,

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -1,5 +1,4 @@
 local log = require("codecompanion.utils.log")
-local config = require("codecompanion.config")
 
 ---@class CodeCompanionCommandOpts:table
 ---@field desc string
@@ -11,17 +10,13 @@ local config = require("codecompanion.config")
 
 local codecompanion = require("codecompanion")
 
-local clean_up_prompt = function(prompt)
-  return prompt:match("%s(.+)")
-end
-
 ---@type CodeCompanionCommand[]
 return {
   {
     cmd = "CodeCompanion",
     callback = function(opts)
       if #vim.trim(opts.args or "") == 0 then
-        vim.ui.input({ prompt = config.opts.command_prompt_prefix }, function(input)
+        vim.ui.input({ prompt = require("codecompanion").config.display.action_palette.prompt }, function(input)
           if #vim.trim(input or "") == 0 then
             return
           end

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -1,4 +1,5 @@
 local log = require("codecompanion.utils.log")
+local config = require("codecompanion.config")
 
 ---@class CodeCompanionCommandOpts:table
 ---@field desc string
@@ -20,7 +21,7 @@ return {
     cmd = "CodeCompanion",
     callback = function(opts)
       if #vim.trim(opts.args or "") == 0 then
-        vim.ui.input({ prompt = "Prompt" }, function(input)
+        vim.ui.input({ prompt = config.opts.command_prompt_prefix }, function(input)
           if #vim.trim(input or "") == 0 then
             return
           end

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -601,6 +601,7 @@ Use Markdown formatting and include the programming language name at the start o
     action_palette = {
       width = 95,
       height = 10,
+      prompt = "Prompt ", -- Prompt used for interactive LLM calls
     },
     chat = {
       window = {
@@ -642,9 +643,6 @@ Use Markdown formatting and include the programming language name at the start o
   -- GENERAL OPTIONS ----------------------------------------------------------
   opts = {
     log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
-
-    -- Prompt used for interactive LLM calls
-    command_prompt_prefix = "Prompt ",
 
     diff = {
       enabled = true,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -643,6 +643,9 @@ Use Markdown formatting and include the programming language name at the start o
   opts = {
     log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
 
+    -- Prompt used for interactive LLM calls
+    command_prompt_prefix = "Prompt ",
+
     diff = {
       enabled = true,
       close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -1,5 +1,4 @@
 local context_utils = require("codecompanion.utils.context")
-local dep = require("codecompanion.utils.deprecate")
 local log = require("codecompanion.utils.log")
 
 local api = vim.api

--- a/lua/codecompanion/strategies.lua
+++ b/lua/codecompanion/strategies.lua
@@ -124,7 +124,7 @@ function Strategies:chat()
         return chat(opts.user_prompt)
       end
 
-      vim.ui.input({ prompt = string.gsub(self.context.filetype, "^%l", string.upper) .. " " .. config.opts.command_prompt_prefix }, function(input)
+      vim.ui.input({ prompt = string.gsub(self.context.filetype, "^%l", string.upper) .. " " .. config.display.action_palette.prompt }, function(input)
         if not input then
           return
         end

--- a/lua/codecompanion/strategies.lua
+++ b/lua/codecompanion/strategies.lua
@@ -124,7 +124,7 @@ function Strategies:chat()
         return chat(opts.user_prompt)
       end
 
-      vim.ui.input({ prompt = string.gsub(self.context.filetype, "^%l", string.upper) .. " Prompt" }, function(input)
+      vim.ui.input({ prompt = string.gsub(self.context.filetype, "^%l", string.upper) .. " " .. config.opts.command_prompt_prefix }, function(input)
         if not input then
           return
         end

--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -198,7 +198,6 @@ function Inline:start(opts)
 
     vim.ui.input({ prompt = title .. " " .. config.opts.command_prompt_prefix }, function(input)
       if not input then
-        log:warn("No input provided")
         return
       end
 

--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -196,7 +196,7 @@ function Inline:start(opts)
       title = string.gsub(self.context.filetype, "^%l", string.upper)
     end
 
-    vim.ui.input({ prompt = title .. " " .. config.opts.command_prompt_prefix }, function(input)
+    vim.ui.input({ prompt = title .. " " .. config.display.action_palette.prompt }, function(input)
       if not input then
         return
       end

--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -196,7 +196,7 @@ function Inline:start(opts)
       title = string.gsub(self.context.filetype, "^%l", string.upper)
     end
 
-    vim.ui.input({ prompt = title .. " Prompt" }, function(input)
+    vim.ui.input({ prompt = title .. " " .. config.opts.command_prompt_prefix }, function(input)
       if not input then
         log:warn("No input provided")
         return


### PR DESCRIPTION
## Description

I don‘t use dressing for inputs so I have the problem that the input is missing a space at the end of the "Prompt" input. A solution would be to just add the space everywhere, but I think it's also fun to have the ability to customize the prompt field. I also deleted the warning for the input, mainly to stay consistent for all inputs.

## Screenshots

The current implementation doesn‘t look good if you don‘t have dressing enabled for input fields:
![image](https://github.com/user-attachments/assets/360e15e8-dde5-4b59-aff3-a78d4914f79d)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
