### PR TITLE
Fix diff provider in editor tool

### DIFF
--- a/lua/codecompanion/helpers/tools/editor.lua
+++ b/lua/codecompanion/helpers/tools/editor.lua
@@ -21,7 +21,7 @@ return {
       -- Diff the buffer
       if config.opts.diff.enabled then
         local ok
-        local provider = config.display.inline.diff.provider
+        local provider = config.opts.diff.provider
         ok, diff = pcall(require, "codecompanion.helpers.diff." .. provider)
 
         if ok then


### PR DESCRIPTION
## Description

The `config.display.inline.diff.provider` option is nil, so I guess it should be `config.opts.diff.provider`

## Screenshots

![image](https://github.com/user-attachments/assets/7091beff-6cbe-494f-a989-013b0062a1d6)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
