### PR TITLE
fix(chat): don't index an empty table

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -94,7 +94,7 @@ M.chat = function(args)
   local adapter
   local context = context_utils.get(api.nvim_get_current_buf(), args)
 
-  if args and args.fargs then
+  if args and args.fargs and #args.fargs > 0 then
     adapter = M.config.adapters[args.fargs[1]:lower()]
   end
 


### PR DESCRIPTION
## Description

With cd6ac62a82e98527850ad419ef59165197629f10, a null access happens when running `:CodeCompanionChat`:
![image](https://github.com/user-attachments/assets/951beb62-8496-49b3-94a1-176e3f0ce3c0)

This PR fixes that by making sure that `fargs` isn't empty before indexing into it.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
