### PR TITLE
feat: add mini_pick to /help command

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -65,6 +65,7 @@ return {
           description = "Insert content from help tags",
           opts = {
             contains_code = false,
+            provider = "telescope", -- telescope|mini_pick
           },
         },
         ["now"] = {

--- a/lua/codecompanion/helpers/slash_commands/help.lua
+++ b/lua/codecompanion/helpers/slash_commands/help.lua
@@ -120,7 +120,27 @@ local Providers = {
     })
   end,
 
-  ---TODO: Add the mini.pick provider
+  ---@param SlashCommand CodeCompanion.SlashCommandHelp
+  ---@return nil
+  mini_pick = function(SlashCommand)
+    local ok, mini_pick = pcall(require, "mini.pick")
+    if not ok then
+      return log:error("mini.pick is not installed")
+    end
+    mini_pick.builtin.help({}, {
+      source = {
+        name = CONSTANTS.PROMPT,
+        choose = function(item)
+          if item == nil then
+            return
+          end
+          local selection = { path = item.filename, tag = item.name }
+          output(SlashCommand, selection)
+        end,
+      },
+    })
+  end,
+
   ---TODO: The fzf-lua provider
 }
 


### PR DESCRIPTION
## Description

This pull request introduces the `mini.pick` plugin as a provider for the `/help` command.
This implementation mirrors the functionality established in the `/file` and `/buffer` commands by utilizing a similar structure and logic.

## Related Issue(s)

No issues.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.

Thank you