### PR TITLE
feature(pickers): Add telescope picker for codecompanion actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ There are keymaps available to accept or reject edits from the LLM in the [inlin
 
 <!-- panvimdoc-ignore-end -->
 
-Run `:CodeCompanionActions` or `:CodeCompanionTelescope` to open the action palette, which gives you access to all of the functionality in the plugin. This is where core actions and the [pre-defined prompts](#clipboard-pre-defined-prompts) are listed.
+Run `:CodeCompanionActions` or `:lua require('telescope').extensions.codecompanion.codecompanion()` to open the action palette, which gives you access to all of the functionality in the plugin. This is where core actions and the [pre-defined prompts](#clipboard-pre-defined-prompts) are listed.
 
 > [!NOTE]
 > Some actions and prompts will only be visible if you're in _Visual mode_.
@@ -218,8 +218,9 @@ For an optimum workflow, I recommend the following keymaps:
 ```lua
 vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
--- or vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionTelescope<cr>", { noremap = true, silent = true })
--- or vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionTelescope<cr>", { noremap = true, silent = true })
+-- or vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>:lua require('telescope').extensions.codecompanion.codecompanion()<cr>", { noremap = true, silent = true })
+-- TODO: update visual selection binding
+-- or vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>:lua require('telescope').extensions.codecompanion.codecompanion()<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("n", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "ga", "<cmd>CodeCompanionAdd<cr>", { noremap = true, silent = true })

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ There are keymaps available to accept or reject edits from the LLM in the [inlin
 
 <!-- panvimdoc-ignore-end -->
 
-Run `:CodeCompanionActions` to open the action palette, which gives you access to all of the functionality in the plugin. This is where core actions and the [pre-defined prompts](#clipboard-pre-defined-prompts) are listed.
+Run `:CodeCompanionActions` or `:CodeCompanionTelescope` to open the action palette, which gives you access to all of the functionality in the plugin. This is where core actions and the [pre-defined prompts](#clipboard-pre-defined-prompts) are listed.
 
 > [!NOTE]
 > Some actions and prompts will only be visible if you're in _Visual mode_.
@@ -207,6 +207,7 @@ Below is a list of all commands in the plugin:
 - `CodeCompanionChat <adapter>` - Open a chat buffer with a specific adapter
 - `CodeCompanionToggle` - Toggle a chat buffer
 - `CodeCompanionActions` - Open the _Action Palette_
+- `CodeCompanionTelescope` - Open the _Action Palette in telescope_
 - `CodeCompanionAdd` - Add visually selected chat to the current chat buffer
 
 **Suggested workflow**
@@ -216,6 +217,8 @@ For an optimum workflow, I recommend the following keymaps:
 ```lua
 vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
+-- or vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionTelescope<cr>", { noremap = true, silent = true })
+-- or vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionTelescope<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("n", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
 vim.api.nvim_set_keymap("v", "ga", "<cmd>CodeCompanionAdd<cr>", { noremap = true, silent = true })

--- a/doc/RECIPES.md
+++ b/doc/RECIPES.md
@@ -27,7 +27,7 @@ require("codecompanion").setup({
 })
 ```
 
-In this example, if you run `:CodeCompanionActions`, you should see "My New Prompt" in the bottom of the _Prompts_ section of the palette. Clicking on your new action will initiate the _chat_ strategy and set the value of the chat buffer based on the _role_ and _content_ that's been specified in the prompt.
+In this example, if you run `:CodeCompanionActions` or `:CodeCompanionTelescope`, you should see "My New Prompt" in the bottom of the _Prompts_ section of the palette. Clicking on your new action will initiate the _chat_ strategy and set the value of the chat buffer based on the _role_ and _content_ that's been specified in the prompt.
 
 In the following sections, we'll explore how you can customise your prompts even more.
 

--- a/doc/RECIPES.md
+++ b/doc/RECIPES.md
@@ -27,7 +27,7 @@ require("codecompanion").setup({
 })
 ```
 
-In this example, if you run `:CodeCompanionActions` or `:CodeCompanionTelescope`, you should see "My New Prompt" in the bottom of the _Prompts_ section of the palette. Clicking on your new action will initiate the _chat_ strategy and set the value of the chat buffer based on the _role_ and _content_ that's been specified in the prompt.
+In this example, if you run `:CodeCompanionActions` or `:lua require('telescope').extensions.codecompanion.codecompanion()`, you should see "My New Prompt" in the bottom of the _Prompts_ section of the palette. Clicking on your new action will initiate the _chat_ strategy and set the value of the chat buffer based on the _role_ and _content_ that's been specified in the prompt.
 
 In the following sections, we'll explore how you can customise your prompts even more.
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -161,7 +161,7 @@ There are keymaps available to accept or reject edits from the LLM in the
 
 **Action Palette**
 
-Run `:CodeCompanionActions` to open the action palette, which gives you access
+Run `:CodeCompanionActions` or `:CodeCompanionTelescope` to open the action palette, which gives you access
 to all of the functionality in the plugin. This is where core actions and the
 |codecompanion-pre-defined-prompts| are listed.
 
@@ -187,6 +187,7 @@ For an optimum workflow, I recommend the following keymaps:
 
 >lua
     vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
+    -- or: vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionTelescope<cr>", { noremap = true, silent = true })
     vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
     vim.api.nvim_set_keymap("n", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
     vim.api.nvim_set_keymap("v", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -188,7 +188,7 @@ For an optimum workflow, I recommend the following keymaps:
 
 >lua
     vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
-    -- or: vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>CodeCompanionTelescope<cr>", { noremap = true, silent = true })
+    -- or: vim.api.nvim_set_keymap("n", "<C-a>", "<cmd>lua require('telescope').extensions.codecompanion.codecompanion()<cr>", { noremap = true, silent = true })
     vim.api.nvim_set_keymap("v", "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
     vim.api.nvim_set_keymap("n", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })
     vim.api.nvim_set_keymap("v", "<LocalLeader>a", "<cmd>CodeCompanionToggle<cr>", { noremap = true, silent = true })

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -92,4 +92,11 @@ return {
     end,
     opts = { desc = "Add the current selection to a chat buffer", range = true },
   },
+  {
+    cmd = "CodeCompanionTelescope",
+    callback = function(opts)
+      require("telescope").extensions.codecompanion.codecompanion()
+    end,
+    opts = { desc = "Select a codecompanion action with telescope" },
+  },
 }

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -92,11 +92,4 @@ return {
     end,
     opts = { desc = "Add the current selection to a chat buffer", range = true },
   },
-  {
-    cmd = "CodeCompanionTelescope",
-    callback = function(opts)
-      require("telescope").extensions.codecompanion.codecompanion()
-    end,
-    opts = { desc = "Select a codecompanion action with telescope" },
-  },
 }

--- a/lua/telescope/_extensions/codecompanion.lua
+++ b/lua/telescope/_extensions/codecompanion.lua
@@ -1,0 +1,79 @@
+local actions_palette = require("codecompanion.actions")
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local conf = require("telescope.config").values
+local action_state = require("telescope.actions.state")
+local telescope_actions = require("telescope.actions")
+
+local cached_opts = {}
+
+local function execute_action(selected, context)
+  if selected.callback then
+    selected.callback(context)
+  elseif selected.strategy then
+    local Strategy = require("codecompanion.strategies")
+    Strategy.new({
+      context = context,
+      selected = selected,
+    }):start(selected.strategy)
+  end
+end
+
+local function actions_palette_selector(items, opts, callback, context)
+  context = context or require("codecompanion.utils.context").get(vim.api.nvim_get_current_buf())
+  opts = vim.tbl_deep_extend("keep", opts or {}, cached_opts)
+
+  pickers
+    .new(opts, {
+      prompt_title = opts.prompt or "CodeCompanion Actions",
+      finder = finders.new_table({
+        results = items,
+        entry_maker = function(entry)
+          return {
+            value = entry,
+            display = entry.name,
+            ordinal = entry.name,
+          }
+        end,
+      }),
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function(prompt_bufnr, map)
+        telescope_actions.select_default:replace(function()
+          local selection = action_state.get_selected_entry()
+          local selected = selection.value
+          telescope_actions.close(prompt_bufnr)
+
+          if selected.picker then
+            local picker_items = selected.picker.items
+            if type(picker_items) == "function" then
+              picker_items = picker_items(context)
+            end
+            local picker_opts = vim.tbl_deep_extend("keep", {
+              prompt = selected.picker.prompt,
+            }, opts)
+            actions_palette_selector(picker_items, picker_opts, callback, context)
+          else
+            if callback then
+              callback(selected)
+            else
+              execute_action(selected, context)
+            end
+          end
+        end)
+        return true
+      end,
+    })
+    :find()
+end
+
+local function codecompanion(opts)
+  cached_opts = opts or {}
+  local context = require("codecompanion.utils.context").get(vim.api.nvim_get_current_buf())
+  actions_palette_selector(actions_palette.static.actions, cached_opts, nil, context)
+end
+
+return require("telescope").register_extension({
+  exports = {
+    codecompanion = codecompanion,
+  },
+})


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  As described here: https://github.com/olimorris/codecompanion.nvim/discussions/248 -- I would prefer the ability to configure the layout of the telescope picker, which cant be done currently. The current implementation seems to use vim.ui.select which I've overriden with Telescope using dressing.nvim. 
  
If we create a telescope picker and export it as an extension, you can pass opts directly to the picker and configure the layout/bindings etc.

My default telescope layout takes up most of the screen, but for pickers with not many options like codecompanion actions, I want to reduce the size.

## Related Issue(s)
https://github.com/olimorris/codecompanion.nvim/discussions/248

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
![image](https://github.com/user-attachments/assets/189e2233-9261-4d30-ab7b-ce97c1662584)

As you can see the layout is now as I wanted when compared to the discussion above, using:

```lua
local small_no_preview = {
  layout_strategy = "vertical",
  previewer = false,
  layout_config = {
    vertical = {
      size = {
        height = "40%",
        width = "40%",
      },
    },
  },
}
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
