### PR TITLE
fix!(copilot): data parsing when stream is false

### DIFF
--- a/doc/ADAPTERS.md
+++ b/doc/ADAPTERS.md
@@ -205,7 +205,7 @@ The first thing to note with streaming endpoints is that they don't return valid
 
 ```lua
 handlers = {
-  chat_output = function(data)
+  chat_output = function(self, data)
     data = data:sub(7)
   end
 }
@@ -218,7 +218,7 @@ We can then decode the JSON using native vim functions:
 
 ```lua
 handlers = {
-  chat_output = function(data)
+  chat_output = function(self, data)
     data = data:sub(7)
     local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
   end
@@ -231,7 +231,7 @@ Examining the output of the API, we see that the streamed data is stored in a `c
 
 ```lua
 handlers = {
-  chat_output = function(data)
+  chat_output = function(self, data)
     ---
     local delta = json.choices[1].delta
   end
@@ -242,7 +242,7 @@ and we can then access the new streamed data that we want to write into the chat
 
 ```lua
 handlers = {
-  chat_output = function(data)
+  chat_output = function(self, data)
     local output = {}
     ---
     local delta = json.choices[1].delta
@@ -259,7 +259,7 @@ And then we can return the output in the following format:
 
 ```lua
 handlers = {
-  chat_output = function(data)
+  chat_output = function(self, data)
     --
     return {
       status = "success",
@@ -273,7 +273,7 @@ Now if we put it all together, and put some checks in place to make sure that we
 
 ```lua
 handlers = {
-  chat_output = function(data)
+  chat_output = function(self, data)
     local output = {}
 
     if data and data ~= "" then
@@ -316,10 +316,11 @@ In the case of OpenAI, once we've checked the data we have back from the LLM and
 
 ```lua
 ---Output the data from the API ready for inlining into the current buffer
+---@param self CodeCompanion.Adapter
 ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
 ---@param context table Useful context about the buffer to inline to
 ---@return string|table|nil
-inline_output = function(data, context)
+inline_output = function(self, data, context)
   -- Data cleansed, parsed and validated
   -- ..
   local content = json.choices[1].delta.content

--- a/doc/codecompanion-adapters.txt
+++ b/doc/codecompanion-adapters.txt
@@ -195,7 +195,7 @@ The chat buffer, which is structured like:
 
 >markdown
     ## Me
-    
+
     Explain Ruby in two words
 <
 
@@ -259,7 +259,7 @@ remove it:
 
 >lua
     handlers = {
-      chat_output = function(data)
+      chat_output = function(self, data)
         data = data:sub(7)
       end
     }
@@ -272,7 +272,7 @@ We can then decode the JSON using native vim functions:
 
 >lua
     handlers = {
-      chat_output = function(data)
+      chat_output = function(self, data)
         data = data:sub(7)
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
       end
@@ -286,7 +286,7 @@ Examining the output of the API, we see that the streamed data is stored in a
 
 >lua
     handlers = {
-      chat_output = function(data)
+      chat_output = function(self, data)
         ---
         local delta = json.choices[1].delta
       end
@@ -298,11 +298,11 @@ chat buffer, with:
 
 >lua
     handlers = {
-      chat_output = function(data)
+      chat_output = function(self, data)
         local output = {}
         ---
         local delta = json.choices[1].delta
-    
+
         if delta.content then
           output.content = delta.content
           output.role = delta.role or nil
@@ -315,7 +315,7 @@ And then we can return the output in the following format:
 
 >lua
     handlers = {
-      chat_output = function(data)
+      chat_output = function(self, data)
         --
         return {
           status = "success",
@@ -330,19 +330,19 @@ we have data in our response:
 
 >lua
     handlers = {
-      chat_output = function(data)
+      chat_output = function(self, data)
         local output = {}
-    
+
         if data and data ~= "" then
           data = data:sub(7)
           local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
-    
+
           local delta = json.choices[1].delta
-    
+
           if delta.content then
             output.content = delta.content
             output.role = delta.role or nil
-    
+
             return {
               status = "success",
               output = output,
@@ -379,10 +379,11 @@ and parsed it as JSON, we simply need to:
 
 >lua
     ---Output the data from the API ready for inlining into the current buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
     ---@param context table Useful context about the buffer to inline to
     ---@return string|table|nil
-    inline_output = function(data, context)
+    inline_output = function(self, data, context)
       -- Data cleansed, parsed and validated
       -- ..
       local content = json.choices[1].delta.content
@@ -424,7 +425,7 @@ handler:
     ---@return nil
     on_stdout = function(self, data)
       local stdout = table.concat(data._stdout_results)
-    
+
       local ok, json = pcall(vim.json.decode, stdout, { luanil = { object = true } })
       if ok then
         if json.error then

--- a/lua/codecompanion/adapters.lua
+++ b/lua/codecompanion/adapters.lua
@@ -108,8 +108,8 @@ local Adapter = {}
 ---@field handlers.setup? fun(self: CodeCompanion.Adapter): boolean
 ---@field handlers.form_parameters fun(self: CodeCompanion.Adapter, params: table, messages: table): table
 ---@field handlers.form_messages fun(self: CodeCompanion.Adapter, messages: table): table
----@field handlers.tokens? fun(data: table): number|nil
----@field handlers.chat_output fun(data: table): table|nil
+---@field handlers.tokens? fun(self: CodeCompanion.Adapter, data: table): number|nil
+---@field handlers.chat_output fun(self: CodeCompanion.Adapter, data: table): table|nil
 ---@field handlers.inline_output fun(self: CodeCompanion.Adapter, data: table, context: table): table|nil
 ---@field handlers.on_stdout fun(self: CodeCompanion.Adapter, data: table): table|nil
 ---@field handlers.teardown? fun(self: CodeCompanion.Adapter): any

--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -106,9 +106,10 @@ return {
     end,
 
     ---Returns the number of tokens generated from the LLM
+    ---@param self CodeCompanion.Adapter
     ---@param data string The data from the LLM
     ---@return number|nil
-    tokens = function(data)
+    tokens = function(self, data)
       if data then
         data = data:sub(6)
         local ok, json = pcall(vim.fn.json_decode, data)
@@ -126,9 +127,10 @@ return {
     end,
 
     ---Output the data from the API ready for insertion into the chat buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data string The streamed JSON data from the API, also formatted by the format_data handler
     ---@return table|nil
-    chat_output = function(data)
+    chat_output = function(self, data)
       local output = {}
 
       -- Skip the event messages
@@ -158,10 +160,11 @@ return {
     end,
 
     ---Output the data from the API ready for inlining into the current buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
     ---@param context table Useful context about the buffer to inline to
     ---@return table|nil
-    inline_output = function(data, context)
+    inline_output = function(self, data, context)
       if type(data) == "string" and string.sub(data, 1, 6) == "event:" then
         return
       end

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -155,11 +155,11 @@ return {
     form_messages = function(self, messages)
       return openai.handlers.form_messages(self, messages)
     end,
-    chat_output = function(data)
-      return openai.handlers.chat_output(data)
+    chat_output = function(self, data)
+      return openai.handlers.chat_output(self, data)
     end,
-    inline_output = function(data, context)
-      return openai.handlers.inline_output(data, context)
+    inline_output = function(self, data, context)
+      return openai.handlers.inline_output(self, data, context)
     end,
     on_stdout = function(self, data)
       return openai.handlers.on_stdout(self, data)

--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -75,9 +75,10 @@ return {
     end,
 
     ---Returns the number of tokens generated from the LLM
+    ---@param self CodeCompanion.Adapter
     ---@param data string The data from the LLM
     ---@return number|nil
-    tokens = function(data)
+    tokens = function(self, data)
       if data and data ~= "" then
         data = data:sub(6)
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
@@ -89,9 +90,10 @@ return {
     end,
 
     ---Output the data from the API ready for insertion into the chat buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data string The streamed JSON data from the API, also formatted by the format_data handler
     ---@return table|nil
-    chat_output = function(data)
+    chat_output = function(self, data)
       local output = {}
 
       if data and data ~= "" then
@@ -111,10 +113,11 @@ return {
     end,
 
     ---Output the data from the API ready for inlining into the current buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
     ---@param context table Useful context about the buffer to inline to
     ---@return table|nil
-    inline_output = function(data, context)
+    inline_output = function(self, data, context)
       if data and data ~= "" then
         data = data:sub(6)
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })

--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -92,9 +92,10 @@ return {
     end,
 
     ---Returns the number of tokens generated from the LLM
+    ---@param self CodeCompanion.Adapter
     ---@param data table The data from the LLM
     ---@return number|nil
-    tokens = function(data)
+    tokens = function(self, data)
       if data then
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
 
@@ -110,9 +111,10 @@ return {
     end,
 
     ---Output the data from the API ready for insertion into the chat buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data callback
     ---@return table|nil
-    chat_output = function(data)
+    chat_output = function(self, data)
       local output = {}
 
       if data and data ~= "" then
@@ -144,10 +146,11 @@ return {
     end,
 
     ---Output the data from the API ready for inlining into the current buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
     ---@param context table Useful context about the buffer to inline to
     ---@return table|nil
-    inline_output = function(data, context)
+    inline_output = function(self, data, context)
       if data and data ~= "" then
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
 

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -49,9 +49,10 @@ return {
     end,
 
     ---Returns the number of tokens generated from the LLM
+    ---@param self CodeCompanion.Adapter
     ---@param data table The data from the LLM
     ---@return number|nil
-    tokens = function(data)
+    tokens = function(self, data)
       if data and data ~= "" then
         local data_mod = data:sub(7)
         local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
@@ -67,9 +68,10 @@ return {
     end,
 
     ---Output the data from the API ready for insertion into the chat buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
     ---@return table|nil [status: string, output: table]
-    chat_output = function(data)
+    chat_output = function(self, data)
       local output = {}
 
       if data and data ~= "" then
@@ -95,10 +97,11 @@ return {
     end,
 
     ---Output the data from the API ready for inlining into the current buffer
+    ---@param self CodeCompanion.Adapter
     ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
     ---@param context table Useful context about the buffer to inline to
     ---@return string|table|nil
-    inline_output = function(data, context)
+    inline_output = function(self, data, context)
       if data and data ~= "" then
         data = data:sub(7)
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -54,7 +54,7 @@ return {
     ---@return number|nil
     tokens = function(self, data)
       if data and data ~= "" then
-        local data_mod = data:sub(7)
+        local data_mod = self.parameters.stream and data:sub(7) or data
         local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
 
         if ok then
@@ -75,12 +75,13 @@ return {
       local output = {}
 
       if data and data ~= "" then
-        local data_mod = data:sub(7)
+        local data_mod = self.parameters.stream and data:sub(7) or data
         local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
 
         if ok then
           if #json.choices > 0 then
-            local delta = json.choices[1].delta
+            local choice = json.choices[1]
+            local delta = self.parameters.stream and choice.delta or choice.message
 
             if delta.content then
               output.content = delta.content
@@ -103,7 +104,7 @@ return {
     ---@return string|table|nil
     inline_output = function(self, data, context)
       if data and data ~= "" then
-        data = data:sub(7)
+        data = self.parameters.stream and data:sub(7) or data
         local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
 
         if ok then
@@ -112,9 +113,10 @@ return {
             return
           end
 
-          local content = json.choices[1].delta.content
-          if content then
-            return content
+          local choice = json.choices[1]
+          local delta = self.parameters.stream and choice.delta or choice.message
+          if delta.content then
+            return delta.content
           end
         end
       end

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -787,7 +787,7 @@ function Chat:submit(opts)
       if data then
         self:get_tokens(data)
 
-        local result = self.adapter.handlers.chat_output(data)
+        local result = self.adapter.handlers.chat_output(self.adapter, data)
         if result and result.status == CONSTANTS.STATUS_SUCCESS then
           if result.output.role then
             result.output.role = CONSTANTS.LLM_ROLE
@@ -1011,7 +1011,7 @@ end
 ---@return nil
 function Chat:get_tokens(data)
   if self.adapter.features.tokens then
-    local tokens = self.adapter.handlers.tokens(data)
+    local tokens = self.adapter.handlers.tokens(self.adapter, data)
     if tokens then
       self.tokens = tokens
     end

--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -262,7 +262,7 @@ function Inline:classify(user_input)
 
         if data then
           self.classification.placement = self.classification.placement
-            .. (self.adapter.handlers.inline_output(data) or "")
+            .. (self.adapter.handlers.inline_output(self.adapter, data) or "")
         end
       end,
       nil,
@@ -360,7 +360,7 @@ function Inline:submit()
       end
 
       if data then
-        local content = self.adapter.handlers.inline_output(data, self.context)
+        local content = self.adapter.handlers.inline_output(self.adapter, data, self.context)
 
         if content then
           vim.schedule(function()

--- a/lua/spec/codecompanion/adapters/helpers.lua
+++ b/lua/spec/codecompanion/adapters/helpers.lua
@@ -4,7 +4,7 @@ function M.chat_buffer_output(stream_response, adapter)
   local output = {}
 
   for _, data in ipairs(stream_response) do
-    output = adapter.handlers.chat_output(data.request)
+    output = adapter.handlers.chat_output(adapter, data.request)
   end
 
   return output.output


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Update openai adapter data parsing (also used by copilot) when stream is set to false.

When stream is set to false the format do not start with `data: ` and message content is in `json.choices[1].message.content` (see #261 log output for the format)

## Related Issue(s)

- Fixes #261

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
