### PR TITLE
feat: add mini pick to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ There are keymaps available to accept or reject edits from the LLM in the [inlin
 
 <!-- panvimdoc-ignore-end -->
 
-Run `:CodeCompanionActions` to open the action palette, which gives you access to all functionality of the plugin. By default the plugin uses `vim.ui.select` however you can change the provider by altering the `display.action_palette.provider` config value. You can also map `:Telescope codecompanion` to load the Telescope extension, as per the suggested workflow below.
+Run `:CodeCompanionActions` to open the action palette, which gives you access to all functionality of the plugin. By default the plugin uses `vim.ui.select` however you can change the provider by altering the `display.action_palette.provider` config value to be `telescope` or `mini_pick`. You can also map `:Telescope codecompanion` to load the Telescope extension, as per the suggested workflow below.
 
 > [!NOTE]
 > Some actions and prompts will only be visible if you're in _Visual mode_.

--- a/lua/codecompanion/actions/providers/mini_pick.lua
+++ b/lua/codecompanion/actions/providers/mini_pick.lua
@@ -1,0 +1,73 @@
+local MiniPick = require("mini.pick")
+local config = require("codecompanion").config
+local log = require("codecompanion.utils.log")
+
+---@class CodeCompanion.Actions.Providers.MiniPick
+---@field validate table Validate an item
+---@field resolve table Resolve an item into an action
+---@field context table Store all arguments in this table
+local Provider = {}
+
+---@class CodeCompanion.Actions.Providers.MiniPick.Args Arguments that can be injected into the chat
+---@field validate table Validate an item
+---@field resolve table Resolve an item into an action
+---@field context table The buffer context
+function Provider.new(args)
+  log:trace("MiniPick actions provider triggered")
+  return setmetatable(args, { __index = Provider })
+end
+
+---The MiniPick picker
+---@param items table The items to display in the picker
+---@param opts? table The options for the picker
+---@return nil
+function Provider:picker(items, opts)
+  opts = opts or {}
+
+  local source = {
+    items = items,
+    name = opts.prompt or "CodeCompanion actions",
+    choose = function(chosen_item)
+      self:select(chosen_item)
+    end,
+    show = function(buf_id, items_to_show, query)
+      local formatted_items = {}
+      for _, item in ipairs(items_to_show) do
+        local description = item.description and " - " .. item.description or ""
+        table.insert(formatted_items, { text = string.format("%s%s", item.name, description) })
+      end
+      MiniPick.default_show(buf_id, formatted_items, query)
+    end,
+  }
+
+  local pick_opts = {
+    window = {
+      config = function()
+        local height = math.floor(0.618 * vim.o.lines)
+        local width = math.floor(0.618 * vim.o.columns)
+        return {
+          border = "rounded",
+          anchor = "NW",
+          height = height,
+          width = width,
+          row = math.floor(0.5 * (vim.o.lines - height)),
+          col = math.floor(0.5 * (vim.o.columns - width)),
+        }
+      end,
+    },
+  }
+
+  MiniPick.start({
+    source = source,
+    options = pick_opts,
+  })
+end
+
+---The action to take when an item is selected
+---@param item table The selected item
+---@return nil
+function Provider:select(item)
+  return require("codecompanion.actions.providers.shared").select(self, item)
+end
+
+return Provider


### PR DESCRIPTION
## Description

This pull request introduces the `mini.pick` plugin as a provider for the `CodeCompanionActions` command, aligning with the Telescope integration in v4 (#260).

**Note:** The only issue with this implementation is that after selecting an item, the cursor remains in the current buffer instead of jumping to the chat buffer. I attempted several fixes without success, so it might need revisiting. However, it's not a major concern and could be addressed later by me or someone else.

Thank you!

## Related Issue(s)

No issues

## Screenshots

<img width="1661" alt="Screenshot 2024-09-29 at 10 09 30 PM" src="https://github.com/user-attachments/assets/c9f55cc3-0c97-421d-b820-f3147766cc4a">

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
