### PR TITLE
feat(prompt_library): add picker field to prompt resolution #274

### DIFF
--- a/lua/codecompanion/actions/prompt_library.lua
+++ b/lua/codecompanion/actions/prompt_library.lua
@@ -44,6 +44,7 @@ function M.resolve(context, config)
       description = description,
       opts = prompt.opts,
       prompts = prompt.prompts,
+      picker = prompt.picker,
     })
 
     ::continue::


### PR DESCRIPTION
This commit introduces the `picker` field to the prompt resolution process in the `prompt_library.lua` file.

## Description

Resolve issue when using custom prompt with picker

## Related Issue(s)

  - Fixes #274 

## Screenshots

Error executing vim.schedule lua callback: ...decompanion.nvim/lua/codecompanion/strategies/inline.lua:404: bad argument #1 to 'ipairs' (table expe
cted, got nil)
stack traceback:
        [C]: in function 'ipairs'
        ...decompanion.nvim/lua/codecompanion/strategies/inline.lua:404: in function 'form_prompt'
        ...decompanion.nvim/lua/codecompanion/strategies/inline.lua:226: in function 'cb'
        ...ocal/share/nvim/lazy/dressing.nvim/lua/dressing/util.lua:206: in function <...ocal/share/nvim/lazy/dressing.nvim/lua/dressing/util.lua:2
02>

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
