### PR TITLE
fix: prompt library conditionals

### DIFF
--- a/lua/codecompanion/actions/prompt_library.lua
+++ b/lua/codecompanion/actions/prompt_library.lua
@@ -39,6 +39,7 @@ function M.resolve(context, config)
     end
 
     table.insert(_prompts, {
+      condition = prompt.condition,
       description = description,
       name = name,
       opts = prompt.opts,

--- a/lua/codecompanion/actions/prompt_library.lua
+++ b/lua/codecompanion/actions/prompt_library.lua
@@ -39,12 +39,12 @@ function M.resolve(context, config)
     end
 
     table.insert(_prompts, {
-      name = name,
-      strategy = prompt.strategy,
       description = description,
+      name = name,
       opts = prompt.opts,
-      prompts = prompt.prompts,
       picker = prompt.picker,
+      prompts = prompt.prompts,
+      strategy = prompt.strategy,
     })
 
     ::continue::


### PR DESCRIPTION
## Description

This PR fixes the issue with `condition` fields in the `prompt_library` option. The `resolve` function does not carry over the setting, and it is therefor not used.

I also sorted the fields, just for improve readability and maintainability.

#### Key Changes
- Reordered fields in the table inserted into `_prompts`:
  - Added `condition` field.
  - Moved `name` field after `description`.
  - Moved `strategy` field to the end.

## Related Issue(s)

- Fixes https://github.com/olimorris/codecompanion.nvim/issues/268

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
