### PR TITLE
make lazy.vim instructions more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Install the plugin with your preferred package manager:
   config = true
 }
 
--- plugins/telescope.lua:
+-- plugins/codecompanion.lua:
 return {
   "olimorris/codecompanion.nvim",
   dependencies = {

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Install the plugin with your preferred package manager:
 **[Lazy.nvim](https://github.com/folke/lazy.nvim)**
 
 ```lua
-{
+
+-- init.lua:
+    {
   "olimorris/codecompanion.nvim",
   dependencies = {
     "nvim-lua/plenary.nvim",
@@ -70,6 +72,20 @@ Install the plugin with your preferred package manager:
   },
   config = true
 }
+
+-- plugins/telescope.lua:
+return {
+  "olimorris/codecompanion.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-treesitter/nvim-treesitter",
+    "hrsh7th/nvim-cmp", -- Optional: For using slash commands and variables in the chat buffer
+    "nvim-telescope/telescope.nvim", -- Optional: For using slash commands
+    { "stevearc/dressing.nvim", opts = {} }, -- Optional: Improves `vim.ui.select`
+  },
+  config = true
+}
+
 ```
 
 **[Packer](https://github.com/wbthomason/packer.nvim)**


### PR DESCRIPTION
confused me when i tried to install, since lazy recommends structured config and the config in the readme showed for the older single file config

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
