### PR TITLE
Fix type for prompt()

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -41,7 +41,7 @@ end
 
 ---Run a prompt from the prompt library
 ---@param name string
----@param args table
+---@param args table?
 ---@return nil
 M.prompt = function(name, args)
   local context = context_utils.get(api.nvim_get_current_buf(), args)


### PR DESCRIPTION
## Description
The call to `context_utils.get(..)` marks `args` as optional.

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
