### PR TITLE
Use default diff in `/commit` command

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -663,7 +663,7 @@ This is the code, for context:
 %s
 ```
 ]],
-              vim.fn.system("git diff --staged")
+              vim.fn.system("git diff --no-ext-diff --staged")
             )
           end,
           opts = {


### PR DESCRIPTION
## Description

Always using the default diff is more stable, users who want to use another diff program can create a new slash command.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
