### PR TITLE
Add undojoin for inline inserts

### DIFF
--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -364,6 +364,7 @@ function Inline:submit()
 
         if content then
           vim.schedule(function()
+            vim.cmd.undojoin()
             self:append_to_buf(content)
             if self.classification.placement == "new" and api.nvim_get_current_buf() == bufnr then
               ui.buf_scroll_to_end(bufnr)


### PR DESCRIPTION
## Description

The edits were inserted in a streaming way, polluting the insert history. 

@olimorris this has the assumption that `overwrite_selection(self.context)` is called before inserting, so the first insert is combined with the deletion.
If this is not the case, it is merged with the last edit the user made, which would be bad.


## Related Issue(s)

[nvim/discussions/325#discussioncomment-10990915)](https://github.com/olimorris/codecompanion.nvim/discussions/325#discussioncomment-10990915)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
