### PR TITLE
chore: update latest sonnet-3-5 version (claude-3-5-sonnet-20241022)

### DIFF
--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -200,9 +200,9 @@ return {
       mapping = "parameters",
       type = "enum",
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
-      default = "claude-3-5-sonnet-20240620",
+      default = "claude-3-5-sonnet-20241022",
       choices = {
-        "claude-3-5-sonnet-20240620",
+        "claude-3-5-sonnet-20241022",
         "claude-3-opus-20240229",
         "claude-3-haiku-20240307",
         "claude-2.1",


### PR DESCRIPTION
## Description

Anthropic released an updated sonnet 3.5 model version `claude-3-5-sonnet-20241022`

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
