### PR TITLE
fix(diff): diff split window wrongly opened in chat window

### DIFF
--- a/lua/codecompanion/helpers/diff/default.lua
+++ b/lua/codecompanion/helpers/diff/default.lua
@@ -51,14 +51,18 @@ function Diff.new(args)
   end
 
   -- Create the diff buffer
-  if config.display.diff.layout == "vertical" then
-    vim.cmd("vsplit")
-  else
-    vim.cmd("split")
-  end
+  -- Use `nvim_win_call()` to ensure that the split is opened
+  -- beside the source window
+  vim.api.nvim_win_call(self.winnr, function()
+    if config.display.diff.layout == "vertical" then
+      vim.cmd("vsplit")
+    else
+      vim.cmd("split")
+    end
+    self.bufnr_diff = api.nvim_create_buf(false, true)
+    self.winnr_diff = api.nvim_get_current_win()
+  end)
 
-  self.bufnr_diff = api.nvim_create_buf(false, true)
-  self.winnr_diff = api.nvim_get_current_win()
   api.nvim_win_set_buf(self.winnr_diff, self.bufnr_diff)
   api.nvim_set_option_value("filetype", self.filetype, { buf = self.bufnr_diff })
   api.nvim_set_option_value("wrap", wrap, { win = self.winnr_diff })


### PR DESCRIPTION
## Description

This patch fixes the issue that the diff split is opened in chat window instead of the source window when the diff layout is "horizontal" and the chat window layout is "vertical".

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

N/A

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

Before (diff split window opened in chat window):

![Screenshot_20241024_025911](https://github.com/user-attachments/assets/845ee282-45d0-48dd-bd61-f34386661348)

After (diff split window opened below source window):

![Screenshot_20241024_030027](https://github.com/user-attachments/assets/114d3fbc-ff81-4fb6-b2b5-9fecad4590cd)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
