### PR TITLE
feat(keymaps): `yank_code` copy focused or the last codeblock.

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -239,6 +239,7 @@ local defaults = {
       },
       opts = {
         register = "+", -- The register to use for yanking code
+        yank_jump_delay_ms = 400, -- Delay in milliseconds before jumping back from the yanked code
       },
     },
     -- INLINE STRATEGY --------------------------------------------------------


### PR DESCRIPTION
## Description
Thank you for the amazing plugin, I love it! Works amazing with the claude for me. 

I wanted to make a small improvement to the `yank code` functionality:

When cursor is inside the code block `yank code` keymap would copy focused codeblock instead of the last one. 
When user wants to copy the last one they would easily jump out of the current code block and press `gy` to copy the last codeblock.

We can also make this addition opt in or opt out in the config. 

Personally I also use `vim.highlight.on_yank`, and it is a bit sad that this is not working with the `yank code` function. 
What do you think about actually jumping to the codeblock, and yanking it with the build in vim yank instead of `vim.fn.setreg` ?

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.

Decided not to open a discussion since this this a very small change and I'll spend more time opening a discussion rather than implementing it. 
