### PR TITLE
fix(editor,config): use actual line breaks for new lines to avoid '\n…

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -833,6 +833,8 @@ You must:
 - Avoid line numbers in code blocks.
 - Avoid wrapping the whole response in triple backticks.
 - Only return code that's relevant to the task at hand. You may not need to return all of the code that the user has shared.
+- Use actual line breaks instead of '\n' in your response to begin new lines.
+- Use '\n' only when you want a literal backslash followed by a character 'n'.
 
 When given a task:
 1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.

--- a/lua/codecompanion/helpers/tools/editor.lua
+++ b/lua/codecompanion/helpers/tools/editor.lua
@@ -8,17 +8,6 @@ local xml2lua = require("codecompanion.utils.xml.xml2lua")
 
 local api = vim.api
 
----Sometimes the LLM will insert new lines as `\n` which are then escaped by
----the XML library. This function unescapes them
----@param str string
----@return string
-local function unescape_breaks(str)
-  if not str then
-    return str
-  end
-  return str:gsub("\\n", "\n")
-end
-
 -- To keep track of the changes made to the buffer, we store them in this table
 local deltas = {}
 local function add_delta(bufnr, line, delta)
@@ -39,7 +28,7 @@ local function add(bufnr, action)
   local start_line = tonumber(action.line)
   local delta = intersect(bufnr, start_line)
 
-  local lines = vim.split(unescape_breaks(action.code), "\n", { plain = true, trimempty = false })
+  local lines = vim.split(action.code, "\n", { plain = true, trimempty = false })
   api.nvim_buf_set_lines(bufnr, start_line + delta - 1, start_line + delta - 1, false, lines)
 
   add_delta(bufnr, start_line, tonumber(#lines))


### PR DESCRIPTION
…' substitution trick (#362)

## Description

Fix #362. Turns out that we just need to tell LLM to use actual linebreaks in the response and remove the string replacement trick.

## Related Issue(s)

#362 

## Screenshots

Before:

![Screenshot_20241025_014606](https://github.com/user-attachments/assets/a4283eb4-67a7-4851-a7de-229490d5fe7e)

After:

![Screenshot_20241025_014636](https://github.com/user-attachments/assets/58f6e989-8c4f-4d67-a657-7635fd75e786)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
