### PR TITLE
feat(adapters): ✨ add Azure OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-Currently supports: Anthropic, Copilot, Gemini, Ollama, OpenAI and xAI adapters<br><br>
+Currently supports: Anthropic, Copilot, Gemini, Ollama, OpenAI, Azure OpenAI and xAI adapters<br><br>
 New features are always announced <a href="https://github.com/olimorris/codecompanion.nvim/discussions/categories/announcements">here</a>
 </p>
 
@@ -28,7 +28,7 @@ Thank you to the following people:
 ## :sparkles: Features
 
 - :speech_balloon: [Copilot Chat](https://github.com/features/copilot) meets [Zed AI](https://zed.dev/blog/zed-ai), in Neovim
-- :electric_plug: Support for Anthropic, Copilot, Gemini, Ollama, OpenAI and xAI LLMs (or bring your own!)
+- :electric_plug: Support for Anthropic, Copilot, Gemini, Ollama, OpenAI, Azure OpenAI and xAI LLMs (or bring your own!)
 - :rocket: Inline transformations, code creation and refactoring
 - :robot: Variables, Slash Commands, Agents/Tools and Workflows to improve LLM output
 - :sparkles: Built in prompt library for common tasks like advice on LSP errors and code explanations
@@ -262,6 +262,7 @@ The plugin uses adapters to connect to LLMs. Out of the box, the plugin supports
 - Gemini (`gemini`) - Requires an API key
 - Ollama (`ollama`) - Both local and remotely hosted
 - OpenAI (`openai`) - Requires an API key
+- Azure OpenAI (`azure_openai`) - Requires an Azure OpenAI service with a model deployment
 - xAI (`xai`) - Requires an API key
 
 The plugin utilises objects called Strategies. These are the different ways that a user can interact with the plugin. The _chat_ strategy harnesses a buffer to allow direct conversation with the LLM. The _inline_ strategy allows for output from the LLM to be written directly into a pre-existing Neovim buffer. The _agent_ and _workflow_ strategies are wrappers for the _chat_ strategy, allowing for [tool use](#robot-agents--tools) and [agentic workflows](#world_map-agentic-workflows).
@@ -419,6 +420,42 @@ require("codecompanion").setup({
           url = "http[s]://open_compatible_ai_url", -- optional: default value is ollama url http://127.0.0.1:11434
           api_key = "OpenAI_API_KEY", -- optional: if your endpoint is authenticated
           chat_url = "/v1/chat/completions", -- optional: default value, override if different
+        },
+      })
+    end,
+  },
+})
+```
+
+**Using Azure OpenAI**
+
+To use Azure OpenAI, you need to have an Azure OpenAI service, an API key, and a model deployment. Follow these steps to configure the adapter:
+
+1. Create an Azure OpenAI service in your Azure portal.
+2. Deploy a model in the Azure OpenAI service.
+3. Obtain the API key from the Azure portal.
+
+Then, configure the adapter in your setup as follows:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      adapter = "azure_openai",
+    },
+    inline = {
+      adapter = "azure_openai",
+    },
+  },
+  adapters = {
+    azure_openai = function()
+      return require("codecompanion.adapters").extend("azure_openai", {
+        env = {
+          api_key = 'YOUR_AZURE_OPENAI_API_KEY',
+          endpoint = 'YOUR_AZURE_OPENAI_ENDPOINT',
+        },
+        schema = {
+          model = "YOUR_DEPLOYMENT_NAME",
         },
       })
     end,

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -15,7 +15,7 @@ Table of Contents                            *codecompanion-table-of-contents*
 FEATURES                                              *codecompanion-features*
 
 - Copilot Chat <https://github.com/features/copilot> meets Zed AI <https://zed.dev/blog/zed-ai>, in Neovim
-- Support for Anthropic, Copilot, Gemini, Ollama, OpenAI and xAI LLMs (or bring your own!)
+- Support for Anthropic, Copilot, Gemini, Ollama, OpenAI, Azure OpenAI and xAI LLMs (or bring your own!)
 - Inline transformations, code creation and refactoring
 - Variables, Slash Commands, Agents/Tools and Workflows to improve LLM output
 - Built in prompt library for common tasks like advice on LSP errors and code explanations
@@ -241,6 +241,7 @@ supports:
 - Gemini (`gemini`) - Requires an API key
 - Ollama (`ollama`) - Both local and remotely hosted
 - OpenAI (`openai`) - Requires an API key
+- Azure OpenAI (`azure_openai`) - Requires an Azure OpenAI service with a model deployment
 - xAI (`xai`) - Requires an API key
 
 The plugin utilises objects called Strategies. These are the different ways
@@ -428,6 +429,43 @@ set an API key:
               url = "http[s]://open_compatible_ai_url", -- optional: default value is ollama url http://127.0.0.1:11434
               api_key = "OpenAI_API_KEY", -- optional: if your endpoint is authenticated
               chat_url = "/v1/chat/completions", -- optional: default value, override if different
+            },
+          })
+        end,
+      },
+    })
+<
+
+**Using Azure OpenAI**
+
+To use Azure OpenAI, you need to have an Azure OpenAI service, an API key, and
+a model deployment. Follow these steps to configure the adapter:
+
+1. Create an Azure OpenAI service in your Azure portal.
+2. Deploy a model in the Azure OpenAI service.
+3. Obtain the API key from the Azure portal.
+
+Then, configure the adapter in your setup as follows:
+
+>lua
+    require("codecompanion").setup({
+      strategies = {
+        chat = {
+          adapter = "azure_openai",
+        },
+        inline = {
+          adapter = "azure_openai",
+        },
+      },
+      adapters = {
+        azure_openai = function()
+          return require("codecompanion.adapters").extend("azure_openai", {
+            env = {
+              api_key = 'YOUR_AZURE_OPENAI_API_KEY',
+              endpoint = 'YOUR_AZURE_OPENAI_ENDPOINT',
+            },
+            schema = {
+              model = "YOUR_DEPLOYMENT_NAME",
             },
           })
         end,

--- a/lua/codecompanion/adapters/azure_openai.lua
+++ b/lua/codecompanion/adapters/azure_openai.lua
@@ -1,0 +1,165 @@
+local openai = require("codecompanion.adapters.openai")
+
+---@class AzureOpenAI.Adapter: CodeCompanion.Adapter
+return {
+  name = "azure_openai",
+  roles = {
+    llm = "assistant",
+    user = "user",
+  },
+  opts = {
+    stream = true,
+  },
+  features = {
+    text = true,
+    tokens = true,
+    vision = true,
+  },
+  url = "${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${api_version}",
+  env = {
+    api_key = "AZURE_OPENAI_API_KEY",
+    endpoint = "AZURE_OPENAI_ENDPOINT",
+    api_version = "2024-06-01",
+    deployment = "schema.model",
+  },
+  raw = {
+    "--no-buffer",
+    "--silent",
+  },
+  headers = {
+    ["Content-Type"] = "application/json",
+    ["api-key"] = "${api_key}",
+  },
+  handlers = {
+    --- Use the OpenAI adapter for the bulk of the work
+    setup = function(self)
+      return openai.handlers.setup(self)
+    end,
+    tokens = function(self, data)
+      return openai.handlers.tokens(self, data)
+    end,
+    form_parameters = function(self, params, messages)
+      return openai.handlers.form_parameters(self, params, messages)
+    end,
+    form_messages = function(self, messages)
+      return openai.handlers.form_messages(self, messages)
+    end,
+    chat_output = function(self, data)
+      return openai.handlers.chat_output(self, data)
+    end,
+    inline_output = function(self, data, context)
+      return openai.handlers.inline_output(self, data, context)
+    end,
+    on_exit = function(self, data)
+      return openai.handlers.on_exit(self, data)
+    end,
+  },
+  schema = {
+    -- See https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions
+    -- model does not exist in the Azure OpenAI API, but this is used as the deployment in the URL.
+    model = {
+      order = 1,
+      mapping = "parameters",
+      type = "string",
+      desc = "Name of the Azure OpenAI model deployment",
+      optional = false,
+    },
+    temperature = {
+      order = 2,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 1,
+      desc = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
+      validate = function(n)
+        return n >= 0 and n <= 2, "Must be between 0 and 2"
+      end,
+    },
+    top_p = {
+      order = 3,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 1,
+      desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
+      validate = function(n)
+        return n >= 0 and n <= 1, "Must be between 0 and 1"
+      end,
+    },
+    stop = {
+      order = 4,
+      mapping = "parameters",
+      type = "list",
+      optional = true,
+      default = nil,
+      subtype = {
+        type = "string",
+      },
+      desc = "Up to 4 sequences where the API will stop generating further tokens.",
+      validate = function(l)
+        return #l >= 1 and #l <= 4, "Must have between 1 and 4 elements"
+      end,
+    },
+    max_tokens = {
+      order = 5,
+      mapping = "parameters",
+      type = "integer",
+      optional = true,
+      default = nil,
+      desc = "The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length.",
+      validate = function(n)
+        return n > 0, "Must be greater than 0"
+      end,
+    },
+    presence_penalty = {
+      order = 6,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 0,
+      desc = "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+      validate = function(n)
+        return n >= -2 and n <= 2, "Must be between -2 and 2"
+      end,
+    },
+    frequency_penalty = {
+      order = 7,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 0,
+      desc = "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
+      validate = function(n)
+        return n >= -2 and n <= 2, "Must be between -2 and 2"
+      end,
+    },
+    logit_bias = {
+      order = 8,
+      mapping = "parameters",
+      type = "map",
+      optional = true,
+      default = nil,
+      desc = "Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID) to an associated bias value from -100 to 100. Use https://platform.openai.com/tokenizer to find token IDs.",
+      subtype_key = {
+        type = "integer",
+      },
+      subtype = {
+        type = "integer",
+        validate = function(n)
+          return n >= -100 and n <= 100, "Must be between -100 and 100"
+        end,
+      },
+    },
+    user = {
+      order = 9,
+      mapping = "parameters",
+      type = "string",
+      optional = true,
+      default = nil,
+      desc = "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. Learn more.",
+      validate = function(u)
+        return u:len() < 100, "Cannot be longer than 100 characters"
+      end,
+    },
+  },
+}

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -10,6 +10,7 @@ local defaults = {
   adapters = {
     -- LLMs -------------------------------------------------------------------
     anthropic = "anthropic",
+    azure_openai = "azure_openai",
     copilot = "copilot",
     gemini = "gemini",
     ollama = "ollama",


### PR DESCRIPTION
## Description

As discussed in https://github.com/olimorris/codecompanion.nvim/discussions/383 I added a new adapter using the OpenAI adapter handlers comparable to xAI and Copilot.

The adapter uses these env vars:

```lua
  env = {
    api_key = "AZURE_OPENAI_API_KEY",
    endpoint = "AZURE_OPENAI_ENDPOINT",
    api_version = "2024-06-01",
    deployment = "schema.model",
  }
```

The first two are also used in the [official OpenAI Python library](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line%2Cjavascript-keyless%2Ctypescript-keyless%2Cpython-new&pivots=programming-language-python#create-a-new-python-application), so they should be pretty standard. The api_version shouldn't change too often, maybe only for newly released models.

I'm not sure about the deployment. Azure OpenAI does not select the model based on a parameter as OpenAI-compatible APIs usually do. Instead each model can be deployed multiple times under custom names. As far as I know usually these deployment names are set the same as the actual OpenAI model name, but I guess not everyone would do that. Because the rest of codecompanion.nvim assumes the model parameter to be set I decided to keep it in there and use it as the configuration for the deployment name.

Note that this is also very similar to the official OpenAI Python library:

```python
import os
from openai import AzureOpenAI
    
client = AzureOpenAI(
    api_key=os.getenv("AZURE_OPENAI_API_KEY"),  
    api_version="2024-02-01",
    azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
    )
    
deployment_name='REPLACE_WITH_YOUR_DEPLOYMENT_NAME' #This will correspond to the custom name you chose for your deployment when you deployed a model. Use a gpt-35-turbo-instruct deployment. 
    
# Send a completion call to generate an answer
print('Sending a test completion job')
start_phrase = 'Write a tagline for an ice cream shop. '
response = client.completions.create(model=deployment_name, prompt=start_phrase, max_tokens=10)
print(start_phrase+response.choices[0].text)
```

Please check if I used the schema value replacement for the env var correctly. I was a bit confused because the docs always mentioned `schema.model.default` when talking about this functionality. I'm also not really sure what to put into the choices for the parameter - the default ones of OpenAI really don't make sense here because of the deployment stuff. I guess I should change it to type string with no default? Open to suggestions.

Example usage:

```lua
  {
    "olimorris/codecompanion.nvim",
    dependencies = {
      -- ...
    },
    config = {
      strategies = {
        chat = {
          adapter = "azure_openai",
        },
        inline = {
          adapter = "azure_openai",
        },
      },
      adapters = {
        azure_openai = function()
          return require("codecompanion.adapters").extend("azure_openai", {
            env = {
              api_key = 'foobar',
              endpoint = 'https://foobar.openai.azure.com/',
            },
            schema = {
              model = "gpt-4o",
            },
          })
        end,
      },
    },
  },
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/olimorris/codecompanion.nvim/discussions/383

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
