### PR TITLE
Add doctoring prompt to library

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -762,7 +762,7 @@ This is the code, for context:
         is_default = true,
         is_slash_cmd = false,
         modes = { "n" },
-        short_name = "Docstrings",
+        short_name = "docstrings",
         auto_submit = true,
         stop_context_insertion = true,
         user_prompt = true,
@@ -785,7 +785,7 @@ This is the code, for context:
               .. "\n"
               .. function_content
               .. "\n```\n"
-              .. "Generate only the docstrings and nothing else using tabs or spaces depending on the current implementation. Do not change anything else in the code. Give only the docstrings. Use the following style to generate the docstrings. If I don't give you a style, use the typical style of the language."
+              .. "Generate only the docstrings and nothing else using tabs or spaces depending on the current implementation. Do not change anything else in the code. Give only the docstrings. Use the following style to generate the docstrings. If I don't give you a function, do nothing. If I don't give you a style, use the typical style of the language."
           end,
         },
       },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -754,6 +754,42 @@ This is the code, for context:
         },
       },
     },
+    ["Generate docstrings"] = {
+      strategy = "inline",
+      description = "Generate docstrings for this function",
+      opts = {
+        index = 11,
+        is_default = true,
+        is_slash_cmd = false,
+        modes = { "n" },
+        short_name = "Docstrings",
+        auto_submit = true,
+        stop_context_insertion = true,
+        user_prompt = true,
+        placement = "add",
+      },
+      prompts = {
+        {
+          role = constants.SYSTEM_ROLE,
+          content = function(context)
+            local get_function_content = require("codecompanion.utils.treesitter").get_function_at_cursor
+            local bufnr = context.bufnr
+            local cursor = context.cursor_pos
+            local function_content = get_function_content(bufnr, cursor)
+
+            return "I want you to act as a senior "
+              .. context.filetype
+              .. " developer. Here is a function I want you to generate the docstrings for: "
+              .. "\n```"
+              .. context.filetype
+              .. "\n"
+              .. function_content
+              .. "\n```\n"
+              .. "Generate only the docstrings and nothing else using tabs or spaces depending on the current implementation. Do not change anything else in the code. Give only the docstrings. Use the following style to generate the docstrings. If I don't give you a style, use the typical style of the language."
+          end,
+        },
+      },
+    },
   },
   -- DISPLAY OPTIONS ----------------------------------------------------------
   display = {

--- a/lua/codecompanion/utils/treesitter.lua
+++ b/lua/codecompanion/utils/treesitter.lua
@@ -94,7 +94,7 @@ function M.get_function_at_cursor(bufnr, cursor)
     lines[#lines] = lines[#lines]:sub(1, end_col)
     return table.concat(lines, "\n")
   else
-    return nil
+    return ""
   end
 end
 


### PR DESCRIPTION
## Description

This PR adds a prompt to generate docstrings to the prompt_library. It uses treesitter to get the content of the function the cursor is on. It prompts the user to input a specific style or uses the languages typical one.

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/discussions/364

## Screenshots

<img width="1528" alt="image" src="https://github.com/user-attachments/assets/3da59372-0c9d-4981-b14b-c95f29a7e1fe">

<img width="1528" alt="image" src="https://github.com/user-attachments/assets/7bd7e382-a1ee-442d-af93-241fed0490ee">

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
