### PR TITLE
feat: add language configuration for LLM responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,18 @@ require("codecompanion").setup({
   }
 })
 ```
+**Changing the Language**
+
+CodeCompanion supports multiple languages for non-code responses. You can configure this in your setup:
+
+```lua
+require('codecompanion').setup({
+  opts = {
+    language = "English" -- Default is "English"
+  }
+})
+```
+
 
 **Using with render-markdown.nvim**
 

--- a/README.md
+++ b/README.md
@@ -297,8 +297,8 @@ require("codecompanion").setup({
   opts = {
     ---@param adapter CodeCompanion.Adapter
     ---@return string
-    system_prompt = function(adapter)
-      if adapter.schema.model.default == "llama3.1:latest" then
+    system_prompt = function(opts)
+      if opts.adapter.schema.model.default == "llama3.1:latest" then
         return "My custom system prompt"
       end
       return "My default system prompt"
@@ -317,7 +317,6 @@ require('codecompanion').setup({
   }
 })
 ```
-
 
 **Using with render-markdown.nvim**
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 November 05
+*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 November 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -293,12 +293,25 @@ setting system prompts that are LLM or model specific:
       opts = {
         ---@param adapter CodeCompanion.Adapter
         ---@return string
-        system_prompt = function(adapter)
-          if adapter.schema.model.default == "llama3.1:latest" then
+        system_prompt = function(opts)
+          if opts.adapter.schema.model.default == "llama3.1:latest" then
             return "My custom system prompt"
           end
           return "My default system prompt"
         end
+      }
+    })
+<
+
+**Changing the Language**
+
+CodeCompanion supports multiple languages for non-code responses. You can
+configure this in your setup:
+
+>lua
+    require('codecompanion').setup({
+      opts = {
+        language = "English" -- Default is "English"
       }
     })
 <

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -830,6 +830,7 @@ This is the code, for context:
   -- GENERAL OPTIONS ----------------------------------------------------------
   opts = {
     log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
+    language = "English", -- The language used for LLM responses
 
     -- If this is false then any default prompt that is marked as containing code
     -- will not be sent to the LLM. Please note that whilst I have made every
@@ -840,7 +841,10 @@ This is the code, for context:
     -- strategy. It is primarily based on the GitHub Copilot Chat's prompt
     -- but with some modifications. You can choose to remove this via
     -- your own config but note that LLM results may not be as good
-    system_prompt = [[You are an AI programming assistant named "CodeCompanion".
+    system_prompt = function(opts)
+      local language = opts.language or "English"
+      return string.format(
+        [[You are an AI programming assistant named "CodeCompanion".
 You are currently plugged in to the Neovim text editor on a user's machine.
 
 Your core tasks include:
@@ -866,12 +870,16 @@ You must:
 - Only return code that's relevant to the task at hand. You may not need to return all of the code that the user has shared.
 - Use actual line breaks instead of '\n' in your response to begin new lines.
 - Use '\n' only when you want a literal backslash followed by a character 'n'.
+- All non-code responses must use %s.
 
 When given a task:
 1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.
 2. Output the code in a single code block, being careful to only return relevant code.
 3. You should always generate short suggestions for the next user turns that are relevant to the conversation.
 4. You can only give one reply for each conversation turn.]],
+        language
+      )
+    end,
   },
 }
 

--- a/lua/codecompanion/strategies/chat.lua
+++ b/lua/codecompanion/strategies/chat.lua
@@ -626,7 +626,10 @@ function Chat:set_system_prompt()
   local prompt = config.opts.system_prompt
   if prompt ~= "" then
     if type(prompt) == "function" then
-      prompt = prompt(self.adapter)
+      prompt = prompt({
+        adapter = self.adapter,
+        language = config.opts.language
+      })
     end
 
     local system_prompt = {


### PR DESCRIPTION
## Description
add language configuration for LLM responses

- Add new 'language' option with default value "English"
- Convert static system prompt to function for language templating
- Add language requirement in system prompt

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
https://github.com/olimorris/codecompanion.nvim/discussions/409

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines.
