### PR TITLE
feat(pickers): Accommodate mini_pick to allow selection of multiple buffers

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -184,6 +184,20 @@ local Providers = {
             return nil
           end
         end,
+        choose_marked = function(marked_items)
+          for _, selection in ipairs(marked_items) do
+            local success, _ = pcall(function()
+              output(SlashCommand, {
+                bufnr = selection.bufnr,
+                name = selection.text,
+                path = selection.text,
+              })
+            end)
+            if not success then
+              break
+            end
+          end
+        end,
       },
     })
   end,


### PR DESCRIPTION
## Description

This change makes mini_pick compatible with PR #406 to enable choosing multiple buffers.

## Related Issue(s)

#406 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command

Thank you