### PR TITLE
fix(tools): add XML block formatting guidance

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 November 06
+*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 November 09
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/lua/codecompanion/strategies/chat/tools/cmd_runner.lua
+++ b/lua/codecompanion/strategies/chat/tools/cmd_runner.lua
@@ -94,6 +94,7 @@ return {
   - If you need information which hasn't been provided to you (e.g. the version of a language you've been asked to write a command in), write that command first and inform the user
   - The output from each command will be shared with you after each command executes
   - Don't use this action to run file commands, use the Files Tool instead. If you don't have access to that then consider whether file operations are required
+  - Make sure the tools xml block is **surrounded by ```xml**
 
 4. **Actions**:
 

--- a/lua/codecompanion/strategies/chat/tools/editor.lua
+++ b/lua/codecompanion/strategies/chat/tools/editor.lua
@@ -188,6 +188,7 @@ return {
   - **Include indentation** in your code
   - **Don't escape** special characters
   - **Wrap code in a CDATA block**, the code could contain characters reserved by XML
+  - Make sure the tools xml block is **surrounded by ```xml**
 
 4. **Actions**:
 

--- a/lua/codecompanion/strategies/chat/tools/files.lua
+++ b/lua/codecompanion/strategies/chat/tools/files.lua
@@ -226,6 +226,7 @@ return {
   - **Wrap contents in a CDATA block**, the contents could contain characters reserved by XML
   - **Don't duplicate code** in the response. Consider writing code directly into the contents tag of the XML
   - The user's current working directory in Neovim is `%s`. They may refer to this in their message to you.
+  - Make sure the tools xml block is **surrounded by ```xml**
 
 4. **Actions**:
 

--- a/lua/codecompanion/strategies/chat/tools/rag.lua
+++ b/lua/codecompanion/strategies/chat/tools/rag.lua
@@ -75,6 +75,7 @@ return {
   - Ensure XML is **valid and follows the schema**
   - **Don't escape** special characters
   - **Wrap queries and URLs in a CDATA block**, the text could contain characters reserved by XML
+  - Make sure the tools xml block is **surrounded by ```xml**
 
 4. **Actions**:
 


### PR DESCRIPTION
## Description

As discussed in https://github.com/olimorris/codecompanion.nvim/discussions/416, in some cases, the agents were not able to execute actions because the `tools` XML was not being parsed correctly. It was due to the fact that the ```xml syntax was not being used for the `tools` XML code block.

## Related Issue(s)

- Implements https://github.com/olimorris/codecompanion.nvim/discussions/416

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
