### PR TITLE
feat(mini_pick): allow multi selection in /files

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/shared/files.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/shared/files.lua
@@ -96,6 +96,16 @@ return {
             return nil
           end
         end,
+        choose_marked = function(selection)
+          for _, selected in ipairs(selection) do
+            local success, _ = pcall(function()
+              output(SlashCommand, { path = selected })
+            end)
+            if not success then
+              break
+            end
+          end
+        end,
       },
     })
   end,


### PR DESCRIPTION
## Description

Accomedate Mini_pick to allow selection of files in the /file command.

## Related Issue(s)

commit 6184bd4e60d4f301cc5f47416a9a90731eb7f8fb


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command

Thank you