### PR TITLE
fix(inline): #426 concat lines with `"\n"` instead of `"  "` two spaces

### DIFF
--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -42,7 +42,7 @@ Please respond to this prompt in the format "<method>", placing the classifictio
 ---@param lines table
 ---@return string
 local function code_block(prompt, filetype, lines)
-  return prompt .. ":\n\n" .. "```" .. filetype .. "\n" .. table.concat(lines, "  ") .. "\n```\n"
+  return prompt .. ":\n\n" .. "```" .. filetype .. "\n" .. table.concat(lines, "\n") .. "\n```\n"
 end
 
 ---Overwrite the given selection in the buffer with an empty string


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
In this particular circumstance with a visual selection when running `:CodeCompanion <write a promp>` it will use this logic branch in the code to put together the markdown codeblock, but instead of concatenating the lines with a `\n` line break, it uses `  ` two spaces. All other codecompanion features operate using `\n`. This PR makes it consistent with the rest of the plugin.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #426

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
See linked gh issue for screenshots.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
