### PR TITLE
fix(diff): last_chat referenced is_visible() directly instead of last_chat.ui

### DIFF
--- a/lua/codecompanion/providers/diff/default.lua
+++ b/lua/codecompanion/providers/diff/default.lua
@@ -54,8 +54,8 @@ function Diff.new(args)
 
   --- Minimize the chat buffer window if there's not enough screen estate
   local last_chat = require("codecompanion").last_chat()
-  if last_chat and last_chat:is_visible() and config.display.diff.close_chat_at > vim.o.columns then
-    last_chat:hide()
+  if last_chat and last_chat.ui:is_visible() and config.display.diff.close_chat_at > vim.o.columns then
+    last_chat.ui:hide()
   end
 
   -- Create the diff buffer


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
Looks like just a couple items got missed in the refactor to using Chat:ui

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
