### PR TITLE
Use correct method in open chats call

### DIFF
--- a/lua/codecompanion/actions/static.lua
+++ b/lua/codecompanion/actions/static.lua
@@ -66,7 +66,7 @@ return {
             description = data.description,
             callback = function()
               codecompanion.close_last_chat()
-              data.chat:open()
+              data.chat.ui:open()
             end,
           })
         end


### PR DESCRIPTION
The `open` method is now in the ui module as of: c902222

## Description

Fixes this error when opening a chat from the "Open Chats" action (`:CodeCompanionActions` => "Open chats" => select):

```
Error executing vim.schedule lua callback: .../codecompanion.nvim/lua/codecompanion/actions/static.lua:69: attempt to call method 'open' (a nil value)
stack traceback:
        .../codecompanion.nvim/lua/codecompanion/actions/static.lua:69: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>

```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and ran the `make docs` command
