### PR TITLE
feat(keymaps): add chat buffer window hide keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ When in the chat buffer, press `?` to bring up a menu that lists the available k
 - `gc` to insert a codeblock in the chat buffer
 - `gd` to view/debug the chat buffer's contents
 - `gf` to fold any codeblocks in the chat buffer
+- `gh` to hide the chat buffer window
 - `gr` to regenerate the last response
 - `gs` to toggle the system prompt on/off
 - `gx` to clear the chat buffer's contents

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -259,6 +259,14 @@ local defaults = {
           callback = "keymaps.toggle_system_prompt",
           description = "Toggle the system prompt",
         },
+        hide = {
+          modes = {
+            n = "gh",
+          },
+          index = 16,
+          callback = "keymaps.hide",
+          description = "Hide Chat",
+        },
       },
       opts = {
         register = "+", -- The register to use for yanking code

--- a/lua/codecompanion/keymaps.lua
+++ b/lua/codecompanion/keymaps.lua
@@ -536,6 +536,12 @@ M.toggle_system_prompt = {
   end,
 }
 
+M.hide = {
+  callback = function(chat)
+    chat.ui:hide()
+  end,
+}
+
 -- INLINE MAPPINGS ------------------------------------------------------------
 
 M.accept_change = {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
I really like to use the `CodeCompanionChat Toggle` command to show and hide a chat window. The problem with the keymaps for the chat window is that it only has a "close" mapping which completely "destroys" the chat. I often find myself wanting to quickly hide the chat window just like if I were to do "Toggle" cmd while a chat window is open.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
