### PR TITLE
docs: update render_headers to show_header_separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,13 +369,13 @@ require('codecompanion').setup({
 
 **Using with render-markdown.nvim**
 
-If you use the fantastic [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) plugin, then you can turn off the `render_headers` option for a cleaner chat buffer:
+If you use the fantastic [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) plugin, then you can turn off the `show_header_separator` option for a cleaner chat buffer:
 
 ```lua
 require("codecompanion").setup({
   display = {
     chat = {
-      render_headers = false,
+      show_header_separator = false,
     }
   }
 })

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -368,13 +368,13 @@ You can also add your own keymaps:
 
 If you use the fantastic render-markdown.nvim
 <https://github.com/MeanderingProgrammer/render-markdown.nvim> plugin, then you
-can turn off the `render_headers` option for a cleaner chat buffer:
+can turn off the `show_header_separator` option for a cleaner chat buffer:
 
 >lua
     require("codecompanion").setup({
       display = {
         chat = {
-          render_headers = false,
+          show_header_separator = false,
         }
       }
     })


### PR DESCRIPTION
## Description

Update the docs for the `render_headers` config option change to `show_header_separator`.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
