### PR TITLE
Fix documentation for system_prompt callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,8 +322,8 @@ require("codecompanion").setup({
   opts = {
     ---@param adapter CodeCompanion.Adapter
     ---@return string
-    system_prompt = function(opts)
-      if opts.adapter.schema.model.default == "llama3.1:latest" then
+    system_prompt = function(adapter)
+      if adapter.schema.model.default == "llama3.1:latest" then
         return "My custom system prompt"
       end
       return "My default system prompt"

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 December 11
+*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 December 15
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -328,8 +328,8 @@ setting system prompts that are LLM or model specific:
       opts = {
         ---@param adapter CodeCompanion.Adapter
         ---@return string
-        system_prompt = function(opts)
-          if opts.adapter.schema.model.default == "llama3.1:latest" then
+        system_prompt = function(adapter)
+          if adapter.schema.model.default == "llama3.1:latest" then
             return "My custom system prompt"
           end
           return "My default system prompt"
@@ -656,7 +656,7 @@ You can call a prompt from the library via a keymap using the `prompt` helper:
 
 In the example above, we’ve set a visual keymap that will trigger the Explain
 prompt. Providing the `short_name` of the prompt as an argument to the helper
-(e.g.� "commit") will resolve the strategy down to an action.
+(e.g. "commit") will resolve the strategy down to an action.
 
 
 THE CHAT BUFFER ~
@@ -812,6 +812,7 @@ The plugin sets the following highlight groups during setup:
 
 The plugin fires many events during its lifecycle:
 
+- `CodeCompanionChatOpened` - Fired after a chat has been opened
 - `CodeCompanionChatClosed` - Fired after a chat has been closed
 - `CodeCompanionChatAdapter` - Fired after the adapter has been set in the chat
 - `CodeCompanionChatModel` - Fired after the model has been set in the chat


### PR DESCRIPTION
The argument to the system_prompt callback is an adapter, not an opt
table containing an adapter.

## Description

I tweaked the docs slightly to correct something I think might be off (it was a
minor papercut issue for me while tinkering with the system_prompt). Because
it's such a small change, I've skipped the discussion steps from the
CONTRIBUTING doc, I hope that's OK.

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README and ran the `make docs` command
