### PR TITLE
docs: add cmd for Lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Install the plugin with your preferred package manager:
     "nvim-lua/plenary.nvim",
     "nvim-treesitter/nvim-treesitter",
   },
+  cmd = {
+    "CodeCompanion",
+    "CodeCompanionChat",
+    "CodeCompanionActions",
+    "CodeCompanionCmd",
+  },
   config = true
 }
 ```

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 December 15
+*codecompanion.txt*       For NVIM v0.10.0       Last change: 2024 December 19
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -46,6 +46,12 @@ Install the plugin with your preferred package manager:
       dependencies = {
         "nvim-lua/plenary.nvim",
         "nvim-treesitter/nvim-treesitter",
+      },
+      cmd = {
+        "CodeCompanion",
+        "CodeCompanionChat",
+        "CodeCompanionActions",
+        "CodeCompanionCmd",
       },
       config = true
     }


### PR DESCRIPTION
## Description

Lazy.nvim will by default not load a plugin until ultimately needed. One way to load the plugin is to enter the CodeCompanion* commands.

Add the commands using `cmd` that will make the plugin load.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
