### PR TITLE
refactor: optimize ts parser usage

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -118,7 +118,7 @@ local function buf_parse_tools(chat)
       llm_role
     )
   )
-  local assistant_tree = self.parser:parse()[1]
+  local assistant_tree = chat.parser:parse()[1]
 
   local llm = {}
   for id, node in assistant_query:iter_captures(assistant_tree:root(), chat.bufnr, 0, -1) do
@@ -766,7 +766,7 @@ function Chat:check_references()
     :totable()
 
   -- And from the refs table
-  for i, ref in pairs(self.refs) do
+  for i, ref in ipairs(self.refs) do
     if vim.tbl_contains(to_remove, ref.id) then
       table.remove(self.refs, i)
     end

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -1,3 +1,6 @@
+---@class vim.treesitter.LanguageTree
+---@field parse function
+
 ---@class TSNode
 ---@field start_pos function
 ---@field end_pos function
@@ -48,6 +51,7 @@
 ---@field id integer The unique identifier for the chat
 ---@field intro_message? boolean Whether the welcome message has been shown
 ---@field messages? table The messages in the chat buffer
+---@field parser vim.treesitter.LanguageTree The parser for the chat buffer
 ---@field References CodeCompanion.Chat.References
 ---@field refs? table<CodeCompanion.Chat.Ref> References which are sent to the LLM e.g. buffers, slash command output
 ---@field settings? table The settings that are used in the adapter of the chat buffer


### PR DESCRIPTION
## Description

This PR looks to optimize Tree-sitter parser usage in the chat buffer

## Related Issue(s)

#552 has reported that a large chat buffer _may_ cause Neovim to balloon in memory usage
