### PR TITLE
fix: references performance

### DIFF
--- a/lua/codecompanion/adapters/openai_compatible.lua
+++ b/lua/codecompanion/adapters/openai_compatible.lua
@@ -66,7 +66,7 @@ end
 local function get_completion_url(self, opts)
   local adapter = require("codecompanion.adapters").resolve(self)
   local url = adapter.env_replaced.chat_url
-  if not adapter.env_replaced.chat_url then
+  if not url then
     url = "/v1/chat/completions"
   end
   return url


### PR DESCRIPTION
## Description

Object nesting between the chat buffer and the references object are now reduced.

## Related Issue(s)

#552

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
