### PR TITLE
chore: update blink config in minimal.lua

### DIFF
--- a/minimal.lua
+++ b/minimal.lua
@@ -30,9 +30,7 @@ local plugins = {
             ["<Tab>"] = { "select_next", "fallback" },
           },
           sources = {
-            completion = {
-              enabled_providers = { "lsp", "path", "buffer", "codecompanion" },
-            },
+            default = { "lsp", "path", "buffer", "codecompanion" },
             providers = {
               codecompanion = {
                 name = "CodeCompanion",


### PR DESCRIPTION
## Description

`minimal.lua` make use of the old `sources.completion.enabled_providers` setting. Newer version of blink now use `sources.default`. This is the same as provided in the codecompanion.nvim README example.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and ran the `make docs` command
