### PR TITLE
feat(chat): adding to chat initializes buffer if needed

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -89,17 +89,21 @@ end
 ---@param args table
 ---@return nil
 M.add = function(args)
+  local context = context_utils.get(api.nvim_get_current_buf(), args)
+  local content = table.concat(context.lines, "\n")
+
   local chat = M.last_chat()
 
   if not chat then
-    return log:warn("No chat buffer found")
+    chat = M.chat()
+
+    if not chat then
+      return log:warn("Could not create chat buffer")
+    end
   end
   if not config.opts.send_code then
     return log:warn("Sending of code to an LLM has been disabled")
   end
-
-  local context = context_utils.get(api.nvim_get_current_buf(), args)
-  local content = table.concat(context.lines, "\n")
 
   chat:add_buf_message({
     role = config.constants.USER_ROLE,
@@ -111,6 +115,7 @@ M.add = function(args)
       .. content
       .. "\n```\n",
   })
+  chat.ui:open()
 end
 
 ---Open a chat buffer and converse with an LLM


### PR DESCRIPTION
## Description

I often found that the first time I would use CodeCompanion would be to add some code to the chat and ask a question. I kept running into the issue where I had not initialized the chat window yet so I would get a "No chat buffer found" warning.

I figured it would be nice if it automatically created a new chat, if one does not already exist when the user calls `:CodeCompanionChat Add`

## Checklist

- [✓ ] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [✓] I've updated the README and ran the `make docs` command