### PR TITLE
fix(inline): fixes gemini-2.0-flash-exp code blocking

### DIFF
--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -136,7 +136,17 @@ return {
           return
         end
 
-        return json.candidates[1].content.parts[1].text
+        local text = json.candidates[1].content.parts[1].text
+        local model = json.modelVersion
+
+        if model == "gemini-2.0-flash-exp" then
+          text = text:gsub("```", "")
+          if context then
+            text = text:gsub(context.filetype .. "\n", "\n")
+          end
+        end
+
+        return text
       end
     end,
 

--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -142,7 +142,7 @@ return {
         if model == "gemini-2.0-flash-exp" then
           text = text:gsub("```", "")
           if context then
-            text = text:gsub(context.filetype .. "\n", "\n")
+            text = text:gsub(context.filetype .. "\n", "")
           end
         end
 

--- a/lua/codecompanion/strategies/inline.lua
+++ b/lua/codecompanion/strategies/inline.lua
@@ -29,6 +29,7 @@ Here are some example prompts and their correct method classification ("<method>
 - "Can you create a method/function for XYZ and put it in a new buffer?" would be `new` as the user is explictly asking for a new buffer
 - "Can you write unit tests for this code?" would be `new` as tests are commonly written in a new file away from the logic of the code they're testing
 - "Why is Neovim so popular?" or "What does this code do?" would be `chat` as the answer does not result in code being written and is a discursive topic leading to additional follow-up questions
+- "Write some comments for this code." would be `replace` as we're changing existing code
 
 The user may also provide a prompt which references a conversation you've had with them previously. Just focus on determining the correct method classification.
 


### PR DESCRIPTION
## Description

I've been having issues with `gemini-2.0-flash-exp` returning code blocks inline, despite the prompt not to. As well as bad classifications... This is an issue with `gemini-2.0-flash-exp`, not CodeCompanion. However I saw other people were having the same issue so thought I'd put out what's worked for me.

This will manually strip out the code blocking if the model is set to `gemini-2.0-flash-exp`. I have also added one more example to the `PLACEMENT_PROMPT` that seems to help with classification a lot.

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/issues/536

## Checklist

- [✓ ] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [✓] I've updated the README and ran the `make docs` command
