### PR TITLE
docs: add opts_extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ When conversing with the LLM, you can leverage variables, slash commands and too
       },
     },
   },
+  opts_extend = {
+    "sources.default",
+  },
 },
 ```
 


### PR DESCRIPTION
## Description

I completely forgot we should probably add this, just in case. Not sure it's worth explaining why `opts_extend` is there?

## Related Discussion

https://github.com/olimorris/codecompanion.nvim/discussions/578#discussion-7758770

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and ran the `make docs` command
