### PR TITLE
Fix completions keymap to allow for multiple completion keywords in a single line

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -206,7 +206,10 @@ M.completion = {
         return
       end
 
-      local prefix, start = unpack(vim.fn.matchstrpos(line:sub(1, col), [[\%(@\|/\|#\|\$\)\S*]]))
+      local before_cursor = line:sub(1, col)
+      local find_current_word = string.find(before_cursor, "%s[^%s]*$")
+      local start = find_current_word or 0
+      local prefix = line:sub(start + 1, col)
       if not prefix then
         return
       end


### PR DESCRIPTION
@olimorris Note: this PR is on top of my other PR #581 so includes those changes (minimal). So if you reject that one or change it, just need to update in this PR accordingly.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
Currently if you try to do two completions in the same line, it deletes everything after the first completion and just provides completions items for that first keyword. See the following as example:

(cursor at end of line below, after `#ls`)
```
I am writing a message and want to reference `#buffer` and include `#ls`
```

When I try to do a completion after `#ls` (for `#lsp`), it jumps back to the first found completion keyword in the line (`#buffer`) and removes everything after it... the following is removed: ` and include #ls` 

It is because the current code is just checking across the entire line for the first match of a trigger character. This PR will instead just look at the "current word" where the cursor is at and ignore the rest of the line (before and after current cursor/word).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README
- [x] I've ran the `make docs` command
