### PR TITLE
feat(completion): Boost score of blink completion suggestions

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -338,6 +338,7 @@ M.setup = function(opts)
             name = "CodeCompanion",
             module = "codecompanion.providers.completion.blink",
             enabled = true,
+            score_offset = 10,
           })
         end)
       end,


### PR DESCRIPTION

## Description

By default, blink's `path` provider has a score offset of 3, meaning that completions for slash commands in the buffer are deep down below possible path completions in the list of suggestions.

Since this suggestion only triggers in the chat buffer, it is reasonable to assume that slashcommands are much more likely to be the correct suggestions than folders at `/`.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/7c020751-e47b-4093-a209-a7340904b9d2)

After:
![image](https://github.com/user-attachments/assets/f6f2b352-da46-4028-a501-698264194297)

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README
- [X] I've ran the `make docs` command
