### PR TITLE
chore: Update minimal config for bug repro

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,12 +59,6 @@ body:
                     sources = {
                       default = { "lsp", "path", "buffer", "codecompanion" },
                       cmdline = {}, -- Disable sources for command-line mode
-                      providers = {
-                        codecompanion = {
-                          name = "CodeCompanion",
-                          module = "codecompanion.providers.completion.blink",
-                        },
-                      },
                     },
                   },
                 },

--- a/minimal.lua
+++ b/minimal.lua
@@ -32,12 +32,6 @@ local plugins = {
           sources = {
             default = { "lsp", "path", "buffer", "codecompanion" },
             cmdline = {}, -- Disable sources for command-line mode
-            providers = {
-              codecompanion = {
-                name = "CodeCompanion",
-                module = "codecompanion.providers.completion.blink",
-              },
-            },
           },
         },
       },


### PR DESCRIPTION
## Description

Updates the minimal config for bug repro to reflect the new recommended basic config relying on automatic blink registration.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README
- [x] I've ran the `make docs` command
