### PR TITLE
fix(chat): Error if changing adapter in empty chat w/o system prompt.

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -461,7 +461,7 @@ M.change_adapter = {
       -- Update the system prompt
       local system_prompt = config.opts.system_prompt
       if type(system_prompt) == "function" then
-        if chat.messages[1].role == "system" then
+        if chat.messages[1] and chat.messages[1].role == "system" then
           chat.messages[1].content = system_prompt(chat.adapter)
         end
       end


### PR DESCRIPTION
## Description

Fixes a small bug where changing adapter does not work if in am empty chat with system prompt disabled.

Repor:

- nvim --clean -u minimal.lua
- :CodeCompanioChat
- gs (remove system prompt)
- Try changing adapter with ga

## Screenshots

With and without change:


https://github.com/user-attachments/assets/b1a2d377-0ad6-4129-a201-1be92fb2da7f


## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README
- [X] I've ran the `make docs` command
