### PR TITLE
fix(copilot): adapt to json usage token response change

### DIFF
--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -97,7 +97,10 @@ return {
 
         if ok then
           if json.usage then
-            local tokens = json.usage.total_tokens
+            local total_tokens = json.usage.total_tokens or 0
+            local completion_tokens = json.usage.completion_tokens or 0
+            local prompt_tokens = json.usage.prompt_tokens or 0
+            local tokens = total_tokens > 0 and total_tokens or completion_tokens + prompt_tokens
             log:trace("Tokens: %s", tokens)
             return tokens
           end


### PR DESCRIPTION
Seems that the Copilot Chat (and potentially openai) response for `usage` token information changed slightly. Adding more robust check as `total_tokens` can be 0 evidently, so if so, will instead add completions and prompt tokens.