### PR TITLE
avoid negative column indexing

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -455,7 +455,7 @@ function Inline:place(placement)
     api.nvim_buf_set_lines(self.context.bufnr, self.context.start_line - 1, self.context.start_line - 1, false, { "" })
     self.context.start_line = self.context.start_line + 1
     pos.line = self.context.start_line - 1
-    pos.col = self.context.start_col - 1
+    pos.col = math.max(0, self.context.start_col - 1)
   elseif placement == "new" then
     local bufnr = api.nvim_create_buf(true, false)
     util.set_option(bufnr, "filetype", self.context.filetype)


### PR DESCRIPTION
When using the "before" placement, if the placement happens on the first column (0), it shouldn't try to move the cursor to the previous column, resulting in a negative column index.

Fixes #613

Note: I only fixed this for `pos.col`, not `pos.line`; I haven't observed any issues with negative line indexing, so I wanted to avoid changing anything for lines, in case it breaks other expectations or clamping of lines already happens in other places (e.g. `vim.api.nvim_buf_set_lines` has the following documentation note: "Out-of-bounds indices are clamped to the nearest valid value, unless `strict_indexing` is set.").