### PR TITLE
fix(utils): parse "boolean_scalar" fields when decoding yaml

### DIFF
--- a/lua/codecompanion/utils/yaml.lua
+++ b/lua/codecompanion/utils/yaml.lua
@@ -86,6 +86,15 @@ local function decode(source, node)
     return text:sub(2, text:len() - 1)
   elseif nt == "integer_scalar" or nt == "float_scalar" then
     return tonumber(vim.treesitter.get_node_text(node, source))
+  elseif nt == "boolean_scalar" then
+    local text = vim.treesitter.get_node_text(node, source)
+    if text == "true" then
+      return true
+    elseif text == "false" then
+      return false
+    else
+      error("Invalid boolean scalar")
+    end
   elseif nt == "null_scalar" then
     return nil
   elseif nt == "ERROR" then


### PR DESCRIPTION
## Description

Current yaml decoding does not decode "boolean_scalar" fields, e.g.

```yaml
is_two_even: true
is_three_even: false
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README
- [ ] I've ran the `make docs` command
