### PR TITLE
Raising error when both blink and cmp are available

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -331,7 +331,7 @@ M.setup = function(opts)
   local has_cmp, cmp = pcall(require, "cmp")
   local has_blink, blink = pcall(require, "blink.cmp")
   if has_blink and has_cmp then
-    return log:error("Both cmp and blink available, please uninstall one")
+    log:warn("Both cmp and blink available, please uninstall one")
   end
   if has_blink then
     pcall(function()

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -330,6 +330,9 @@ M.setup = function(opts)
   -- Setup completion for blink.cmp and cmp
   local has_cmp, cmp = pcall(require, "cmp")
   local has_blink, blink = pcall(require, "blink.cmp")
+  if has_blink and has_cmp then
+    return log:error("Both cmp and blink available, please uninstall one")
+  end
   if has_blink then
     pcall(function()
       blink.add_provider("codecompanion", {


### PR DESCRIPTION
It happened to me that I had blink cmp declared as a dependency and never used (and I know it is a bad practice), and I couldn't understand why the slash commands weren't working in the chat. This should give an heads up to people who could face the same problem

