### PR TITLE
Remove Unnecessary Comment in Copilot Adapter

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -159,7 +159,6 @@ return {
         return false
       end
 
-      -- _github_token = { token = "ABC123", expires_at = os.time() + 3600 }
       _github_token = authorize_token()
       if not _github_token or vim.tbl_isempty(_github_token) then
         log:error("Copilot Adapter: Could not authorize your GitHub Copilot token")


### PR DESCRIPTION
## Description

While trying to figure out how CodeCompanion calls Copilot, I found what looks like an unnecessary comment left there which was probably used for debugging before but someone forgot to take it out.

## Related Issue(s)

This PR doesn't fix any issues but is something I found while figuring out the code.

## Screenshots

I don't think screenshots are needed.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR (Since this PR is removing only 1 comment, I don't think its necessary to open a discussion for it)
- [x] I've updated the README
- [ ] I've ran the `make docs` command (should I run make docs since I didn't change anything of significance?)
