### PR TITLE
feat: register source for filetype in blink.cmp

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -59,11 +59,13 @@ EOF
 
 ## Completion
 
-Out of the box, the plugin supports completion with both [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [blink.cmp](https://github.com/Saghen/blink.cmp). For the latter, ensure that you've added `codecompanion` as a source:
+Out of the box, the plugin supports completion with both [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [blink.cmp](https://github.com/Saghen/blink.cmp). For the latter, on version <= 0.10.0, ensure that you've added `codecompanion` as a source:
 
 ```lua
 sources = {
-  default = { "lsp", "path", "snippets", "buffer", "codecompanion" }
+  per_filetype = {
+    codecompanion = { "codecompanion" },
+  }
 },
 ```
 

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -339,6 +339,9 @@ M.setup = function(opts)
         score_offset = 10,
       })
     end)
+    pcall(function()
+      blink.add_filetype_source("codecompanion", "codecompanion")
+    end)
   -- We need to check for blink alongside cmp as blink.compat has a module that
   -- is detected by a require("cmp") call and a lot of users have it installed
   -- Reference: https://github.com/olimorris/codecompanion.nvim/discussions/501


### PR DESCRIPTION
## Description

I've added support for plugins to add `per_filetype` sources dynamically. It will fail if the user has set the `per_filetype` to a function, which should be extremely rare for this case. Open to feedback on the API! It's currently only available on `main`, and will be included in the next release (0.11.0).

I've also switched the recommended setup for <= 0.10.0 to use `sources.per_filetype` to avoid conflicts with other sources.

P.S. apologies for all the blink.cmp issues you've had to deal with. If I had it my way, less people would be using my plugin while it's still in beta :smile: Love the new docs site!

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README
- [x] I've ran the `make docs` command
