### PR TITLE
Use `nui.nvim` to open chat window to the edge of editor

### DIFF
--- a/lua/codecompanion/utils/nui_ui.lua
+++ b/lua/codecompanion/utils/nui_ui.lua
@@ -1,0 +1,26 @@
+local Split = require("nui.split")
+
+local config = require("codecompanion.config")
+
+local M = {}
+
+---Check if nui is enabled and installed
+---@return boolean
+function M.enabled()
+  local status = pcall(require, "nui.split")
+  if not status or not config.display.chat.window.nui then
+    return false
+  end
+  return true
+end
+
+---Split window and position it
+---@param win_opts table
+---@param position string left, right, top, bottom
+function M.split(win_opts, position)
+  win_opts.position = position
+  local win = Split(win_opts)
+  win:mount()
+end
+
+return M


### PR DESCRIPTION
## Description

Draft PR to implement [nui.nvim](https://github.com/MunifTanjim/nui.nvim) to send the chat window to the edge of the editor.

Based on previous [discussion](https://github.com/olimorris/codecompanion.nvim/discussions/592), here are some of the  points to work on:
- [x] We make this feature "opt-in" in the config => *added `config.display.chat.window.nui`, a better parameter should be chosen. The implementation also checks if `nui.nvim` is installed.*
- [ ] We have a separate section in the README dedicated to the UI customisation (I'll be happy to write that)
- [x] We have a nui_ui.lua file to house all of the nui logic - I'm anticipating that others may wish to make PRs for this so would be sensible to separate this into its own file => *added in `utils`*
- [ ] We add a test specifically for nui. I want to ensure we can still add new features quickly to the plugin and be confident we're not breaking the UI

## Related Issue(s)

- Implementation of the discussion in #592 

## Screenshots

![draft](https://github.com/user-attachments/assets/dec4bd47-e2d1-4f8c-9a37-aa020c17d42e)

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README
- [ ] I've ran the `make docs` command
