### PR TITLE
fix(inline): end_col out of range

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -64,6 +64,11 @@ local function overwrite_selection(context)
     context.start_col = context.start_col - 1
   end
 
+  local line_length = #vim.api.nvim_buf_get_lines(context.bufnr, context.end_line - 1, context.end_line, true)[1]
+  if context.end_col > line_length then
+    context.end_col = line_length
+  end
+
   api.nvim_buf_set_text(
     context.bufnr,
     context.start_line - 1,


### PR DESCRIPTION
## Description

Sometimes, the end_col is wider than the line length, so this PR is fixing it, this happens particularly with the `$` motion.

## Related Issue(s)

Fix #688

## Screenshots


https://github.com/user-attachments/assets/982b3a37-cd9f-402b-bbae-5e9a2447e939



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README
- [ ] I've ran the `make docs` command 
