### PR TITLE
fix(deepseek): messages order in deepseek adapter

### DIFF
--- a/lua/codecompanion/adapters/deepseek.lua
+++ b/lua/codecompanion/adapters/deepseek.lua
@@ -71,27 +71,6 @@ return {
         model = model()
       end
 
-      ---System role is only allowed as the first message, after this we must label
-      ---all system messages as assistant
-      local has_system = false
-      messages = vim
-          .iter(messages)
-          :map(function(m)
-            local role = m.role
-            if role == self.roles.llm then
-              if not has_system then
-                has_system = true
-              else
-                role = "assistant"
-              end
-            end
-            return {
-              role = role,
-              content = m.content,
-            }
-          end)
-          :totable()
-
       ---DeepSeek-R1 doesn't allow consecutive messages from the same role,
       ---so we concatenate them into a single message
       for _, msg in ipairs(messages) do
@@ -105,6 +84,27 @@ return {
           })
         end
       end
+
+      ---System role is only allowed as the first message, after this we must label
+      ---all system messages as assistant
+      local has_system = false
+      processed = vim
+        .iter(processed)
+        :map(function(m)
+          local role = m.role
+          if role == self.roles.llm then
+            if not has_system then
+              has_system = true
+            else
+              role = "assistant"
+            end
+          end
+          return {
+            role = role,
+            content = m.content,
+          }
+        end)
+        :totable()
 
       return { messages = processed }
     end,

--- a/tests/adapters/test_deepseek.lua
+++ b/tests/adapters/test_deepseek.lua
@@ -50,19 +50,21 @@ describe("DeepSeek adapter", function()
     h.eq(response[#response].output, adapter_helpers.chat_buffer_output(response, adapter))
   end)
 
-  it("converts subsequent system messages to assistant role", function()
+  it("concatenates subsequent system messages and converts all system messages after user message to assistant role", function()
     local input = {
       { role = adapter.roles.llm,  content = "System1" },
-      { role = adapter.roles.user, content = "User1" },
       { role = adapter.roles.llm,  content = "System2" },
+      { role = adapter.roles.user, content = "User1" },
+      { role = adapter.roles.llm,  content = "System3" },
+      { role = adapter.roles.llm,  content = "System4" },
       { role = adapter.roles.user, content = "User2" },
     }
 
     local expected = {
       messages = {
-        { role = "system",    content = "System1" },
+        { role = "system",    content = "System1\n\nSystem2" },
         { role = "user",      content = "User1" },
-        { role = "assistant", content = "System2" },
+        { role = "assistant", content = "System3\n\nSystem4" },
         { role = "user",      content = "User2" },
       }
     }


### PR DESCRIPTION
## Description


Deepseek R1 doesn't work when you don't have a `user` message after a `system` message. The current code transforms all messages (except first) with `system` roles to `assistant` roles. This logic breaks the chat when you have two or more system prompts at the beginning because Deepseek R1 requires a `user` message after a `system` message.

For example, if you try to send the following messages:

```
[
   { role: "system",  message: CodeCompanionMessage },
   { role: "system",  message: CustomMessage},
   { role: "user", message: question },
]
```

After transforming messages, you end up with:

```
[
   { role: "system",  message: CodeCompanionMessage },
   { role: "assistant",  message: CustomMessage},
   { role: "user", message: question },
]
```

This is not accepted by Deepseek, resulting in:

> Error: {"error":{"message":"The first message (except the system message) of deepseek-reasoner must be a user message, but an assistant message detected.","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}

In this PR, I moved the code that changes all `system` roles (except the first one) to `assistant` to be called after message concatenation with the same role.

As a result, you can have multiple system messages at the beginning, and they will be concatenated. All other system messages will be transformed to assistant messages (if such situations exist).

Ping @bashtoni 

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/issues/696

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README
- [x] I've ran the `make docs` command
