### PR TITLE
chore: add notification

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -467,6 +467,7 @@ M.change_adapter = {
   desc = "Change the adapter",
   callback = function(chat)
     if config.display.chat.show_settings then
+      util.notify("Cannot change adapter while chat.show_settings is enabled", vim.log.levels.WARN)
       return
     end
 

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -467,8 +467,7 @@ M.change_adapter = {
   desc = "Change the adapter",
   callback = function(chat)
     if config.display.chat.show_settings then
-      util.notify("Cannot change adapter while chat.show_settings is enabled", vim.log.levels.WARN)
-      return
+      return util.notify("Adapter can't be changed when `display.chat.show_settings = true`", vim.log.levels.WARN)
     end
 
     local function select_opts(prompt, conditional)


### PR DESCRIPTION
## Description

I was confused why I couldn't change my adapter to another one. I added notification to warn future users that show_settings disables the ability to change adapter.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README
- [x] I've ran the `make docs` command
