### PR TITLE
fix(picker): models picker doesn't show for deepseek adapter

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -527,7 +527,7 @@ M.change_adapter = {
       if type(models) == "function" then
         models = models(chat.adapter)
       end
-      if not models or #models < 2 then
+      if not models or vim.tbl_count(models) < 2 then
         return
       end
 


### PR DESCRIPTION
## Description

Adding support for reasoning broke the models picker. This is a fix for that

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README
- [x] I've ran the `make docs` command
