### PR TITLE
fix(chat): more graceful cancellations

### DIFF
--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -139,7 +139,7 @@ function Client:request(payload, actions, opts)
     end,
     on_error = function(err)
       vim.schedule(function()
-        cb(err, nil)
+        actions.callback(err, nil)
         return util.fire("RequestFinished", opts)
       end)
     end,


### PR DESCRIPTION
## Description

Pressing `q` in the chat buffer whilst chatting to an LLM is currently a cluster f*ck. This PR addresses that.