### PR TITLE
fix(fetch): cached url folder needed to be created first on windows

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -87,6 +87,7 @@ end
 local function write_cache(hash, data)
   local p = Path:new(CONSTANTS.CACHE_PATH .. "/" .. hash)
   p.filename = p:expand()
+  vim.fn.mkdir(CONSTANTS.CACHE_PATH, "p")
   p:touch({ parents = true })
   p:write(data or "", "w")
 end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
Trying to use the fetch slash command I was getting the error in the screenshot below.

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
![image](https://github.com/user-attachments/assets/1b98679e-c5e7-4cdc-8b56-a8217a4ed56f)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
