### PR TITLE
fix(workspaces): workspace path constant cleared after first use

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -88,6 +88,11 @@ function SlashCommand:read_workspace_file(path)
   if not path then
     path = CONSTANTS.WORKSPACE_FILE
   end
+  if not path then
+    path = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json")
+    CONSTANTS.WORKSPACE_FILE = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json")
+  end
+
   if not vim.uv.fs_stat(path) then
     return log:warn(fmt("Could not find a workspace file at `%s`", path))
   end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
This is a weird one. I could not pinpoint the culprit, but if I started a chat convo, used /workspace slash command (works fine the first time), but then create a new convo and try /workspace slash again it gives a plenary error (see screenshot below).

The path arg going into the function is blank and somehow the CONSTANT for the path in that file is also suddenly blank.

You can see what I mean by the change in my commit (a couple lines). This solves my immediate problem but I have no clue if there is something more / deeper that has to be addressed 🤷‍♂️ 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
No idea but curious if this is somehow related to #756 ?

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
![TabTip - Shell_Handwriting_Canvas_B4bKogwdUp_2025-01-28_22-14-58](https://github.com/user-attachments/assets/b5e26ed3-c171-478c-8624-155e260cb591)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
