### PR TITLE
feat: add symbols for scala

### DIFF
--- a/queries/scala/symbols.scm
+++ b/queries/scala/symbols.scm
@@ -1,0 +1,29 @@
+; Ref: https://github.com/stevearc/aerial.nvim/blob/master/queries/scala/aerial.scm
+; MIT License
+(package_clause
+  name: (package_identifier) @name
+  (#set! "kind" "Package")) @symbol
+
+(import_declaration
+  path: (identifier) @name
+  (#set! "kind" "Import")) @symbol
+
+(trait_definition
+  name: (identifier) @name
+  (#set! "kind" "Interface")) @symbol
+
+(object_definition
+  name: (identifier) @name
+  (#set! "kind" "Class")) @symbol
+
+(class_definition
+  name: (identifier) @name
+  (#set! "kind" "Class")) @symbol
+
+(function_declaration
+  name: (identifier) @name
+  (#set! "kind" "Function")) @symbol
+
+(function_definition
+  name: (identifier) @name
+  (#set! "kind" "Function")) @symbol

--- a/queries/scala/symbols.scm
+++ b/queries/scala/symbols.scm
@@ -2,7 +2,7 @@
 ; MIT License
 (package_clause
   name: (package_identifier) @name
-  (#set! "kind" "Package")) @symbol
+  (#set! "kind" "Import")) @symbol
 
 (import_declaration
   path: (identifier) @name


### PR DESCRIPTION
## Description

Add scala symbols following the pattern of using the defined symbols file in the Aerial library.

## Related Issue(s)
n/a

## Screenshots
<img width="1809" alt="Screenshot 2025-01-29 at 3 40 31 PM" src="https://github.com/user-attachments/assets/6e1e7528-28c8-4b01-a477-06553220a2ac" />
Screenshot with providing scala symbols referencing the plugin locally with this change.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
