### PR TITLE
fix: handle multiline userdata in copilot adapter

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -60,7 +60,13 @@ local function get_token()
 
   for _, file_path in ipairs(file_paths) do
     if vim.uv.fs_stat(file_path) then
-      local userdata = vim.json.decode(vim.fn.readfile(file_path)[1])
+      local userdata = vim.fn.readfile(file_path)
+
+      if vim.islist(userdata) then
+        userdata = table.concat(userdata, " ")
+      end
+
+      local userdata = vim.json.decode(userdata)
       for key, value in pairs(userdata) do
         if string.find(key, "github.com") then
           return value.oauth_token


### PR DESCRIPTION
## Description

Hi, thank you for the plugin.

I encountered a bug with the copilot provider: when opening the chat buffer and entering text, then pressing `Enter`, it crashes by outputting:

![image](https://github.com/user-attachments/assets/a6c46acf-ea6a-4e1d-87a8-8f41fb53d5a6)

When looking at the source code, I found that you'll read only one line of the file:
```lua
      local userdata = vim.json.decode(vim.fn.readfile(file_path)[1])
```

`vim.fn.readfile` returns a list of lines.

So this PR will adapt the code to read the content and then concatenate all lines of this content to pass to `json.decode`.

Maybe `vim.json.decode(vim.fn.readfile(file_path)[1])` was intended to fix an edge case.

Do not hesitate to tell me if something needs to be changed or to explain why it was done that way.

Thanks!



## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
