### PR TITLE
refactor(adapters): schema->parameters is cleaned up

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -120,10 +120,9 @@ function Adapter.new(args)
   return setmetatable(args, { __index = Adapter })
 end
 
----TODO: Refactor this to return self so we can chain it
 ---Get the default settings from the schema
 ---@return table
-function Adapter:get_default_settings()
+function Adapter:make_from_schema()
   local settings = {}
 
   for key, value in pairs(self.schema) do
@@ -201,9 +200,7 @@ end
 ---@param settings? table
 ---@return CodeCompanion.Adapter
 function Adapter:map_schema_to_params(settings)
-  if not settings then
-    settings = self:get_default_settings()
-  end
+  settings = settings or self:make_from_schema()
 
   for k, v in pairs(settings) do
     local mapping = self.schema[k] and self.schema[k].mapping

--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -80,14 +80,6 @@ return {
     ---@param messages table
     ---@return table
     form_parameters = function(self, params, messages)
-      if type(params.model) == "function" then
-        params.model = params.model(self)
-      end
-      vim.iter(params.options):each(function(k, v)
-        if type(v) == "function" then
-          params[k] = v(self)
-        end
-      end)
       return params
     end,
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -49,7 +49,7 @@ local function ts_parse_settings(bufnr, adapter)
   -- If the user has disabled settings in the chat buffer, use the default settings
   if not config.display.chat.show_settings then
     if adapter then
-      _cached_settings[bufnr] = adapter:get_default_settings()
+      _cached_settings[bufnr] = adapter:make_from_schema()
       return _cached_settings[bufnr]
     end
   end
@@ -65,7 +65,7 @@ local function ts_parse_settings(bufnr, adapter)
   local end_line = -1
   if adapter then
     -- Account for the two YAML lines and the fact Tree-sitter is 0-indexed
-    end_line = vim.tbl_count(adapter:get_default_settings()) + 2 - 1
+    end_line = vim.tbl_count(adapter:make_from_schema()) + 2 - 1
   end
 
   for _, matches, _ in query:iter_matches(root, bufnr, 0, end_line) do
@@ -368,10 +368,8 @@ end
 ---@param settings table
 ---@return self
 function Chat:apply_settings(settings)
-  self.settings = settings or schema.get_default(self.adapter.schema, self.opts.settings)
-
-  -- Reset the cache
-  _cached_settings[self.bufnr] = self.settings
+  _cached_settings[self.bufnr] = settings
+  self.settings = settings
 
   return self
 end


### PR DESCRIPTION
## Description

This refactor cleans up the fix that was implemented for Ollama not working after the chat debugging was added.

## Related Issue(s)

#769