### PR TITLE
fix(chat): navigate between roles in buffer

### DIFF
--- a/lua/codecompanion/utils/treesitter.lua
+++ b/lua/codecompanion/utils/treesitter.lua
@@ -19,7 +19,7 @@ function M.goto_heading(direction, count)
 
   local root_tree = parser:parse()[1]:root()
 
-  local query = vim.treesitter.query.parse("markdown", [[(atx_heading) @heading]])
+  local query = vim.treesitter.query.parse("markdown", [[(atx_heading (atx_h2_marker) @heading)]])
 
   local from_row, to_row, found_headings
   if direction == "next" then


### PR DESCRIPTION
## Description

As we output adapter's reasoning under H3 headers, the current header navigation moves between ALL headers rather than just H2 ones. This fix addresses that.