### PR TITLE
fix(slash_commands): scope constants to be local

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -8,7 +8,7 @@ local util = require("codecompanion.utils")
 local api = vim.api
 local fmt = string.format
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "Buffer",
   PROMPT = "Select buffer(s)",
 }

--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -9,7 +9,7 @@ local util_hash = require("codecompanion.utils.hash")
 
 local fmt = string.format
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "Fetch",
   CACHE_PATH = vim.fn.stdpath("cache") .. "/codecompanion/urls",
 }

--- a/lua/codecompanion/strategies/chat/slash_commands/file.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/file.lua
@@ -6,7 +6,7 @@ local util = require("codecompanion.utils")
 
 local fmt = string.format
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "File",
   PROMPT = "Select file(s)",
 }

--- a/lua/codecompanion/strategies/chat/slash_commands/help.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/help.lua
@@ -8,7 +8,7 @@ local ts = vim.treesitter
 
 local line_count = 0
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "Help",
   PROMPT = "Select a help tag",
   MAX_LINES = config.strategies.chat.slash_commands.help.opts.max_lines,

--- a/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
@@ -14,7 +14,7 @@ local util = require("codecompanion.utils")
 local fmt = string.format
 local get_node_text = vim.treesitter.get_node_text --[[@type function]]
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "Symbols",
   PROMPT = "Select symbol(s)",
 }

--- a/lua/codecompanion/strategies/chat/slash_commands/terminal.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/terminal.lua
@@ -2,7 +2,7 @@ local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local util = require("codecompanion.utils")
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "Terminal Output",
 }
 

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -5,7 +5,7 @@ local util = require("codecompanion.utils")
 
 local fmt = string.format
 
-CONSTANTS = {
+local CONSTANTS = {
   NAME = "Workspace",
   PROMPT = "Select a workspace group",
   WORKSPACE_FILE = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json"),


### PR DESCRIPTION
## Description

Scopes were global which caused issues when mixing different slash commands with workspaces.