### PR TITLE
fix diff provider documentation

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -206,14 +206,12 @@ There are a number of diff settings available to you:
 ```lua
 require("codecompanion").setup({
   display = {
-    chat = {
-      diff = {
-        enabled = true,
-        close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...
-        layout = "vertical", -- vertical|horizontal split for default provider
-        opts = { "internal", "filler", "closeoff", "algorithm:patience", "followwrap", "linematch:120" },
-        provider = "default", -- default|mini_diff
-      },
+    diff = {
+      enabled = true,
+      close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...
+      layout = "vertical", -- vertical|horizontal split for default provider
+      opts = { "internal", "filler", "closeoff", "algorithm:patience", "followwrap", "linematch:120" },
+      provider = "default", -- default|mini_diff
     },
   },
 }),


### PR DESCRIPTION
## Description

The documentation currently nests the diff settings under `opts.display.chat.diff`, when they should really be under `opts.display.diff`.