### PR TITLE
fix(chat): can debug adapters with `schema.model.default` as a function

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -87,7 +87,6 @@ local function replace_var(adapter, str)
 end
 
 ---@class CodeCompanion.Adapter
----@field args CodeCompanion.Adapter
 local Adapter = {}
 
 ---@class CodeCompanion.Adapter
@@ -115,7 +114,6 @@ local Adapter = {}
 ---@field handlers.teardown? fun(self: CodeCompanion.Adapter): any
 ---@field schema table Set of parameters for the generative AI service that the user can customise in the chat buffer
 
----@param args CodeCompanion.Adapter
 ---@return CodeCompanion.Adapter
 function Adapter.new(args)
   return setmetatable(args, { __index = Adapter })
@@ -162,7 +160,7 @@ function Adapter:get_env_vars()
     elseif type(v) == "string" and is_env_var(v) then
       self.env_replaced[k] = get_env_var(v)
     elseif type(v) == "function" then
-      self.env_replaced[k] = v()
+      self.env_replaced[k] = v(self)
     else
       local schema = get_schema(self, v)
       if schema then
@@ -190,7 +188,7 @@ function Adapter:set_env_vars(object)
       if type(v) == "string" then
         replaced[k] = replace_var(self, v)
       elseif type(v) == "function" then
-        replaced[k] = v(self)
+        replaced[k] = replace_var(self, v(self))
       else
         replaced[k] = v
       end

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -966,8 +966,8 @@ local M = {
 M.setup = function(args)
   args = args or {}
   if args.constants then
-	vim.notify("codecompanion.nvim: Your config table cannot have field 'constants', vim.log.levels.ERROR")
-	return
+    vim.notify("codecompanion.nvim: Your config table cannot have field 'constants', vim.log.levels.ERROR")
+    return
   end
   M.config = vim.tbl_deep_extend("force", vim.deepcopy(defaults), args)
 end

--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -45,7 +45,7 @@ function Debug:render()
   local adapter = vim.deepcopy(self.chat.adapter)
 
   if type(adapter.schema.model.choices) == "function" then
-    models = adapter.schema.model.choices()
+    models = adapter.schema.model.choices(adapter)
   else
     models = adapter.schema.model.choices
   end

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -364,14 +364,12 @@ function Chat:_get_settings_key(opts)
   return key_name, node
 end
 
----Apply custom settings to the chat buffer
+---Format and apply settings to the chat buffer
 ---@param settings? table
 ---@return self
 function Chat:apply_settings(settings)
-  settings = settings or schema.get_default(self.adapter.schema, self.opts.settings)
-
-  self.settings = settings
-  _cached_settings[self.bufnr] = settings
+  self.settings = settings or schema.get_default(self.adapter.schema, self.opts.settings)
+  _cached_settings[self.bufnr] = self.settings
 
   return self
 end

--- a/tests/adapters/test_ollama.lua
+++ b/tests/adapters/test_ollama.lua
@@ -2,6 +2,8 @@ local adapter
 local adapter_helpers = require("tests.adapters.helpers")
 local h = require("tests.helpers")
 
+local chat
+
 --------------------------------------------------- OUTPUT FROM THE CHAT BUFFER
 local messages = { {
   content = "Explain Ruby in two words",
@@ -67,11 +69,43 @@ describe("Ollama adapter", function()
     adapter = require("codecompanion.adapters").extend("ollama", {
       schema = {
         model = {
-          default = "llama2",
+          default = function()
+            return "llama2"
+          end,
           choices = { "llama2" },
         },
       },
     })
+    chat, _ = h.setup_chat_buffer(nil, adapter)
+  end)
+
+  after_each(function()
+    h.teardown_chat_buffer()
+  end)
+
+  it("correctly forms the settings", function()
+    -- Equivalent to the chat:submit() method
+    local params = adapter:map_schema_to_params(chat.settings).parameters
+    h.eq({
+      model = adapter.schema.model.default,
+      options = {
+        mirostat = 0,
+        mirostat_eta = 0.1,
+        mirostat_tau = 5,
+        num_ctx = 2048,
+        num_predict = -1,
+        repeat_last_n = 64,
+        repeat_penalty = 1.1,
+        seed = 0,
+        temperature = 0.8,
+        tfs_z = 1,
+        top_k = 40,
+        top_p = 0.9,
+      },
+    }, params)
+
+    -- Expands the model function
+    h.eq(type(adapter.handlers.form_parameters(adapter, adapter:set_env_vars(params), messages).model), "string")
   end)
 
   it("can form messages to be sent to the API", function()

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -99,39 +99,40 @@ Helpers.config = {
   },
 }
 
-Helpers.setup_chat_buffer = function(config)
+Helpers.setup_chat_buffer = function(config, adapter)
   local codecompanion = require("codecompanion")
 
-  local adapter = {
-    name = "TestAdapter",
-    url = "https://api.openai.com/v1/chat/completions",
-    roles = {
-      llm = "assistant",
-      user = "user",
-    },
-    headers = {
-      content_type = "application/json",
-    },
-    parameters = {
-      stream = true,
-    },
-    handlers = {
-      form_parameters = function()
-        return {}
-      end,
-      form_messages = function()
-        return {}
-      end,
-      is_complete = function()
-        return false
-      end,
-    },
-    schema = {
-      model = {
-        default = "gpt-3.5-turbo",
+  adapter = adapter
+    or {
+      name = "TestAdapter",
+      url = "https://api.openai.com/v1/chat/completions",
+      roles = {
+        llm = "assistant",
+        user = "user",
       },
-    },
-  }
+      headers = {
+        content_type = "application/json",
+      },
+      parameters = {
+        stream = true,
+      },
+      handlers = {
+        form_parameters = function()
+          return {}
+        end,
+        form_messages = function()
+          return {}
+        end,
+        is_complete = function()
+          return false
+        end,
+      },
+      schema = {
+        model = {
+          default = "gpt-3.5-turbo",
+        },
+      },
+    }
 
   codecompanion.setup(config or Helpers.config)
 

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -12,7 +12,7 @@ T["References"] = new_set({
     pre_case = function()
       chat, _ = h.setup_chat_buffer()
     end,
-    post_once = function()
+    post_case = function()
       h.teardown_chat_buffer()
     end,
   },


### PR DESCRIPTION
Previously debugging the chat buffer for adapters such as Ollama was troublesome