### PR TITLE
docs: update suggested markview configuration

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -267,8 +267,10 @@ As the Chat Buffer uses markdown as its syntax, you can use popular rendering pl
   "OXY2DEV/markview.nvim",
   ft = { "markdown", "codecompanion" },
   opts = {
-    filetypes = { "markdown", "codecompanion" },
-    buf_ignore = {},
+    preview = {
+      filetypes = { "markdown", "codecompanion" },
+      ignore_buftypes = {},
+    },
   },
 },
 ```

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -265,7 +265,7 @@ As the Chat Buffer uses markdown as its syntax, you can use popular rendering pl
 ```lua
 {
   "OXY2DEV/markview.nvim",
-  ft = { "markdown", "codecompanion" },
+  lazy = false,
   opts = {
     preview = {
       filetypes = { "markdown", "codecompanion" },


### PR DESCRIPTION
## Description
The previosly suggested markview config for chat buffer rendering is deprecated in markview. See the discussion #802 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
