### PR TITLE
Fix unavailable constant for mini_pick provider

### DIFF
--- a/lua/codecompanion/providers/slash_commands/mini_pick.lua
+++ b/lua/codecompanion/providers/slash_commands/mini_pick.lua
@@ -26,7 +26,7 @@ function MiniPick:display(transformer)
   end
   return {
     source = {
-      name = CONSTANTS.PROMPT,
+      name = self.title or "CodeCompanion",
       choose = function(selected)
         local success, _ = pcall(function()
           return self.output(transformer(selected))


### PR DESCRIPTION
## Description

This addresses a bug that prevents slash commands from using mini_pick as a provider.

## Related Issue(s)

Fixes #803 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
