### PR TITLE
feat(workspaces): handle multiple workflows better

### DIFF
--- a/doc/extending/workspace.md
+++ b/doc/extending/workspace.md
@@ -47,6 +47,10 @@ removed from the chat buffer
 > [!INFO]
 > When a user selects a group to load, the workspace slash command will iterate through the group adding the description first and then sequentially adding the files and symbols. For the latter two, their description is added first, before their content.
 
+### System Prompts
+
+Currently, workspaces allow for system prompts to exist at the top-level of the workspace file and at a group level. The plugin will always insert top-level system prompts at the first index in the messages table in the chat buffer. Any group system prompts will be added afterwards.
+
 ## Groups
 
 Groups are the core of the workspace file. They are where logical groupings of files and/or symbols are defined. Exploring the _Chat Buffer_ group in detail:

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -162,19 +162,22 @@ function SlashCommand:output(selected_group, opts)
 
   if group.opts then
     if group.opts.remove_config_system_prompt then
-      self.Chat:remove_system_prompt()
+      self.Chat:remove_tagged_message("from_config")
     end
   end
 
   -- Add the system prompts
-  if self.workspace.system_prompt or group.system_prompt then
-    local system_prompt = ""
-    if self.workspace.system_prompt and group.system_prompt then
-      system_prompt = self.workspace.system_prompt .. "\n\n" .. group.system_prompt
-    else
-      system_prompt = self.workspace.system_prompt or group.system_prompt
-    end
-    self.Chat:set_system_prompt(replace_vars(self.workspace, group, system_prompt))
+  if self.workspace.system_prompt then
+    self.Chat:add_system_prompt(
+      replace_vars(self.workspace, group, self.workspace.system_prompt),
+      { index = 1, visible = false, tag = self.workspace.name .. " // Workspace" }
+    )
+  end
+  if group.system_prompt then
+    self.Chat:add_system_prompt(
+      replace_vars(self.workspace, group, group.system_prompt),
+      { visible = false, tag = group.name .. " // Workspace Group" }
+    )
   end
 
   -- Add the description as a user message

--- a/tests/strategies/chat/slash_commands/test_workspace.lua
+++ b/tests/strategies/chat/slash_commands/test_workspace.lua
@@ -83,4 +83,15 @@ T["Workspace"]["can add system prompts"] = function()
   h.eq("High level system prompt", chat.messages[1].content)
 end
 
+T["Workspace"]["top-level prompts are not duplicated and are ordered correctly"] = function()
+  set_workspace("tests/stubs/workspace_multiple.json")
+  wks:output("Test 1")
+  wks:output("Test 2")
+
+  h.eq("High level system prompt", chat.messages[1].content)
+  h.eq("Group prompt 1", chat.messages[2].content)
+  h.eq("Group prompt 2", chat.messages[3].content)
+  expect_starts_with("A test description", chat.messages[4].content)
+end
+
 return T

--- a/tests/stubs/messages.lua
+++ b/tests/stubs/messages.lua
@@ -1,0 +1,30 @@
+local messages = {
+  {
+    content = "An example system prompt",
+    cycle = 1,
+    id = 1628281114,
+    opts = {
+      tag = "from_config",
+      visible = false,
+    },
+    role = "system",
+  },
+  {
+    content = "Are you working?",
+    cycle = 1,
+    id = 1817986341,
+    opts = {
+      visible = true,
+    },
+    role = "user",
+  },
+  {
+    content = "Yes, I am here to assist you with your programming tasks. How can I help you today?",
+    cycle = 1,
+    id = 197565474,
+    opts = {
+      visible = true,
+    },
+    role = "llm",
+  },
+}

--- a/tests/stubs/workspace_multiple.json
+++ b/tests/stubs/workspace_multiple.json
@@ -5,7 +5,24 @@
   "system_prompt": "High level system prompt",
   "groups": [
     {
-      "name": "Test",
+      "name": "Test 1",
+      "system_prompt": "Group prompt 1",
+      "opts": {
+        "remove_config_system_prompt": true
+      },
+      "vars": {
+        "base_dir": "tests/stubs"
+      },
+      "files": [
+        {
+          "description": "A test description",
+          "path": "${base_dir}/stub.go"
+        }
+      ]
+    },
+    {
+      "name": "Test 2",
+      "system_prompt": "Group prompt 2",
       "opts": {
         "remove_config_system_prompt": true
       },


### PR DESCRIPTION
## Description

When adding multiple workspaces to the chat buffer, system prompts were being duplicated. Also, top-level system prompts in the workspace file should come first ahead of group-level ones.