### PR TITLE
Add o3-mini to Copilot Adapter

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -210,6 +210,7 @@ return {
         "claude-3.5-sonnet",
         "o1-2024-12-17",
         "o1-mini-2024-09-12",
+        "o3-mini",
       },
     },
     temperature = {


### PR DESCRIPTION
## Description

o3-mini was released today so I decided to add it to your plugin while I was at it.

## Related Issue(s)

No related issue, just OpenAI panicking at Deepseek's R1 😄 

## Screenshots
![Screenshot 2025-01-31 at 9 30 48 PM](https://github.com/user-attachments/assets/385e3ef6-085a-4224-84a0-36bcde2b469d)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
