### PR TITLE
Make ui chat title configurable

### DIFF
--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -86,7 +86,7 @@ function UI:open()
       row = window.row or math.floor((vim.o.lines - height) / 2),
       col = window.col or math.floor((vim.o.columns - width) / 2),
       border = window.border,
-      title = "CodeCompanion",
+      title = window.title or "CodeCompanion",
       title_pos = "center",
       zindex = 45,
     }


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
We can now define both a custom title for the chat window and a higlight group by doing something like:
```lua
window = {
    title = { { 'CodeCompanion', 'TelescopeTitle' } },
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
https://github.com/olimorris/codecompanion.nvim/discussions/815


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
