### PR TITLE
feat(events): add strategy and adapter to payload

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -712,7 +712,15 @@ function Chat:submit(opts)
       done = function()
         self:done(output)
       end,
-    }, { bufnr = bufnr })
+    }, {
+      bufnr = bufnr,
+      strategy = "chat",
+      adapter = {
+        name = self.adapter.name,
+        formatted_name = self.adapter.formatted_name,
+        model = self.adapter.schema.model.default,
+      },
+    })
 end
 
 ---Increment the cycle count in the chat buffer

--- a/lua/codecompanion/strategies/cmd.lua
+++ b/lua/codecompanion/strategies/cmd.lua
@@ -63,7 +63,15 @@ function Cmd:start()
       end
     end,
     done = function() end,
-  }, { bufnr = self.context.bufnr })
+  }, {
+    bufnr = self.context.bufnr,
+    strategy = "cmd",
+    adapter = {
+      name = self.adapter.name,
+      formatted_name = self.adapter.formatted_name,
+      model = self.adapter.schema.model.default,
+    },
+  })
 end
 
 return Cmd

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -277,7 +277,15 @@ function Inline:classify(user_input)
         },
       }),
       { callback = cb, done = done },
-      { bufnr = self.context.bufnr }
+      {
+        bufnr = self.context.bufnr,
+        strategy = "inline",
+        adapter = {
+          name = self.adapter.name,
+          formatted_name = self.adapter.formatted_name,
+          model = self.adapter.schema.model.default,
+        },
+      }
     )
   else
     self.classification.placement = self.opts.placement
@@ -384,7 +392,15 @@ function Inline:submit()
 
   self.current_request = client
     .new({ adapter = self.adapter:map_schema_to_params(), user_args = { event = "InlineSubmit" } })
-    :request(self.adapter:map_roles(self.classification.prompts), { callback = cb, done = done }, { bufnr = bufnr })
+    :request(self.adapter:map_roles(self.classification.prompts), { callback = cb, done = done }, {
+      bufnr = bufnr,
+      strategy = "inline",
+      adapter = {
+        name = self.adapter.name,
+        formatted_name = self.adapter.formatted_name,
+        model = self.adapter.schema.model.default,
+      },
+    })
 end
 
 ---When a defined prompt is sent alongside the user's input, we need to do some


### PR DESCRIPTION
## Description

Add more detail to the event payload. Output will now be something like:

```lua
{
  buf = 3,
  data = {
    adapter = {
      formatted_name = "Copilot",
      model = "o3-mini-2025-01-31",
      name = "copilot"
    },
    bufnr = 3,
    strategy = "chat" -- "inline" | "cmd"
  },
  event = "User",
  file = "CodeCompanionRequestStarted",
  group = 13,
  id = 29,
  match = "CodeCompanionRequestStarted"
}
```

## Related Issue(s)

#813