### PR TITLE
fix(http): prevent model from no schema.model

### DIFF
--- a/lua/codecompanion/adapters/non_llm/jina.lua
+++ b/lua/codecompanion/adapters/non_llm/jina.lua
@@ -10,6 +10,11 @@ return {
     ["X-Return-Format"] = "text",
     ["Accept"] = "application/json",
   },
+  schema = {
+    model = {
+      default = "jina",
+    },
+  },
   handlers = {
     set_body = function(self, data)
       return { url = data.url }

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -170,7 +170,7 @@ function Client:request(payload, actions, opts)
   opts.adapter = {
     name = adapter.name,
     formatted_name = adapter.formatted_name,
-    model = adapter.schema.model.default,
+    model = adapter.schema.model.default or "",
   }
 
   util.fire("RequestStarted", opts)


### PR DESCRIPTION
## Description

Some models may not have a `schema.model.default` value so we need to check against that in the `http.lua` file.