### PR TITLE
feat(slash_cmds): can be functions and modules

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -56,6 +56,11 @@ function SlashCommands:execute(item, chat)
   local label = item.label:sub(1)
   log:debug("Executing slash command: %s", label)
 
+  -- If the user has provided a callback function, use that
+  if type(item.config.callback) == "function" then
+    return item.config.callback(chat)
+  end
+
   local callback = resolve(item.config.callback)
   if not callback then
     return log:error("Slash command not found: %s", label)


### PR DESCRIPTION
## Description

Allows for a user to have:

```lua
["mycmd"] = {
  description = "describe what mycmd inserts",
  callback = function(chat)
    return chat:add_buf_message({ content = "My custom command" })
  end,
  opts = {
    contains_code = true
  }
}
```

in their config instead of pointing to a lua module.