### PR TITLE
docs: clarify chat buffer prompt submission methods

### DIFF
--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -69,7 +69,7 @@ require("codecompanion").setup({
 
 The Chat Buffer is where you can converse with an LLM from within Neovim. It operates on a single response per turn, basis.
 
-Run `:CodeCompanionChat` to open a chat buffer. Type your prompt and press `<CR>`. Or, run `:CodeCompanionChat why are Lua and Neovim so perfect together?` to send a prompt directly to the chat buffer. Toggle the chat buffer with `:CodeCompanionChat Toggle`.
+Run `:CodeCompanionChat` to open a chat buffer. Type your prompt and send it by pressing `<C-s>` while in insert mode or `<CR>` in normal mode. Alternatively, run `:CodeCompanionChat why are Lua and Neovim so perfect together?` to open the chat buffer and send a prompt at the same time. Toggle the chat buffer with `:CodeCompanionChat Toggle`.
 
 You can add context from your code base by using _Variables_ and _Slash Commands_ in the chat buffer.
 


### PR DESCRIPTION
## Description

Updated the documentation to clearly explain how users can send prompts in the chat buffer. Specified that `<C-s>` works in insert mode and `<CR>` in normal mode for better readability.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
