### PR TITLE
fix: delete diff buffers instead of closing

### DIFF
--- a/lua/codecompanion/providers/diff/default.lua
+++ b/lua/codecompanion/providers/diff/default.lua
@@ -109,7 +109,7 @@ end
 ---@return nil
 function Diff:teardown()
   vim.cmd("diffoff")
-  api.nvim_win_close(self.diff.win, false)
+  api.nvim_buf_delete(self.diff.buf, {})
   util.fire("DiffDetached", { diff = "default", bufnr = self.bufnr })
 end
 


### PR DESCRIPTION
## Description

When closed, a diff buffer still exists (it's just hidden and unlisted). It also keeps "diffthis" set. This can lead to complicated and confusing diffs as the number of dangling buffers increases.

Since diff buffers are temporary and not re-used it should be safe to delete them instead of closing them.

## Related Issue(s)

- Fixes #851

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
