### PR TITLE
Fix typo in doc/extending/prompts.md.

### DIFF
--- a/doc/extending/prompts.md
+++ b/doc/extending/prompts.md
@@ -78,7 +78,7 @@ To make this example complete, we can leverage a pre-hook to create a new buffer
       pre_hook = function()
         local bufnr = vim.api.nvim_create_buf(true, false)
         vim.api.nvim_set_current_buf(bufnr)
-        vim.api.nvim_set_option_value("filetype", "html", { buf = buf } )
+        vim.api.nvim_set_option_value("filetype", "html", { buf = bufnr } )
         return bufnr
       end
     }


### PR DESCRIPTION
## Description

Update code block to correctly pass buffer number.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [] I've updated the README and/or relevant docs pages
