### PR TITLE
feat(events): new request streaming event

### DIFF
--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -20,6 +20,7 @@ The events that you can access are:
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline strategy
 - `CodeCompanionInlineFinished` - Fired at the end of the Inline strategy
 - `CodeCompanionRequestStarted` - Fired at the start of any API request
+- `CodeCompanionRequestStreaming` - Fired at the start of a streaming API request
 - `CodeCompanionRequestFinished` - Fired at the end of any API request
 - `CodeCompanionDiffAttached` - Fired when in Diff mode
 - `CodeCompanionDiffDetached` - Fired when exiting Diff mode

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -149,9 +149,15 @@ function Client:request(payload, actions, opts)
     -- Turn off plenary's default compression
     request_opts["compressed"] = adapter.opts.compress or false
 
+    local streaming = false
+
     -- This will be called multiple times until the stream is finished
     request_opts["stream"] = self.opts.schedule(function(_, data)
       if data and data ~= "" then
+        if not streaming then
+          streaming = true
+          util.fire("RequestStreaming", opts)
+        end
         log:trace("Output data:\n%s", data)
       end
       cb(nil, data)


### PR DESCRIPTION
## Description

Once a request starts streaming, `CodeCompanionRequestStreaming` will be fired with the following payload:

```lua

{
  buf = 10,
  data = {
    adapter = {
      formatted_name = "Copilot",
      model = "gpt-4o-2024-08-06",
      name = "copilot"
    },
    bufnr = 10,
    id = 972808,
    strategy = "chat"
  },
  event = "User",
  file = "CodeCompanionRequestStreaming",
  group = 13,
  id = 29,
  match = "CodeCompanionRequestStreaming"
}
```

## Related Issue(s)

As discussed in #875