### PR TITLE
Fix pinned file references

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/file.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/file.lua
@@ -150,8 +150,17 @@ function SlashCommand:read(selected)
     return ""
   end
 
+  -- Make path relative
+  local relative_path
+  if selected.relative_path then
+    relative_path = selected.relative_path
+  elseif selected[1] then
+    relative_path = selected[1]
+  else
+    relative_path = vim.fn.fnamemodify(selected.path, ":.")
+  end
+
   local ft = vim.filetype.match({ filename = selected.path })
-  local relative_path = selected.relative_path or selected[1] or selected.path
   local id = "<file>" .. relative_path .. "</file>"
 
   return content, ft, id, relative_path


### PR DESCRIPTION
## Description

On the references object in the chat buffer, the full path is always used for a file. But the relative path is displayed in the chat buffer. This caused a mismatch when re-sending a pinned file's contents.

## Related Issue(s)

#889