### PR TITLE
fix(workspaces): add description to urls from cache

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -17,17 +17,20 @@ local CONSTANTS = {
 ---Format the output for the chat buffer
 ---@param url string
 ---@param text string
+---@param opts table
 ---@return string
-local function format_output(url, text)
-  return fmt(
-    [[Here is the content from `%s` that I'm sharing with you:
+local function format_output(url, text, opts)
+  local output = [[%s
 
 <content>
 %s
-</content>]],
-    url,
-    text
-  )
+</content>]]
+
+  if opts and opts.description then
+    return fmt(output, opts.description, text)
+  end
+
+  return fmt(output, "Here is the output from " .. url .. " that I'm sharing with you:", text)
 end
 
 ---Output the contents of the URL to the chat buffer
@@ -40,7 +43,7 @@ local function output(chat, data, opts)
 
   chat:add_message({
     role = config.constants.USER_ROLE,
-    content = format_output(data.url, data.content),
+    content = format_output(data.url, data.content, opts),
   }, { reference = id, visible = false })
 
   chat.references:add({
@@ -224,7 +227,7 @@ function SlashCommand:output(url, opts)
     log:debug("Fetch Slash Command: Ignoring cache")
     return call_fetch()
   end
-  if opts and opts.auto_restore_cache then
+  if opts and opts.auto_restore_cache and is_cached(hash) then
     log:debug("Fetch Slash Command: Auto restoring from cache")
     return read_cache(self.Chat, url, hash, opts)
   end

--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -104,6 +104,7 @@ function SlashCommands.references(chat, slash_command, opts)
     -- double opts out of the opts table. Hacky, for sure.
     opts.silent = true
     opts.url = opts.url or opts.path
+    opts.description = opts.description
     opts.auto_restore_cache = opts.opts.auto_restore_cache
     opts.ignore_cache = opts.opts.ignore_cache
 

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -203,6 +203,7 @@ function SlashCommand:output(selected_group, opts)
   if group.urls and vim.tbl_count(group.urls) > 0 then
     vim.iter(group.urls):each(function(url)
       url.path = url.url
+      url.description = url.description
       --TODO: Refactor this...we're adding to an options table to then strip it away in slash_commands/init.lua
       url.opts = {
         ignore_cache = url.ignore_cache,


### PR DESCRIPTION
## Description

- Previously, if a user attempted to restore a url from a cache and it didn't exist then an error would be throw
- Workspace descriptions were not added to the URLs