### PR TITLE
fix(chat): header separator is now detected

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -146,6 +146,9 @@ local function ts_parse_messages(chat, start_range)
   for id, node in query:iter_captures(root, chat.bufnr, start_range - 1, -1) do
     if query.captures[id] == "role" then
       last_role = get_node_text(node, chat.bufnr)
+      if config.display.chat.show_header_separator then
+        last_role = vim.trim(last_role:gsub(config.display.chat.separator, ""))
+      end
     elseif last_role == user_role and query.captures[id] == "content" then
       table.insert(content, get_node_text(node, chat.bufnr))
     end


### PR DESCRIPTION
## Description

`v12.0.0` introduced more explicit Tree-sitter queries which extracted the user's role from the H2 header in the chat buffer, without any of the `##`. This failed to account for if users had `config.display.chat.show_header_separator` turned on, which in most cases would have added an ` -` to the end of the role. This fix accounts for that.

## Related Issue(s)

#887 #899