### PR TITLE
Add config option to show only custom/defined adapters with change ad…

### DIFF
--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -215,3 +215,20 @@ require("codecompanion").setup({
   },
 }),
 ```
+
+## Hiding Default Adapters
+
+By default, the plugin shows all available adapters, including the defaults. If you prefer to only display the adapters defined in your user configuration, you can set the `show_defaults` option to `false`:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    opts = {
+      show_defaults = false,
+    },
+    -- Define your custom adapters here
+  },
+})
+```
+
+When `show_defaults` is set to `false`, only the adapters specified in your configuration will be used, hiding the default ones provided by the plugin.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -26,7 +26,7 @@ local defaults = {
     -- OPTIONS ----------------------------------------------------------------
     opts = {
       allow_insecure = false, -- Allow insecure connections?
-      only_custom = false, -- Only use/show custom adapters
+      show_defaults = true, -- Show default adapters
       proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
     },
   },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -26,6 +26,7 @@ local defaults = {
     -- OPTIONS ----------------------------------------------------------------
     opts = {
       allow_insecure = false, -- Allow insecure connections?
+      only_custom = false, -- Only use/show custom adapters
       proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
     },
   },

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -245,10 +245,10 @@ M.setup = function(opts)
   -- Setup the plugin's config
   config.setup(opts)
   if opts and opts.adapters then
-    if config.adapters.opts.only_custom then
-        config.adapters = vim.deepcopy(opts.adapters)
-    else
+    if config.adapters.opts.show_defaults then
       config.adapters = require("codecompanion.utils.adapters").extend(config.adapters, opts.adapters)
+    else
+      config.adapters = vim.deepcopy(opts.adapters)
     end
   end
 

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -245,7 +245,11 @@ M.setup = function(opts)
   -- Setup the plugin's config
   config.setup(opts)
   if opts and opts.adapters then
-    require("codecompanion.utils.adapters").extend(config.adapters, opts.adapters)
+    if config.adapters.opts.only_custom then
+        config.adapters = vim.deepcopy(opts.adapters)
+    else
+      config.adapters = require("codecompanion.utils.adapters").extend(config.adapters, opts.adapters)
+    end
   end
 
   local cmds = require("codecompanion.commands")

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -447,15 +447,6 @@ M.change_adapter = {
     end
 
     local adapters = vim.deepcopy(config.adapters)
-    if config.display.chat.show_only_custom_adapters then
-        local custom_adapters = {}
-        for key, value in pairs(adapters) do
-            if type(value) == "function" then
-                custom_adapters[key] = value
-            end
-        end
-        adapters = custom_adapters
-    end
     local current_adapter = chat.adapter.name
     local current_model = vim.deepcopy(chat.adapter.schema.model.default)
 

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -447,6 +447,15 @@ M.change_adapter = {
     end
 
     local adapters = vim.deepcopy(config.adapters)
+    if config.display.chat.show_only_custom_adapters then
+        local custom_adapters = {}
+        for key, value in pairs(adapters) do
+            if type(value) == "function" then
+                custom_adapters[key] = value
+            end
+        end
+        adapters = custom_adapters
+    end
     local current_adapter = chat.adapter.name
     local current_model = vim.deepcopy(chat.adapter.schema.model.default)
 


### PR DESCRIPTION
…apter keymap

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

I want to only display my defined  adapters when using the `change_adapter` keymap.

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/discussions/873#discussioncomment-12107770 

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

Rather than displaying every single adapter now the list shows only adapters defined in the config file.

![image](https://github.com/user-attachments/assets/1ba8f11f-9724-4821-82f6-441c296f8e33)

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
