### PR TITLE
feat: add adapter for mistral ia

### DIFF
--- a/lua/codecompanion/adapters/mistral.lua
+++ b/lua/codecompanion/adapters/mistral.lua
@@ -194,28 +194,6 @@ return {
         "mistral-small",
       },
     },
-    reasoning_effort = {
-      order = 2,
-      mapping = "parameters",
-      type = "string",
-      optional = true,
-      condition = function(schema)
-        local model = schema.model.default
-        if type(model) == "function" then
-          model = model()
-        end
-        if schema.model.choices[model] and schema.model.choices[model].opts then
-          return schema.model.choices[model].opts.can_reason
-        end
-      end,
-      default = "medium",
-      desc = "Constrains effort on reasoning for reasoning models. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.",
-      choices = {
-        "high",
-        "medium",
-        "low",
-      },
-    },
     temperature = {
       order = 3,
       mapping = "parameters",
@@ -283,34 +261,6 @@ return {
       desc = "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
       validate = function(n)
         return n >= -2 and n <= 2, "Must be between -2 and 2"
-      end,
-    },
-    logit_bias = {
-      order = 9,
-      mapping = "parameters",
-      type = "map",
-      optional = true,
-      default = nil,
-      desc = "Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID) to an associated bias value from -100 to 100. Use https://platform.openai.com/tokenizer to find token IDs.",
-      subtype_key = {
-        type = "integer",
-      },
-      subtype = {
-        type = "integer",
-        validate = function(n)
-          return n >= -100 and n <= 100, "Must be between -100 and 100"
-        end,
-      },
-    },
-    user = {
-      order = 10,
-      mapping = "parameters",
-      type = "string",
-      optional = true,
-      default = nil,
-      desc = "A unique identifier representing your end-user, which can help Mistral AI to monitor and detect abuse. Learn more.",
-      validate = function(u)
-        return u:len() < 100, "Cannot be longer than 100 characters"
       end,
     },
   },

--- a/lua/codecompanion/adapters/mistral.lua
+++ b/lua/codecompanion/adapters/mistral.lua
@@ -1,0 +1,317 @@
+local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils.adapters")
+
+---@class MistralAI.Adapter: CodeCompanion.Adapter
+return {
+  name = "mistral",
+  formatted_name = "󱕫 Mistral",
+  roles = {
+    llm = "assistant",
+    user = "user",
+  },
+  opts = {
+    stream = true,
+  },
+  features = {
+    text = true,
+    tokens = true,
+    vision = true,
+  },
+  url = "https://api.mistral.ai/v1/chat/completions",
+  env = {
+    api_key = "MISTRAL_API_KEY",
+  },
+  headers = {
+    ["Content-Type"] = "application/json",
+    Authorization = "Bearer ${api_key}",
+  },
+  handlers = {
+    ---@param self CodeCompanion.Adapter
+    ---@return boolean
+    setup = function(self)
+      local model = self.schema.model.default
+      local model_opts = self.schema.model.choices[model]
+      if model_opts and model_opts.opts then
+        self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
+      end
+
+      if self.opts and self.opts.stream then
+        self.parameters.stream = true
+      end
+      return true
+    end,
+
+    ---Set the parameters
+    ---@param self CodeCompanion.Adapter
+    ---@param params table
+    ---@param messages table
+    ---@return table
+    form_parameters = function(self, params, messages)
+      return params
+    end,
+
+    ---Set the format of the role and content for the messages from the chat buffer
+    ---@param self CodeCompanion.Adapter
+    ---@param messages table Format is: { { role = "user", content = "Your prompt here" } }
+    ---@return table
+    form_messages = function(self, messages)
+      messages = vim
+        .iter(messages)
+        :map(function(m)
+          local model = self.schema.model.default
+          if type(model) == "function" then
+            model = model()
+          end
+          if vim.startswith(model, "o1") and m.role == "system" then
+            m.role = self.roles.user
+          end
+
+          return {
+            role = m.role,
+            content = m.content,
+          }
+        end)
+        :totable()
+
+      return { messages = messages }
+    end,
+
+    ---Returns the number of tokens generated from the LLM
+    ---@param self CodeCompanion.Adapter
+    ---@param data table The data from the LLM
+    ---@return number|nil
+    tokens = function(self, data)
+      if data and data ~= "" then
+        local data_mod = utils.clean_streamed_data(data)
+        local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
+
+        if ok then
+          if json.usage then
+            local tokens = json.usage.total_tokens
+            log:trace("Tokens: %s", tokens)
+            return tokens
+          end
+        end
+      end
+    end,
+
+    ---Output the data from the API ready for insertion into the chat buffer
+    ---@param self CodeCompanion.Adapter
+    ---@param data table The streamed JSON data from the API, also formatted by the format_data handler
+    ---@return table|nil [status: string, output: table]
+    chat_output = function(self, data)
+      local output = {}
+
+      if data and data ~= "" then
+        local data_mod = utils.clean_streamed_data(data)
+        local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
+
+        if ok and json.choices and #json.choices > 0 then
+          local choice = json.choices[1]
+
+          if choice.finish_reason then
+            local reason = choice.finish_reason
+            if reason ~= "stop" and reason ~= "" then
+              return {
+                status = "error",
+                output = "The stream was stopped with the a finish_reason of '" .. reason .. "'",
+              }
+            end
+          end
+
+          local delta = (self.opts and self.opts.stream) and choice.delta or choice.message
+
+          if delta then
+            if delta.role then
+              output.role = delta.role
+            else
+              output.role = nil
+            end
+
+            -- Some providers may return empty content
+            if delta.content then
+              output.content = delta.content
+            else
+              output.content = ""
+            end
+
+            return {
+              status = "success",
+              output = output,
+            }
+          end
+        end
+      end
+    end,
+
+    ---Output the data from the API ready for inlining into the current buffer
+    ---@param self CodeCompanion.Adapter
+    ---@param data string|table The streamed JSON data from the API, also formatted by the format_data handler
+    ---@param context table Useful context about the buffer to inline to
+    ---@return string|table|nil
+    inline_output = function(self, data, context)
+      if data and data ~= "" then
+        data = utils.clean_streamed_data(data)
+        local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
+
+        if ok then
+          --- Some third-party Mistral AI forwarding services may have a return package with an empty json.choices.
+          if not json.choices or #json.choices == 0 then
+            return
+          end
+
+          local choice = json.choices[1]
+          local delta = (self.opts and self.opts.stream) and choice.delta or choice.message
+          if delta.content then
+            return delta.content
+          end
+        end
+      end
+    end,
+
+    ---Function to run when the request has completed. Useful to catch errors
+    ---@param self CodeCompanion.Adapter
+    ---@param data table
+    ---@return nil
+    on_exit = function(self, data)
+      if data.status >= 400 then
+        log:error("Error: %s", data.body)
+        return data.body
+      end
+    end,
+  },
+  schema = {
+    model = {
+      order = 1,
+      mapping = "parameters",
+      type = "enum",
+      desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
+      ---@type string|fun(): string
+      default = "mistral-large-latest",
+      choices = {
+        "mistral-large-latest",
+        "mistral-medium",
+        "mistral-small",
+      },
+    },
+    reasoning_effort = {
+      order = 2,
+      mapping = "parameters",
+      type = "string",
+      optional = true,
+      condition = function(schema)
+        local model = schema.model.default
+        if type(model) == "function" then
+          model = model()
+        end
+        if schema.model.choices[model] and schema.model.choices[model].opts then
+          return schema.model.choices[model].opts.can_reason
+        end
+      end,
+      default = "medium",
+      desc = "Constrains effort on reasoning for reasoning models. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.",
+      choices = {
+        "high",
+        "medium",
+        "low",
+      },
+    },
+    temperature = {
+      order = 3,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 0.2,
+      desc = "What sampling temperature to use, between 0 and 0.7. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
+      validate = function(n)
+        return n >= 0 and n <= 2, "Must be between 0 and 2"
+      end,
+    },
+    top_p = {
+      order = 4,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 1,
+      desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
+      validate = function(n)
+        return n >= 0 and n <= 1, "Must be between 0 and 1"
+      end,
+    },
+    stop = {
+      order = 5,
+      mapping = "parameters",
+      type = "list",
+      optional = true,
+      default = nil,
+      subtype = {
+        type = "string",
+      },
+      desc = "Up to 4 sequences where the API will stop generating further tokens.",
+      validate = function(l)
+        return #l >= 1 and #l <= 4, "Must have between 1 and 4 elements"
+      end,
+    },
+    max_tokens = {
+      order = 6,
+      mapping = "parameters",
+      type = "integer",
+      optional = true,
+      default = nil,
+      desc = "The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length.",
+      validate = function(n)
+        return n > 0, "Must be greater than 0"
+      end,
+    },
+    presence_penalty = {
+      order = 7,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 0,
+      desc = "Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.",
+      validate = function(n)
+        return n >= -2 and n <= 2, "Must be between -2 and 2"
+      end,
+    },
+    frequency_penalty = {
+      order = 8,
+      mapping = "parameters",
+      type = "number",
+      optional = true,
+      default = 0,
+      desc = "Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.",
+      validate = function(n)
+        return n >= -2 and n <= 2, "Must be between -2 and 2"
+      end,
+    },
+    logit_bias = {
+      order = 9,
+      mapping = "parameters",
+      type = "map",
+      optional = true,
+      default = nil,
+      desc = "Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID) to an associated bias value from -100 to 100. Use https://platform.openai.com/tokenizer to find token IDs.",
+      subtype_key = {
+        type = "integer",
+      },
+      subtype = {
+        type = "integer",
+        validate = function(n)
+          return n >= -100 and n <= 100, "Must be between -100 and 100"
+        end,
+      },
+    },
+    user = {
+      order = 10,
+      mapping = "parameters",
+      type = "string",
+      optional = true,
+      default = nil,
+      desc = "A unique identifier representing your end-user, which can help Mistral AI to monitor and detect abuse. Learn more.",
+      validate = function(u)
+        return u:len() < 100, "Cannot be longer than 100 characters"
+      end,
+    },
+  },
+}

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -19,6 +19,7 @@ local defaults = {
     ollama = "ollama",
     openai = "openai",
     xai = "xai",
+    mistral = "mistral",
     -- NON-LLMs ---------------------------------------------------------------
     non_llms = {
       jina = "jina",

--- a/tests/adapters/test_mistral.lua
+++ b/tests/adapters/test_mistral.lua
@@ -1,0 +1,96 @@
+local adapter
+local messages
+local response
+
+local adapter_helpers = require("tests.adapters.helpers")
+local h = require("tests.helpers")
+
+describe("Mistral adapter", function()
+  before_each(function()
+    adapter = require("codecompanion.adapters").resolve("mistral")
+
+    ---------------------------------------------------------- STREAMING OUTPUT
+    messages = { {
+      content = "Explain Ruby in two words",
+      role = "user",
+    } }
+
+    response = {
+      {
+        request = [[data: {"id":"4f8c2452d38241219662c71bffdd4581","object":"chat.completion.chunk","created":1739718831,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}]],
+        output = {
+          content = "",
+          role = "assistant",
+        },
+      },
+      {
+        request = [[data: {"id":"4f8c2452d38241219662c71bffdd4581","object":"chat.completion.chunk","created":1739718831,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":"Object"},"finish_reason":null}]}]],
+        output = {
+          content = "Object",
+        },
+      },
+      {
+        request = [[data: {"id":"4f8c2452d38241219662c71bffdd4581","object":"chat.completion.chunk","created":1739718831,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":"-"},"finish_reason":null}]}]],
+        output = {
+          content = "-",
+        },
+      },
+      {
+        request = [[data: {"id":"4f8c2452d38241219662c71bffdd4581","object":"chat.completion.chunk","created":1739718831,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":"Oriented"},"finish_reason":null}]}]],
+        output = {
+          content = "Oriented",
+        },
+      },
+      {
+        request = [[data: {"id":"4f8c2452d38241219662c71bffdd4581","object":"chat.completion.chunk","created":1739718831,"model":"mistral-large-latest","choices":[{"index":0,"delta":{"content":" Programming"},"finish_reason":null}]}]],
+        output = {
+          content = " Programming",
+        },
+      },
+    }
+    -------------------------------------------------------------------- // END
+  end)
+
+  it("can form messages to be sent to the API", function()
+    h.eq({ messages = messages }, adapter.handlers.form_messages(adapter, messages))
+  end)
+
+  it("can output streamed data into a format for the chat buffer", function()
+    h.eq(
+      { content = "Object-Oriented Programming", role = "assistant" },
+      adapter_helpers.chat_buffer_output(response, adapter)
+    )
+  end)
+end)
+
+describe("Mistral adapter with NO STREAMING", function()
+  before_each(function()
+    response = {
+      {
+        request = {
+          body = '{\n "id":"9dc1b04f00d844a687aa93fa28ca5c95",\n "object":"chat.completion",\n "created":1739718775,\n "model":"mistral-large-latest",\n "choices":[\n {\n "index":0,\n "message":{\n "role":"assistant",\n "tool_calls":null,\n "content":"Object-Oriented Programming.\n\n(If you\'re looking for two words that describe Ruby more uniquely, consider: "Elegant Syntax")"\n },\n "finish_reason":"stop"\n },\n ],\n "usage":{\n "prompt_tokens":18,\n "total_tokens":53,\n "completion_tokens":35\n }\n }\n',
+          exit = 0,
+          headers = {
+            "date: Sun, 16 Feb 2025 15:12:55 GMT",
+            "content-type: application/json",
+          },
+          status = 200,
+        },
+        output = {
+          content = 'Object-Oriented Programming.\n\n(If you\'re looking for two words that describe Ruby more uniquely, consider: "Elegant Syntax")',
+          role = "assistant",
+        },
+      },
+    }
+
+    adapter = require("codecompanion.adapters").extend("mistral", {
+      opts = {
+        stream = false,
+      },
+    })
+  end)
+
+  it("can output data into a format for the chat buffer", function()
+    h.eq(response[#response].output, adapter_helpers.chat_buffer_output(response, adapter))
+  end)
+end)


### PR DESCRIPTION
## Description

Add an adapter for [Mistral IA](console.mistral.ai). Why? Because I've tried using the OpenAI compatible adapter but Mistral rejects the request because some parameters in the request payload.

## Screenshots

![image](https://github.com/user-attachments/assets/4438437c-fa01-4a48-a1a0-20b39cedaf4a)

![image](https://github.com/user-attachments/assets/12af35c8-b23c-4c4d-a8a7-0316c7106ce0)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
