### PR TITLE
feat(tools): allow passing a table as the `callback` of a tool.

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -140,6 +140,8 @@ require("codecompanion").setup({
 
 When users introduce the agent `@my_agent` in the chat buffer, it can call the tools you listed (like `@my_tool`) to perform tasks on your code.
 
+The `callback` option for a tool can also be a [`CodeCompanion.Tool`](/extending/tools) object, which is a table with specific keys that defines the interface and workflow of the tool.
+
 ## Layout
 
 You can change the appearance of the chat buffer by changing the `display.chat.window` table in your configuration:

--- a/lua/codecompanion/strategies/chat/tools/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/init.lua
@@ -592,6 +592,10 @@ end
 function Tools.resolve(tool)
   local callback = tool.callback
 
+  if type(callback) == "table" then
+    return callback --[[@as CodeCompanion.Tool]]
+  end
+
   local ok, module = pcall(require, "codecompanion." .. callback)
   if ok then
     log:debug("[Tools] %s identified", callback)


### PR DESCRIPTION
## Description

This allows the tool to be "configured" before being loaded by codecompanion. It makes it easier for plugin devs to provide integrations with codecompanion.

## Related Issue(s)

- Fixes #931 

## Demo

Before this PR you have to put the tool in a `lua/codecompanion/my_plugin/tool.lua` and use it as:
```lua
agents = {
  tools = {
    my_plugin = {
      callback = "my_plugin.tool"
    },
  }
}
```
Now you can do 
```lua
agents = {
  tools = {
    my_plugin = {
      callback = require("my_plugin").make_tool(opts)
    },
  }
}
```
where `opts` can contain parameters to set up the tool.
## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
