### PR TITLE
Explicitly map <CR> to telescope select_default slash command

### DIFF
--- a/lua/codecompanion/providers/slash_commands/telescope.lua
+++ b/lua/codecompanion/providers/slash_commands/telescope.lua
@@ -20,7 +20,7 @@ end
 ---The function to display the provider
 ---@return function
 function Telescope:display()
-  return function()
+  return function(_, map)
     local actions = require("telescope.actions")
     local action_state = require("telescope.actions.state")
 
@@ -39,7 +39,7 @@ function Telescope:display()
         end
       end)
     end)
-
+    map({'i', 'n'}, '<CR>', actions.select_default)
     return true
   end
 end


### PR DESCRIPTION
In my telescope config I define an insert mode `<CR>` mapping for the `find_files` picker: https://github.com/petobens/dotfiles/blob/42327e961e9112c2e5c0dea3a6bd141f7f95011a/nvim/lua/plugin-config/telescope_config.lua#L650-L654

Without the changes in this PR if I pressed enter (`<CR>`)  on multiple selections when using the `/file` slash command then files would get opened (see GIF) rather than being added to the chat buffer i.e my original `find_files` mapping would take priority over the attach mapping function despite the docs say that this shouldn't happen https://github.com/nvim-telescope/telescope.nvim/blob/master/doc/telescope.txt#L1977. 

Dunno if there is a better way of doing this. Feel free to close/recommend something else.

![multi_codecompanion](https://github.com/user-attachments/assets/7488b371-13c6-473d-a34a-f813fe9f3c0a)
 