### PR TITLE
Ollama - Fix inline output parsing and adapter caching

### DIFF
--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -219,10 +219,10 @@ return {
 
     ---Function to run when the request has completed. Useful to catch errors
     ---@param self CodeCompanion.Adapter
-    ---@param data table
+    ---@param data? table
     ---@return nil
     on_exit = function(self, data)
-      if data.status >= 400 then
+      if data and data.status >= 400 then
         log:error("Error %s: %s", data.status, data.body)
       end
     end,

--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -161,10 +161,10 @@ return {
 
     ---Function to run when the request has completed. Useful to catch errors
     ---@param self CodeCompanion.Adapter
-    ---@param data table
+    ---@param data? table
     ---@return nil
     on_exit = function(self, data)
-      if data.status >= 400 then
+      if data and data.status >= 400 then
         log:error("Error: %s", data.body)
       end
     end,

--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -3,25 +3,38 @@ local curl = require("plenary.curl")
 local log = require("codecompanion.utils.log")
 local utils = require("codecompanion.utils.adapters")
 
+local _cached_adapter
+
+---Reset the cached adapter
+---@return nil
+local function reset()
+  _cached_adapter = nil
+end
+
 ---Get a list of available Ollama models
 ---@params self CodeCompanion.Adapter
 ---@params opts? table
 ---@return table
 local function get_models(self, opts)
-  local adapter = require("codecompanion.adapters").resolve(self)
-  if not adapter then
-    log:error("Could not resolve Ollama adapter in the `get_models` function")
-    return {}
+  -- Prevent the adapter from being resolved multiple times due to `get_models`
+  -- having both `default` and `choices` functions
+  if not _cached_adapter then
+    local adapter = require("codecompanion.adapters").resolve(self)
+    if not adapter then
+      log:error("Could not resolve Ollama adapter in the `get_models` function")
+      return {}
+    end
+    _cached_adapter = adapter
   end
 
-  adapter:get_env_vars()
-  local url = adapter.env_replaced.url
+  _cached_adapter:get_env_vars()
+  local url = _cached_adapter.env_replaced.url
 
   local headers = {
     ["content-type"] = "application/json",
   }
-  if adapter.env_replaced.api_key then
-    headers["Authorization"] = "Bearer " .. adapter.env_replaced.api_key
+  if _cached_adapter.env_replaced.api_key then
+    headers["Authorization"] = "Bearer " .. _cached_adapter.env_replaced.api_key
   end
 
   local ok, response = pcall(function()
@@ -162,26 +175,29 @@ return {
     ---@param context table Useful context about the buffer to inline to
     ---@return table|nil
     inline_output = function(self, data, context)
+      if self.opts.stream then
+        return log:error("Inline output is not supported for non-streaming models")
+      end
+
       if data and data ~= "" then
-        if not self.opts.stream then
-          data = data.body
-        end
-        local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
+        local ok, json = pcall(vim.json.decode, data.body, { luanil = { object = true } })
 
         if not ok then
-          return log:error("Error decoding JSON: %s", data.body)
+          log:error("Error decoding JSON: %s", data.body)
+          return { status = "error", output = json }
         end
 
-        return json.message.content
+        return { status = "success", output = json.message.content }
       end
     end,
 
     ---Function to run when the request has completed. Useful to catch errors
     ---@param self CodeCompanion.Adapter
-    ---@param data table
+    ---@param data? table
     ---@return nil
     on_exit = function(self, data)
-      if data.status >= 400 then
+      reset()
+      if data and data.status >= 400 then
         log:error("Error: %s", data.body)
       end
     end,

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -172,10 +172,10 @@ return {
 
     ---Function to run when the request has completed. Useful to catch errors
     ---@param self CodeCompanion.Adapter
-    ---@param data table
+    ---@param data? table
     ---@return nil
     on_exit = function(self, data)
-      if data.status >= 400 then
+      if data and data.status >= 400 then
         log:error("Error: %s", data.body)
       end
     end,

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -950,6 +950,7 @@ function Chat:stop()
         job:shutdown()
       end)
     end
+    self.adapter.handlers.on_exit(self.adapter)
   end
 
   self.subscribers:stop()

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -368,6 +368,7 @@ function Inline:stop()
   if self.current_request then
     self.current_request:shutdown()
     self.current_request = nil
+    self.adapter.handlers.on_exit(self.adapter)
   end
 end
 

--- a/tests/adapters/test_ollama.lua
+++ b/tests/adapters/test_ollama.lua
@@ -149,4 +149,8 @@ describe("Ollama adapter with NO STREAMING", function()
   it("can output data into a format for the chat buffer", function()
     h.eq(response[#response].output, adapter_helpers.chat_buffer_output(response, adapter))
   end)
+
+  it("can output data into a format for the inline assistant", function()
+    h.eq(response[#response].output.content, adapter_helpers.inline_buffer_output(response, adapter))
+  end)
 end)

--- a/tests/strategies/inline/test_inline.lua
+++ b/tests/strategies/inline/test_inline.lua
@@ -40,6 +40,22 @@ T["Inline"]["can parse markdown output correctly"] = function()
   h.eq("add", xml.placement)
 end
 
+T["Inline"]["can parse Ollama output correctly"] = function()
+  local xml = inline:parse_output(
+    "```xml\n<response>\n  <code><![CDATA[\n/**\n * Executes an action based on the current action type.\n */\n]]></code>\n  <language>php</language>\n  <placement>before</placement>\n</response>\n```"
+  )
+  h.eq(
+    [[
+
+/**
+ * Executes an action based on the current action type.
+ */
+]],
+    xml.code
+  )
+  h.eq("before", xml.placement)
+end
+
 T["Inline"]["handles different placements"] = function()
   -- Test 'add' placement
   inline:place("add")
@@ -93,21 +109,21 @@ T["Inline"]["forms correct prompts"] = function()
   h.eq("<user_prompt>Hello World</user_prompt>", inline.prompts[#inline.prompts].content)
 end
 
--- T["Inline"]["generates correct prompt structure"] = function()
---   local submitted_prompts = {}
---
---   -- Mock the submit function
---   function inline:submit(prompts)
---     submitted_prompts = prompts
---   end
---
---   inline:prompt("Test prompt")
---
---   h.eq(#submitted_prompts, 2) -- Should be a system prompt and the user prompt
---   h.eq(submitted_prompts[1].role, "system")
---   h.eq(submitted_prompts[2].role, "user")
---   h.eq(submitted_prompts[2].content, "<user_prompt>Test prompt</user_prompt>")
--- end
+T["Inline"]["generates correct prompt structure"] = function()
+  local submitted_prompts = {}
+
+  -- Mock the submit function
+  function inline:submit(prompts)
+    submitted_prompts = prompts
+  end
+
+  inline:prompt("Test prompt")
+
+  h.eq(#submitted_prompts, 2) -- Should be a system prompt and the user prompt
+  h.eq(submitted_prompts[1].role, "system")
+  h.eq(submitted_prompts[2].role, "user")
+  h.eq(submitted_prompts[2].content, "<user_prompt>Test prompt</user_prompt>")
+end
 
 T["Inline"]["the first word can be an adapter"] = function()
   -- Mock the submit function


### PR DESCRIPTION
## Description

The Ollama model allows `schema.models.default` and `schema.models.choices` to be functions. Without caching, during the same request, this is potentially "expensive" as the adapter class has to resolve them.

The `handlers.on_exit` function is the ideal place to reset the cache however it's only called when the request ends completely. If the user cancels the request then previously it was not called.

This PR fixes the above and also streamlines Ollama's `inline_output` method.