### PR TITLE
make stderr capturing work for "streaming" job output

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/init.lua
@@ -363,7 +363,11 @@ function Tools:run()
             table.insert(strip_ansi(stdout), data)
           end)
         end,
-        on_stderr = function(err, _)
+        on_stderr = function(err, data)
+          vim.schedule(function()
+            table.insert(strip_ansi(stderr), data)
+          end)
+
           if err then
             vim.schedule(function()
               stderr = strip_ansi(err)


### PR DESCRIPTION
I noticed when asking the LLM to run a command, my `cargo build` errors weren't being logged and instead the response was:

> There was an error from the command `cargo build`:
> 
> ```txt
> Tool failed with code 101 and no output
> ```

With this change, the error is correctly captured and added to the prompt:

> There was an error from the command `cargo build`:
> 
> ```txt
> bunch of stderr output here...
> ```

This might not be the correct way to solve the issue, but in the logs I always see the `err` variable as `nil`, and Plenary docs aren't very helpful on understanding what the variable represents. Feel free to close this and solve it the proper way, but this _worked on my machine_.