### PR TITLE
fix(inline): ensure placement is in lower case

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -434,12 +434,12 @@ function Inline:done(output)
     log:error("[%s] %s", adapter_name, xml.error)
     return self:reset()
   end
-  if xml and not xml.code and xml.placement ~= "chat" then
+  if xml and not xml.code and string.lower(xml.placement) ~= "chat" then
     log:error("[%s] Returned no code", adapter_name)
     return self:reset()
   end
 
-  local placement = xml and xml.placement or self.classification.placement
+  local placement = xml and string.lower(xml.placement) or string.lower(self.classification.placement)
   log:debug("[Inline] Placement: %s", placement)
   if not placement then
     log:error("[%s] No placement returned", adapter_name)


### PR DESCRIPTION
## Description

Gemini is marvellous to talk to and a pain in the backside to program with. Instead of returning the placement in lower case like every LLM, it likes to capitalise it...