### PR TITLE
fix: add space to fetch ui input message

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -184,7 +184,7 @@ end
 ---@param opts? table
 ---@return nil|string
 function SlashCommand:execute(SlashCommands, opts)
-  vim.ui.input({ prompt = "Enter a URL" }, function(url)
+  vim.ui.input({ prompt = "Enter a URL: " }, function(url)
     if url == "" or not url then
       return nil
     end


### PR DESCRIPTION
Following my comment here https://github.com/olimorris/codecompanion.nvim/issues/948#issuecomment-2667153570 I've added a space to the fetch input message. Before and after images follow

![Screenshot_2025-02-19_09:57:44](https://github.com/user-attachments/assets/307ceea5-b6cb-4490-923c-d686186c8c2b)
![Screenshot_2025-02-19_09:56:15](https://github.com/user-attachments/assets/7b0f6066-e025-4e85-a108-11e7a6ce34ec)

