### PR TITLE
feat(chat): when `stderr` is not empty, do not discard `stdout` when exit code is 0

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/init.lua
@@ -404,6 +404,11 @@ function Tools:run()
               output.error(cmd, strip_ansi(stderr))
               log:debug("[Tools] %s finished with stderr: %s", self.tool.name, stderr)
               stderr = {}
+              if code == 0 then
+                output.success(cmd, strip_ansi(stdout))
+                log:trace("[Tools] %s finished with output: %s", self.tool.name, stdout)
+                stdout = {}
+              end
             elseif not vim.tbl_isempty(stdout) then
               output.success(cmd, strip_ansi(stdout))
               log:trace("[Tools] %s finished with output: %s", self.tool.name, stdout)


### PR DESCRIPTION
## Description

Currently, the tool class discard `stdout` when `stderr` is not empty even if the exit code is 0. In the real world a lot of programs/libraries (in my case, [VectorCode](https://github.com/Davidyz/VectorCode/wiki/Neovim-Integrations#tool)) use `stderr` for warnings that don't actually terminate the command. The current way in which `stdout` and `stderr` are handled caused false negatives in some cases (outputs with useful information get thrown away).

> I'm not sure if it's appropriate to call both `output.error` and `output.success`. I simply copied the code under `elseif not vim.tbl_isempty(stdout) then` here.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
