### PR TITLE
feat(chat): easier to add refs from external sources

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -113,6 +113,8 @@ require("codecompanion").setup({
 })
 ```
 
+Credit to [@lazymaniac](https://github.com/lazymaniac) for the [inspiration](https://github.com/olimorris/codecompanion.nvim/discussions/958).
+
 > [!NOTE]
 > You can also point the callback to a lua file that resides within your own configuration
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -89,12 +89,23 @@ require("codecompanion").setup({
   strategies = {
     chat = {
       slash_commands = {
-        ["mycmd"] = {
-          description = "My fancy new command",
+        ["git_files"] = {
+          description = "List git files",
           ---@param chat CodeCompanion.Chat
           callback = function(chat)
-            return chat:add_buf_message({ content = "Just writing to the chat buffer" })
+            local handle = io.popen("git ls-files")
+            if handle ~= nil then
+              local result = handle:read("*a")
+              handle:close()
+              local id = "<git_files>"
+              chat:add_reference({ content = result }, "git", id, { reference = id, visible = false })
+            else
+              return vim.notify("No git files available", vim.log.levels.INFO, { title = "CodeCompanion" })
+            end
           end,
+          opts = {
+            contains_code = false,
+          },
         },
       },
     },

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -97,8 +97,7 @@ require("codecompanion").setup({
             if handle ~= nil then
               local result = handle:read("*a")
               handle:close()
-              local id = "<git_files>"
-              chat:add_reference({ content = result }, "git", id, { reference = id, visible = false })
+              chat:add_reference({ content = result }, "git", "<git_files>")
             else
               return vim.notify("No git files available", vim.log.levels.INFO, { title = "CodeCompanion" })
             end

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -841,6 +841,18 @@ function Chat:done(output)
   self:reset()
 end
 
+---Add a reference to the chat buffer (Useful for user's adding custom Slash Commands)
+---@param data { role: string, content: string }
+---@param source string
+---@param id string
+---@param opts? table Options for the message
+function Chat:add_reference(data, source, id, opts)
+  opts = opts or { visible = false }
+
+  self.references:add({ source = source, id = id })
+  self:add_message(data, opts)
+end
+
 ---Reconcile the references table to the references in the chat buffer
 ---@return nil
 function Chat:check_references()

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -847,7 +847,7 @@ end
 ---@param id string
 ---@param opts? table Options for the message
 function Chat:add_reference(data, source, id, opts)
-  opts = opts or { visible = false }
+  opts = opts or { reference = id, visible = false }
 
   self.references:add({ source = source, id = id })
   self:add_message(data, opts)


### PR DESCRIPTION
## Description

Previously if users were trying to add a reference to the chat buffer, it involved two method calls. Now users can use `chat:add_reference`.