### PR TITLE
fix(chat): add missing write flag attribute when editing files

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/files.lua
+++ b/lua/codecompanion/strategies/chat/tools/files.lua
@@ -83,11 +83,12 @@ local function edit(action)
     return util.notify(fmt("No data found in %s", action.path))
   end
 
-  if not content:find(vim.pesc(action.search)) then
+  local changed, substitutions_count = content:gsub(vim.pesc(action.search), vim.pesc(action.replace))
+  if substitutions_count == 0 then
     return util.notify(fmt("Could not find the search string in %s", action.path))
   end
 
-  p:write(content:gsub(vim.pesc(action.search), vim.pesc(action.replace)))
+  p:write(changed, "w")
 end
 
 ---Delete a file

--- a/tests/strategies/chat/tools/test_files.lua
+++ b/tests/strategies/chat/tools/test_files.lua
@@ -47,11 +47,11 @@ This is line 5]],
 
   it("can edit a file", function()
     local path = "~/tmp/test.txt"
-    files.actions.edit({ path = path, search = "Hello World", replace = "Hello CodeCompanion" })
+    files.actions.edit({ path = path, search = "Hello World", replace = "Hello Code" })
 
     local file = io.open(vim.fs.normalize(path), "r")
     local contents = file:read("*a")
-    h.eq("Hello CodeCompanion", contents)
+    h.eq("Hello Code", contents)
     file:close()
   end)
 


### PR DESCRIPTION
## Description
Previously, the return values of `gsub` were passed to `p:write`. This is incorrect because `gsub` returns two values: the changed data and the number of substitutions made. Since the method signature for `write` is `write(txt, flag, mode)`, the number of substitutions returned by `gsub` was incorrectly passed as the flag attribute. This could lead to incorrect behavior.

Passing `"w"` explicitly means that the file will be opened for writing, and if it has any content, it will be truncated.

I also modified the test so that it would fail with the previous implementation. The reason for the failure is that when invoking `write` with the changed text and a flag of 1 (1 is the number of substitutions returned by gsub, and by accident it also corresponds to the O_WRONLY flag), the file is not truncated. Since the substitution text is shorter than the original file content, some leftovers remain in the file.

P.S. I've read the contributing guide but decided not to start a discussion since it seems like an obvious oversight. I hope you don't mind. :)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
