### PR TITLE
Add reference handling to workflow processing

### DIFF
--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -176,6 +176,11 @@ function Strategies:workflow()
     context = self.context,
     messages = messages,
   })
+
+  if workflow.references then
+    add_ref(workflow, chat)
+  end
+
   table.remove(prompts, 1)
 
   -- Then when it completes we send the next batch and so on


### PR DESCRIPTION
## Description

When a workflow contains references, they are now properly processed using the add_ref function.

## Related Issue(s)

Actually it's just a Q&A discussion: https://github.com/olimorris/codecompanion.nvim/discussions/957

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make docs` to update the vimdoc pages
