### PR TITLE
fix(ollama): allow users to customize the authorization header in `get_models`

### DIFF
--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -33,8 +33,13 @@ local function get_models(self, opts)
   local headers = {
     ["content-type"] = "application/json",
   }
+
+  local auth_header = "Bearer "
+  if _cached_adapter.env_replaced.authorization then
+    auth_header = _cached_adapter.env_replaced.authorization .. " "
+  end
   if _cached_adapter.env_replaced.api_key then
-    headers["Authorization"] = "Bearer " .. _cached_adapter.env_replaced.api_key
+    headers["Authorization"] = auth_header .. _cached_adapter.env_replaced.api_key
   end
 
   local ok, response = pcall(function()


### PR DESCRIPTION
## Description

Currently the `get_models` function in the Ollama adapter forces users to use  `Bearer` in the authorization header if an api key exists.

## Related Issue(s)

#976