### PR TITLE
Add Claude 3.7 Sonnet model to Anthropic adapter

### DIFF
--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -233,8 +233,9 @@ return {
       mapping = "parameters",
       type = "enum",
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
-      default = "claude-3-5-sonnet-20241022",
+      default = "claude-3-7-sonnet-20250219",
       choices = {
+        "claude-3-7-sonnet-20250219",
         "claude-3-5-sonnet-20241022",
         "claude-3-5-haiku-20241022",
         "claude-3-opus-20240229",


### PR DESCRIPTION
## Description

This simply adds the new param for Claude 3.7 Sonnet to the Anthropic adapter and makes it default. It does not make the changes necessary to enable the thinking/reasoning mode.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
