### PR TITLE
Add Extended Thinking and Extended Output for Claude 3.7

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*       For NVIM v0.10.0       Last change: 2025 February 20
+*codecompanion.txt*       For NVIM v0.10.0       Last change: 2025 February 25
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -646,7 +646,7 @@ USER CONTRIBUTED ADAPTERS ~
 
 Thanks to the community for building and supporting the following adapters:
 
-- Venice.ai <https://github.com/olimorris/codecompanion.nvim/discussions/775>
+- Venice.ai <https://github.com/olimorris/codecompanion.nvim/discussions/972>
 - Fireworks.ai <https://github.com/olimorris/codecompanion.nvim/discussions/693>
 
 The section of the discussion forums which is dedicated to user created
@@ -1467,17 +1467,26 @@ nearest codeblock.
 
 AUTOMATICALLY UPDATE A BUFFER ~
 
-The |codecompanion-usage-chat-buffer-agents-editor| tool enables an LLM to
-modify code in a Neovim buffer. This is especially useful if you do not wish to
-manually apply an LLM’s suggestions yourself. Simply tag it in the chat
-buffer with `@editor`.
+The |codecompanion-usage-chat-buffer-agents-editor| tool, combined with the
+`#buffer` variable, enables an LLM to modify code in a Neovim buffer. This is
+especially useful if you do not wish to manually apply an LLM’s suggestions
+yourself. Simply tag it in the chat buffer with `@editor`. To ensure the LLM
+can consistently see the changes that it’s applied, be sure to
+|codecompanion-usage-chat-buffer--references| your buffers.
 
 
 RUN TESTS FROM THE CHAT BUFFER ~
 
 The |codecompanion-usage-chat-buffer-agents-cmd-runner| tool enables an LLM to
 execute commands on your machine. This can be useful if you wish the LLM to run
-a test suite on your behalf and give insight on failing cases.
+a test suite on your behalf and give insight on failing cases. Simply tag the
+`@cmd_runner` in the chat buffer and ask it run your tests with a suitable
+command e.g. `pytest`.
+
+
+NAVIGATING BETWEEN RESPONSES IN THE CHAT BUFFER ~
+
+You can quickly move between responses in the chat buffer using `[[` or `]]`.
 
 
 QUICKLY ACCESSING A CHAT BUFFER ~
@@ -2503,7 +2512,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -317,7 +317,7 @@ return {
       default = 4096,
       desc = "The maximum number of tokens to generate before stopping. This parameter only specifies the absolute maximum number of tokens to generate. Different models have different maximum values for this parameter.",
       validate = function(n)
-        return n > 0 and n <= 32768, "Must be between 0 and 32768"
+        return n > 0 and n <= 128000, "Must be between 0 and 128000"
       end,
     },
     temperature = {

--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -43,8 +43,8 @@ return {
       end
 
       -- Add the extended output header if enabled
-      if self.parameters.extended_output then
-        self.headers["anthropic-beta"] = "prompt-caching-2024-07-31,output-128k-2025-02-19"
+      if self.temp.extended_output then
+        self.headers["anthropic-beta"] = (self.headers["anthropic-beta"] .. "," or "") .. "output-128k-2025-02-19"
       end
 
       return true

--- a/lua/codecompanion/adapters/anthropic.lua
+++ b/lua/codecompanion/adapters/anthropic.lua
@@ -263,7 +263,7 @@ return {
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
       default = "claude-3-7-sonnet-20250219",
       choices = {
-        "claude-3-7-sonnet-20250219",
+        ["claude-3-7-sonnet-20250219"] = { opts = { can_reason = true } },
         "claude-3-5-sonnet-20241022",
         "claude-3-5-haiku-20241022",
         "claude-3-opus-20240229",
@@ -285,6 +285,12 @@ return {
       optional = true,
       default = false,
       desc = "Enable extended thinking for more thorough reasoning. Requires thinking_budget to be set.",
+      condition = function(schema)
+        local model = schema.model.default
+        if schema.model.choices[model] and schema.model.choices[model].opts then
+          return schema.model.choices[model].opts.can_reason
+        end
+      end,
     },
     thinking_budget = {
       order = 4,
@@ -295,6 +301,12 @@ return {
       desc = "The maximum number of tokens to use for thinking when extended_thinking is enabled. Must be less than max_tokens.",
       validate = function(n)
         return n > 0, "Must be greater than 0"
+      end,
+      condition = function(schema)
+        local model = schema.model.default
+        if schema.model.choices[model] and schema.model.choices[model].opts then
+          return schema.model.choices[model].opts.can_reason
+        end
       end,
     },
     max_tokens = {

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1034,11 +1034,11 @@ function Chat:add_buf_message(data, opts)
   -- Add data to the chat buffer
   local function append_data()
     if data.reasoning then
-      has_been_reasoning = true
-      if new_response then
+      if not has_been_reasoning then
         table.insert(lines, "### Reasoning")
         table.insert(lines, "")
       end
+      has_been_reasoning = true
       write(data.reasoning)
     end
     if data.content then


### PR DESCRIPTION
## Description

Claude 3.7 adds DeepSeek R1-like 'extended thinking' - see https://www.anthropic.com/news/visible-extended-thinking
This PR adds support for this, and also [extended output](https://docs.anthropic.com/en/docs/about-claude/models/extended-thinking-models#extended-output-capabilities-beta).
Like the DeepSeek plugin, it outputs the 'thinking' text when streaming.

One thing I'd appreciate feedback on. I've added parameters that don't directly map to API parameters, which I then set to nil later once we've built the actual params/header required. Is there a better way to do this?

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make docs` to update the vimdoc pages
