### PR TITLE
fix(adapters): only try and replace str variables

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -12,6 +12,7 @@ local log = require("codecompanion.utils.log")
 ---@field headers table The headers to pass to the request
 ---@field parameters table The parameters to pass to the request
 ---@field body table Additional body parameters to pass to the request
+---@field temp? table A table to store temporary values which are not passed to the request
 ---@field raw? table Any additional curl arguments to pass to the request
 ---@field opts? table Additional options for the adapter
 ---@field handlers table Functions which link the output from the request to CodeCompanion
@@ -105,6 +106,10 @@ end
 ---@param str string
 ---@return string
 local function replace_var(adapter, str)
+  if type(str) ~= "string" then
+    return str
+  end
+
   local pattern = "${(.-)}"
 
   local result = str:gsub(pattern, function(var)


### PR DESCRIPTION
## Description

Previously the adapter would error if a function returned a number, because it was trying to do variable replacement on it.