### PR TITLE
feat(adapters): add claude-3.7-sonnet to copilot

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -209,6 +209,7 @@ return {
         ["o3-mini-2025-01-31"] = { opts = { can_reason = true } },
         ["o1-2024-12-17"] = { opts = { can_reason = true } },
         ["o1-mini-2024-09-12"] = { opts = { can_reason = true } },
+        "claude-3.7-sonnet",
         "claude-3.5-sonnet",
         "gpt-4o-2024-08-06",
         "gemini-2.0-flash-001",


### PR DESCRIPTION
## Description

If you've enabled Claude 3.7-sonnet in your GitHub settings, you can now use this with the Copilot adapter.

I've not added in any reasoning parameters for this. Just the model.