### PR TITLE
feat: add gemini-2.0-pro-exp-02-05 model option

### DIFF
--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -177,6 +177,7 @@ return {
       default = "gemini-2.0-flash",
       choices = {
         "gemini-2.0-flash",
+        "gemini-2.0-pro-exp-02-05",
         "gemini-1.5-flash",
         "gemini-1.5-pro",
         "gemini-1.0-pro",


### PR DESCRIPTION
Adds the experimental Gemini 2.0 Pro model (exp-02-05) to the list of selectable models in the Gemini adapter.

## Description

Adds the experimental Gemini 2.0 Pro model (exp-02-05) to the list of selectable models in the Gemini adapter.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
