### PR TITLE
feat(copilot): get available models from copilot endpoint

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -123,6 +123,7 @@ local function get_and_authorize_token()
 end
 
 local _cached_adapter
+local _cached_available_models
 
 ---Reset the cached adapter
 ---@return nil
@@ -135,6 +136,10 @@ end
 ---@params opts? table
 ---@return table
 local function get_models(self, opts)
+  if _cached_available_models then
+    return _cached_available_models
+  end
+
   if not _cached_adapter then
     local adapter = require("codecompanion.adapters").resolve(self)
     if not adapter then
@@ -183,6 +188,8 @@ local function get_models(self, opts)
       models[model.id] = { opts = choice_opts }
     end
   end
+
+  _cached_available_models = models
 
   return models
 end

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -145,7 +145,7 @@ local function get_models(self, opts)
   end
 
   get_and_authorize_token()
-  local url = "https://api.individual.githubcopilot.com"
+  local url = "https://api.githubcopilot.com"
   local headers = _cached_adapter.headers
   headers["Authorization"] = "Bearer " .. _github_token.token
 

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -104,6 +104,89 @@ local function authorize_token()
   return _github_token
 end
 
+---Get and authorize a GitHub Copilot token
+---@return boolean success
+local function get_and_authorize_token()
+  _oauth_token = get_token()
+  if not _oauth_token then
+    log:error("Copilot Adapter: No token found. Please refer to https://github.com/github/copilot.vim")
+    return false
+  end
+
+  _github_token = authorize_token()
+  if not _github_token or vim.tbl_isempty(_github_token) then
+    log:error("Copilot Adapter: Could not authorize your GitHub Copilot token")
+    return false
+  end
+
+  return true
+end
+
+local _cached_adapter
+
+---Reset the cached adapter
+---@return nil
+local function reset()
+  _cached_adapter = nil
+end
+
+---Get a list of available Copilot models
+---@params self CodeCompanion.Adapter
+---@params opts? table
+---@return table
+local function get_models(self, opts)
+  if not _cached_adapter then
+    local adapter = require("codecompanion.adapters").resolve(self)
+    if not adapter then
+      log:error("Could not resolve Copilot adapter in the `get_models` function")
+      return {}
+    end
+    _cached_adapter = adapter
+  end
+
+  get_and_authorize_token()
+  local url = "https://api.individual.githubcopilot.com"
+  local headers = _cached_adapter.headers
+  headers["Authorization"] = "Bearer " .. _github_token.token
+
+  local ok, response = pcall(function()
+    return curl.get(url .. "/models", {
+      sync = true,
+      headers = headers,
+      insecure = config.adapters.opts.allow_insecure,
+      proxy = config.adapters.opts.proxy,
+    })
+  end)
+  if not ok then
+    log:error("Could not get the Copilot models from " .. url .. "/models.\nError: %s", response)
+    return {}
+  end
+
+  local ok, json = pcall(vim.json.decode, response.body)
+  if not ok then
+    log:error("Could not parse the response from " .. url .. "/models")
+    return {}
+  end
+
+  local models = {}
+  for _, model in ipairs(json.data) do
+    if model.model_picker_enabled and model.capabilities.type == "chat" then
+      local choice_opts = {}
+
+      -- streaming support
+      if model.capabilities.supports.streaming then
+        choice_opts.stream = true
+      else
+        choice_opts.stream = false
+      end
+
+      models[model.id] = { opts = choice_opts }
+    end
+  end
+
+  return models
+end
+
 ---@class Copilot.Adapter: CodeCompanion.Adapter
 return {
   name = "copilot",
@@ -139,7 +222,14 @@ return {
     ---@return boolean
     setup = function(self)
       local model = self.schema.model.default
-      local model_opts = self.schema.model.choices[model]
+      local choices = self.schema.model.choices
+      if type(model) == "function" then
+        model = model()
+      end
+      if type(choices) == "function" then
+        choices = choices()
+      end
+      local model_opts = choices[model]
       if model_opts and model_opts.opts then
         self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
       end
@@ -148,19 +238,7 @@ return {
         self.parameters.stream = true
       end
 
-      _oauth_token = get_token()
-      if not _oauth_token then
-        log:error("Copilot Adapter: No token found. Please refer to https://github.com/github/copilot.vim")
-        return false
-      end
-
-      _github_token = authorize_token()
-      if not _github_token or vim.tbl_isempty(_github_token) then
-        log:error("Copilot Adapter: Could not authorize your GitHub Copilot token")
-        return false
-      end
-
-      return true
+      return get_and_authorize_token()
     end,
 
     --- Use the OpenAI adapter for the bulk of the work
@@ -194,6 +272,7 @@ return {
       return openai.handlers.inline_output(self, data, context)
     end,
     on_exit = function(self, data)
+      reset()
       return openai.handlers.on_exit(self, data)
     end,
   },
@@ -204,18 +283,10 @@ return {
       type = "enum",
       desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
       ---@type string|fun(): string
-      default = "gpt-4o-2024-08-06",
-      choices = {
-        ["o3-mini-2025-01-31"] = { opts = { can_reason = true } },
-        ["o1-2024-12-17"] = { opts = { can_reason = true } },
-        ["o1-mini-2024-09-12"] = { opts = { can_reason = true } },
-        "claude-3.7-sonnet",
-        "claude-3.5-sonnet",
-        "claude-3.7-sonnet",
-        "claude-3.7-sonnet-thought",
-        "gpt-4o-2024-08-06",
-        "gemini-2.0-flash-001",
-      },
+      default = "gpt-4o",
+      choices = function(self)
+        return get_models(self)
+      end,
     },
     reasoning_effort = {
       order = 2,
@@ -224,11 +295,15 @@ return {
       optional = true,
       condition = function(schema)
         local model = schema.model.default
+        local choices = schema.model.choices
         if type(model) == "function" then
           model = model()
         end
-        if schema.model.choices[model] and schema.model.choices[model].opts then
-          return schema.model.choices[model].opts.can_reason
+        if type(choices) == "function" then
+          choices = choices()
+        end
+        if choices[model] and choices[model].opts then
+          return choices[model].opts.can_reason
         end
       end,
       default = "medium",


### PR DESCRIPTION
## Related Issue(s)

From discussion #858
https://github.com/olimorris/codecompanion.nvim/discussions/858#discussioncomment-12311109

## Screenshots

![Screenshot 2025-02-25 at 16 21 31](https://github.com/user-attachments/assets/14044ace-08c0-4dc6-9806-83e47cf73761)

During the development of this feature I was able to access "claude-3.7". Now I can no longer access claude 3.7 in vscode. Maybe they have [restricted the access](https://github.blog/changelog/2025-02-24-claude-3-7-sonnet-is-now-available-in-github-copilot-in-public-preview/)? (im on student plan)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
