### PR TITLE
fix(adapters): inline editing with copilot

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -178,9 +178,7 @@ local function get_models(self, opts)
 
       -- streaming support
       if model.capabilities.supports.streaming then
-        choice_opts.stream = true
-      else
-        choice_opts.stream = false
+        choice_opts.can_stream = true
       end
 
       models[model.id] = { opts = choice_opts }
@@ -235,12 +233,11 @@ return {
         choices = choices(self)
       end
       local model_opts = choices[model]
-      if model_opts and model_opts.opts then
-        self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
-      end
 
-      if self.opts and self.opts.stream then
+      if (self.opts and self.opts.stream) and (model_opts and model_opts.opts and model_opts.opts.can_stream) then
         self.parameters.stream = true
+      else
+        self.parameters.stream = nil
       end
 
       return get_and_authorize_token()

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -372,13 +372,16 @@ function Inline:stop()
   end
 end
 
+local _streaming = true
+
 ---Submit the prompts to the LLM to process
 ---@param prompt table The prompts to send to the LLM
 ---@return nil
 function Inline:submit(prompt)
   log:info("[Inline] Request started")
 
-  -- Inline editing only works with streaming off
+  -- Inline editing only works with streaming off - We should remember the current status
+  _streaming = self.adapter.opts.stream
   self.adapter.opts.stream = false
 
   -- Set keymaps and start diffing
@@ -483,6 +486,7 @@ end
 ---Reset the inline prompt class
 ---@return nil
 function Inline:reset()
+  self.adapter.opts.stream = _streaming
   self.current_request = nil
   api.nvim_buf_del_keymap(self.bufnr, "n", "q")
   api.nvim_clear_autocmds({ group = self.aug })
@@ -676,7 +680,7 @@ function Inline:to_chat()
   end
 
   -- Turn streaming back on
-  self.adapter.opts.stream = true
+  self.adapter.opts.stream = _streaming
 
   return require("codecompanion.strategies.chat").new({
     context = self.context,


### PR DESCRIPTION
## Description

Getting models dynamically in the Copilot adapter was leading us to overwrite the `opts.stream` variable in the adapter itself. This meant that `inline_output` couldn't be called.

## Related Issue(s)

#1036