### PR TITLE
refactor adapter `condition` and add schema types

### DIFF
--- a/doc/extending/adapters.md
+++ b/doc/extending/adapters.md
@@ -443,8 +443,9 @@ temperature = {
   mapping = "parameters",
   type = "number",
   default = 0,
-  condition = function(schema)
-    local model = schema.model.default
+  ---@param self CodeCompanion.Adapter
+  condition = function(self)
+    local model = self.schema.model.default
     if type(model) == "function" then
       model = model()
     end
@@ -458,5 +459,5 @@ temperature = {
 },
 ```
 
-You'll see we've specified a function call for the `condition` key. We're simply checking that the model name doesn't being with `o1` as these models don't accept temperature as a parameter. You'll also see we've specified a function call for the `validate` key. We're simply checking that the value of the temperature is between 0 and 2.
+You'll see we've specified a function call for the `condition` key. We're simply checking that the model name doesn't start with `o1` as these models don't accept temperature as a parameter. You'll also see we've specified a function call for the `validate` key. We're simply checking that the value of the temperature is between 0 and 2.
 

--- a/lua/codecompanion/adapters/azure_openai.lua
+++ b/lua/codecompanion/adapters/azure_openai.lua
@@ -54,6 +54,7 @@ return {
   schema = {
     -- See https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions
     -- model does not exist in the Azure OpenAI API, but this is used as the deployment in the URL.
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",
@@ -62,6 +63,7 @@ return {
       optional = false,
       -- schema.model.default should be populated by the user in their config
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 2,
       mapping = "parameters",
@@ -73,6 +75,7 @@ return {
         return n >= 0 and n <= 2, "Must be between 0 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     top_p = {
       order = 3,
       mapping = "parameters",
@@ -84,6 +87,7 @@ return {
         return n >= 0 and n <= 1, "Must be between 0 and 1"
       end,
     },
+    ---@type CodeCompanion.Schema
     stop = {
       order = 4,
       mapping = "parameters",
@@ -98,6 +102,7 @@ return {
         return #l >= 1 and #l <= 4, "Must have between 1 and 4 elements"
       end,
     },
+    ---@type CodeCompanion.Schema
     max_tokens = {
       order = 5,
       mapping = "parameters",
@@ -109,6 +114,7 @@ return {
         return n > 0, "Must be greater than 0"
       end,
     },
+    ---@type CodeCompanion.Schema
     presence_penalty = {
       order = 6,
       mapping = "parameters",
@@ -120,6 +126,7 @@ return {
         return n >= -2 and n <= 2, "Must be between -2 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     frequency_penalty = {
       order = 7,
       mapping = "parameters",
@@ -131,6 +138,7 @@ return {
         return n >= -2 and n <= 2, "Must be between -2 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     logit_bias = {
       order = 8,
       mapping = "parameters",
@@ -148,6 +156,7 @@ return {
         end,
       },
     },
+    ---@type CodeCompanion.Schema
     user = {
       order = 9,
       mapping = "parameters",

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -279,6 +279,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",
@@ -290,6 +291,7 @@ return {
         return get_models(self)
       end,
     },
+    ---@type CodeCompanion.Schema
     reasoning_effort = {
       order = 2,
       mapping = "parameters",
@@ -303,13 +305,14 @@ return {
         "low",
       },
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 3,
       mapping = "parameters",
       type = "number",
       default = 0,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end
@@ -324,13 +327,14 @@ return {
       default = 15000,
       desc = "The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length.",
     },
+    ---@type CodeCompanion.Schema
     top_p = {
       order = 5,
       mapping = "parameters",
       type = "number",
       default = 1,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end
@@ -338,13 +342,14 @@ return {
       end,
       desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
     },
+    ---@type CodeCompanion.Schema
     n = {
       order = 6,
       mapping = "parameters",
       type = "number",
       default = 1,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end

--- a/lua/codecompanion/adapters/deepseek.lua
+++ b/lua/codecompanion/adapters/deepseek.lua
@@ -111,6 +111,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",
@@ -123,6 +124,7 @@ return {
         "deepseek-chat",
       },
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 2,
       mapping = "parameters",
@@ -134,6 +136,7 @@ return {
         return n >= 0 and n <= 2, "Must be between 0 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     top_p = {
       order = 3,
       mapping = "parameters",
@@ -145,6 +148,7 @@ return {
         return n >= 0 and n <= 1, "Must be between 0 and 1"
       end,
     },
+    ---@type CodeCompanion.Schema
     stop = {
       order = 4,
       mapping = "parameters",
@@ -159,6 +163,7 @@ return {
         return #l >= 1 and #l <= 16, "Must have between 1 and 16 elements"
       end,
     },
+    ---@type CodeCompanion.Schema
     max_tokens = {
       order = 5,
       mapping = "parameters",
@@ -170,6 +175,7 @@ return {
         return n > 0, "Must be greater than 0"
       end,
     },
+    ---@type CodeCompanion.Schema
     presence_penalty = {
       order = 6,
       mapping = "parameters",
@@ -181,6 +187,7 @@ return {
         return n >= -2 and n <= 2, "Must be between -2 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     frequency_penalty = {
       order = 7,
       mapping = "parameters",
@@ -192,6 +199,7 @@ return {
         return n >= -2 and n <= 2, "Must be between -2 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     logprobs = {
       order = 8,
       mapping = "parameters",
@@ -203,6 +211,7 @@ return {
         type = "integer",
       },
     },
+    ---@type CodeCompanion.Schema
     user = {
       order = 9,
       mapping = "parameters",

--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -170,6 +170,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       type = "enum",
@@ -183,6 +184,7 @@ return {
         "gemini-1.0-pro",
       },
     },
+    ---@type CodeCompanion.Schema
     maxOutputTokens = {
       order = 2,
       mapping = "body.generationConfig",
@@ -194,6 +196,7 @@ return {
         return n > 0, "Must be greater than 0"
       end,
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 3,
       mapping = "body.generationConfig",
@@ -205,6 +208,7 @@ return {
         return n >= 0 and n <= 2, "Must be between 0 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     topP = {
       order = 4,
       mapping = "body.generationConfig",
@@ -216,6 +220,7 @@ return {
         return n > 0, "Must be greater than 0"
       end,
     },
+    ---@type CodeCompanion.Schema
     topK = {
       order = 5,
       mapping = "body.generationConfig",
@@ -227,6 +232,7 @@ return {
         return n > 0, "Must be greater than 0"
       end,
     },
+    ---@type CodeCompanion.Schema
     presencePenalty = {
       order = 6,
       mapping = "body.generationConfig",
@@ -235,6 +241,7 @@ return {
       default = nil,
       desc = "Presence penalty applied to the next token's logprobs if the token has already been seen in the response",
     },
+    ---@type CodeCompanion.Schema
     frequencyPenalty = {
       order = 7,
       mapping = "body.generationConfig",

--- a/lua/codecompanion/adapters/githubmodels.lua
+++ b/lua/codecompanion/adapters/githubmodels.lua
@@ -129,6 +129,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",
@@ -147,19 +148,21 @@ return {
         "Codestral-2501",
       },
     },
+    ---@type CodeCompanion.Schema
     reasoning_effort = {
       order = 2,
       mapping = "parameters",
       type = "string",
       optional = true,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end
-        if schema.model.choices[model] and schema.model.choices[model].opts then
-          return schema.model.choices[model].opts.can_reason
+        if self.schema.model.choices[model] and self.schema.model.choices[model].opts then
+          return self.schema.model.choices[model].opts.can_reason
         end
+        return false
       end,
       default = "medium",
       desc = "Constrains effort on reasoning for reasoning models. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.",
@@ -169,13 +172,14 @@ return {
         "low",
       },
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 3,
       mapping = "parameters",
       type = "number",
       default = 0,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end
@@ -183,6 +187,7 @@ return {
       end,
       desc = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
     },
+    ---@type CodeCompanion.Schema
     max_tokens = {
       order = 4,
       mapping = "parameters",
@@ -190,13 +195,14 @@ return {
       default = 4096,
       desc = "The maximum number of tokens to generate in the chat completion. The total length of input tokens and generated tokens is limited by the model's context length.",
     },
+    ---@type CodeCompanion.Schema
     top_p = {
       order = 5,
       mapping = "parameters",
       type = "number",
       default = 1,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end
@@ -204,13 +210,14 @@ return {
       end,
       desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
     },
+    ---@type CodeCompanion.Schema
     n = {
       order = 6,
       mapping = "parameters",
       type = "number",
       default = 1,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end

--- a/lua/codecompanion/adapters/huggingface.lua
+++ b/lua/codecompanion/adapters/huggingface.lua
@@ -57,6 +57,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",
@@ -70,6 +71,7 @@ return {
         "mistralai/Mistral-Nemo-Instruct-2407",
       },
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 2,
       mapping = "parameters",
@@ -81,6 +83,7 @@ return {
         return n >= 0 and n <= 2, "Must be between 0 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     max_tokens = {
       order = 3,
       mapping = "parameters",
@@ -92,6 +95,7 @@ return {
         return n > 0, "Must be greater than 0"
       end,
     },
+    ---@type CodeCompanion.Schema
     top_p = {
       order = 4,
       mapping = "parameters",
@@ -104,6 +108,7 @@ return {
       end,
     },
     -- caveat to using the cache: https://huggingface.co/docs/api-inference/parameters#caching
+    ---@type CodeCompanion.Schema
     ["x-use-cache"] = {
       order = 5,
       mapping = "headers",
@@ -113,6 +118,7 @@ return {
       desc = "Whether to use the cache layer on the inference API...",
       choices = { "true", "false" },
     },
+    ---@type CodeCompanion.Schema
     ["x-wait-for-model"] = {
       order = 6,
       mapping = "headers",

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -25,7 +25,7 @@ local log = require("codecompanion.utils.log")
 ---@field handlers.inline_output fun(self: CodeCompanion.Adapter, data: table, context: table): table|nil
 ---@field handlers.on_exit? fun(self: CodeCompanion.Adapter, data: table): table|nil
 ---@field handlers.teardown? fun(self: CodeCompanion.Adapter): any
----@field schema? table Set of parameters for the generative AI service that the user can customise in the chat buffer
+---@field schema table Set of parameters for the generative AI service that the user can customise in the chat buffer
 
 ---Check if a variable starts with "cmd:"
 ---@param var string
@@ -134,7 +134,7 @@ function Adapter:make_from_schema()
 
   -- Process regular schema values
   for key, value in pairs(self.schema) do
-    if type(value.condition) == "function" and not value.condition(self.schema) then
+    if type(value.condition) == "function" and not value.condition(self) then
       goto continue
     end
 

--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -208,6 +208,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",
@@ -220,6 +221,7 @@ return {
         return get_models(self)
       end,
     },
+    ---@type CodeCompanion.Schema
     temperature = {
       order = 2,
       mapping = "parameters.options",
@@ -231,6 +233,7 @@ return {
         return n >= 0 and n <= 2, "Must be between 0 and 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     num_ctx = {
       order = 3,
       mapping = "parameters.options",
@@ -242,6 +245,7 @@ return {
         return n > 0, "Must be a positive number"
       end,
     },
+    ---@type CodeCompanion.Schema
     mirostat = {
       order = 4,
       mapping = "parameters.options",
@@ -253,6 +257,7 @@ return {
         return n == 0 or n == 1 or n == 2, "Must be 0, 1, or 2"
       end,
     },
+    ---@type CodeCompanion.Schema
     mirostat_eta = {
       order = 5,
       mapping = "parameters.options",
@@ -264,6 +269,7 @@ return {
         return n > 0, "Must be a positive number"
       end,
     },
+    ---@type CodeCompanion.Schema
     mirostat_tau = {
       order = 6,
       mapping = "parameters.options",
@@ -275,6 +281,7 @@ return {
         return n > 0, "Must be a positive number"
       end,
     },
+    ---@type CodeCompanion.Schema
     repeat_last_n = {
       order = 7,
       mapping = "parameters.options",
@@ -286,6 +293,7 @@ return {
         return n >= -1, "Must be -1 or greater"
       end,
     },
+    ---@type CodeCompanion.Schema
     repeat_penalty = {
       order = 8,
       mapping = "parameters.options",
@@ -297,6 +305,7 @@ return {
         return n >= 0, "Must be a non-negative number"
       end,
     },
+    ---@type CodeCompanion.Schema
     seed = {
       order = 9,
       mapping = "parameters.options",
@@ -308,6 +317,7 @@ return {
         return n >= 0, "Must be a non-negative number"
       end,
     },
+    ---@type CodeCompanion.Schema
     stop = {
       order = 10,
       mapping = "parameters.options",
@@ -319,6 +329,7 @@ return {
         return s:len() > 0, "Cannot be an empty string"
       end,
     },
+    ---@type CodeCompanion.Schema
     tfs_z = {
       order = 11,
       mapping = "parameters.options",
@@ -330,6 +341,7 @@ return {
         return n >= 0, "Must be a non-negative number"
       end,
     },
+    ---@type CodeCompanion.Schema
     num_predict = {
       order = 12,
       mapping = "parameters.options",
@@ -341,6 +353,7 @@ return {
         return n >= -2, "Must be -2 or greater"
       end,
     },
+    ---@type CodeCompanion.Schema
     top_k = {
       order = 13,
       mapping = "parameters.options",
@@ -352,6 +365,7 @@ return {
         return n >= 0, "Must be a non-negative number"
       end,
     },
+    ---@type CodeCompanion.Schema
     top_p = {
       order = 14,
       mapping = "parameters.options",

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -205,13 +205,13 @@ return {
       mapping = "parameters",
       type = "string",
       optional = true,
-      condition = function(schema)
-        local model = schema.model.default
+      condition = function(self)
+        local model = self.schema.model.default
         if type(model) == "function" then
           model = model()
         end
-        if schema.model.choices[model] and schema.model.choices[model].opts then
-          return schema.model.choices[model].opts.can_reason
+        if self.schema.model.choices[model] and self.schema.model.choices[model].opts then
+          return self.schema.model.choices[model].opts.can_reason
         end
       end,
       default = "medium",

--- a/lua/codecompanion/adapters/openai_compatible.lua
+++ b/lua/codecompanion/adapters/openai_compatible.lua
@@ -120,6 +120,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",

--- a/lua/codecompanion/adapters/xai.lua
+++ b/lua/codecompanion/adapters/xai.lua
@@ -53,6 +53,7 @@ return {
     end,
   },
   schema = {
+    ---@type CodeCompanion.Schema
     model = {
       order = 1,
       mapping = "parameters",

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -1,9 +1,7 @@
 local Curl = require("plenary.curl")
 local Path = require("plenary.path")
-
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
-local schema = require("codecompanion.schema")
 local util = require("codecompanion.utils")
 
 ---@class CodeCompanion.Client
@@ -22,6 +20,18 @@ Client.static.opts = {
   schedule = { default = vim.schedule_wrap },
 }
 
+local function transform_static(opts)
+  local ret = {}
+  for k, v in pairs(Client.static.opts) do
+    if opts and opts[k] ~= nil then
+      ret[k] = opts[k]
+    else
+      ret[k] = v.default
+    end
+  end
+  return ret
+end
+
 ---@class CodeCompanion.ClientArgs
 ---@field adapter CodeCompanion.Adapter
 ---@field opts nil|table
@@ -34,7 +44,7 @@ function Client.new(args)
 
   return setmetatable({
     adapter = args.adapter,
-    opts = args.opts or schema.get_default(Client.static.opts, args.opts),
+    opts = args.opts or transform_static(args.opts),
     user_args = args.user_args or {},
   }, { __index = Client })
 end

--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -144,7 +144,7 @@ function Debug:render()
         end)
 
         if type(val) == "function" then
-          val = val()
+          val = val(self.adapter)
         end
         if vim.tbl_count(models) > 1 then
           table.insert(lines, "  " .. key .. ' = "' .. val .. '", ' .. other_models)
@@ -157,6 +157,13 @@ function Debug:render()
         table.insert(lines, "  " .. key .. " = " .. tostring(val) .. ",")
       elseif type(val) == "string" then
         table.insert(lines, "  " .. key .. ' = "' .. val .. '",')
+      elseif type(val) == "function" then
+        local expanded_val = val(self.adapter)
+        if type(expanded_val) == "number" or type(expanded_val) == "boolean" then
+          table.insert(lines, "  " .. key .. " = " .. tostring(val(self.adapter)) .. ",")
+        else
+          table.insert(lines, "  " .. key .. ' = "' .. tostring(val(self.adapter)) .. '",')
+        end
       else
         table.insert(lines, "  " .. key .. " = " .. vim.inspect(val))
       end

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -276,7 +276,7 @@ function Chat.new(args)
   util.fire("ChatModel", { bufnr = self.bufnr, id = self.id, model = self.adapter.schema.model.default })
   util.fire("ChatCreated", { bufnr = self.bufnr, from_prompt_library = self.from_prompt_library, id = self.id })
 
-  self:apply_settings(schema.get_default(self.adapter.schema, args.settings))
+  self:apply_settings(schema.get_default(self.adapter, args.settings))
 
   self.ui = require("codecompanion.strategies.chat.ui").new({
     adapter = self.adapter,
@@ -433,7 +433,7 @@ end
 ---@param settings? table
 ---@return nil
 function Chat:apply_settings(settings)
-  self.settings = settings or schema.get_default(self.adapter.schema)
+  self.settings = settings or schema.get_default(self.adapter)
 
   if not config.display.chat.show_settings then
     _cached_settings[self.bufnr] = self.settings

--- a/tests/adapters/test_anthropic.lua
+++ b/tests/adapters/test_anthropic.lua
@@ -125,3 +125,28 @@ describe("Anthropic adapter with NO STREAMING", function()
     h.eq(response[#response].output.content, adapter_helpers.inline_buffer_output(response, adapter))
   end)
 end)
+
+describe("Anthropic Schema", function()
+  it("Non-Reasoning models have less tokens", function()
+    local non_reasoning = require("codecompanion.adapters").extend("anthropic", {
+      schema = {
+        model = {
+          default = "claude-3-5-sonnet-20241022",
+        },
+      },
+    })
+    local output = require("codecompanion.adapters").resolve(non_reasoning)
+    h.eq(4096, output.schema.max_tokens.default(non_reasoning))
+  end)
+  it("Reasoning models have more tokens", function()
+    local reasoning = require("codecompanion.adapters").extend("anthropic", {
+      schema = {
+        model = {
+          default = "claude-3-7-sonnet-20250219",
+        },
+      },
+    })
+    local output = require("codecompanion.adapters").resolve(reasoning)
+    h.eq(17000, output.schema.max_tokens.default(reasoning))
+  end)
+end)


### PR DESCRIPTION
## Description

`schema.*.condition` previously only received the `CodeCompanion.Schema` as a parameter which put it at odds with `schema.*.default` which received `CodeCompanion.Adapter`. Previously, this worked fine. However, with the advent of reasoning models, different schema structures are required for different models. This PR makes it easier to control what schema is displayed to the user and therefore what can be edited as part of the request.

This PR also adds types to the schema values.