### PR TITLE
fix(adapters): copilot reset cache on exit

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -125,12 +125,6 @@ end
 local _cached_adapter
 local _cached_available_models
 
----Reset the cached adapter
----@return nil
-local function reset()
-  _cached_adapter = nil
-end
-
 ---Get a list of available Copilot models
 ---@params self CodeCompanion.Adapter
 ---@params opts? table
@@ -274,7 +268,6 @@ return {
       return openai.handlers.inline_output(self, data, context)
     end,
     on_exit = function(self, data)
-      reset()
       return openai.handlers.on_exit(self, data)
     end,
   },


### PR DESCRIPTION
## Description

Draft: Currently, the adapters cache is reset after every request. This combined with the recent fixes in c0a820e0184ac0714c608b06fd3822abe79492cb have lead to the token not being passed as part of the request.

## Related Issue(s)

#1052