### PR TITLE
fix(adapters): overwriting of vars

### DIFF
--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -61,7 +61,9 @@ function Client:request(payload, actions, opts)
   opts = opts or {}
   local cb = log:wrap_cb(actions.callback, "Response error: %s") --[[@type function]]
 
-  local adapter = self.adapter
+  -- Make a copy of the adapter to ensure that we replace variables in every request
+  local adapter = vim.deepcopy(self.adapter)
+
   local handlers = adapter.handlers
 
   if handlers and handlers.setup then


### PR DESCRIPTION
## Description

Variables are overwritten in the adapter, permanently. This results in adapters like Copilot, which need to regularly update their environment with a token, holding expired information. This PR addresses this by ensuring any variable replacement is done on a copy of the adapter rather than the adapter itself.

## Related Issue(s)

#1052 