### PR TITLE
Add flag `display.chat.follow`

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -206,7 +206,6 @@ require("codecompanion").setup({
         return " (" .. tokens .. " tokens)"
       end,
     },
-    follow = true, -- Scroll down and place the cursor at the end
   },
 }),
 ```
@@ -292,6 +291,21 @@ As the Chat Buffer uses markdown as its syntax, you can use popular rendering pl
 },
 ```
 
+### Auto scrolling
+
+By default, the page scrolls down automatically as the response streams, with the cursor placed at the end.
+This can be distracting if you are focusing on the earlier content while the page scrolls up away during a long response.
+You can disable this behavior using a flag:
+
+```lua
+require("codecompanion").setup({
+  display = {
+    chat = {
+      auto_scroll = false
+    },
+  },
+}),
+```
 ## Additional Options
 
 There are also a number of other options that you can customize:

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -206,6 +206,7 @@ require("codecompanion").setup({
         return " (" .. tokens .. " tokens)"
       end,
     },
+    follow = true, -- Scroll down and place the cursor at the end
   },
 }),
 ```

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -890,6 +890,7 @@ This is the code, for context:
       token_count = function(tokens, adapter) -- The function to display the token count
         return " (" .. tokens .. " tokens)"
       end,
+      follow = true, -- Scroll down and place the cursor to the end
     },
     diff = {
       enabled = true,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -875,6 +875,7 @@ This is the code, for context:
           wrap = true,
         },
       },
+      auto_scroll = true, -- Automatically scroll down and place the cursor at the end
       intro_message = "Welcome to CodeCompanion ✨! Press ? for options",
 
       show_header_separator = false, -- Show header separators in the chat buffer? Set this to false if you're using an external markdown formatting plugin
@@ -890,7 +891,6 @@ This is the code, for context:
       token_count = function(tokens, adapter) -- The function to display the token count
         return " (" .. tokens .. " tokens)"
       end,
-      follow = true, -- Scroll down and place the cursor at the end
     },
     diff = {
       enabled = true,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -890,7 +890,7 @@ This is the code, for context:
       token_count = function(tokens, adapter) -- The function to display the token count
         return " (" .. tokens .. " tokens)"
       end,
-      follow = true, -- Scroll down and place the cursor to the end
+      follow = true, -- Scroll down and place the cursor at the end
     },
     diff = {
       enabled = true,

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -743,7 +743,7 @@ function Chat:submit(opts)
   log:trace("Messages:\n%s", self.messages)
   log:info("Chat request started")
 
-  if not config.display.chat.follow then
+  if not config.display.chat.auto_scroll then
     vim.cmd("stopinsert")
   end
   self.ui:lock_buf()
@@ -1075,7 +1075,7 @@ function Chat:add_buf_message(data, opts)
       self.ui:lock_buf()
     end
 
-    if config.display.chat.follow then
+    if config.display.chat.auto_scroll then
       if cursor_moved and self.ui:is_active() then
         self.ui:follow()
       elseif not self.ui:is_active() then

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -743,6 +743,9 @@ function Chat:submit(opts)
   log:trace("Messages:\n%s", self.messages)
   log:info("Chat request started")
 
+  if not config.display.chat.follow then
+    vim.cmd("stopinsert")
+  end
   self.ui:lock_buf()
 
   self:set_range(2) -- this accounts for the LLM header
@@ -1072,10 +1075,12 @@ function Chat:add_buf_message(data, opts)
       self.ui:lock_buf()
     end
 
-    if cursor_moved and self.ui:is_active() then
-      self.ui:follow()
-    elseif not self.ui:is_active() then
-      self.ui:follow()
+    if config.display.chat.follow then
+      if cursor_moved and self.ui:is_active() then
+        self.ui:follow()
+      elseif not self.ui:is_active() then
+        self.ui:follow()
+      end
     end
   end
 


### PR DESCRIPTION
## Description
When the response is long, it just scrolls up away while reading.
Add a flag to control this behavior. 
It's on by default to prevent introducing changes.
Turn it off explicitly if annoyed. 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
