### PR TITLE
patch(agents): tool.callback can be a function and fixed tools config docs

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -128,10 +128,7 @@ require("codecompanion").setup({
       tools = {
         ["my_tool"] = {
           description = "Run a custom task",
-          callback = function(command)
-            -- Perform the custom task here
-            return "Tool result"
-          end,
+          callback = require("user.codecompanion.tools.my_tool")
         },
         groups = {
           ["my_group"] = {
@@ -152,7 +149,7 @@ require("codecompanion").setup({
 
 When users introduce the agent `@my_agent` in the chat buffer, it can call the tools you listed (like `@my_tool`) to perform tasks on your code.
 
-The `callback` option for a tool can also be a [`CodeCompanion.Tool`](/extending/tools) object, which is a table with specific keys that defines the interface and workflow of the tool.
+A tool is a [`CodeCompanion.Tool`](/extending/tools) table with specific keys that define the interface and workflow of the tool. The table can be resolved using the `callback` option. The `callback` option can be a table itself or either a function or a string that points to a luafile that return the table.
 
 Some tools, such as the [@cmd_runner](/usage/chat-buffer/agents.html#cmd-runner), require the user to approve any commands before they're executed. This can be changed by altering the config for each tool:
 

--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -406,6 +406,10 @@ function Agent.resolve(tool)
     return callback --[[@as CodeCompanion.Agent.Tool]]
   end
 
+  if type(callback) == "function" then
+    return callback() --[[@as CodeCompanion.Agent.Tool]]
+  end
+
   local ok, module = pcall(require, "codecompanion." .. callback)
   if ok then
     log:debug("[Tools] %s identified", callback)


### PR DESCRIPTION


## Description
* Tool callback can now be a function which enables lazy loading of any modules that return tool schemas and also mitigates any errors due to some plugin not loaded to the runtime by the time `codecompanion.setup` is called.

* Fixed incorrect documentation for configuring tools as the below doesn't return the `Tool` schema.

#### Incorrect docs 
```lua
tools = {
    ["my_tool"] = {
          description = "Run a custom task",
          callback = function(command)
            -- Perform the custom task here
            return "Tool result"
          end,
     }
}
```
* Did not commit `make docs` changes as there were many updates non related to this commit which the author may run in a docs or chore commit later. 


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
