### PR TITLE
fix: header separator causing references not to be added to the chat

### DIFF
--- a/lua/codecompanion/strategies/chat/references.lua
+++ b/lua/codecompanion/strategies/chat/references.lua
@@ -58,6 +58,10 @@ local function ts_parse_buffer(chat)
     end
   end
 
+  if config.display.chat.show_header_separator then
+    role = vim.trim(role:gsub(config.display.chat.separator, ""))
+  end
+
   if role_node and role == user_role then
     local start_row, _, end_row, _ = role_node:range()
     return {
@@ -248,6 +252,9 @@ function References:get_from_chat()
   for id, node in query:iter_captures(root, chat.bufnr, chat.header_line - 1, -1) do
     if query.captures[id] == "role" then
       role = vim.treesitter.get_node_text(node, chat.bufnr)
+      if config.display.chat.show_header_separator then
+        role = vim.trim(role:gsub(config.display.chat.separator, ""))
+      end
     elseif role == user_role and query.captures[id] == "ref" then
       local ref = vim.treesitter.get_node_text(node, chat.bufnr)
       -- Clean both pinned and watched icons


### PR DESCRIPTION
## Related Issue(s)

#1067