### PR TITLE
fix(chat): update system prompt to avoid using h1 and h2 headers

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -943,6 +943,7 @@ You must:
 - Avoid including line numbers in code blocks.
 - Avoid wrapping the whole response in triple backticks.
 - Only return code that's directly relevant to the task at hand. You may omit code that isn’t necessary for the solution.
+- Avoid using H1 and H2 headers in your responses.
 - Use actual line breaks in your responses; only use "\n" when you want a literal backslash followed by 'n'.
 - All non-code text responses must be written in the %s language indicated.
 


### PR DESCRIPTION
## Description

Claude 3.7 loves to use H1 and H2 headers in its response. The impact of this is it measures with the visuals and navigation in the chat buffer.