### PR TITLE
docs(tools): update documentation on function-based tool return type.

### DIFF
--- a/doc/extending/tools.md
+++ b/doc/extending/tools.md
@@ -171,7 +171,7 @@ cmds = {
   ---@param self CodeCompanion.Agent.Tool The Tools object
   ---@param actions table The action object
   ---@param input? any The output from the previous function call
-  ---@return nil|{ status: string, msg: string }
+  ---@return nil|{ status: "success"|"error", data: any }
   function(self, actions, input)
     -- Get the numbers and operation requested by the LLM
     local num1 = tonumber(actions.num1)

--- a/lua/codecompanion/strategies/chat/agents/executor/func.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/func.lua
@@ -71,7 +71,7 @@ function FuncExecutor:proceed_to_next(output)
 end
 
 ---Run the tool's function
----@param func fun(self: CodeCompanion.Agent, actions: table, input: any)
+---@param func fun(self: CodeCompanion.Agent, actions: table, input: any):{status:"success"|"error", data:any}?
 ---@param action table
 ---@param input? any
 ---@param callback? fun(output: any)


### PR DESCRIPTION
## Description

The documentation has an error on the return type of function-based tools. See the patch for details.

I also included the type annotation to the executor.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
