### PR TITLE
fix(func_tool): allow non-table values (numbers) to be passed.

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -167,10 +167,8 @@ end
 function Executor:success(action, output)
   log:debug("Executor:success")
   self.agent.status = self.agent.constants.STATUS_SUCCESS
-  if type(output) == "string" then
+  if output then
     table.insert(self.agent.stdout, output)
-  elseif type(output) == "table" then
-    vim.list_extend(self.agent.stdout, output)
   end
   self.output.success(action)
 end


### PR DESCRIPTION
…values (numbers) to be used.

## Description

The changes in #1104 means that only `string` and `table` are allowed for `output`, which breaks the calculator tool demo from the documentation. 

## Related Issue(s)

Fix an issue introduced by #1104 

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
