### PR TITLE
feat(tool): implement a callback for async function-based tool.

### DIFF
--- a/doc/extending/tools.md
+++ b/doc/extending/tools.md
@@ -164,7 +164,8 @@ end,
 
 **Function-based Tools**
 
-Function-based tools use the `cmds` table to define functions that will be executed one after another. Each function has three parameters, itself, the actions request by the LLM, any input from a previous function call and a `output_handler` callback for async execution. 
+Function-based tools use the `cmds` table to define functions that will be executed one after another. Each function has four parameters, itself, the actions request by the LLM, any input from a previous function call and a `output_handler` callback for async execution. 
+The `output_handler` handles the result for an asynchronous tool. For a synchronous tool (like the calculator) you can ignore it.
 For the purpose of our calculator example:
 
 ```lua
@@ -215,7 +216,7 @@ cmds = {
 },
 ```
 For a synchronous tool, you only need to `return` the result table as demonstrated.
-However, if you need to invoke some asynchronous actions in the tool, you can use the `output_handler` to submit any results to the executor:
+However, if you need to invoke some asynchronous actions in the tool, you can use the `output_handler` to submit any results to the executor, which will then invoke `output` functions to handle the results:
 ```lua
 cmds = {
   function(agent, actions, input, output_handler)
@@ -230,7 +231,8 @@ cmds = {
 Note that:
 
 1. the `output_handler` will be called only once. Subsequent calls will be discarded;
-2. a synchronous tool should **return** the results and avoid calling `output_handler`, whereas an asynchronous tool should call the `output_handler` and return `nil`.
+2. A tool function should EITHER return the result table (synchronous), OR call the `output_handler` with the result table as the only argument (asynchronous), but not both. 
+If a function tries to both return the result and call the `output_handler`, the result will be undefined because there's no guarantee which output will be handled first.
 
 Similarly with command-based tools, the output is written to the `stdout` or `stderr` tables on the agent file. However, with function-based tools, the user must manually specify the outcome of the execution which in turn redirects the output to the correct table:
 

--- a/lua/codecompanion/strategies/chat/agents/executor/func.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/func.lua
@@ -79,8 +79,14 @@ end
 function FuncExecutor:run(func, action, input, callback)
   log:debug("FuncExecutor:run")
 
+  local tool_finished = false
   ---@param msg {status:"success"|"error", data:any}
   local function output_handler(msg)
+    if tool_finished then
+      log:warn("output_handler for tool %s is called more than once.", self.executor.tool.name)
+      return
+    end
+    tool_finished = true
     if msg.status == self.executor.agent.constants.STATUS_ERROR then
       return self.executor:error(action, msg.data or "An error occurred")
     end

--- a/lua/codecompanion/strategies/chat/agents/executor/func.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/func.lua
@@ -71,27 +71,37 @@ function FuncExecutor:proceed_to_next(output)
 end
 
 ---Run the tool's function
----@param func fun(self: CodeCompanion.Agent, actions: table, input: any):{status:"success"|"error", data:any}?
+---@param func fun(self: CodeCompanion.Agent, actions: table, input: any, output_handler: fun(msg:{status:"success"|"error", data:any}):any):{status:"success"|"error", data:any}?
 ---@param action table
 ---@param input? any
 ---@param callback? fun(output: any)
 ---@return nil
 function FuncExecutor:run(func, action, input, callback)
   log:debug("FuncExecutor:run")
+
+  ---@param msg {status:"success"|"error", data:any}
+  local function output_handler(msg)
+    if msg.status == self.executor.agent.constants.STATUS_ERROR then
+      return self.executor:error(action, msg.data or "An error occurred")
+    end
+
+    self.executor:success(action, msg.data)
+
+    if callback then
+      callback(msg)
+    end
+  end
+
   local ok, output = pcall(function()
-    return func(self.executor.agent, action, input)
+    return func(self.executor.agent, action, input, output_handler)
   end)
   if not ok then
     return self.executor:error(action, output)
   end
-  if output.status == self.executor.agent.constants.STATUS_ERROR then
-    return self.executor:error(action, output.data or "An error occurred")
-  end
 
-  self.executor:success(action, output.data)
-
-  if callback then
-    callback(output)
+  if output ~= nil then
+    -- otherwise async and should be called from within the func
+    output_handler(output)
   end
 end
 

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -91,6 +91,14 @@ return {
           callback = vim.fn.getcwd() .. "/tests/strategies/chat/agents/tools/stubs/func_queue_2.lua",
           description = "Some function tool to test",
         },
+        ["func_async_1"] = {
+          callback = vim.fn.getcwd() .. "/tests/strategies/chat/agents/tools/stubs/func_async_1.lua",
+          description = "Some function tool to test",
+        },
+        ["func_async_2"] = {
+          callback = vim.fn.getcwd() .. "/tests/strategies/chat/agents/tools/stubs/func_async_2.lua",
+          description = "Some function tool to test",
+        },
         ["func_approval"] = {
           callback = vim.fn.getcwd() .. "/tests/strategies/chat/agents/tools/stubs/func.lua",
           description = "Some function tool to test but with approval",

--- a/tests/strategies/chat/agents/executor/test_queue_async.lua
+++ b/tests/strategies/chat/agents/executor/test_queue_async.lua
@@ -1,0 +1,74 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+
+local child = MiniTest.new_child_neovim()
+T = new_set({
+  hooks = {
+    pre_case = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+
+      -- Load helpers and set up the environment in the child process
+      child.lua([[
+        require("tests.log")
+        h = require('tests.helpers')
+        chat, agent = h.setup_chat_buffer()
+
+        -- Reset test globals
+        _G._test_func = nil
+        _G._test_exit = nil
+        _G._test_order = nil
+        _G._test_output = nil
+        _G._test_setup = nil
+      ]])
+    end,
+    post_case = function()
+      child.lua([[h.teardown_chat_buffer()]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["Agent"] = new_set()
+T["Agent"]["queue"] = new_set()
+
+T["Agent"]["queue"]["can queue multiple async functions"] = function()
+  h.eq(vim.NIL, child.lua_get([[_G._test_order]]))
+
+  child.lua([[
+    local queue = require("tests.strategies.chat.agents.tools.stubs.xml.async_queue_xml")
+    local xml = queue.run()
+    agent:execute(chat, xml)
+    vim.wait(3000)
+  ]])
+
+  -- Test order
+  h.eq(
+    "AsyncFunc[Setup]->AsyncFunc[Success]->AsyncFunc[Exit]->Cmd[Setup]->Cmd[Success]->Cmd[Exit]->AsyncFunc2[Setup]->AsyncFunc2[Success]->AsyncFunc2[Exit]",
+    child.lua_get([[_G._test_order]])
+  )
+
+  -- Test that the function was called
+  h.eq("Data 1 Data 2", child.lua_get([[_G._test_func]]))
+end
+
+T["Agent"]["queue"]["can queue async function with sync function"] = function()
+  h.eq(vim.NIL, child.lua_get([[_G._test_order]]))
+
+  child.lua([[
+    local queue = require("tests.strategies.chat.agents.tools.stubs.xml.mixed_queue_xml")
+    local xml = queue.run()
+    agent:execute(chat, xml)
+    vim.wait(3000)
+  ]])
+
+  -- Test order
+  h.eq(
+    "Func[Setup]->Func[Success]->Func[Exit]->AsyncFunc2[Setup]->AsyncFunc2[Success]->AsyncFunc2[Exit]",
+    child.lua_get([[_G._test_order]])
+  )
+
+  -- Test that the function was called
+  h.eq("Data 1 Data 2", child.lua_get([[_G._test_func]]))
+end
+return T

--- a/tests/strategies/chat/agents/executor/test_queue_async.lua
+++ b/tests/strategies/chat/agents/executor/test_queue_async.lua
@@ -39,7 +39,7 @@ T["Agent"]["queue"]["can queue multiple async functions"] = function()
     local queue = require("tests.strategies.chat.agents.tools.stubs.xml.async_queue_xml")
     local xml = queue.run()
     agent:execute(chat, xml)
-    vim.wait(3000)
+    vim.wait(2100)
   ]])
 
   -- Test order
@@ -59,7 +59,7 @@ T["Agent"]["queue"]["can queue async function with sync function"] = function()
     local queue = require("tests.strategies.chat.agents.tools.stubs.xml.mixed_queue_xml")
     local xml = queue.run()
     agent:execute(chat, xml)
-    vim.wait(3000)
+    vim.wait(1100)
   ]])
 
   -- Test order

--- a/tests/strategies/chat/agents/tools/stubs/func_async_1.lua
+++ b/tests/strategies/chat/agents/tools/stubs/func_async_1.lua
@@ -1,0 +1,44 @@
+return {
+  name = "func_async_1",
+  system_prompt = function(schema)
+    return "my func system prompt"
+  end,
+  cmds = {
+    function(self, actions, input, cb)
+      local spacer = ""
+      if _G._test_func then
+        spacer = " "
+      end
+      _G._test_func = (_G._test_func or "") .. spacer .. actions.data
+      assert(type(cb) == "function")
+      coroutine.wrap(function()
+        local co = coroutine.running()
+        vim.defer_fn(function()
+          coroutine.resume(co)
+        end, 1000)
+        coroutine.yield()
+        cb({ status = "success", data = actions.data })
+      end)()
+    end,
+  },
+  handlers = {
+    -- Should only be called once
+    setup = function(self)
+      _G._test_order = (_G._test_order or "") .. "AsyncFunc[Setup]"
+      _G._test_setup = (_G._test_setup or "") .. "Setup"
+    end,
+    -- Should only be called once
+    on_exit = function(self)
+      _G._test_order = (_G._test_order or "") .. "->AsyncFunc[Exit]"
+      _G._test_exit = (_G._test_exit or "") .. "Exited"
+    end,
+  },
+  output = {
+    -- Should be called multiple times
+    success = function(self, cmd, output)
+      _G._test_order = (_G._test_order or "") .. "->AsyncFunc[Success]"
+      _G._test_output = (_G._test_output or "") .. "Ran with success"
+      return "stdout is populated!"
+    end,
+  },
+}

--- a/tests/strategies/chat/agents/tools/stubs/func_async_2.lua
+++ b/tests/strategies/chat/agents/tools/stubs/func_async_2.lua
@@ -1,0 +1,44 @@
+return {
+  name = "func_async_2",
+  system_prompt = function(schema)
+    return "my func system prompt"
+  end,
+  cmds = {
+    function(self, actions, input, cb)
+      local spacer = ""
+      if _G._test_func then
+        spacer = " "
+      end
+      _G._test_func = (_G._test_func or "") .. spacer .. actions.data
+      assert(type(cb) == "function")
+      coroutine.wrap(function()
+        local co = coroutine.running()
+        vim.defer_fn(function()
+          coroutine.resume(co)
+        end, 500)
+        coroutine.yield()
+        cb({ status = "success", data = actions.data })
+      end)()
+    end,
+  },
+  handlers = {
+    -- Should only be called once
+    setup = function(self)
+      _G._test_order = (_G._test_order or "") .. "->AsyncFunc2[Setup]"
+      _G._test_setup = (_G._test_setup or "") .. "Setup"
+    end,
+    -- Should only be called once
+    on_exit = function(self)
+      _G._test_order = (_G._test_order or "") .. "->AsyncFunc2[Exit]"
+      _G._test_exit = (_G._test_exit or "") .. "Exited"
+    end,
+  },
+  output = {
+    -- Should be called multiple times
+    success = function(self, cmd, output)
+      _G._test_order = (_G._test_order or "") .. "->AsyncFunc2[Success]"
+      _G._test_output = (_G._test_output or "") .. "Ran with success"
+      return "stdout is populated!"
+    end,
+  },
+}

--- a/tests/strategies/chat/agents/tools/stubs/xml/async_queue_xml.lua
+++ b/tests/strategies/chat/agents/tools/stubs/xml/async_queue_xml.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+function M.run(name)
+  return string.format(
+    [[<tools>
+  <tool name="func_async_1">
+    <action type="type1"><data>Data 1</data></action>
+  </tool>
+  <tool name="cmd_queue"></tool>
+  <tool name="func_async_2">
+    <action type="type1"><data>Data 2</data></action>
+  </tool>
+</tools>]],
+    name
+  )
+end
+
+return M

--- a/tests/strategies/chat/agents/tools/stubs/xml/mixed_queue_xml.lua
+++ b/tests/strategies/chat/agents/tools/stubs/xml/mixed_queue_xml.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+function M.run(name)
+  return string.format(
+    [[<tools>
+  <tool name="func_queue">
+    <action type="type1"><data>Data 1</data></action>
+  </tool>
+  <tool name="func_async_2">
+    <action type="type1"><data>Data 2</data></action>
+  </tool>
+</tools>]],
+    name
+  )
+end
+
+return M


### PR DESCRIPTION
## Description

This PR implements a `output_handler` parameter for the function tool, which can be called by an async callback used in the function tool body.

## Related Issue(s)

Discussed in #1103 

## Details

Previously a function-based tool has the following signature:
```
fun(agent, actions, input): {status: "success"|"error", data: any}
```
This PR introduces a 4th parameter, `output_handler`, which invokes the `executor:success` or `executor:error`. This allows users to build async function tools without blocking the UI. Example:
```lua
cmds = {
  function(agent, actions, input, output_handler)
    -- this is for demonstration only
    vim.lsp.client.request(lsp_method, lsp_param, function(err, result, _, _)
      output_handler({status = "success", data = result})
    end, buf_nr)
  end
}
```
I tested this with the calculator demo (as a synchronous function) and a WIP VectorCode tool that uses async LSP request. Both worked fine, and for the async tool, the virtual text `Tool processing ...` disappeared as usual. If this is a feasible implementation, I can update the documentation as well.

I'm a total noob at unit tests for neovim plugins, so that'll have to wait...

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
