### PR TITLE
fix(adapters): add mistral to the config

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -16,6 +16,7 @@ local defaults = {
     gemini = "gemini",
     githubmodels = "githubmodels",
     huggingface = "huggingface",
+    mistral = "mistral",
     ollama = "ollama",
     openai = "openai",
     xai = "xai",


### PR DESCRIPTION
## Description

This adds Mistral to the `config.lua` file so users can leverage it easily in their config.
