### PR TITLE
fix(blink): add support to blink newer than 0.13.1

### DIFF
--- a/plugin/codecompanion.lua
+++ b/plugin/codecompanion.lua
@@ -66,7 +66,8 @@ local has_cmp, cmp = pcall(require, "cmp")
 local has_blink, blink = pcall(require, "blink.cmp")
 if has_blink then
   pcall(function()
-    blink.add_provider("codecompanion", {
+    local add_provider = blink.add_source_provider or blink.add_provider
+    add_provider("codecompanion", {
       name = "CodeCompanion",
       module = "codecompanion.providers.completion.blink",
       enabled = true,


### PR DESCRIPTION
## Description

**Problem**: Blink recently deprecated blink.add_provider fn which now prints a big warning that it's deprecated

**Solution**: Add backward compatible detection for function to call to add a new provider

see [deprecation commit](https://github.com/Saghen/blink.cmp/commit/183dd1468a3a943f16735a671a2983db8f50c504)

## Screenshots

NA

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] ~~I've updated the README and/or relevant docs pages~~ N/A
- [ ] ~~I've run `make docs` to update the vimdoc pages~~ N/A
