### PR TITLE
fix(ollama): remove option `tfs_z`

### DIFF
--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -330,18 +330,6 @@ return {
       end,
     },
     ---@type CodeCompanion.Schema
-    tfs_z = {
-      order = 11,
-      mapping = "parameters.options",
-      type = "number",
-      optional = true,
-      default = 1.0,
-      desc = "Tail free sampling is used to reduce the impact of less probable tokens from the output. A higher value (e.g., 2.0) will reduce the impact more, while a value of 1.0 disables this setting. (default: 1)",
-      validate = function(n)
-        return n >= 0, "Must be a non-negative number"
-      end,
-    },
-    ---@type CodeCompanion.Schema
     num_predict = {
       order = 12,
       mapping = "parameters.options",


### PR DESCRIPTION
## Description
ollama remove option `tfs_z`
https://github.com/ollama/ollama/pull/8515

Ollama warn log:
```
level=WARN source=types.go:522 msg="invalid option provided" option=tfs_z
```
https://github.com/olimorris/codecompanion.nvim/discussions/1151

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
