### PR TITLE
fix(adapters): copilot token issue when changing adapter

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -151,7 +151,7 @@ local function get_models(self, opts)
 
   get_and_authorize_token()
   local url = "https://api.githubcopilot.com"
-  local headers = _cached_adapter.headers
+  local headers = vim.deepcopy(_cached_adapter.headers)
   headers["Authorization"] = "Bearer " .. _github_token.token
 
   local ok, response = pcall(function()


### PR DESCRIPTION
## Description

When switching adapters to the Copilot adapter, the user would encounter an unauthorized token error after 25 minutes. This was due to the bearer token being hard-coded in the header when the `get_models` function was called.

## Related Issue(s)

#1149