### PR TITLE
Allow Empty Tables to Be Encoded as Array or Objects

### DIFF
--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -3,6 +3,7 @@ local Path = require("plenary.path")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local util = require("codecompanion.utils")
+local json = require("codecompanion.utils.json")
 
 ---@class CodeCompanion.Client
 ---@field adapter CodeCompanion.Adapter
@@ -16,7 +17,7 @@ Client.static = {}
 Client.static.opts = {
   post = { default = Curl.post },
   get = { default = Curl.get },
-  encode = { default = vim.json.encode },
+  encode = { default = json.encode },
   schedule = { default = vim.schedule_wrap },
 }
 

--- a/lua/codecompanion/utils/json.lua
+++ b/lua/codecompanion/utils/json.lua
@@ -3,7 +3,11 @@ local M = {}
 ---@param data any
 ---@return string
 M.encode = function(data)
-  return vim.json.encode(data)
+  local output = vim.json.encode(data)
+  -- Replace instances where an empty array should actually be an empty object.
+  -- Specify an empty object by adding a single entry of "empty_object" to
+  -- the table.
+  return output:gsub('%["__empty_object__"%]', "{}")
 end
 
 ---Decode a yaml node

--- a/lua/codecompanion/utils/json.lua
+++ b/lua/codecompanion/utils/json.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+---@param data any
+---@return string
+M.encode = function(data)
+  return vim.json.encode(data)
+end
+
+---Decode a yaml node
+---@param source string
+---@return table
+M.decode = function(source)
+  return vim.json.decode(source)
+end
+
+return M


### PR DESCRIPTION
## Description

This may be too niche for anyone else to find useful.  However, it works well for me and may come in handy for others.

### TL;DR
Modify the utility that parses Lua tables to JSON so that it's possible to dictate whether an empty table should be encoded as an empty _array_ (current behavior) or an empty _object_.  To mark a table as an empty _object_, it needs to (ironically) include a single entry of `"__empty_object__"`.

### Full Explanation
I really like the UX of interacting with LLMs via Neovim.  However, my most common use-case so far is to use LLMs to summarize internet search results.  None of the current adapters support this out of the box, though it's easy enough to extend the `body` of any adapter to include the necessary inputs.

However, Google Gemini is my provider of choice and as luck would have it, the payload looks like this:
```json
...
"tools": [
  { "google_search": {} }
]
...
```

Unfortunately, the built-in `vim.json.encode` function will always parse the empty object as an array.  Since Google's API does not currently accept _any_ options for the `google_search` tool, it _has_ to be passed as an empty object.

## Related Issue(s)
N/A

## Screenshots
N/A

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
