### PR TITLE
fix: (#1175) 

### DIFF
--- a/lua/codecompanion/strategies/chat/variables/user.lua
+++ b/lua/codecompanion/strategies/chat/variables/user.lua
@@ -22,7 +22,7 @@ function Variable:output()
 
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
-    content = self.config.callback(),
+    content = self.config.callback(self),
   }, { reference = id, tag = "variable", visible = false })
 
   self.Chat.references:add({

--- a/lua/codecompanion/strategies/inline/variables/init.lua
+++ b/lua/codecompanion/strategies/inline/variables/init.lua
@@ -67,6 +67,18 @@ function Variables:output()
     local var_config = self.config[var]
     local callback = var_config.callback
 
+    if type(callback) == "function" then
+      local ok, output = pcall(callback, self)
+      if not ok then
+        log:error("[Variables] %s could not be resolved: %s", var, output)
+      else
+        if output then
+          table.insert(outputs, output)
+        end
+      end
+      goto skip
+    end
+
     -- Resolve them and add them to the outputs
     local ok, module = pcall(require, "codecompanion." .. callback)
     if ok then


### PR DESCRIPTION
inline variables can be functions, chat variable function callbacks gets self

CodeCompanion.Inline.Variable config.callback can be a function. This function will have a single argument i.e CodeCompanion.Inline.Variable

CodeCompanion.Variable.User config.function callback will receive a single argument i.e CodeCompanion.Variable.User

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make docs` to update the vimdoc pages
