### PR TITLE
fix(blink): cursor put at wrong position after accepting

### DIFF
--- a/lua/codecompanion/providers/completion/blink/init.lua
+++ b/lua/codecompanion/providers/completion/blink/init.lua
@@ -126,10 +126,8 @@ end
 
 function M:execute(ctx, item, callback, default_implementation)
   if vim.tbl_contains({ "variable", "tool" }, item.data.type) then
-    -- TODO: remove type check once blink.cmp 0.14+ is released
     if type(default_implementation) == "function" then
-      vim.lsp.util.apply_text_edits({ item.textEdit }, ctx.bufnr, "utf-8")
-      vim.bo[ctx.bufnr].buflisted = false
+      default_implementation()
     end
 
     return callback()


### PR DESCRIPTION
## Description

When using blink.cmp cursor was not correctly set up after selecting an option

## Related Issue(s)
https://github.com/olimorris/codecompanion.nvim/issues/1159

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
