### PR TITLE
Add gemini 2.5 pro option to gemini adapter

### DIFF
--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -177,6 +177,7 @@ return {
       desc = "The model that will complete your prompt. See https://ai.google.dev/gemini-api/docs/models/gemini#model-variations for additional details and options.",
       default = "gemini-2.0-flash",
       choices = {
+        "gemini-2.5-pro-exp-03-25",
         "gemini-2.0-flash",
         "gemini-2.0-pro-exp-02-05",
         "gemini-1.5-flash",


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
Google recently released their Gemini 2.5 pro model. Simply adding it as an option to the gemini adapter.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
