### PR TITLE
feat(symbols): add symbols for Java

### DIFF
--- a/queries/java/symbols.scm
+++ b/queries/java/symbols.scm
@@ -1,0 +1,40 @@
+; Expanded from Ref: https://github.com/stevearc/aerial.nvim/blob/master/queries/java/aerial.scm
+; MIT License
+
+(package_declaration
+  (scoped_identifier) @name
+  (#set! "kind" "Import")) @symbol
+
+(import_declaration
+  (scoped_identifier) @name
+  (#set! "kind" "Import")) @symbol
+
+(interface_declaration
+  name: (identifier) @name
+  (#set! "kind" "Interface")) @symbol
+
+(method_declaration
+  name: (identifier) @name @start
+  (#set! "kind" "Method")) @symbol
+
+(constructor_declaration
+  name: (identifier) @name
+  (#set! "kind" "Constructor")) @symbol
+
+(class_declaration
+  name: (identifier) @name
+  (#set! "kind" "Class")) @symbol
+
+(record_declaration
+  name: (identifier) @name
+  (#set! "kind" "Class")) @symbol
+
+(enum_declaration
+  name: (identifier) @name
+  (#set! "kind" "Enum")) @symbol
+
+(field_declaration
+  declarator: (variable_declarator
+    name: (identifier) @name)
+  (#set! "kind" "Field")) @symbol
+

--- a/queries/java/symbols.scm
+++ b/queries/java/symbols.scm
@@ -17,10 +17,6 @@
   name: (identifier) @name @start
   (#set! "kind" "Method")) @symbol
 
-(constructor_declaration
-  name: (identifier) @name
-  (#set! "kind" "Constructor")) @symbol
-
 (class_declaration
   name: (identifier) @name
   (#set! "kind" "Class")) @symbol

--- a/queries/java/symbols.scm
+++ b/queries/java/symbols.scm
@@ -29,8 +29,3 @@
   name: (identifier) @name
   (#set! "kind" "Enum")) @symbol
 
-(field_declaration
-  declarator: (variable_declarator
-    name: (identifier) @name)
-  (#set! "kind" "Field")) @symbol
-


### PR DESCRIPTION
## Description

Adds the Treesitter symbol queries for Java from [Aerial](https://github.com/stevearc/aerial.nvim/blob/master/queries/java/aerial.scm).

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
