### PR TITLE
refactor: move Gemini to OpenAI endpoint

### DIFF
--- a/tests/adapters/stubs/gemini_no_streaming.txt
+++ b/tests/adapters/stubs/gemini_no_streaming.txt
@@ -1,34 +1,20 @@
 {
-  "candidates": [
-    {
-      "content": {
-        "parts": [
-          {
-            "text": "Elegant, dynamic.\nWhat can I help you with next?\n"
-          }
-        ],
-        "role": "model"
-      },
-      "finishReason": "STOP",
-      "avgLogprobs": -0.15357250826699392
-    }
-  ],
-  "usageMetadata": {
-    "promptTokenCount": 405,
-    "candidatesTokenCount": 14,
-    "totalTokenCount": 419,
-    "promptTokensDetails": [
-      {
-        "modality": "TEXT",
-        "tokenCount": 405
-      }
+    "choices": [
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "content": "Elegant, dynamic.\\n\\nNext question?\\n",
+                "role": "assistant"
+            }
+        }
     ],
-    "candidatesTokensDetails": [
-      {
-        "modality": "TEXT",
-        "tokenCount": 14
-      }
-    ]
-  },
-  "modelVersion": "gemini-2.0-flash"
+    "created": 1743460357,
+    "model": "gemini-2.0-flash",
+    "object": "chat.completion",
+    "usage": {
+        "completion_tokens": 9,
+        "prompt_tokens": 419,
+        "total_tokens": 428
+    }
 }

--- a/tests/adapters/stubs/gemini_streaming.txt
+++ b/tests/adapters/stubs/gemini_streaming.txt
@@ -1,2 +1,5 @@
-data: {"candidates": [{"content": {"parts": [{"text": "Inter"}],"role": "model"}}],"usageMetadata": {"promptTokenCount": 442,"totalTokenCount": 442,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 442}]},"modelVersion": "gemini-2.0-flash"}
-data: {"candidates": [{"content": {"parts": [{"text": "preted, versatile.\n\nWhat else can I help you with?\n"}],"role": "model"},"finishReason": "STOP"}],"usageMetadata": {"promptTokenCount": 438,"candidatesTokenCount": 16,"totalTokenCount": 454,"promptTokensDetails": [{"modality": "TEXT","tokenCount": 438}],"candidatesTokensDetails": [{"modality": "TEXT","tokenCount": 16}]},"modelVersion": "gemini-2.0-flash"}
+data: {"choices":[{"delta":{"content":"Elegant","role":"assistant"},"index":0}],"created":1743460109,"model":"gemini-2.0-flash","object":"chat.completion.chunk","usage":{"completion_tokens":0,"prompt_tokens":425,"total_tokens":425}}
+Tokens: 425
+data: {"choices":[{"delta":{"content":", dynamic.\n\nNext question?\n","role":"assistant"},"finish_reason":"stop","index":0}],"created":1743460109,"model":"gemini-2.0-flash","object":"chat.completion.chunk","usage":{"completion_tokens":9,"prompt_tokens":419,"total_tokens":428}}
+Tokens: 428
+data: [DONE]

--- a/tests/adapters/test_gemini.lua
+++ b/tests/adapters/test_gemini.lua
@@ -29,109 +29,23 @@ T["Gemini adapter"]["can form messages to be sent to the API"] = function()
   }
 
   local output = {
-    system_instruction = {
-      role = "user",
-      parts = {
-        { text = "Follow the user's request" },
-        { text = "Respond in code" },
-      },
-    },
-    contents = {
+    messages = {
       {
+        content = "Follow the user's request",
+        role = "system",
+      },
+      {
+        content = "Respond in code",
+        role = "system",
+      },
+      {
+        content = "Explain Ruby in two words",
         role = "user",
-        parts = {
-          { text = "Explain Ruby in two words" },
-        },
       },
     },
   }
 
   h.eq(output, adapter.handlers.form_messages(adapter, messages))
-end
-
-T["Gemini adapter"]["can form messages with system prompt"] = function()
-  local messages_with_system = {
-    {
-      content = "You are a helpful assistant",
-      role = "system",
-      id = 1,
-      cycle = 1,
-      opts = { visible = false },
-    },
-    {
-      content = "hello",
-      id = 2,
-      opts = { visible = true },
-      role = "user",
-    },
-    {
-      content = "Hi, how can I help?",
-      id = 3,
-      opts = { visible = true },
-      role = "llm",
-    },
-  }
-
-  local output = {
-    system_instruction = {
-      role = "user",
-      parts = {
-        { text = "You are a helpful assistant" },
-      },
-    },
-    contents = {
-      {
-        role = "user",
-        parts = {
-          { text = "hello" },
-        },
-      },
-      {
-        role = "user",
-        parts = {
-          { text = "Hi, how can I help?" },
-        },
-      },
-    },
-  }
-
-  h.eq(output, adapter.handlers.form_messages(adapter, messages_with_system))
-end
-
-T["Gemini adapter"]["can form messages without system prompt"] = function()
-  local messages_without_system = {
-    {
-      content = "hello",
-      id = 1,
-      opts = { visible = true },
-      role = "user",
-    },
-    {
-      content = "Hi, how can I help?",
-      id = 2,
-      opts = { visible = true },
-      role = "llm",
-    },
-  }
-
-  local output = {
-    contents = {
-      {
-        role = "user",
-        parts = {
-          { text = "hello" },
-        },
-      },
-      {
-        role = "user",
-        parts = {
-          { text = "Hi, how can I help?" },
-        },
-      },
-    },
-  }
-
-  h.eq(output, adapter.handlers.form_messages(adapter, messages_without_system))
 end
 
 T["Gemini adapter"]["Streaming"] = new_set()
@@ -146,7 +60,7 @@ T["Gemini adapter"]["Streaming"]["can output streamed data into the chat buffer"
     end
   end
 
-  h.expect_starts_with("Interpreted, versatile.", output)
+  h.expect_starts_with("Elegant, dynamic", output)
 end
 
 T["Gemini adapter"]["No Streaming"] = new_set({


### PR DESCRIPTION
## Description

Gemini now has an [OpenAI compatible endpoint](https://ai.google.dev/gemini-api/docs/openai#rest). This means we can move away from their hideous default and reuse the OpenAI adapter. It also paves the way for easier tool use in the function calling PR.
