### PR TITLE
fix(ui): respect opts.visible for non-"system" roles

### DIFF
--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -235,7 +235,7 @@ function UI:render(context, messages, opts)
 
   local function add_messages_to_buf(msgs)
     for i, msg in ipairs(msgs) do
-      if msg.role ~= config.constants.SYSTEM_ROLE or (msg.opts and msg.opts.visible ~= false) then
+      if msg.role ~= config.constants.SYSTEM_ROLE and (msg.opts and msg.opts.visible ~= false) then
         -- For workflow prompts: Ensure main user role doesn't get spaced
         if i > 1 and self.last_role ~= msg.role and msg.role ~= config.constants.USER_ROLE then
           spacer()


### PR DESCRIPTION
## Description

opts.visible is not respected for non-"system" roles in chat.

## Related Issue(s)

  - Fixes #1203

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
