### PR TITLE
fix(agents): system_prompt in tools.groups can be a function

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -283,10 +283,15 @@ function Agent:parse(chat, message)
 
     if groups and not vim.tbl_isempty(groups) then
       for _, group in ipairs(groups) do
-        if self.tools_config.groups[group].system_prompt then
+        local schema = self.tools_config.groups[group]
+        local system_prompt = schema.system_prompt
+        if type(system_prompt) == "function" then
+          system_prompt = system_prompt(schema)
+        end
+        if system_prompt then
           chat:add_message({
             role = config.constants.SYSTEM_ROLE,
-            content = self.tools_config.groups[group].system_prompt,
+            content = system_prompt,
           }, { tag = "tool", visible = false })
         end
       end


### PR DESCRIPTION
## Description
<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

system_prompt of tools.groups being a function makes it dynamic and the following possible.

```lua
        groups = {
            mcp = {
                description = "MCP Servers Tool",
                system_prompt = function(_)
                    -- get the running hub instance
                    local hub = require("mcphub").get_hub_instance()
                    return hub:get_active_servers_prompt() -- generates prompt from currently running mcp servers
                end,
                tools = {"use_mcp_tool","access_mcp_resource"},
            },
        },
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make docs` to update the vimdoc pages
