### PR TITLE
Don't trim empty lines with user role and empty content

### DIFF
--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -248,7 +248,8 @@ function UI:render(context, messages, opts)
           self:set_header(lines, set_llm_role(self.roles.llm, self.adapter))
         end
 
-        for _, text in ipairs(vim.split(msg.content, "\n", { plain = true, trimempty = true })) do
+        local trimempty = not (msg.role == "user" and msg.content == "")
+        for _, text in ipairs(vim.split(msg.content, "\n", { plain = true, trimempty = trimempty })) do
           table.insert(lines, text)
         end
 


### PR DESCRIPTION
This fixes my comment in https://github.com/olimorris/codecompanion.nvim/issues/959#issuecomment-2694619521

Basically if the user prompt content is empty we don't set the trimempty flag which allows to have an empty line between the user role (Me) and the actual content.

![trimempty](https://github.com/user-attachments/assets/a65188dd-998d-4905-8d0c-2ba80447c28a)
