### PR TITLE
Add blank line before user role

### DIFF
--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -242,6 +242,9 @@ function UI:render(context, messages, opts)
         end
 
         if msg.role == config.constants.USER_ROLE and last_set_role ~= config.constants.USER_ROLE then
+          if last_set_role ~= nil then
+            spacer()
+          end
           self:set_header(lines, self.roles.user)
         end
         if msg.role == config.constants.LLM_ROLE and last_set_role ~= config.constants.LLM_ROLE then


### PR DESCRIPTION
This addresses my second comment https://github.com/olimorris/codecompanion.nvim/issues/959#issuecomment-2694619521 by adding a blank line between the system role content and the user role heading.

![spacer](https://github.com/user-attachments/assets/8542ef4b-e24a-4795-bbf8-7e2e922930b8)
