### PR TITLE
fix(files tool): be more explicit about the xml schema

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/files.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/files.lua
@@ -274,7 +274,7 @@ return {
 
 3. **Key Points**:
   - **Only use when you deem it necessary**. The user has the final control on these operations through an approval mechanism.
-  - Ensure XML is **valid and follows the schema**
+  - Ensure XML is **valid and follows the schema of the provided xml files below**. Using the exact same tags is crucial: for example use <contents> in plural instead of <content>.
   - **Include indentation** in the file's content
   - **Don't escape** special characters
   - **Wrap contents in a CDATA block**, the contents could contain characters reserved by XML


### PR DESCRIPTION
## Description

This is the make the @files tool's prompt more accurate: updating prompt to say that the xml schema is provided below and to respect the tags accurately.

## Related Issue(s)

The @files tool failed few times whereas the other tools don't fail for me.
Upon investigation , in one instance, the LLM didn't respect the schema exactly and used `<content>` instead of `<contents>`.
Other tools such as @editor has an explicit section called [XML schema](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/strategies/chat/agents/tools/editor.lua#L287) whereas with @files it doesn't explicitly say it, that might be the reason.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages - N/A
- [x] I've run `make docs` to update the vimdoc pages - N/A
