### PR TITLE
feat: allow toggling the visibility of individual references.

### DIFF
--- a/lua/codecompanion/strategies/chat/references.lua
+++ b/lua/codecompanion/strategies/chat/references.lua
@@ -78,6 +78,9 @@ end
 ---@param ref CodeCompanion.Chat.Ref
 ---@param row integer
 local function add(chat, ref, row)
+  if not ref.opts.visible then
+    return
+  end
   local lines = {}
 
   table.insert(lines, string.format("> - %s", ref.id))
@@ -121,6 +124,11 @@ function References:add(ref)
     -- Ensure both properties exist with defaults
     ref.opts.pinned = ref.opts.pinned or false
     ref.opts.watched = ref.opts.watched or false
+    ref.opts.visible = ref.opts.visible
+
+    if ref.opts.visible == nil then
+      ref.opts.visible = config.display.chat.show_references
+    end
     table.insert(self.Chat.refs, ref)
     -- If it's a buffer reference and it's being watched, start watching
     if ref.bufnr and ref.opts.watched then

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -82,6 +82,7 @@
 ---@field opts? table
 ---@field opts.pinned? boolean Whether this reference is pinned
 ---@field opts.watched? boolean Whether this reference is being watched for changes
+---@field opts.visible? boolean Whether this reference should be shown in the chat UI
 ---@field bufnr? number The buffer number if this is a buffer reference
 
 ---@class CodeCompanion.Chat.UI

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -164,6 +164,7 @@ T["References"]["Can be pinned"] = function()
       id = "<buf>pinned example</buf>",
       opts = {
         pinned = true,
+        visible = true,
         watched = false,
       },
       path = "tests.stubs.file.txt",
@@ -173,6 +174,7 @@ T["References"]["Can be pinned"] = function()
       id = "<buf>unpinned example</buf>",
       opts = {
         pinned = false,
+        visible = true,
         watched = false,
       },
       path = "test2",


### PR DESCRIPTION
## Description

This PR allows certain references to be hidden from the chat buffer. This is useful for tools/slash commands that add _a lot_ of references to the chat buffer.

Reference providers (tool, slash command, variable, etc.) can use the `visible` option to choose whether it should be shown in the chat UI:
```lua
agent.chat.references:add({
  source = "tool",
  id = "ref_id",
  opts = { visible = false },
})
```

The value for the `visible` key falls back to `config.display.chat.show_references`, so it should respect existing configurations.

## Related Issue(s)

See [here](https://github.com/Davidyz/VectorCode/pull/72#issuecomment-2799884579).

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
