### PR TITLE
fix(slash_cmds): focus on chat window after closing snacks picker

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -51,6 +51,7 @@ local providers = {
       source = "buffers",
       prompt = snacks.title,
       confirm = snacks:display(),
+      main = { file = false },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/file.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/file.lua
@@ -48,6 +48,7 @@ local providers = {
       source = "files",
       prompt = snacks.title,
       confirm = snacks:display(),
+      main = { file = false },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/help.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/help.lua
@@ -147,6 +147,7 @@ local providers = {
       source = "help",
       prompt = snacks.title,
       confirm = snacks:display(),
+      main = { file = false },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
@@ -83,6 +83,7 @@ local providers = {
       source = "files",
       prompt = snacks.title,
       confirm = snacks:display(),
+      main = { file = false },
     })
   end,
 


### PR DESCRIPTION
## Description
The default Snacks.picker options requires the main window to be a file (leading to the behavior in the referenced issue) but this can be configured.
<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)
Fixes #971
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #971
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
