### PR TITLE
feat(events): add context to InlineStarted event data payload

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -413,6 +413,7 @@ function Inline:submit(prompt)
       end,
     }, {
       bufnr = self.bufnr,
+      context = self.context or {},
       strategy = "inline",
     })
 end


### PR DESCRIPTION
## Description

This pull request adds `context` to the `InlineStarted` data payload event, primarily to retrieve `start_line` and `end_line`. This enables the creation of various extmarks, such as status column icons, virtual text, etc.

## Related Issue(s)

## Screenshots

Here is a simple example of extmarks added to add status column icon when the `InlineStarted` event is triggered and cleared at the `InlineFinished` event.

![codecompanion](https://github.com/user-attachments/assets/0aeb58ae-0553-4c60-b1ad-c4b5abe023e3)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
