### PR TITLE
feat: tools can be hidden from cmp menu when they are from a group

### DIFF
--- a/lua/codecompanion/completion.lua
+++ b/lua/codecompanion/completion.lua
@@ -88,8 +88,8 @@ function M.tools()
   -- Add tools
   vim
     .iter(config.strategies.chat.tools)
-    :filter(function(label)
-      return label ~= "opts" and label ~= "groups"
+    :filter(function(label, value)
+      return label ~= "opts" and label ~= "groups" and value.visible ~= false
     end)
     :each(function(label, v)
       table.insert(items, {


### PR DESCRIPTION
## Description

Tools can be hidden from cmp menu when they are from a group. 
Useful in cases where tools in a group can't be used individually as there is no separate system_prompt for each tool but only for the combined group.

E.g `@mcp` group provides the system_prompt for both tools. Individual `use_mcp_tool` and `access_mcp_resource` have a empty system_prompt. Showing these in the cmp might lead to user just using `@use_mcp_tool` rather than `@mcp` group. Ability to hide them with `visible = false` avoids this.

### Current: Unnecessary tools shown

![image](https://github.com/user-attachments/assets/7ad46669-9bd9-4e21-bf9b-eac0d35ac20e)

### Hidden tools

![image](https://github.com/user-attachments/assets/9f89edef-9a30-44c3-9770-ee70edba23ef)


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
