### PR TITLE
fix(refs): can handle blank messages

### DIFF
--- a/lua/codecompanion/strategies/chat/references.lua
+++ b/lua/codecompanion/strategies/chat/references.lua
@@ -158,6 +158,10 @@ function References:clear(message)
     return message or nil
   end
 
+  if message and message.content == "" then
+    return message
+  end
+
   local parser = vim.treesitter.get_string_parser(message.content, "markdown")
   local query = vim.treesitter.query.get("markdown", "reference")
   local root = parser:parse()[1]:root()


### PR DESCRIPTION
## Description

We allow user messages to be blank, but didn't handle the clearing of any references and the fact messages can be blank.

## Related Issue(s)

#1311