### PR TITLE
fix: don't remove tools by checking chat refs while auto_submitting

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -696,7 +696,11 @@ function Chat:submit(opts)
   message = self.references:clear(self.messages[#self.messages])
 
   self:replace_vars_and_tools(message)
-  self:check_references()
+
+  local tools_config = config.strategies.chat.tools
+  if not tools_config.opts.auto_submit_success and not tools_config.opts.auto_submit_errors then
+    self:check_references()
+  end
   self:add_pins()
 
   -- Check if the user has manually overridden the adapter


### PR DESCRIPTION

## Related Issue(s)

Set `auto_submit_success` or `auto_submit_errors` and use some tool. It fails with "Bad Request" error.

## Description

With `auto_submit_success` and `auto_submit_error` the request fails with "Bad Request". 

The Bad Request is raised due to tools field not present in the request body json file when auto sending the request after a tool call. Having a tool_call_id or role = tool and not having the tools field might be the cause.

The tools are being removed in the below code by comparing them with refs from the chat. This leads to all tools being removed as refs might not be rendered in the chat when in auto_submitting.

```lua
---Reconcile the references table to the references in the chat buffer
---@return nil
function Chat:check_references()
  local refs = self.references:get_from_chat()
  if vim.tbl_isempty(refs) and vim.tbl_isempty(self.refs) then
    return
  end

  -- Fetch references that exist on the chat object but not in the buffer
  local to_remove = vim
    .iter(self.refs)
    :filter(function(ref)
      return not vim.tbl_contains(refs, ref.id)
    end)
    :map(function(ref)
      return ref.id
    end)
    :totable()

  if vim.tbl_isempty(to_remove) then
    return
  end
```

This PR bypasses the check_references() when auto_submit_success or auto_submit_errors is set to true. 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added
[test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
