### PR TITLE
fix(tools): `tool_call_id` collisions of gemini model

### DIFF
--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -171,7 +171,8 @@ return {
               -- We need this to ensure the #tool_calls = #tool_responses
               local id = tool.id
               if not id or id == "" then
-                id = string.format("call_%d", tool_index)
+                -- HACK: append `json.created` to avoid `tool_call_id` collisions
+                id = string.format("call_%d_%d", tool_index, (json.created or 0))
               end
 
               if self.opts.stream then

--- a/tests/adapters/test_gemini.lua
+++ b/tests/adapters/test_gemini.lua
@@ -84,7 +84,7 @@ T["Gemini adapter"]["Streaming"]["can process tools"] = function()
         arguments = '{"units":"celsius","location":"London"}',
         name = "weather",
       },
-      id = "call_1",
+      id = "call_1_1743628522",
       type = "function",
     },
     {
@@ -93,7 +93,7 @@ T["Gemini adapter"]["Streaming"]["can process tools"] = function()
         arguments = '{"units":"celsius","location":"Paris"}',
         name = "weather",
       },
-      id = "call_2",
+      id = "call_2_1743628522",
       type = "function",
     },
   }
@@ -140,7 +140,7 @@ T["Gemini adapter"]["No Streaming"]["can process tools"] = function()
         arguments = '{"location":"London, UK","units":"celsius"}',
         name = "weather",
       },
-      id = "call_1",
+      id = "call_1_1743631193",
       type = "function",
     },
     {
@@ -149,7 +149,7 @@ T["Gemini adapter"]["No Streaming"]["can process tools"] = function()
         arguments = '{"units":"celsius","location":"Paris, France"}',
         name = "weather",
       },
-      id = "call_2",
+      id = "call_2_1743631193",
       type = "function",
     },
   }


### PR DESCRIPTION
## Description

Use `json.created` as a workaround complement for gemini models when the call_id is missing.

## Related Issue(s)

Fixes the id collusion part of #1311 

## Screenshots

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added
[test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
