### PR TITLE
Fix: Set filetype to codecompanion for chat debug buffer

### DIFF
--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -226,9 +226,10 @@ function Debug:render()
 
   ui.create_float(lines, {
     bufnr = self.bufnr,
-    filetype = "lua",
+    filetype = "codecompanion",
     ignore_keymaps = true,
     relative = "editor",
+    syntax = "lua",
     title = "Debug Chat",
     window = window,
     opts = {

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -1,3 +1,4 @@
+local utils = require("codecompanion.utils")
 local log = require("codecompanion.utils.log")
 
 local api = vim.api
@@ -15,7 +16,11 @@ M.create_float = function(lines, opts)
 
   local bufnr = opts.bufnr or api.nvim_create_buf(false, true)
 
-  require("codecompanion.utils").set_option(bufnr, "filetype", opts.filetype or "codecompanion")
+  utils.set_option(bufnr, "filetype", opts.filetype or "codecompanion")
+
+  if opts.syntax then
+    utils.set_option(bufnr, "syntax", opts.syntax)
+  end
 
   local winnr = api.nvim_open_win(bufnr, true, {
     relative = opts.relative or "cursor",

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -1,5 +1,5 @@
-local utils = require("codecompanion.utils")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local api = vim.api
 


### PR DESCRIPTION
The debug chat buffer filetype was incorrectly set to lua.
This commit corrects the filetype to codecompanion, while preserving lua syntax highlighting.
This ensures proper plugin behavior based on the filetype.