### PR TITLE
fix(inline): added check for placement "new"

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -701,6 +701,10 @@ function Inline:start_diff()
     return
   end
 
+  if self.classification.placement == "new" then
+    return
+  end
+
   keymaps
     .new({
       bufnr = self.context.bufnr,


### PR DESCRIPTION
placement new should not create diffs views in neovim

## Description
This pull request fix an issue when placement "new" create a diffview in neovim. This cause the following error to happen:
```
Error executing vim.schedule lua callback: ...panion.nvim/lua/codecompanion/providers/diff/default.lua:79:
Cursor position outside buffer
stack traceback:
   [C]: in function 'nvim_win_set_cursor'
   ...panion.nvim/lua/codecompanion/providers/diff/default.lua:79: in function 'new'
   ...panion.nvim/lua/codecompanion/strategies/inline/init.lua:720: in function 'start_diff'
   ...panion.nvim/lua/codecompanion/strategies/inline/init.lua:468: in function <...panion.nvim/lua/codecompanion/strategies/inline/init.lua:467>
```
<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)
https://github.com/olimorris/codecompanion.nvim/issues/1308
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added
[test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
