### PR TITLE
fix(chat): prevent double references in the chat buffer

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -832,9 +832,7 @@ end
 ---@param chat CodeCompanion.Chat
 ---@return nil
 local function ready_chat_buffer(chat)
-  local last_sender = chat.messages[#chat.messages].role
-
-  if last_sender ~= config.constants.USER_ROLE then
+  if chat.last_role ~= config.constants.USER_ROLE then
     chat:increment_cycle()
     chat:add_buf_message({ role = config.constants.USER_ROLE, content = "" })
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -832,16 +832,20 @@ end
 ---@param chat CodeCompanion.Chat
 ---@return nil
 local function ready_chat_buffer(chat)
-  chat:increment_cycle()
-  chat:add_buf_message({ role = config.constants.USER_ROLE, content = "" })
+  local last_sender = chat.messages[#chat.messages].role
 
-  chat:set_text_editing_area(-2)
-  chat.ui:display_tokens(chat.parser, chat.header_line)
-  chat.references:render()
+  if last_sender ~= config.constants.USER_ROLE then
+    chat:increment_cycle()
+    chat:add_buf_message({ role = config.constants.USER_ROLE, content = "" })
 
-  -- If we're running any tooling, let them handle the subscriptions instead
-  if not chat.tools:loaded() then
-    chat.subscribers:process(chat)
+    chat:set_text_editing_area(-2)
+    chat.ui:display_tokens(chat.parser, chat.header_line)
+    chat.references:render()
+
+    -- If we're running any tooling, let them handle the subscriptions instead
+    if not chat.tools:loaded() then
+      chat.subscribers:process(chat)
+    end
   end
 
   log:info("Chat request finished")
@@ -1067,8 +1071,6 @@ function Chat:close()
   util.fire("ChatModel", { bufnr = self.bufnr, id = self.id, model = nil })
   self = nil
 end
-
-local has_been_reasoning = false
 
 ---Add a message directly to the chat buffer. This will be visible to the user
 ---@param data table

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -206,18 +206,23 @@ T["References"]["Can be pinned"] = function()
   h.eq(child.lua_get([[_G.chat.messages[#_G.chat.messages].content]]), "Basic Slash Command")
 
   child.lua([[
+    -- Mock the submit
+    _G.chat:add_buf_message({
+      role = "llm",
+      content = "Ooooh. I'm not sure. They probably do a lot!",
+    })
     _G.chat.status = "success"
-    _G.chat:done({ content = "Some data" })
+    _G.chat:done({ content = "This is a mocked response" })
   ]])
 
   local buffer = child.lua_get([[h.get_buf_lines(_G.chat.bufnr)]])
 
-  h.eq("> Context:", buffer[3])
+  h.eq("> Context:", buffer[15])
   h.eq(
     string.format("> - %s<buf>pinned example</buf>", child.lua_get([[config.display.chat.icons.pinned_buffer]])),
-    buffer[8]
+    buffer[16]
   )
-  h.eq("> - <buf>unpinned example</buf>", buffer[9])
+  h.eq("> - <buf>unpinned example</buf>", buffer[17])
 
   h.eq({
     {

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -200,20 +200,19 @@ T["References"]["Can be pinned"] = function()
   h.eq(child.lua_get([[#_G.chat.messages]]), 2, "There are three messages")
   h.eq(child.lua_get([[_G.chat.refs[1].opts.pinned]]), true, "Reference is pinned")
 
-  child.lua([[_G.chat:submit()]])
-
-  h.eq(child.lua_get([[#_G.chat.messages]]), 4, "There are four messages")
-  h.eq(child.lua_get([[_G.chat.messages[#_G.chat.messages].content]]), "Basic Slash Command")
-
   child.lua([[
     -- Mock the submit
     _G.chat:add_buf_message({
       role = "llm",
       content = "Ooooh. I'm not sure. They probably do a lot!",
     })
+    _G.chat:submit()
     _G.chat.status = "success"
     _G.chat:done({ content = "This is a mocked response" })
   ]])
+
+  h.eq(child.lua_get([[#_G.chat.messages]]), 4, "There are four messages")
+  h.eq(child.lua_get([[_G.chat.messages[#_G.chat.messages].content]]), "Basic Slash Command")
 
   local buffer = child.lua_get([[h.get_buf_lines(_G.chat.bufnr)]])
 


### PR DESCRIPTION
## Description

Sometimes there can be double references appearing in the chat buffer.