### PR TITLE
fix(reference): make sure ref with `opts.visible = false` are hidden.

### DIFF
--- a/lua/codecompanion/strategies/chat/references.lua
+++ b/lua/codecompanion/strategies/chat/references.lua
@@ -194,7 +194,7 @@ function References:render()
   table.insert(lines, "> Context:")
 
   for _, ref in pairs(chat.refs) do
-    if not ref then
+    if not ref or (ref.opts and ref.opts.visible == false) then
       goto continue
     end
     if ref.opts and ref.opts.pinned then
@@ -205,6 +205,10 @@ function References:render()
       table.insert(lines, string.format("> - %s", ref.id))
     end
     ::continue::
+  end
+  if #lines == 1 then
+    -- no ref added
+    return
   end
   table.insert(lines, "")
 

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -279,6 +279,25 @@ T["References"]["Render"] = function()
   )
 end
 
+T["References"]["Render invisible"] = function()
+  child.lua([[
+    _G.chat.refs = {
+      {
+        id = "<buf>pinned example</buf>",
+        path = "tests.stubs.file.txt",
+        source = "tests.strategies.chat.slash_commands.basic",
+        opts = {
+          visible = false,
+          pinned = true,
+        },
+      },
+    }
+    _G.chat.references:render()
+  ]])
+
+  h.eq({ "## foo", "", "" }, child.lua_get([[h.get_buf_lines(_G.chat.bufnr)]]))
+end
+
 T["References"]["can be cleared from messages"] = function()
   child.lua([[
     _G.chat.references:add({


### PR DESCRIPTION
## Description

I was unable to hide references even if I added them with `opts = {visible = false}`.

Specifically, the extra test I added in this PR fails without this patch.

## Screenshots

![image](https://github.com/user-attachments/assets/0279f232-64f7-4756-b241-f24e5fc10244)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added
[test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make docs` to update the vimdoc pages
