### PR TITLE
feat: replace `vim.fn.confirm` with `vim.ui.select`

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -112,36 +112,32 @@ function Executor:setup(input)
       prompt = ("Run the %q tool?"):format(self.tool.name)
     end
 
-    vim.ui.select(
-      { "Yes", "No", "Cancel" },
-      {
-        prompt = prompt,
-        format_item = function(item)
-          if item == "Yes" then
-            return "Yes"
-          elseif item == "No" then
-            return "No"
-          else
-            return "Cancel"
-          end
-        end,
-      },
-      function(choice)
-       if not choice or choice == "Cancel" then -- No selection or cancelled 
-          log:debug("Executor:execute - Tool cancelled")
-          finalize_agent(self)
-          self:close()
-          return
-        elseif choice == "Yes" then -- Selected yes
-          log:debug("Executor:execute - Tool approved")
-          self:execute(cmd, input)
-        elseif choice == "No" then -- Selected no
-          log:debug("Executor:execute - Tool rejected")
-          self.output.rejected(cmd)
-          self:setup()
+    vim.ui.select({ "Yes", "No", "Cancel" }, {
+      prompt = prompt,
+      format_item = function(item)
+        if item == "Yes" then
+          return "Yes"
+        elseif item == "No" then
+          return "No"
+        else
+          return "Cancel"
         end
+      end,
+    }, function(choice)
+      if not choice or choice == "Cancel" then -- No selection or cancelled
+        log:debug("Executor:execute - Tool cancelled")
+        finalize_agent(self)
+        self:close()
+        return
+      elseif choice == "Yes" then -- Selected yes
+        log:debug("Executor:execute - Tool approved")
+        self:execute(cmd, input)
+      elseif choice == "No" then -- Selected no
+        log:debug("Executor:execute - Tool rejected")
+        self.output.rejected(cmd)
+        self:setup()
       end
-    )
+    end)
   else
     self:execute(cmd, input)
   end

--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -112,21 +112,36 @@ function Executor:setup(input)
       prompt = ("Run the %q tool?"):format(self.tool.name)
     end
 
-    local ok, choice = pcall(vim.fn.confirm, prompt, "&Yes\n&No\n&Cancel")
-    if not ok or choice == 0 or choice == 3 then -- Esc or Cancel
-      log:debug("Executor:execute - Tool cancelled")
-      finalize_agent(self)
-      return self:close()
-    end
-    if choice == 1 then -- Yes
-      log:debug("Executor:execute - Tool approved")
-      self:execute(cmd, input)
-    end
-    if choice == 2 then -- No
-      log:debug("Executor:execute - Tool rejected")
-      self.output.rejected(cmd)
-      return self:setup()
-    end
+    vim.ui.select(
+      { "Yes", "No", "Cancel" },
+      {
+        prompt = prompt,
+        format_item = function(item)
+          if item == "Yes" then
+            return "Yes"
+          elseif item == "No" then
+            return "No"
+          else
+            return "Cancel"
+          end
+        end,
+      },
+      function(choice)
+       if not choice or choice == "Cancel" then -- No selection or cancelled 
+          log:debug("Executor:execute - Tool cancelled")
+          finalize_agent(self)
+          self:close()
+          return
+        elseif choice == "Yes" then -- Selected yes
+          log:debug("Executor:execute - Tool approved")
+          self:execute(cmd, input)
+        elseif choice == "No" then -- Selected no
+          log:debug("Executor:execute - Tool rejected")
+          self.output.rejected(cmd)
+          self:setup()
+        end
+      end
+    )
   else
     self:execute(cmd, input)
   end


### PR DESCRIPTION
## Description

Replace `vim.fn.confirm` with `vim.ui.select`, this will improve the UI experience when using function tool calling!

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
