### PR TITLE
fix(tools): tools can now be deleted as references

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -950,16 +950,21 @@ function Chat:check_references()
     :totable()
 
   -- Clear any tool's schemas
-  self.tools.schemas = vim
-    .iter(self.tools.schemas)
-    :filter(function(tool_schemas)
-      if vim.tbl_contains(to_remove, tool_schemas) then
-        -- TODO: Remove from tools_in_use
-        return false
+  local schemas_to_keep = {}
+  local tools_in_use_to_keep = {}
+  for id, schema in pairs(self.tools.schemas) do
+    if not vim.tbl_contains(to_remove, id) then
+      schemas_to_keep[id] = schema
+      local tool_name = id:match("<tool>(.*)</tool>")
+      if tool_name and self.tools.in_use[tool_name] then
+        tools_in_use_to_keep[tool_name] = true
       end
-      return true
-    end)
-    :totable()
+    else
+      log:debug("Removing tool schema and usage flag for ID: %s", id) -- Optional logging
+    end
+  end
+  self.tools.schemas = schemas_to_keep
+  self.tools.in_use = tools_in_use_to_keep
 end
 
 ---Add updated content from the pins to the chat buffer

--- a/tests/expectations.lua
+++ b/tests/expectations.lua
@@ -5,6 +5,19 @@ H.eq = MiniTest.expect.equality --[[@type function]]
 H.not_eq = MiniTest.expect.no_equality --[[@type function]]
 
 --[[@type function]]
+H.expect_truthy = MiniTest.new_expectation(
+  "value is truthy",
+  -- Predicate: returns true if value is not false and not nil
+  function(value)
+    return value ~= false and value ~= nil
+  end,
+  -- Fail context: explains why it failed
+  function(value)
+    return string.format("\nExpected value to be truthy (not false or nil), but got:\n%s", vim.inspect(value))
+  end
+)
+
+--[[@type function]]
 H.expect_starts_with = MiniTest.new_expectation(
   "string starts with",
   function(pattern, str)


### PR DESCRIPTION
## Description

As discussed in #1336, when tools are deleted as references, this causes an error as the tool schema table goes from a dictionary to an array. This PR corrects that.