### PR TITLE
Minor fix to focus on floating chat windows after closing snacks picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [15.1.1](https://github.com/olimorris/codecompanion.nvim/compare/v15.1.0...v15.1.1) (2025-05-03)
+
+
+### Bug Fixes
+
+* **inline:** "new" placement doesn't create diffview ([#1343](https://github.com/olimorris/codecompanion.nvim/issues/1343)) ([9ab6ac1](https://github.com/olimorris/codecompanion.nvim/commit/9ab6ac1126d89f74b9882e4343eb1397e4b052da))
+
 ## [15.1.0](https://github.com/olimorris/codecompanion.nvim/compare/v15.0.8...v15.1.0) (2025-05-02)
 
 

--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -51,7 +51,7 @@ local providers = {
       source = "buffers",
       prompt = snacks.title,
       confirm = snacks:display(),
-      main = { file = false , float = true },
+      main = { file = false, float = true },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -51,7 +51,7 @@ local providers = {
       source = "buffers",
       prompt = snacks.title,
       confirm = snacks:display(),
-      main = { file = false },
+      main = { file = false , float = true },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/file.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/file.lua
@@ -48,7 +48,7 @@ local providers = {
       source = "files",
       prompt = snacks.title,
       confirm = snacks:display(),
-      main = { file = false },
+      main = { file = false, float = true },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/help.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/help.lua
@@ -147,7 +147,7 @@ local providers = {
       source = "help",
       prompt = snacks.title,
       confirm = snacks:display(),
-      main = { file = false , float = true },
+      main = { file = false, float = true },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/help.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/help.lua
@@ -147,7 +147,7 @@ local providers = {
       source = "help",
       prompt = snacks.title,
       confirm = snacks:display(),
-      main = { file = false },
+      main = { file = false , float = true },
     })
   end,
 

--- a/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
@@ -83,7 +83,7 @@ local providers = {
       source = "files",
       prompt = snacks.title,
       confirm = snacks:display(),
-      main = { file = false },
+      main = { file = false, float = true },
     })
   end,
 


### PR DESCRIPTION
## Description

I noticed that after #1248 I was still seeing issue #971. It seems that this is because I was using the float layout and there is another option to set if the chat window is a floating window:

https://github.com/folke/snacks.nvim/blob/bc0630e43be5699bb94dadc302c0d21615421d93/lua/snacks/picker/core/main.lua#L8

I think this is comes under straightforward bug fix so no prior discussion

## Related Issue(s)

- Fixes #971 for floating windows


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
