### PR TITLE
refactor(chat): make some public methods private

### DIFF
--- a/lua/codecompanion/providers/completion/cmp/models.lua
+++ b/lua/codecompanion/providers/completion/cmp/models.lua
@@ -22,7 +22,7 @@ end
 function source:complete(request, callback)
   local chat = require("codecompanion").buf_get_chat(0)
   if chat then
-    chat:complete_models(request, callback)
+    chat:complete_models(callback)
   else
     callback({ items = {}, isIncomplete = false })
   end

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -791,7 +791,9 @@ function Chat:submit(opts)
     })
   end
 
-  -- NOTE: Sometimes the last message is a tool call so we need to account for that
+  -- NOTE: There are instances when submit is called with no user message. Such
+  -- as in the case of tools auto-submitting responses. References should be
+  -- excluded and we can do this by checking for user messages.
   if message then
     message = self.references:clear(self.messages[#self.messages])
     self.replace_vars_and_tools(self, message)

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -183,19 +183,6 @@ local function make_id(val)
   return hash.hash(val)
 end
 
----Apply any tools or variables that a user has tagged in their message
----@param chat CodeCompanion.Chat
----@param message table
----@return nil
-local function replace_vars_and_tools(chat, message)
-  if chat.agents:parse(chat, message) then
-    message.content = chat.agents:replace(message.content)
-  end
-  if chat.variables:parse(chat, message) then
-    message.content = chat.variables:replace(message.content, chat.context.bufnr)
-  end
-end
-
 ---Set the editable text area. This allows us to scope the Tree-sitter queries to a specific area
 ---@param chat CodeCompanion.Chat
 ---@param modifier? number
@@ -760,6 +747,18 @@ function Chat:add_message(data, opts)
   return self
 end
 
+---Apply any tools or variables that a user has tagged in their message
+---@param message table
+---@return nil
+function Chat:replace_vars_and_tools(message)
+  if self.agents:parse(self, message) then
+    message.content = self.agents:replace(message.content)
+  end
+  if self.variables:parse(self, message) then
+    message.content = self.variables:replace(message.content, self.context.bufnr)
+  end
+end
+
 ---Submit the chat buffer's contents to the LLM
 ---@param opts? table
 ---@return nil
@@ -795,7 +794,7 @@ function Chat:submit(opts)
   -- NOTE: Sometimes the last message is a tool call so we need to account for that
   if message then
     message = self.references:clear(self.messages[#self.messages])
-    replace_vars_and_tools(self, message)
+    self.replace_vars_and_tools(self, message)
     self:check_references()
     add_pins(self)
   end

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -823,6 +823,7 @@ function Chat:submit(opts)
 
   log:trace("Settings:\n%s", settings)
   log:trace("Messages:\n%s", self.messages)
+  log:trace("Tools:\n%s", payload.tools)
   log:info("Chat request started")
 
   local output = {}

--- a/tests/test_strategies.lua
+++ b/tests/test_strategies.lua
@@ -104,19 +104,5 @@ describe("Chat Strategy", function()
         },
       },
     }
-    -- local Strategy = require("codecompanion.strategies")
-    --   .new({
-    --     context = { bufnr = 1, filetype = "lua", mode = "n" },
-    --     selected = item,
-    --   })
-    --   :start(item.strategy)
-
-    -- local messages = Strategy:get_messages()
-    --
-    -- assert.equals("system", messages[#messages - 1].role)
-    -- assert.equals("My system prompt", messages[#messages - 1].content)
-    --
-    -- assert.equals("user", messages[#messages].role)
-    -- assert.equals("My user prompt", messages[#messages].content)
   end)
 end)


### PR DESCRIPTION
## Description

As we get more community extensions, they will be making use of the chat buffers public methods. This refactor reduces the amount of public methods to tighten scope and make future refactors less troublesome.