### PR TITLE
fix(tools): tool groups are replaced properly in the chat buffer

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1656,8 +1656,7 @@ RUN TESTS FROM THE CHAT BUFFER ~
 The |codecompanion-usage-chat-buffer-agents-cmd-runner| tool enables an LLM to
 execute commands on your machine. This can be useful if you wish the LLM to run
 a test suite on your behalf and give insight on failing cases. Simply tag the
-`@cmd_runner` in the chat buffer and ask it run your tests with a suitable
-command e.g. `pytest`.
+`@cmd_runner` in the chat buffer and ask it run your tests.
 
 
 NAVIGATING BETWEEN RESPONSES IN THE CHAT BUFFER ~
@@ -1955,7 +1954,11 @@ disk:
 @FULL_STACK_DEV ~
 
 The plugin enables tools to be grouped together. The `@full_stack_dev` agent is
-a combination of the `@cmd_runner`, `@editor` and `@files` tools.
+a combination of the `@cmd_runner`, `@editor` and `@files` tools:
+
+>md
+    Let's use the @full_stack_dev tools to create a new app
+<
 
 
 APPROVALS ~
@@ -2659,7 +2662,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI’S API OUTPUT
+OPENAI�S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/usage/chat-buffer/agents.md
+++ b/doc/usage/chat-buffer/agents.md
@@ -78,7 +78,12 @@ The _@files_ tool leverages the [Plenary.Path](https://github.com/nvim-lua/plena
 
 ## @full_stack_dev
 
-The plugin enables tools to be grouped together. The _@full_stack_dev_ agent is a combination of the _@cmd_runner_, _@editor_ and _@files_ tools.
+The plugin enables tools to be grouped together. The _@full_stack_dev_ agent is a combination of the _@cmd_runner_, _@editor_ and _@files_ tools:
+
+```md
+Let's use the @full_stack_dev tools to create a new app
+```
+
 
 ## Approvals
 

--- a/doc/usage/introduction.md
+++ b/doc/usage/introduction.md
@@ -12,7 +12,7 @@ The [editor](/usage/chat-buffer/agents#editor) tool, combined with the `#buffer`
 
 ## Run tests from the chat buffer
 
-The [cmd_runner](/usage/chat-buffer/agents#cmd-runner) tool enables an LLM to execute commands on your machine. This can be useful if you wish the LLM to run a test suite on your behalf and give insight on failing cases. Simply tag the `@cmd_runner` in the chat buffer and ask it run your tests with a suitable command e.g. `pytest`.
+The [cmd_runner](/usage/chat-buffer/agents#cmd-runner) tool enables an LLM to execute commands on your machine. This can be useful if you wish the LLM to run a test suite on your behalf and give insight on failing cases. Simply tag the `@cmd_runner` in the chat buffer and ask it run your tests.
 
 ## Navigating between responses in the chat buffer
 

--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -259,7 +259,8 @@ function Agent:replace(message)
     end
   end
   for group, _ in pairs(self.tools_config.groups) do
-    message = vim.trim(message:gsub(CONSTANTS.PREFIX .. group, ""))
+    local tools = table.concat(self.tools_config.groups[group].tools, ", ")
+    message = vim.trim(message:gsub(CONSTANTS.PREFIX .. group, tools))
   end
 
   return message


### PR DESCRIPTION
## Description

Previously, if my prompt was:

`I want to test the @mcp tools. What should we test first?`

The LLM receives:

`I want to test the  tools. What should we test first?`

When really it should receive:

`I want to test the access_mcp_resource, use_mcp_tool tools. What should we test first?`