### PR TITLE
fix: call all subscribers on getting llm response

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -191,6 +191,7 @@ function Executor:close()
   log:debug("Executor:close")
   self.handlers.on_exit()
   util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
+  chat.subscribers:process(chat)
   _G.codecompanion_current_tool = nil
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

In the previous 1e2f69a9a65bd716cf897393e7af65fc74907ed8 commit, self.subscribers:process was removed without corresponding call in the ready_chat_buffer. 

![image](https://github.com/user-attachments/assets/b1432e8f-acf7-4a73-9ee4-0c05de1af1f6)

This PR process all subscribers in the ready_chat_buffer.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
