### PR TITLE
Fix/adapter resolution

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -272,6 +272,9 @@ function Adapter.extend(adapter, opts)
     ok, adapter_config = pcall(require, "codecompanion.adapters." .. adapter)
     if not ok then
       adapter_config = config.adapters[adapter]
+      if type(adapter_config) == "function" then
+        adapter_config = adapter_config()
+      end
     end
   elseif type(adapter) == "function" then
     adapter_config = adapter()

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -150,17 +150,23 @@ function Client:request(payload, actions, opts)
           opts.status = "error"
         end
 
-        util.fire("RequestFinished", opts)
+        if not opts.silent then
+          util.fire("RequestFinished", opts)
+        end
         cleanup(opts.status)
         if self.user_args.event then
-          util.fire("RequestFinished" .. (self.user_args.event or ""), opts)
+          if not opts.silent then
+            util.fire("RequestFinished" .. (self.user_args.event or ""), opts)
+          end
         end
       end)
     end,
     on_error = function(err)
       vim.schedule(function()
         actions.callback(err, nil)
-        return util.fire("RequestFinished", opts)
+        if not opts.silent then
+          util.fire("RequestFinished", opts)
+        end
       end)
     end,
   }
@@ -178,7 +184,9 @@ function Client:request(payload, actions, opts)
       end
       if not has_started_steaming then
         has_started_steaming = true
-        util.fire("RequestStreaming", opts)
+        if not opts.silent then
+          util.fire("RequestStreaming", opts)
+        end
       end
       cb(nil, data, adapter)
     end)
@@ -201,13 +209,17 @@ function Client:request(payload, actions, opts)
       or "",
   }
 
-  util.fire("RequestStarted", opts)
+  if not opts.silent then
+    util.fire("RequestStarted", opts)
+  end
 
   if job and job.args then
     log:debug("Request:\n%s", job.args)
   end
   if self.user_args.event then
-    util.fire("RequestStarted" .. (self.user_args.event or ""), opts)
+    if not opts.silent then
+      util.fire("RequestStarted" .. (self.user_args.event or ""), opts)
+    end
   end
 
   return job

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -34,7 +34,7 @@
 ---@field auto_submit? boolean Automatically submit the chat when the chat buffer is created
 ---@field context? table Context of the buffer that the chat was initiated from
 ---@field from_prompt_library? boolean Whether the chat was initiated from the prompt library
----@field ignore_system_prompt? table Do not send the default system prompt with the request
+---@field ignore_system_prompt? boolean Do not send the default system prompt with the request
 ---@field last_role? string The role of the last response in the chat buffer
 ---@field messages? table The messages to display in the chat buffer
 ---@field settings? table The settings that are used in the adapter of the chat buffer


### PR DESCRIPTION
## Description

This is a very rare bug which only happens when `Chat.new()` is passed a adapter name e.g while restoring chats in the history extension.

When we create chat with `Chat.new({adapter = "adapter_name"})`, the
adapter is resolved with require which when failed used to be returned
as `config.adapters[name]` . When user defines the adapter as a function
this throws an error.

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
