### PR TITLE
fix(diff): use mini_diff default if mini.diff is available

### DIFF
--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -13,7 +13,7 @@ end
 ---Get the default Diff provider
 ---@return string
 local function diff_providers()
-  if pcall(require, "mini_diff") then
+  if pcall(require, "mini.diff") then
     return "mini_diff"
   else
     return "default"


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->
Disclaimer: Lua newbie here

I think we want diff to default to `mini_diff`/`mini.diff` when the latter  is available on the path. As is, this fails for me, and the attached patch fixes it.
 
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
