### PR TITLE
Allow to automatically choose default model when switching adapters

### DIFF
--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -303,3 +303,20 @@ require("codecompanion").setup({
   },
 })
 ```
+
+## Controlling Model Choices
+
+When switching between adapters, the plugin typically displays all available model choices for the selected adapter. If you want to simplify the interface and have the default model automatically chosen (without showing any model selection UI), you can set the `show_model_choices` option to `false`:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    opts = {
+      show_model_choices = false,
+    },
+    -- Define your custom adapters here
+  },
+})
+```
+
+With `show_model_choices = false`, the default model (as defined in the adapter's schema) will be automatically selected when changing adapters, and no model selection will be shown to the user.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -33,6 +33,7 @@ local defaults = {
       cache_models_for = 1800, -- Cache adapter models for this long (seconds)
       proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
       show_defaults = true, -- Show default adapters
+      show_model_choices = true, -- Show model choices when changing adapter
     },
   },
   constants = constants,

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -507,6 +507,9 @@ M.change_adapter = {
 
       -- Select a model
       local models = chat.adapter.schema.model.choices
+      if not config.adapters.opts.show_model_choices then
+        models = { chat.adapter.schema.model.default }
+      end
       if type(models) == "function" then
         models = models(chat.adapter)
       end


### PR DESCRIPTION
Hi! This tries to have an easier way of switching between models by having a config option that automatically chooses the default model rather than displaying all available model choices (which we briefly discussed here https://github.com/olimorris/codecompanion.nvim/discussions/873#discussioncomment-12105260). 

Dunno if this is the best  (or even the proper way) of doing it though.
