### PR TITLE
fix: deepseek adapter no tools check

### DIFF
--- a/lua/codecompanion/adapters/deepseek.lua
+++ b/lua/codecompanion/adapters/deepseek.lua
@@ -43,7 +43,7 @@ return {
       local model_opts = self.schema.model.choices[model]
 
       if model_opts.opts and model_opts.opts.can_use_tools == false then
-        if vim.tbl_count(tools) > 0 then
+        if type(tools) == "table" and vim.tbl_count(tools) > 0 then
           log:warn("Tools are not supported for this model")
         end
         return


### PR DESCRIPTION
## Description

Fix the deepseek adapter no tools check used to warn the user when the model doesn't support tools. This fixes the following error:
```lua
E5108: Error executing lua: vim/shared.lua:0: t: expected table, got boolean
stack traceback:
	[C]: in function 'error'
	vim/shared.lua: in function 'validate'
	vim/shared.lua: in function 'tbl_count'
	...decompanion.nvim/lua/codecompanion/adapters/deepseek.lua:46: in function 'form_tools'
	.../nvim/lazy/codecompanion.nvim/lua/codecompanion/http.lua:86: in function 'request'
	...ompanion.nvim/lua/codecompanion/strategies/chat/init.lua:832: in function 'submit'
	...anion.nvim/lua/codecompanion/strategies/chat/keymaps.lua:216: in function 'rhs'
	...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:80: in function <...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:77>
```

## Related Issue(s)
  - Fixes #1371

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
