### PR TITLE
fix(chat): tools should be empty table if not used

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -819,7 +819,7 @@ function Chat:submit(opts)
 
   local payload = {
     messages = self.adapter:map_roles(vim.deepcopy(self.messages)),
-    tools = (not vim.tbl_isempty(self.tools.schemas) and { self.tools.schemas }),
+    tools = (not vim.tbl_isempty(self.tools.schemas) and { self.tools.schemas } or {}),
   }
 
   log:trace("Settings:\n%s", mapped_settings)


### PR DESCRIPTION
## Description

If tools weren't used in a chat, the chat buffer was setting the tools table as a boolean rather than an empty table.

## Related Issue(s)

#1371