### PR TITLE
fix(workflows): ensure references are rendered

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -187,13 +187,13 @@ end
 ---Close the execution of the tool
 ---@return nil
 function Executor:close()
-  local chat = self.agent.chat
-  log:debug("Executor:close")
-  self.handlers.on_exit()
-  util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
-  _G.codecompanion_current_tool = nil
   vim.schedule(function()
+    local chat = self.agent.chat
+    log:debug("Executor:close")
+    self.handlers.on_exit()
+    util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
     chat.subscribers:process(chat)
+    _G.codecompanion_current_tool = nil -- This must come last
   end)
 end
 

--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -191,8 +191,10 @@ function Executor:close()
   log:debug("Executor:close")
   self.handlers.on_exit()
   util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
-  chat.subscribers:process(chat)
   _G.codecompanion_current_tool = nil
+  vim.schedule(function()
+    chat.subscribers:process(chat)
+  end)
 end
 
 return Executor

--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -187,11 +187,12 @@ end
 ---Close the execution of the tool
 ---@return nil
 function Executor:close()
+  local chat = self.agent.chat
+  log:debug("Executor:close")
+  self.handlers.on_exit()
+  util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
+
   vim.schedule(function()
-    local chat = self.agent.chat
-    log:debug("Executor:close")
-    self.handlers.on_exit()
-    util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
     chat.subscribers:process(chat)
     _G.codecompanion_current_tool = nil -- This must come last
   end)

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -744,6 +744,8 @@ function Chat:add_message(data, opts)
     table.insert(self.messages, message)
   end
 
+  self.last_role = data.role
+
   return self
 end
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -744,8 +744,6 @@ function Chat:add_message(data, opts)
     table.insert(self.messages, message)
   end
 
-  self.last_role = data.role
-
   return self
 end
 


### PR DESCRIPTION
## Description

With changes in #1348, subscribers in workflows would not result in references not being rendered. This was caused by issues in the timing of when the code was executed.