### PR TITLE
Add Snacks as actions provider

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 05
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -426,8 +426,8 @@ to the plugin’s features, including your prompts from the
 
 By default the plugin uses `vim.ui.select`, however, you can change the
 provider by altering the `display.action_palette.provider` config value to be
-`telescope` or `mini_pick`. You can also call the Telescope extension with
-`:Telescope codecompanion`.
+`telescope`, `mini_pick` or `snacks`. You can also call the Telescope extension
+with `:Telescope codecompanion`.
 
 
   [!NOTE] Some actions and prompts will only be visible if you’re in `Visual
@@ -520,8 +520,9 @@ LAYOUT ~
 
 
   [!NOTE] The Action Palette also supports Telescope.nvim
-  <https://github.com/nvim-telescope/telescope.nvim> and mini.pick
-  <https://github.com/echasnovski/mini.pick>
+  <https://github.com/nvim-telescope/telescope.nvim>, mini.pick
+  <https://github.com/echasnovski/mini.pick> and snacks.nvim
+  <https://github.com/folke/snacks.nvi>
 You can change the appearance of the chat buffer by changing the
 `display.action_palette` table in your configuration:
 
@@ -532,7 +533,7 @@ You can change the appearance of the chat buffer by changing the
           width = 95,
           height = 10,
           prompt = "Prompt ", -- Prompt used for interactive LLM calls
-          provider = "default", -- Can be "default", "telescope", or "mini_pick". If not specified, the plugin will autodetect installed providers.
+          provider = "default", -- Can be "default", "telescope", "mini_pick" or "snacks". If not specified, the plugin will autodetect installed providers.
           opts = {
             show_default_actions = true, -- Show the default actions in the action palette?
             show_default_prompt_library = true, -- Show the default prompt library in the action palette?

--- a/doc/configuration/action-palette.md
+++ b/doc/configuration/action-palette.md
@@ -9,7 +9,7 @@ The Action Palette holds plugin specific items like the ability to launch a chat
 ## Layout
 
 > [!NOTE]
-> The Action Palette also supports [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) and [mini.pick](https://github.com/echasnovski/mini.pick)
+> The Action Palette also supports [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim), [mini.pick](https://github.com/echasnovski/mini.pick) and [snacks.nvim](https://github.com/folke/snacks.nvim)
 
 You can change the appearance of the chat buffer by changing the `display.action_palette` table in your configuration:
 
@@ -20,7 +20,7 @@ require("codecompanion").setup({
       width = 95,
       height = 10,
       prompt = "Prompt ", -- Prompt used for interactive LLM calls
-      provider = "default", -- Can be "default", "telescope", or "mini_pick". If not specified, the plugin will autodetect installed providers.
+      provider = "default", -- Can be "default", "telescope", "mini_pick" or "snacks". If not specified, the plugin will autodetect installed providers.
       opts = {
         show_default_actions = true, -- Show the default actions in the action palette?
         show_default_prompt_library = true, -- Show the default prompt library in the action palette?

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -24,6 +24,7 @@ require("codecompanion").setup({
   },
 }),
 ```
+
 In the example above, we're using the Anthropic adapter for both the chat and inline strategies.
 
 Because most LLMs require an API key you'll need to share that with the adapter. By default, adapters will look in your environment for a `*_API_KEY` where `*` is the name of the adapter such as `ANTHROPIC` or `OPENAI`. However, you can extend the adapter and change the API key like so:
@@ -144,7 +145,7 @@ Use CodeCompanion to create Neovim commands in command-line mode (`:h Command-li
 
 Run `:CodeCompanionActions` to open the action palette, which gives you access to the plugin's features, including your prompts from the [prompt library](/configuration/prompt-library).
 
-By default the plugin uses `vim.ui.select`, however, you can change the provider by altering the `display.action_palette.provider` config value to be `telescope` or `mini_pick`. You can also call the Telescope extension with `:Telescope codecompanion`.
+By default the plugin uses `vim.ui.select`, however, you can change the provider by altering the `display.action_palette.provider` config value to be `telescope`, `mini_pick`  or `snacks`. You can also call the Telescope extension with `:Telescope codecompanion`.
 
 > [!NOTE]
 > Some actions and prompts will only be visible if you're in _Visual mode_.
@@ -183,4 +184,3 @@ vim.cmd([[cab cc CodeCompanion]])
 
 > [!NOTE]
 > You can also assign prompts from the library to specific mappings. See the [prompt library](configuration/prompt-library#assigning-prompts-to-a-keymap) section for more information.
-

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -894,7 +894,7 @@ You must create or modify a workspace file through a series of prompts over mult
       width = 95,
       height = 10,
       prompt = "Prompt ", -- Prompt used for interactive LLM calls
-      provider = providers.action_palette, -- default|telescope|mini_pick
+      provider = providers.action_palette, -- default|telescope|mini_pick|snacks
       opts = {
         show_default_actions = true, -- Show the default actions in the action palette?
         show_default_prompt_library = true, -- Show the default prompt library in the action palette?

--- a/lua/codecompanion/providers/actions/snacks.lua
+++ b/lua/codecompanion/providers/actions/snacks.lua
@@ -1,0 +1,74 @@
+local Snacks = require("snacks")
+local log = require("codecompanion.utils.log")
+
+---@class CodeCompanion.Actions.Provider.Snacks: CodeCompanion.SlashCommand.Provider
+---@field context table
+---@field resolve function
+local Provider = {}
+
+---@params CodeCompanion.Actions.ProvidersArgs
+function Provider.new(args)
+  log:trace("Snacks actions provider triggered")
+  -- Ensure we have the resolve function
+  if not args.resolve then
+    args.resolve = require("codecompanion.actions").resolve
+  end
+
+  return setmetatable(args, { __index = Provider })
+end
+
+---@param items table The items to display in the picker
+---@param opts? table The options for the picker
+---@return nil
+function Provider:picker(items, opts)
+  opts = opts or {}
+
+  -- Store provider reference
+  local provider = self
+
+  -- Transform items to include both display text and original data
+  local picker_items = {}
+  for _, item in ipairs(items) do
+    local description = item.description and " - " .. item.description or ""
+    table.insert(picker_items, {
+      text = string.format("%s%s", item.name, description),
+      item = item,
+    })
+  end
+  -- Create Snacks picker
+  Snacks.picker({
+    items = picker_items,
+    title = opts.prompt or "CodeCompanion actions",
+    -- Use the default layout for the picker
+    layout = { preset = "select" },
+    -- Define what happens when an item is confirmed
+    confirm = function(picker, item)
+      if item and item.item then
+        -- Close the picker
+        picker:close()
+        -- Process the selection using the provider's resolve method or select method
+        if provider.resolve then
+          provider.resolve(item.item, provider.context)
+        else
+          provider:select(item.item)
+        end
+      end
+    end,
+    -- Format each item for display
+    format = function(item)
+      return { { item.text } }
+    end,
+  })
+end
+
+---The action to take when an item is selected
+---@param item table The selected item
+---@return nil
+function Provider:select(item)
+  if self.resolve then
+    return self.resolve(item, self.context)
+  end
+  return require("codecompanion.providers.actions.shared").select(self, item)
+end
+
+return Provider

--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -5,6 +5,8 @@ local function action_palette_providers()
     return "telescope"
   elseif pcall(require, "mini.pick") then
     return "mini_pick"
+  elseif pcall(require, "snacks") then
+    return "snacks"
   else
     return "default"
   end


### PR DESCRIPTION
## Description

Adding [snacks.nvim](https://github.com/folke/snacks.nvim) as an action provider.

## Related Issue(s)

#1255 

## Screenshots

<img width="2008" alt="image" src="https://github.com/user-attachments/assets/a59f5f7b-c4a2-43a3-ab01-290a28f3ed5f" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
