### PR TITLE
fix(openai): do not send empty tools array

### DIFF
--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -110,6 +110,9 @@ return {
       if not self.opts.tools or not tools then
         return
       end
+      if vim.tbl_count(tools) == 0 then
+        return
+      end
 
       local transformed = {}
       for _, tool in pairs(tools) do


### PR DESCRIPTION
## Description

Another instance of DeepSeek deviating from the OpenAI API format.

## Related Issue(s)

#1378

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
