### PR TITLE
Broken markdown syntax should send proper user message; Allow dynamic user role

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -522,7 +522,7 @@ LAYOUT ~
   [!NOTE] The Action Palette also supports Telescope.nvim
   <https://github.com/nvim-telescope/telescope.nvim>, mini.pick
   <https://github.com/echasnovski/mini.pick> and snacks.nvim
-  <https://github.com/folke/snacks.nvi>
+  <https://github.com/folke/snacks.nvim>
 You can change the appearance of the chat buffer by changing the
 `display.action_palette` table in your configuration:
 
@@ -1245,8 +1245,10 @@ customized in the configuration:
             end,
     
             ---The header name for your messages
-            ---@type string
-            user = "Me",
+            ---@type string|fun(adapter: CodeCompanion.Adapter): string
+            user = function(adapter)
+    			return vim.env.USER:gsub("^%l", string.upper)
+            end,
           }
         }
       }
@@ -1258,8 +1260,6 @@ By default, the LLM’s responses will be placed under a header such as
 This option can be in the form of a string or a function that returns a string.
 If you opt for a function, the first parameter will always be the adapter from
 the chat buffer.
-
-The user role is currently only available as a string.
 
 
 MARKDOWN RENDERING
@@ -2699,7 +2699,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -295,8 +295,10 @@ require("codecompanion").setup({
         end,
 
         ---The header name for your messages
-        ---@type string
-        user = "Me",
+        ---@type string|fun(adapter: CodeCompanion.Adapter): string
+        user = function(adapter)
+			return vim.env.USER:gsub("^%l", string.upper)
+        end,
       }
     }
   }
@@ -304,8 +306,6 @@ require("codecompanion").setup({
 ```
 
 By default, the LLM's responses will be placed under a header such as `CodeCompanion (DeepSeek)`, leveraging the current adapter in the chat buffer. This option can be in the form of a string or a function that returns a string. If you opt for a function, the first parameter will always be the adapter from the chat buffer.
-
-The user role is currently only available as a string.
 
 ### Markdown Rendering
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1230,6 +1230,7 @@ function Chat:clear()
   self.tools:clear()
 
   log:trace("Clearing chat buffer")
+  self.context.is_visual = false
   self.ui:render(self.context, self.messages, self.opts):set_intro_msg()
   self:add_system_prompt()
   util.fire("ChatCleared", { bufnr = self.bufnr, id = self.id })

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -279,7 +279,7 @@ local function ts_parse_messages(chat, start_range)
   for id, node in query:iter_captures(root, chat.bufnr, start_range - 1, -1) do
     if query.captures[id] == "role" then
       last_role = helpers.format_role(get_node_text(node, chat.bufnr))
-    elseif last_role == user_role and query.captures[id] == "content" then
+    elseif last_role == chat.ui.resolved_roles.user and query.captures[id] == "content" then
       table.insert(content, get_node_text(node, chat.bufnr))
     end
   end
@@ -305,7 +305,7 @@ local function ts_parse_headers(chat)
   for id, node in query:iter_captures(root, chat.bufnr) do
     if query.captures[id] == "role_only" then
       local role = helpers.format_role(get_node_text(node, chat.bufnr))
-      if role == user_role then
+      if role == chat.ui.resolved_roles.user then
         last_match = node
       end
     end
@@ -1089,11 +1089,12 @@ function Chat:add_buf_message(data, opts)
 
   -- Add a new header to the chat buffer
   local function new_role()
+    self.ui:resolve_roles()
     new_response = true
     self.last_role = data.role
     table.insert(lines, "")
     table.insert(lines, "")
-    self.ui:set_header(lines, config.strategies.chat.roles[data.role])
+    self.ui:set_header(lines, data.role)
   end
 
   -- Add data to the chat buffer

--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -246,7 +246,7 @@ function UI:render(context, messages, opts)
 
         if msg.opts and msg.opts.tag == "tool_output" then
           table.insert(lines, "### Tool Output")
-          table.insert(lines, "")
+          spacer()
         end
 
         local trimempty = not (msg.role == "user" and msg.content == "")
@@ -259,7 +259,12 @@ function UI:render(context, messages, opts)
 
         -- The Chat:Submit method will parse the last message and it to the messages table
         if i == #msgs then
-          table.remove(msgs, i)
+          if msgs[i].role ~= config.constants.USER_ROLE then
+            self:set_header(lines, config.constants.USER_ROLE)
+            spacer()
+          else
+            table.remove(msgs, i)
+          end
         end
       end
     end

--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -298,11 +298,11 @@ function UI:render(context, messages, opts)
   -- If the user has visually selected some text, add that to the chat buffer
   if context and context.is_visual and not opts.stop_context_insertion then
     log:trace("Adding visual selection to chat buffer")
-    table.insert(lines, "```" .. context.filetype)
+    table.insert(lines, "````" .. context.filetype)
     for _, line in ipairs(context.lines) do
       table.insert(lines, line)
     end
-    table.insert(lines, "```")
+    table.insert(lines, "````")
   end
 
   self:unlock_buf()

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -95,6 +95,7 @@
 ---@field winnr number
 ---@field settings table
 ---@field tokens number
+---@field resolved_roles table
 
 ---@class CodeCompanion.Chat.UIArgs
 ---@field adapter CodeCompanion.Adapter


### PR DESCRIPTION
## Description

The reason for this PR is to address a bug relating to treesitter parsing in the buffer. 

The issue was previously opened and was closed as not planned. https://github.com/olimorris/codecompanion.nvim/issues/913

While I was testing MCPHub's write tool, when user makes some changes to the LLM output we send a diff block of what's  changed to the LLM. As we enclose the result of the MCP tool inside triple ticks and the diff is also in the triple ticks this broke the markdown syntax of the buffer. (Although I fixed it in mcphub to enclose mcp tool response in 4 backticks, this issue will still happen in other situations)

![image](https://github.com/user-attachments/assets/fa4c9b8a-41e5-454a-b185-aec134c33848)

When I tried to send something when the buffer is broken, instead of sending my message, it sent the initial prompt.

I thought this was fixed, and when searched through the issues I found this, 

![image](https://github.com/user-attachments/assets/7a91751f-19bd-46bc-808a-8cf0d869aeb9)

I realized the issue was due to `ts_parse_messages` unable to form a proper tree thereby not recognizing the correct last user header even though we give it the header_line. 

On some thought, I felt we can do this without the ts parsing. I removed the `ts_parse_messages` and `ts_parse_headers` and replaced them with some simple functions. 

There are two scenarios where we are using ts to identify the user header_line. 

1. When `Chat.new()` is called with some messages, we are using `ts_parse_headers` to set `self.header_line`. When I loaded this broken conversation using history extension, the same issue happened. It set the header_line to 1. 
2. When we submit the message, as described above

For 1, get all the lines, from bottom up find the header line and set `self.header_line`

For 2, whenever we get a response from the llm even though the syntax is broken, the header_line is always set correctly using `set_text_editing_area(chat, modifier)`. As we know the last header line we just have to get all the lines after that line, remove empty lines and references and we get the user message. 

This seems to work very well  unless there is something I'm missing.


While working on this, I felt that resolving dynamic roles and setting the headers is related to the parsing of messages and headers. The current logic for resolving roles is confusing and it doesn't allow user role to be a function. The first commit allows user and llm roles to be dynamic. It resolves the roles when UI.new() is called and whenever a new_role() is rendered to the buffer while chatting. The resolved_roles property of UI class is used by everyone that needs the resolved roles which allows something like this

```lua
user = function(adapter)
    local time_elapsed = os.difftime(os.time(), time)
    local minutes = math.floor(time_elapsed / 60)
    local seconds = time_elapsed % 60
    return string.format("  Ravitemer " .. string.format("(%02d:%02d)", minutes, seconds))
end,
```
![image](https://github.com/user-attachments/assets/0bbbd918-7926-4337-9912-29f2eac0bc37)

Also some minor bugs that I found along the way.


<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
