### PR TITLE
refactor(providers): centralize provider selection logic

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -117,7 +117,7 @@ local defaults = {
           description = "Insert open buffers",
           opts = {
             contains_code = true,
-            provider = providers.pickers, -- telescope|snacks|mini_pick|fzf_lua|default
+            provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
         },
         ["fetch"] = {
@@ -133,7 +133,7 @@ local defaults = {
           opts = {
             contains_code = true,
             max_lines = 1000,
-            provider = providers.pickers, -- telescope|snacks|mini_pick|fzf_lua|default
+            provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
         },
         ["help"] = {
@@ -142,7 +142,7 @@ local defaults = {
           opts = {
             contains_code = false,
             max_lines = 128, -- Maximum amount of lines to of the help file to send (NOTE: Each vimdoc line is typically 10 tokens)
-            provider = providers.help, -- telescope|snacks|mini_pick|fzf_lua
+            provider = providers.help, -- telescope|fzf_lua|mini_pick|snacks
           },
         },
         ["now"] = {
@@ -157,7 +157,7 @@ local defaults = {
           description = "Insert symbols for a selected file",
           opts = {
             contains_code = true,
-            provider = providers.pickers, -- telescope|snacks|mini_pick|fzf_lua|default
+            provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
         },
         ["terminal"] = {

--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -1,59 +1,76 @@
+---@class ProviderSpec
+---@field module string module name
+---@field name string provider name
+---@field condition? function condition function to check if the provider is available
+
+---@class Providers<T>: { [string]: T}
+
+---@type Providers<ProviderSpec>
+local all_provider_configs = {
+  telescope = { module = "telescope", name = "telescope" },
+  mini_pick = { module = "mini.pick", name = "mini_pick" },
+  snacks = {
+    module = "snacks",
+    name = "snacks",
+    condition = function(snacks_module)
+      -- User might have Snacks installed but picker might be disabled
+      return snacks_module and snacks_module.config.picker.enabled
+    end,
+  },
+  mini_diff = { module = "mini.diff", name = "mini_diff" },
+  fzf_lua = { module = "fzf-lua", name = "fzf_lua" },
+}
+
+---@param preferred_provider_keys table<string> table of provider names
+---@param master_configs Providers<ProviderSpec> table of all provider configurations
+---@param default_name string fallback provider name
+---@return string available provider name
+local function find_provider(preferred_provider_keys, master_configs, default_name)
+  for _, key in ipairs(preferred_provider_keys) do
+    local config = master_configs[key]
+    if config then
+      local success, loaded_module = pcall(require, config.module)
+      if success then
+        if config.condition then
+          if config.condition(loaded_module) then
+            return config.name
+          end
+        else
+          return config.name -- No condition, module loaded successfully
+        end
+      end
+    end
+  end
+  return default_name
+end
+
 ---Get the default Action Palette provider
 ---@return string
 local function action_palette_providers()
-  if pcall(require, "telescope") then
-    return "telescope"
-  elseif pcall(require, "fzf-lua") then
-    return "fzf_lua"
-  elseif pcall(require, "mini.pick") then
-    return "mini_pick"
-  elseif pcall(require, "snacks") then
-    return "snacks"
-  else
-    return "default"
-  end
+  local preferred_keys = { "telescope", "fzf_lua", "mini_pick", "snacks" }
+  return find_provider(preferred_keys, all_provider_configs, "default")
 end
 
 ---Get the default Diff provider
 ---@return string
 local function diff_providers()
-  if pcall(require, "mini.diff") then
-    return "mini_diff"
-  else
-    return "default"
-  end
+  local preferred_keys = { "mini_diff" }
+  return find_provider(preferred_keys, all_provider_configs, "default")
 end
 
 ---Get the default Vim Help provider
 ---@return string
 local function help_providers()
-  if pcall(require, "telescope") then
-    return "telescope"
-  elseif pcall(require, "snacks") then
-    return "snacks"
-  elseif pcall(require, "fzf-lua") then
-    return "fzf_lua"
-  elseif pcall(require, "mini.pick") then
-    return "mini_pick"
-  else
-    return "telescope" -- @todo: warn
-  end
+  local preferred_keys = { "telescope", "fzf_lua", "mini_pick", "snacks" }
+  -- TODO: warn if falling back to telescope when it's also the first choice but others failed
+  return find_provider(preferred_keys, all_provider_configs, "telescope")
 end
 
 ---Get the default picker provider
 ---@return string
 local function pick_providers()
-  if pcall(require, "telescope") then
-    return "telescope"
-  elseif pcall(require, "snacks") then
-    return "snacks"
-  elseif pcall(require, "fzf-lua") then
-    return "fzf_lua"
-  elseif pcall(require, "mini.pick") then
-    return "mini_pick"
-  else
-    return "default"
-  end
+  local preferred_keys = { "telescope", "fzf_lua", "mini_pick", "snacks" }
+  return find_provider(preferred_keys, all_provider_configs, "default")
 end
 
 return {


### PR DESCRIPTION
## Description

- Introduce `ProviderSpec` and `Providers` types to define provider configurations.
- Add a unified `find_provider` function to handle provider selection based on availability and optional conditions.
- Refactor all provider selection functions (`action_palette_providers`, `diff_providers`, `help_providers`, `pick_providers`) to use the new logic, improving maintainability and extensibility.
- Improve logic for selecting Snacks as a provider

## Related Issue(s)
None, but key highligh is, as a part of the refactor it improve picker selection specially in case of `Snacks`. It is possible that picker might be disable and we should respect that.

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
