### PR TITLE
docs: add history extension to community extensions

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 06
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 07
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -522,7 +522,7 @@ LAYOUT ~
   [!NOTE] The Action Palette also supports Telescope.nvim
   <https://github.com/nvim-telescope/telescope.nvim>, mini.pick
   <https://github.com/echasnovski/mini.pick> and snacks.nvim
-  <https://github.com/folke/snacks.nvi>
+  <https://github.com/folke/snacks.nvim>
 You can change the appearance of the chat buffer by changing the
 `display.action_palette` table in your configuration:
 
@@ -2699,7 +2699,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/extensions/history.md
+++ b/doc/extensions/history.md
@@ -1,0 +1,127 @@
+# History
+
+[![Tests](https://github.com/ravitemer/codecompanion-history.nvim/actions/workflows/ci.yml/badge.svg)](https://github.com/ravitemer/codecompanion-history.nvim/actions)
+
+The [History extension](https://github.com/ravitemer/codecompanion-history.nvim) for CodeCompanion provides persistent chat history management, allowing you to save, browse, and restore chat sessions across Neovim restarts. It includes automatic title generation and flexible storage options.
+
+<p>
+<video controls muted src="https://github.com/user-attachments/assets/04a6ad1f-8351-4381-ae60-00c352a1670c"></video>
+</p>
+
+## Features
+
+- 💾 Automatic chat session saving with context preservation
+- 🎯 Smart title generation for chats 
+- 🔄 Continue from where you left
+- 📚 Browse saved chats with preview
+- 🔍 Multiple picker interfaces
+- ⚡ Restore chat sessions with full context and tools state
+
+The following CodeCompanion features are preserved when saving and restoring chats:
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+|  System Prompts | ✅  | System prompt used in the chat |
+|  Messages History | ✅  | All messages |
+|  LLM Adapter | ✅  | The specific adapter used for the chat |
+|  LLM Settings | ✅  | Model, temperature and other adapter settings |
+|  Tools | ✅  | Tool schemas and their system prompts |
+|  Tool Outputs | ✅  | Tool execution results |
+|  Variables | ✅  | Variables used in the chat |
+|  References | ✅  | Code snippets and command outputs added via slash commands |
+|  Pinned References | ✅  | Pinned references |
+|  Watchers | ⚠  | Saved but requires original buffer context to resume watching |
+
+> [!NOTE]
+> As this is an extension that deeply integrates with CodeCompanion's internal APIs, occasional compatibility issues may arise when CodeCompanion updates. If you encounter any bugs or unexpected behavior, please [raise an issue](https://github.com/ravitemer/codecompanion-history.nvim/issues) to help us maintain compatibility.
+
+## Installation
+
+First, install the plugin
+
+```lua
+{
+    "olimorris/codecompanion.nvim",
+    dependencies = {
+        --other plugins
+        "ravitemer/codecompanion-history.nvim"
+    }
+}
+```
+
+For detailed information, please refer to the [documentation](https://github.com/ravitemer/codecompanion-history.nvim#installation).
+
+Next, register history as an extension in your CodeCompanion config:
+
+```lua
+require("codecompanion").setup({
+    extensions = {
+        history = {
+            enabled = true,
+            opts = {
+                -- Keymap to open history from chat buffer (default: gh)
+                keymap = "gh",
+                -- Automatically generate titles for new chats
+                auto_generate_title = true,
+                ---On exiting and entering neovim, loads the last chat on opening chat
+                continue_last_chat = false,
+                ---When chat is cleared with `gx` delete the chat from history
+                delete_on_clearing_chat = false,
+                -- Picker interface ("telescope" or "default")
+                picker = "telescope",
+                ---Enable detailed logging for history extension
+                enable_logging = false,
+                ---Directory path to save the chats
+                dir_to_save = vim.fn.stdpath("data") .. "/codecompanion-history",
+            }
+        }
+    }
+})
+```
+
+## Usage 
+
+#### 🎯 Commands
+
+- `:CodeCompanionHistory` - Open the history browser
+
+#### ⌨️ Chat Buffer Keymaps
+
+- `gh` - Open history browser (customizable via `opts.keymap`)
+
+#### 📚 History Browser
+
+The history browser shows all your saved chats with:
+- Title (auto-generated or custom)
+- Last updated time  
+- Preview of chat contents
+
+Actions in history browser:
+- `<CR>` - Open selected chat
+- `d` - Delete selected chat in normal mode (Doesn't apply to default vim.ui.select)
+
+#### 🔧 API
+
+The history extension exports the following functions that can be accessed via `require("codecompanion").extensions.history`:
+
+```lua
+-- Get the storage location for saved chats
+get_location(): string?
+
+-- Save a chat to storage (uses last chat if none provided)
+save_chat(chat?: CodeCompanion.Chat)
+
+-- Get metadata for all saved chats
+get_chats(): table<string, ChatIndexData>
+
+-- Load a specific chat by its save_id
+load_chat(save_id: string): ChatData?
+
+-- Delete a chat by its save_id
+delete_chat(save_id: string): boolean
+```
+
+## Additional Resources
+
+- Visit [codecompanion-history.nvim](https://github.com/ravitemer/codecompanion-history.nvim) to see how it works.
+- Found a bug? [Raise an issue](https://github.com/ravitemer/codecompanion-history.nvim/issues).


### PR DESCRIPTION
## Description

This PR adds [history extension](https://github.com/ravitemer/codecompanion-history.nvim) to community extensions. 

## ✨ Features

- 💾 Automatic chat session saving with context preservation
- 🎯 Smart title generation for chats 
- 🔄 Continue from where you left
- 📚 Browse saved chats with preview
- 🔍 Multiple picker interfaces
- ⚡ Restore chat sessions with full context and tools state



## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots


https://github.com/user-attachments/assets/04a6ad1f-8351-4381-ae60-00c352a1670c

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
