### PR TITLE
docs: update history extension with new features

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 07
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 09
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/doc/extensions/history.md
+++ b/doc/extensions/history.md
@@ -10,8 +10,10 @@ The [History extension](https://github.com/ravitemer/codecompanion-history.nvim)
 
 ## Features
 
-- 💾 Automatic chat session saving with context preservation
-- 🎯 Smart title generation for chats 
+- 💾 Flexible chat saving:
+  - Automatic session saving (can be disabled)
+  - Manual save with dedicated keymap
+- 🎯 Smart title generation for chats
 - 🔄 Continue from where you left
 - 📚 Browse saved chats with preview
 - 🔍 Multiple picker interfaces
@@ -67,12 +69,16 @@ require("codecompanion").setup({
                 continue_last_chat = false,
                 ---When chat is cleared with `gx` delete the chat from history
                 delete_on_clearing_chat = false,
-                -- Picker interface ("telescope" or "default")
+                -- Picker interface ("telescope" or "snacks" or "default")
                 picker = "telescope",
                 ---Enable detailed logging for history extension
                 enable_logging = false,
                 ---Directory path to save the chats
                 dir_to_save = vim.fn.stdpath("data") .. "/codecompanion-history",
+                -- Save all chats by default
+                auto_save = true,
+                -- Keymap to save the current chat manually
+                save_chat_keymap = "sc",
             }
         }
     }
@@ -88,6 +94,7 @@ require("codecompanion").setup({
 #### ⌨️ Chat Buffer Keymaps
 
 - `gh` - Open history browser (customizable via `opts.keymap`)
+- `sc` - Save current chat manually (customizable via `opts.save_chat_keymap`)
 
 #### 📚 History Browser
 
@@ -125,3 +132,6 @@ delete_chat(save_id: string): boolean
 
 - Visit [codecompanion-history.nvim](https://github.com/ravitemer/codecompanion-history.nvim) to see how it works.
 - Found a bug? [Raise an issue](https://github.com/ravitemer/codecompanion-history.nvim/issues).
+
+
+


### PR DESCRIPTION
## Description

This PR updates the History extension with new additional configuration.

This includes more flexible chat saving options by adding configurable auto-save behavior and manual save functionality. Users now have better control over when their chats are saved.

### Features Added

- ✨ **Configurable Auto-Save**: 
  - New `auto_save` option (default: true) to enable/disable automatic saving
  - When enabled, saves chat state after each message and LLM response
  - When disabled, relies on manual saving only

- 🔑 **Manual Save Functionality**:
  - New `save_chat_keymap` option (default: "sc") for manual saving
  - Allows saving chat state on-demand regardless of auto-save setting
  - Works consistently in both auto-save enabled and disabled modes

### Implementation Details

- Added new configuration options:
  ```lua
  opts = {
    -- Save all chats by default
    auto_save = true,
    -- Keymap to save the current chat manually
    save_chat_keymap = "sc",
  }
  ```

## Breaking Changes

None. Default behavior (auto-save enabled) maintains backward compatibility.


<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
