### PR TITLE
Better handle missing tools

### DIFF
--- a/tests/strategies/chat/agents/test_agents.lua
+++ b/tests/strategies/chat/agents/test_agents.lua
@@ -129,6 +129,32 @@ T["Agent"][":execute"]["a malformed response from the LLM is handled"] = functio
   h.expect_starts_with("You made an error in calling the weather tool:", output)
 end
 
+T["Agent"][":execute"]["a missing tool is handled"] = function()
+  child.lua([[
+    local tools = {
+      {
+        id = 1,
+        type = "function",
+        ["function"] = {
+          name = "missing_tool",
+          arguments = {
+          },
+        },
+      },
+    }
+
+    local chat = _G.chat
+    chat.tools.in_use = {
+      weather = true
+    }
+    _G.agent:execute(chat, tools)
+  ]])
+
+  local output = child.lua_get([[chat.messages[#chat.messages].content]])
+  h.expect_starts_with("Tool `missing_tool` not found", output)
+  h.eq(true, output:find("`weather`") ~= nil)
+end
+
 T["Agent"][":execute"]["a nested response from the LLM"] = function() end
 
 T["Agent"][":replace"] = new_set()


### PR DESCRIPTION
## Description

### BUG 

When LLM calls a tool that is missing, subsequent prompts fail with `Bad Request` error due to missing message with `tool` role. 

To address this we return the error mentioning that the tool is not found along providing it the available_tools as tool call response, so that on next prompts LLM corrects the tool call.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
