### PR TITLE
refactor: add adapter.model and adapter.model.opts to schema

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 09
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 10
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -615,6 +615,9 @@ If you do not want to store secrets in plain text, prefix commands with `cmd:`:
   [!NOTE] In this example, we’re using the 1Password CLI to extract the OpenAI
   API Key. You could also use gpg as outlined here
   <https://github.com/olimorris/codecompanion.nvim/discussions/601>
+Environment variables can also be functions and as a parameter, they receive a
+copy of the adapter itself.
+
 
 ADAPTER SETTINGS ~
 

--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -63,6 +63,8 @@ require("codecompanion").setup({
 > [!NOTE]
 > In this example, we're using the 1Password CLI to extract the OpenAI API Key. You could also use gpg as outlined [here](https://github.com/olimorris/codecompanion.nvim/discussions/601)
 
+Environment variables can also be functions and as a parameter, they receive a copy of the adapter itself.
+
 ## Configuring Adapter Settings
 
 LLMs have many settings such as model, temperature and max_tokens. In an adapter, these sit within a schema table and can be configured during setup:

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -288,7 +288,7 @@ function Adapter.extend(adapter, opts)
   return Adapter.new(adapter_config)
 end
 
----Set the model on the adapter for convenience
+---Set the model name and options on the adapter for convenience
 ---@param adapter CodeCompanion.Adapter
 ---@return CodeCompanion.Adapter
 function Adapter.set_model(adapter)

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -308,7 +308,7 @@ function Adapter.set_model(adapter)
     end
 
     if type(choices) == "table" then
-      adapter.model.opts = choices[model]
+      adapter.model.opts = (choices[model] and choices[model].opts) and choices[model].opts
     end
   end
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -604,6 +604,7 @@ function Chat:apply_model(model)
   end
 
   self.adapter.schema.model.default = model
+  self.adapter = adapters.set_model(self.adapter)
 
   return self
 end

--- a/tests/test_adapter.lua
+++ b/tests/test_adapter.lua
@@ -180,6 +180,21 @@ T["Adapter"]["will not set environment variables if it doesn't need to"] = funct
   h.eq(child.lua_get([[_G.test_adapter2.parameters]]), params)
 end
 
+T["Adapter"]["environment variables can be functions"] = function()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").extend("openai", {
+      env = {
+        api_key = function()
+          return "test_api_key"
+        end,
+      }
+    })
+    return adapter:get_env_vars().env_replaced.api_key
+  ]])
+
+  h.eq("test_api_key", result)
+end
+
 T["Adapter"]["can update a model on the adapter"] = function()
   local result = child.lua([[
     local adapter = require("codecompanion.adapters").extend(test_adapter)
@@ -189,7 +204,6 @@ T["Adapter"]["can update a model on the adapter"] = function()
   h.eq({ name = "gpt-4-0125-preview" }, result)
 
   result = child.lua([[
-    require("tests.log")
     local adapter = require("codecompanion.adapters").extend("openai", {
       schema = {
         model = {

--- a/tests/test_adapter.lua
+++ b/tests/test_adapter.lua
@@ -1,113 +1,131 @@
 local h = require("tests.helpers")
 
-local utils = require("codecompanion.utils.adapters")
-
-local test_adapter = {
-  name = "TestAdapter",
-  url = "https://api.testgenai.com/v1/chat/completions",
-  headers = {
-    content_type = "application/json",
-  },
-  parameters = {
-    stream = true,
-  },
-  schema = {
-    model = {
-      order = 1,
-      mapping = "parameters.data",
-      type = "enum",
-      desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
-      default = "gpt-4-0125-preview",
-      choices = {
-        "gpt-4-1106-preview",
-        "gpt-4",
-        "gpt-3.5-turbo-1106",
-        "gpt-3.5-turbo",
-      },
-    },
-    temperature = {
-      order = 2,
-      mapping = "parameters.options",
-      type = "number",
-      optional = true,
-      default = 1,
-      desc = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
-      validate = function(n)
-        return n >= 0 and n <= 2, "Must be between 0 and 2"
-      end,
-    },
-    top_p = {
-      order = 3,
-      mapping = "parameters.options",
-      type = "number",
-      optional = true,
-      default = 1,
-      desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
-      validate = function(n)
-        return n >= 0 and n <= 1, "Must be between 0 and 1"
-      end,
-    },
-  },
-}
-
-local chat_buffer_settings = {
-  frequency_penalty = 0,
-  model = "gpt-4-0125-preview",
-  presence_penalty = 0,
-  temperature = 1,
-  top_p = 1,
-  stop = nil,
-  max_tokens = nil,
-  logit_bias = nil,
-  user = nil,
-}
-
-local test_adapter2 = {
-  name = "TestAdapter2",
-  url = "https://api.oli.ai/v1/chat/${model}",
-  env = {
-    home = "HOME",
-    model = "schema.model.default",
-  },
-  parameters = {
-    stream = true,
-  },
-  headers = {
-    content_type = "application/json",
-    home = "${home}",
-  },
-  schema = {
-    model = {
-      order = 1,
-      type = "enum",
-      desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
-      default = "oli_model_v2",
-    },
-    temperature = {
-      default = "${home}",
-      mapping = "parameters.temperature",
-    },
-  },
-}
-
+local expect = MiniTest.expect
 local new_set = MiniTest.new_set
-local T = new_set()
+
+local child = MiniTest.new_child_neovim()
+T = new_set({
+  hooks = {
+    pre_once = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+      child.lua([[
+        utils = require("codecompanion.utils.adapters")
+
+        _G.test_adapter = {
+          name = "TestAdapter",
+          url = "https://api.testgenai.com/v1/chat/completions",
+          headers = {
+            content_type = "application/json",
+          },
+          parameters = {
+            stream = true,
+          },
+          schema = {
+            model = {
+              order = 1,
+              mapping = "parameters.data",
+              type = "enum",
+              desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
+              default = "gpt-4-0125-preview",
+              choices = {
+                "gpt-4-1106-preview",
+                "gpt-4",
+                "gpt-3.5-turbo-1106",
+                "gpt-3.5-turbo",
+              },
+            },
+            temperature = {
+              order = 2,
+              mapping = "parameters.options",
+              type = "number",
+              optional = true,
+              default = 1,
+              desc = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
+              validate = function(n)
+                return n >= 0 and n <= 2, "Must be between 0 and 2"
+              end,
+            },
+            top_p = {
+              order = 3,
+              mapping = "parameters.options",
+              type = "number",
+              optional = true,
+              default = 1,
+              desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
+              validate = function(n)
+                return n >= 0 and n <= 1, "Must be between 0 and 1"
+              end,
+            },
+          },
+        }
+
+        _G.chat_buffer_settings = {
+          frequency_penalty = 0,
+          model = "gpt-4-0125-preview",
+          presence_penalty = 0,
+          temperature = 1,
+          top_p = 1,
+          stop = nil,
+          max_tokens = nil,
+          logit_bias = nil,
+          user = nil,
+        }
+
+        _G.test_adapter2 = {
+          name = "TestAdapter2",
+          url = "https://api.oli.ai/v1/chat/${model}",
+          env = {
+            home = "HOME",
+            model = "schema.model.default",
+          },
+          parameters = {
+            stream = true,
+          },
+          headers = {
+            content_type = "application/json",
+            home = "${home}",
+          },
+          schema = {
+            model = {
+              order = 1,
+              type = "enum",
+              desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
+              default = "oli_model_v2",
+            },
+            temperature = {
+              default = "${home}",
+              mapping = "parameters.temperature",
+            },
+          },
+        }
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
 
 T["Adapter"] = new_set()
+
 T["Adapter"]["can form parameters from a chat buffer's settings"] = function()
-  local adapter = require("codecompanion.adapters").extend("openai")
-  local result = adapter:map_schema_to_params(chat_buffer_settings)
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").extend("openai")
+    local result = adapter:map_schema_to_params(_G.chat_buffer_settings)
 
-  -- Ignore this for now
-  result.parameters.stream = nil
-  result.parameters.stream_options = nil
+    -- Ignore these for now
+    result.parameters.stream = nil
+    result.parameters.stream_options = nil
 
-  h.eq(chat_buffer_settings, result.parameters)
+    return result.parameters
+  ]])
+
+  h.eq(child.lua_get([[_G.chat_buffer_settings]]), result)
 end
 
 T["Adapter"]["can nest parameters based on an adapter's schema"] = function()
-  local adapter = require("codecompanion.adapters").extend(test_adapter)
-  local result = adapter:map_schema_to_params(chat_buffer_settings)
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").extend(_G.test_adapter)
+    return adapter:map_schema_to_params(_G.chat_buffer_settings).parameters
+  ]])
 
   local expected = {
     stream = true,
@@ -120,25 +138,33 @@ T["Adapter"]["can nest parameters based on an adapter's schema"] = function()
     },
   }
 
-  h.eq(expected, result.parameters)
+  h.eq(expected, result)
 end
 
 T["Adapter"]["can form environment variables"] = function()
-  local adapter = require("codecompanion.adapters").extend(test_adapter2)
-  local result = adapter:get_env_vars()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").extend(test_adapter2)
+    return adapter:get_env_vars()
+  ]])
 
-  h.eq(test_adapter2.schema.model.default, result.env_replaced.model)
+  h.eq(child.lua_get([[_G.test_adapter2.schema.model.default]]), result.env_replaced.model)
   h.eq(os.getenv("HOME"), result.env_replaced.home)
 end
 
 T["Adapter"]["can set environment variables in the adapter"] = function()
-  local adapter = require("codecompanion.adapters").extend(test_adapter2)
-  adapter:get_env_vars()
+  local result = child.lua([[
+    adapter = require("codecompanion.adapters").extend(_G.test_adapter2)
+    adapter:get_env_vars()
 
-  local url = adapter:set_env_vars(adapter.url)
-  h.eq("https://api.oli.ai/v1/chat/oli_model_v2", url)
+    return adapter:set_env_vars(adapter.url)
+  ]])
 
-  local headers = adapter:set_env_vars(adapter.headers)
+  h.eq("https://api.oli.ai/v1/chat/oli_model_v2", result)
+
+  local headers = child.lua([[
+    return adapter:set_env_vars(adapter.headers)
+  ]])
+
   h.eq({
     content_type = "application/json",
     home = os.getenv("HOME"),
@@ -146,47 +172,55 @@ T["Adapter"]["can set environment variables in the adapter"] = function()
 end
 
 T["Adapter"]["will not set environment variables if it doesn't need to"] = function()
-  local adapter = require("codecompanion.adapters").extend(test_adapter2)
-  adapter:get_env_vars()
+  local params = child.lua([[
+    local adapter = require("codecompanion.adapters").extend(test_adapter2)
+    adapter:get_env_vars()
+    return adapter:set_env_vars(adapter.parameters)
+  ]])
 
-  local params = adapter:set_env_vars(adapter.parameters)
-  h.eq(test_adapter2.parameters, params)
+  h.eq(child.lua_get([[_G.test_adapter2.parameters]]), params)
 end
 
-T["Adapter"]["can consolidate consecutive messages"] = function()
-  local messages = {
-    { role = "system", content = "This is a system prompt" },
-    { role = "user", content = "Foo" },
-    { role = "user", content = "Bar" },
-  }
+T["Adapter"]["utils"] = new_set()
+
+T["Adapter"]["utils"]["can consolidate consecutive messages"] = function()
+  child.lua([[
+    messages = {
+      { role = "system", content = "This is a system prompt" },
+      { role = "user", content = "Foo" },
+      { role = "user", content = "Bar" },
+    }
+  ]])
 
   h.eq({
     { role = "system", content = "This is a system prompt" },
     { role = "user", content = "Foo\n\nBar" },
-  }, utils.merge_messages(messages))
+  }, child.lua_get([[utils.merge_messages(messages)]]))
 end
 
-T["Adapter"]["can smartly merge tables together"] = function()
-  local messages = {
-    {
-      role = "user",
-      content = {
-        content = "Foo",
-        tool_id = "123",
+T["Adapter"]["utils"]["can smartly merge tables together"] = function()
+  child.lua([[
+    messages = {
+      {
+        role = "user",
+        content = {
+          content = "Foo",
+          tool_id = "123",
+        },
       },
-    },
-    {
-      role = "user",
-      content = {
-        content = "Bar",
-        tool_id = "456",
+      {
+        role = "user",
+        content = {
+          content = "Bar",
+          tool_id = "456",
+        },
       },
-    },
-    {
-      role = "assistant",
-      content = "Foobar ftw!",
-    },
-  }
+      {
+        role = "assistant",
+        content = "Foobar ftw!",
+      },
+    }
+  ]])
 
   h.eq({
     {
@@ -206,50 +240,26 @@ T["Adapter"]["can smartly merge tables together"] = function()
       content = "Foobar ftw!",
       role = "assistant",
     },
-  }, utils.merge_messages(messages))
+  }, child.lua_get([[utils.merge_messages(messages)]]))
 end
 
-T["Adapter"]["can consolidate system messages"] = function()
-  local messages = {
-    { role = "system", content = "This is a system prompt" },
-    { role = "user", content = "Foo" },
-    { role = "assistant", content = "Bar" },
-    { role = "system", content = "This is ANOTHER system prompt" },
-    { role = "user", content = "Baz" },
-  }
+T["Adapter"]["utils"]["can consolidate system messages"] = function()
+  child.lua([[
+    messages = {
+      { role = "system", content = "This is a system prompt" },
+      { role = "user", content = "Foo" },
+      { role = "assistant", content = "Bar" },
+      { role = "system", content = "This is ANOTHER system prompt" },
+      { role = "user", content = "Baz" },
+    }
+  ]])
 
   h.eq({
     { role = "system", content = "This is a system prompt This is ANOTHER system prompt" },
     { role = "user", content = "Foo" },
     { role = "assistant", content = "Bar" },
     { role = "user", content = "Baz" },
-  }, utils.merge_system_messages(messages))
-end
-
-T["Adapter"]["can be used to remove groups of messages"] = function()
-  local messages = {
-    { role = "system", content = "This is a system prompt" },
-    { role = "system", content = "This is another system prompt" },
-    { role = "user", content = "Foo" },
-    { role = "user", content = "Bar" },
-  }
-
-  -- Taken directly from the Anthropic adapter
-  local sys_prompt = utils.get_msg_index("system", messages)
-  if sys_prompt and #sys_prompt > 0 then
-    -- Sort the prompts in descending order so we can remove them from the table without shifting indexes
-    table.sort(sys_prompt, function(a, b)
-      return a > b
-    end)
-    for _, prompt in ipairs(sys_prompt) do
-      table.remove(messages, prompt)
-    end
-  end
-
-  h.eq({
-    { role = "user", content = "Foo" },
-    { role = "user", content = "Bar" },
-  }, messages)
+  }, child.lua_get([[utils.merge_system_messages(messages)]]))
 end
 
 return T


### PR DESCRIPTION
## Description

Add some helper methods to enable users to access models more easily on adapters.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
