### PR TITLE
fix(deepseek): inline prompt to chat causes error

### DIFF
--- a/lua/codecompanion/adapters/deepseek.lua
+++ b/lua/codecompanion/adapters/deepseek.lua
@@ -43,7 +43,7 @@ return {
       local model_opts = self.schema.model.choices[model]
 
       if model_opts.opts and model_opts.opts.can_use_tools == false then
-        if vim.tbl_count(tools) > 0 then
+        if tools and vim.tbl_count(tools) > 0 then
           log:warn("Tools are not supported for this model")
         end
         return


### PR DESCRIPTION
## Description

I failed to check that the tools table existed on the DeepSeek adapter.

## Related Issue(s)

#1405 

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
