### PR TITLE
feat(chat): call slash commands with keymaps

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -982,11 +982,17 @@ Slash Commands
 (invoked with `/`) let you dynamically insert context into the chat buffer,
 such as file contents or date/time.
 
-The plugin supports providers like `telescope`, `mini_pick`, `fzf_lua` and
-`snacks` (as in snacks.nvim). By default, the plugin will automatically detect
-if you have any of those plugins installed and duly select them. Failing that,
-the in-build `default` provider will be used. Please see the
-|codecompanion-usage-chat-buffer-index| usage section for full details:
+The plugin supports providers like telescope
+<https://github.com/nvim-telescope/telescope.nvim>, mini_pick
+<https://github.com/echasnovski/mini.pick>, fzf_lua
+<https://github.com/ibhagwan/fzf-lua> and snacks.nvim
+<https://github.com/folke/snacks.nvim>. By default, the plugin will
+automatically detect if you have any of those plugins installed and duly set
+them as the default provider. Failing that, the in-built `default` provider
+will be used. Please see the |codecompanion-usage-chat-buffer-index| usage
+section for information on how to use Slash Commands.
+
+You can configure Slash Commands with:
 
 >lua
     require("codecompanion").setup({
@@ -1044,6 +1050,31 @@ Credit to @lazymaniac <https://github.com/lazymaniac> for the inspiration
 
   [!NOTE] You can also point the callback to a lua file that resides within your
   own configuration
+
+KEYMAPS
+
+Slash Commands can also be called via keymaps, in the chat buffer. Simply add a
+`keymap` table to the Slash Command you’d like to call. For example:
+
+>lua
+    require("codecompanion").setup({
+      strategies = {
+        chat = {
+          slash_commands = {
+            ["buffer"] = {
+              keymap = {
+                modes = {
+                  i = "<C-b>",
+                  n = { "<C-b>", "gb" },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
 
 AGENTS AND TOOLS ~
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -62,7 +62,9 @@ require("codecompanion").setup({
 
 [Slash Commands](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua#L114) (invoked with `/`) let you dynamically insert context into the chat buffer, such as file contents or date/time.
 
-The plugin supports providers like `telescope`, `mini_pick`, `fzf_lua` and `snacks` (as in snacks.nvim). By default, the plugin will automatically detect if you have any of those plugins installed and duly select them. Failing that, the in-build `default` provider will be used. Please see the [Chat Buffer](/usage/chat-buffer/index) usage section for full details:
+The plugin supports providers like [telescope](https://github.com/nvim-telescope/telescope.nvim), [mini_pick](https://github.com/echasnovski/mini.pick), [fzf_lua](https://github.com/ibhagwan/fzf-lua) and [snacks.nvim](https://github.com/folke/snacks.nvim). By default, the plugin will automatically detect if you have any of those plugins installed and duly set them as the default provider. Failing that, the in-built `default` provider will be used. Please see the [Chat Buffer](/usage/chat-buffer/index) usage section for information on how to use Slash Commands.
+
+You can configure Slash Commands with:
 
 ```lua
 require("codecompanion").setup({
@@ -119,6 +121,30 @@ Credit to [@lazymaniac](https://github.com/lazymaniac) for the [inspiration](htt
 
 > [!NOTE]
 > You can also point the callback to a lua file that resides within your own configuration
+
+### Keymaps
+
+Slash Commands can also be called via keymaps, in the chat buffer. Simply add a `keymap` table to the Slash Command you'd like to call. For example:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      slash_commands = {
+        ["buffer"] = {
+          keymap = {
+            modes = {
+              i = "<C-b>",
+              n = { "<C-b>", "gb" },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+```
 
 ## Agents and Tools
 

--- a/lua/codecompanion/strategies/chat/helpers.lua
+++ b/lua/codecompanion/strategies/chat/helpers.lua
@@ -1,4 +1,5 @@
 local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
 
 local M = {}
 
@@ -22,6 +23,23 @@ function M.strip_references(messages)
     -- we do not increment i, since removing shifts everything down
   end
   return messages
+end
+
+---Get the keymaps from the slash commands
+---@param slash_commands table
+---@return table
+function M.slash_command_keymaps(slash_commands)
+  local keymaps = {}
+  for k, v in pairs(slash_commands) do
+    if v.keymap then
+      keymaps[k] = {}
+      keymaps[k].description = v.description
+      keymaps[k].callback = "keymaps." .. k
+      keymaps[k].modes = v.keymap.modes
+    end
+  end
+
+  return keymaps
 end
 
 return M

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -570,6 +570,18 @@ function Chat.new(args)
       :set()
   end
 
+  local slash_command_keymaps = helpers.slash_command_keymaps(config.strategies.chat.slash_commands)
+  if vim.tbl_count(slash_command_keymaps) > 0 then
+    keymaps
+      .new({
+        bufnr = self.bufnr,
+        callbacks = require("codecompanion.strategies.chat.slash_commands.keymaps"),
+        data = self,
+        keymaps = slash_command_keymaps,
+      })
+      :set()
+  end
+
   ---@cast self CodeCompanion.Chat
   self:add_system_prompt()
   set_autocmds(self)

--- a/lua/codecompanion/strategies/chat/slash_commands/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/keymaps.lua
@@ -1,0 +1,14 @@
+local config = require("codecompanion.config")
+local slash_commands = require("codecompanion.strategies.chat.slash_commands")
+
+local M = {}
+
+for name, cmd in pairs(config.strategies.chat.slash_commands) do
+  M[name] = {
+    callback = function(chat)
+      return slash_commands.new():execute({ label = name, config = cmd }, chat)
+    end,
+  }
+end
+
+return M

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -180,6 +180,20 @@ return {
         },
       },
       slash_commands = {
+        ["buffer"] = {
+          callback = "strategies.chat.slash_commands.buffer",
+          description = "Insert open buffers",
+          keymap = {
+            modes = {
+              i = "<C-b>",
+              n = { "<C-b>" },
+            },
+          },
+          opts = {
+            contains_code = true,
+            provider = "default",
+          },
+        },
         ["file"] = {
           callback = "strategies.chat.slash_commands.file",
           description = "Insert a file",

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -186,7 +186,7 @@ return {
           keymap = {
             modes = {
               i = "<C-b>",
-              n = { "<C-b>" },
+              n = { "<C-b>", "gb" },
             },
           },
           opts = {

--- a/tests/strategies/chat/slash_commands/test_keymaps.lua
+++ b/tests/strategies/chat/slash_commands/test_keymaps.lua
@@ -1,0 +1,43 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local T = MiniTest.new_set()
+
+local child = MiniTest.new_child_neovim()
+T = new_set({
+  hooks = {
+    pre_once = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+      child.lua([[
+        h = require('tests.helpers')
+      ]])
+    end,
+    post_once = function()
+      child.lua([[
+        h.teardown_chat_buffer()
+      ]])
+    end,
+  },
+})
+
+T["Slash Command Keymaps"] = new_set()
+
+T["Slash Command Keymaps"]["can be obtained from the config"] = function()
+  local result = child.lua([[
+    local h = require("codecompanion.strategies.chat.helpers")
+    return h.slash_command_keymaps(require("tests.config").strategies.chat.slash_commands)
+  ]])
+
+  h.eq({
+    buffer = {
+      callback = "keymaps.buffer",
+      description = "Insert open buffers",
+      modes = {
+        i = "<C-b>",
+        n = { "<C-b>" },
+      },
+    },
+  }, result)
+end
+
+return T

--- a/tests/strategies/chat/slash_commands/test_keymaps.lua
+++ b/tests/strategies/chat/slash_commands/test_keymaps.lua
@@ -34,7 +34,7 @@ T["Slash Command Keymaps"]["can be obtained from the config"] = function()
       description = "Insert open buffers",
       modes = {
         i = "<C-b>",
-        n = { "<C-b>" },
+        n = { "<C-b>", "gb" },
       },
     },
   }, result)


### PR DESCRIPTION
## Description

This feature allows users to call slash commands via keymaps, in the chat buffer.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [X] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
