### PR TITLE
fix(adapters): stack overflow if default model is function

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -301,12 +301,9 @@ function Adapter.set_model(adapter)
     local model = adapter.schema.model.default
     local choices = adapter.schema.model.choices
 
-    if type(model) == "function" then
-      adapter.model.name = model()
-    else
+    if type(model) == "string" then
       adapter.model.name = model
     end
-
     if type(choices) == "table" then
       adapter.model.opts = (choices[model] and choices[model].opts) and choices[model].opts
     end


### PR DESCRIPTION
## Description

#1403 introduced some helper functions to enable users to more easily access the current model. However, if the model is a function this caused a stack overflow. This PR stops the executing of this function.

## Related Issue(s)

#1415

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
