### PR TITLE
Allow adapters to modify http requests as needed

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 10
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 12
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1054,7 +1054,7 @@ Credit to @lazymaniac <https://github.com/lazymaniac> for the inspiration
 KEYMAPS
 
 Slash Commands can also be called via keymaps, in the chat buffer. Simply add a
-`keymap` table to the Slash Command you’d like to call. For example:
+`keymaps` table to the Slash Command you’d like to call. For example:
 
 >lua
     require("codecompanion").setup({
@@ -1062,7 +1062,7 @@ Slash Commands can also be called via keymaps, in the chat buffer. Simply add a
         chat = {
           slash_commands = {
             ["buffer"] = {
-              keymap = {
+              keymaps = {
                 modes = {
                   i = "<C-b>",
                   n = { "<C-b>", "gb" },
@@ -2639,6 +2639,7 @@ file:
     ---@field handlers.form_messages fun()
     ---@field handlers.chat_output fun()
     ---@field handlers.inline_output fun()
+    ---@field handlers.modify_request_opts? fun(self: CodeCompanion.Adapter, data: table, request_opts: table): table|nil Function which lets the adapter modify the http request parameters before the request is sent
     ---@field handlers.on_exit? fun()
     ---@field handlers.teardown? fun()
     ---@field schema table Set of parameters for the LLM that the user can customise in the chat buffer
@@ -2763,7 +2764,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/extending/adapters.md
+++ b/doc/extending/adapters.md
@@ -32,6 +32,7 @@ Let's take a look at the interface of an adapter as per the `adapter.lua` file:
 ---@field handlers.form_messages fun()
 ---@field handlers.chat_output fun()
 ---@field handlers.inline_output fun()
+---@field handlers.modify_request_opts? fun(self: CodeCompanion.Adapter, data: table, request_opts: table): table|nil Function which lets the adapter modify the http request parameters before the request is sent
 ---@field handlers.on_exit? fun()
 ---@field handlers.teardown? fun()
 ---@field schema table Set of parameters for the LLM that the user can customise in the chat buffer
@@ -459,4 +460,3 @@ temperature = {
 ```
 
 You'll see we've specified a function call for the `condition` key. We're simply checking that the model name doesn't start with `o1` as these models don't accept temperature as a parameter. You'll also see we've specified a function call for the `validate` key. We're simply checking that the value of the temperature is between 0 and 2.
-

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -19,6 +19,8 @@ local log = require("codecompanion.utils.log")
 ---@field handlers table Functions which link the output from the request to CodeCompanion
 ---@field handlers.setup? fun(self: CodeCompanion.Adapter): boolean
 ---@field handlers.set_body? fun(self: CodeCompanion.Adapter, data: table): table|nil
+---@field handlers.set_form? fun(self: CodeCompanion.Adapter, data: table): table|nil # Function which lets the adapter modify the form data sent in the http request
+---@field handlers.modify_request_opts? fun(self: CodeCompanion.Adapter, data: table, request_opts: table): table|nil Function which lets the adapter modify the http request parameters before the request is sent
 ---@field handlers.form_parameters fun(self: CodeCompanion.Adapter, params: table, messages: table): table
 ---@field handlers.form_messages fun(self: CodeCompanion.Adapter, messages: table): table
 ---@field handlers.form_tools fun(self: CodeCompanion.Adapter, tools: table): table

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -103,7 +103,7 @@ function Client:request(payload, actions, opts)
   if form then
     for name, content in pairs(form) do
       -- first check that content isn't already referencing a file with leading "@" or "<" character
-      if content:sub(1, 1) ~= "@" and content.sub(1, 1) ~= "<" then
+      if content:sub(1, 1) ~= "@" and content:sub(1, 1) ~= "<" then
         -- make a temporary file
         local form_file = Path.new(vim.fn.tempname())
         form_file:write(vim.split(content, "\n"), "w")
@@ -112,6 +112,8 @@ function Client:request(payload, actions, opts)
 
         -- add the entry for curl
         form_filenames[name] = "<" .. form_file.filename
+      else
+        form_filenames[name] = content
       end
     end
   end

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,3 +1,8 @@
+-- Add the current directory (.) to Lua's search path
+-- The pattern './?.lua' allows require('mod') to find ./mod.lua
+-- The pattern './?/init.lua' allows require('mod') to find ./mod/init.lua
+package.path = package.path .. ";./?.lua;./?/init.lua"
+
 vim.cmd([[let &rtp.=','.getcwd()]])
 
 vim.cmd("set rtp+=./deps/plenary.nvim")

--- a/tests/test_http.lua
+++ b/tests/test_http.lua
@@ -98,4 +98,220 @@ describe("Client", function()
     assert.equal(raw_args[#raw_args - 1], "--arg1-RAW_VALUE")
     assert.equal(raw_args[#raw_args], "--arg2-RAW_VALUE")
   end)
+
+  -- tests for handlers.set_form
+  it("uses set_form handler to provide form data", function()
+    local mock_request = stub.new().returns(nil)
+    local form_data = { form_field1 = "value1", form_field2 = "value2" }
+
+    -- Create adapter with set_form handler
+    local test_adapter = vim.deepcopy(adapter)
+    test_adapter.handlers.set_form = function(self, payload)
+      return form_data
+    end
+
+    Client.static.opts = {
+      post = { default = mock_request },
+      encode = { default = stub.new().returns("{}") },
+    }
+
+    test_adapter = require("codecompanion.adapters").new(test_adapter)
+
+    Client.new({ adapter = test_adapter }):request({}, { callback = stub.new() })
+
+    assert.stub(mock_request).was_called(1)
+    local request_args = mock_request.calls[1].refs[1]
+
+    -- Verify form data is passed to the request
+    -- The request_opts should include form field with filenames
+    assert.not_nil(request_args.form)
+    -- We can't directly compare the form values since they're converted to filenames
+    -- But we can check that the keys match
+    assert.equal(vim.tbl_count(request_args.form), vim.tbl_count(form_data))
+    for k, _ in pairs(form_data) do
+      assert.not_nil(request_args.form[k])
+    end
+  end)
+
+  it("uses tempfiles to handle set_form data", function()
+    local mock_request = stub.new().returns(nil)
+    local form_data = { form_field1 = "value1", form_field2 = "value2" }
+
+    -- Create adapter with set_form handler
+    local test_adapter = vim.deepcopy(adapter)
+    test_adapter.handlers.set_form = function(self, payload)
+      return form_data
+    end
+
+    -- Mock the Path functionality to avoid actual file creation
+    local original_path_new = require("plenary.path").new
+    local created_files = {}
+    local path_mocks = {}
+
+    require("plenary.path").new = function(filename)
+      -- Create a unique mock path for each call
+      local mock_path = "mock_path_" .. #created_files + 1
+      local mock = {
+        filename = mock_path,
+        write = stub.new(),
+        rm = stub.new(),
+      }
+      table.insert(created_files, mock)
+      return mock
+    end
+
+    -- Mock tempname to return predictable values
+    local original_tempname = vim.fn.tempname
+    local tempname_counter = 0
+    vim.fn.tempname = function()
+      tempname_counter = tempname_counter + 1
+      return "temp_file_" .. tempname_counter
+    end
+
+    Client.static.opts = {
+      post = { default = mock_request },
+      encode = { default = stub.new().returns("{}") },
+    }
+
+    test_adapter = require("codecompanion.adapters").new(test_adapter)
+
+    Client.new({ adapter = test_adapter }):request({}, { callback = stub.new() })
+
+    -- Restore original functions
+    require("plenary.path").new = original_path_new
+    vim.fn.tempname = original_tempname
+
+    assert.stub(mock_request).was_called(1)
+    local request_args = mock_request.calls[1].refs[1]
+
+    -- Verify form exists
+    assert.not_nil(request_args.form)
+
+    -- Form keys should match
+    assert.equal(vim.tbl_count(request_args.form), vim.tbl_count(form_data))
+
+    -- For each field in form_data, there should be a corresponding entry in request_args.form
+    for field_name, _ in pairs(form_data) do
+      -- The value should be a file reference
+      assert.not_nil(request_args.form[field_name])
+      -- The value should start with < (file input for curl)
+      assert.equals("<", request_args.form[field_name]:sub(1, 1))
+    end
+
+    -- Check that each created file had write called on it
+    for _, mock_file in ipairs(created_files) do
+      assert.stub(mock_file.write).was_called(1)
+    end
+  end)
+
+  it("preserves form values that already reference files with set_form", function()
+    local mock_request = stub.new().returns(nil)
+
+    -- Form with values that already reference files with @ and < prefixes
+    local form_data = {
+      messages = "@file.txt",
+      message2 = "<file2.txt",
+    }
+
+    -- Create adapter with set_form handler that returns file references
+    local test_adapter = vim.deepcopy(adapter)
+    test_adapter.handlers.set_form = function(self, payload)
+      return form_data
+    end
+
+    Client.static.opts = {
+      post = { default = mock_request },
+      encode = { default = stub.new().returns("{}") },
+    }
+
+    test_adapter = require("codecompanion.adapters").new(test_adapter)
+
+    Client.new({ adapter = test_adapter }):request({}, { callback = stub.new() })
+
+    assert.stub(mock_request).was_called(1)
+    local request_args = mock_request.calls[1].refs[1]
+
+    -- The form object exists in the request
+    assert.not_nil(request_args.form)
+
+    -- The form fields should be passed through directly without modification
+    assert.equal(form_data.message2, request_args.form.message2)
+    assert.equal(form_data.messages, request_args.form.messages)
+    assert.equal(form_data.message2, request_args.form.message2)
+  end)
+
+  it("handles nil set_form handler", function()
+    local mock_request = stub.new().returns(nil)
+
+    -- Create adapter without set_form handler
+    local test_adapter = vim.deepcopy(adapter)
+    test_adapter.handlers.set_form = nil
+
+    Client.static.opts = {
+      post = { default = mock_request },
+      encode = { default = stub.new().returns("{}") },
+    }
+
+    test_adapter = require("codecompanion.adapters").new(test_adapter)
+
+    Client.new({ adapter = test_adapter }):request({}, { callback = stub.new() })
+
+    assert.stub(mock_request).was_called(1)
+    local request_args = mock_request.calls[1].refs[1]
+
+    -- Verify form is nil when handler is not present
+    assert.is_nil(request_args.form)
+  end)
+
+  -- tests for handlers.modify_request_opts
+  it("uses modify_request_opts handler to modify request options", function()
+    local mock_request = stub.new().returns(nil)
+
+    -- Create adapter with modify_request_opts handler
+    local test_adapter = vim.deepcopy(adapter)
+    test_adapter.handlers.modify_request_opts = function(self, payload, request_opts)
+      request_opts.url = "http://modified.example.com/api"
+      request_opts.headers.Authorization = "Bearer modified_token"
+      return request_opts
+    end
+
+    Client.static.opts = {
+      post = { default = mock_request },
+      encode = { default = stub.new().returns("{}") },
+    }
+
+    test_adapter = require("codecompanion.adapters").new(test_adapter)
+
+    Client.new({ adapter = test_adapter }):request({}, { callback = stub.new() })
+
+    assert.stub(mock_request).was_called(1)
+    local request_args = mock_request.calls[1].refs[1]
+
+    -- Verify request options were modified
+    assert.equal(request_args.url, "http://modified.example.com/api")
+    assert.equal(request_args.headers.Authorization, "Bearer modified_token")
+  end)
+
+  it("handles nil modify_request_opts handler", function()
+    local mock_request = stub.new().returns(nil)
+
+    -- Create adapter without modify_request_opts handler
+    local test_adapter = vim.deepcopy(adapter)
+    -- handlers.modify_request_opts is already nil
+
+    Client.static.opts = {
+      post = { default = mock_request },
+      encode = { default = stub.new().returns("{}") },
+    }
+
+    test_adapter = require("codecompanion.adapters").new(test_adapter)
+
+    Client.new({ adapter = test_adapter }):request({}, { callback = stub.new() })
+
+    assert.stub(mock_request).was_called(1)
+    local request_args = mock_request.calls[1].refs[1]
+
+    -- Original URL should remain unchanged
+    assert.equal(request_args.url, "https://api.openai.com/v1/chat/completions")
+  end)
 end)


### PR DESCRIPTION
## Description

Adds two handlers to give adapters more flexibility in crafting the http request.
- `set_form` - Function which lets the adapter modify the form data sent in the http request
- `modify_request_opts` - Function which lets the adapter modify the http request parameters before the request is sent

Without this, the http requests are limited to sending content in the body, and the encoding is json.
This works for most LLM's, but not for LLM's with different request requirements.

The two new handlers can enable codecompanion to work with LLM's with non-standard request requirements.
For example, this enables adapters to send form data, and also to alter the encoding of the body before the request is sent.

## Related Issue(s)
## Screenshots
## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
