### PR TITLE
feat(copilot): Update models

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -307,7 +307,7 @@ return {
       type = "enum",
       desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
       ---@type string|fun(): string
-      default = "gpt-4o",
+      default = "gpt-4.1",
       choices = function(self)
         return get_models(self)
       end,


### PR DESCRIPTION
## Description

Switch copilot default model from `gpt-4o` to `gpt-4.1`

* Similar to the openai change https://github.com/olimorris/codecompanion.nvim/pull/1346
* `gpt-4.1` is described as a better replacement for `gpt-4o` by GitHub [here](https://docs.github.com/en/copilot/using-github-copilot/ai-models/choosing-the-right-ai-model-for-your-task#gpt-41)
* It's also the same usage limits as `gpt-4o` for free users and the only model with unlimited use for all paid user tiers ([Model multipliers](https://docs.github.com/en/copilot/managing-copilot/monitoring-usage-and-entitlements/about-premium-requests#model-multipliers))

[Sorry, opened a PR without an issue or discussion first, but this seemed so small as to not be worth discussing ahead of time. Of course just close if not wanted :smile: ]