### PR TITLE
fix(inline): don't modify prompts going to the chat buffer

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -305,11 +305,11 @@ function Inline:prompt(user_prompt)
       log:info("[Inline] User input received: %s", input)
       add_prompt("<user_prompt>" .. input .. "</user_prompt>", user_role)
       self.prompts = prompts
-      return self:submit(prompts)
+      return self:submit(vim.deepcopy(prompts))
     end)
   else
     self.prompts = prompts
-    return self:submit(prompts)
+    return self:submit(vim.deepcopy(prompts))
   end
 end
 


### PR DESCRIPTION
## Related Issue(s)

#1442

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
