### PR TITLE
fix: include `kind` option in all `vim.ui.select` calls

### DIFF
--- a/lua/codecompanion/providers/slash_commands/default.lua
+++ b/lua/codecompanion/providers/slash_commands/default.lua
@@ -76,6 +76,7 @@ end
 ---@return function
 function Default:display()
   return vim.ui.select(self.to_display, {
+    kind = "codecompanion.nvim",
     prompt = self.title,
     format_item = function(item)
       return self.to_format(item)

--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -113,6 +113,7 @@ function Executor:setup(input)
     end
 
     vim.ui.select({ "Yes", "No", "Cancel" }, {
+      kind = "codecompanion.nvim",
       prompt = prompt,
       format_item = function(item)
         if item == "Yes" then

--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -153,6 +153,7 @@ end
 ---@return nil
 local function load_from_cache(chat, url, hash, adapter, opts, cb)
   return vim.ui.select({ "Yes", "No" }, {
+    kind = "codecompanion.nvim",
     prompt = "Load the URL from the cache?",
   }, function(choice)
     if not choice then

--- a/lua/codecompanion/strategies/chat/slash_commands/help.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/help.lua
@@ -111,6 +111,7 @@ local function output(SlashCommand, selected)
 
   if line_count > CONSTANTS.MAX_LINES then
     vim.ui.select({ "Yes", "No" }, {
+      kind = "codecompanion.nvim",
       prompt = "The help file is more than " .. CONSTANTS.MAX_LINES .. " lines. Do you want to trim it?",
     }, function(choice)
       if not choice then

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -186,7 +186,7 @@ function SlashCommand:execute(SlashCommands, opts)
   -- end
 
   -- Let the user select a group
-  vim.ui.select(groups, { prompt = "Select a Group to load" }, function(choice)
+  vim.ui.select(groups, { kind = "codecompanion.nvim", prompt = "Select a Group to load" }, function(choice)
     if not choice then
       return nil
     end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

To ease picker customization, this PR adds the `kind` option to all usages of `vim.ui.select`.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
