### PR TITLE
Feat/allow custom curl libs

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -178,12 +178,14 @@ local function get_models(self, opts)
     if model.model_picker_enabled and model.capabilities.type == "chat" then
       local choice_opts = {}
 
-      -- streaming support
       if model.capabilities.supports.streaming then
         choice_opts.can_stream = true
       end
       if model.capabilities.supports.tool_calls then
         choice_opts.can_use_tools = true
+      end
+      if model.capabilities.supports.vision then
+        choice_opts.has_vision = true
       end
 
       models[model.id] = { opts = choice_opts }
@@ -207,11 +209,11 @@ return {
   opts = {
     stream = true,
     tools = true,
+    vision = true,
   },
   features = {
     text = true,
     tokens = true,
-    vision = false,
   },
   url = "https://api.githubcopilot.com/chat/completions",
   env = {
@@ -248,6 +250,9 @@ return {
       end
       if (self.opts and self.opts.tools) and (model_opts and model_opts.opts and not model_opts.opts.can_use_tools) then
         self.opts.tools = false
+      end
+      if (self.opts and self.opts.vision) and (model_opts and model_opts.opts and not model_opts.opts.has_vision) then
+        self.opts.vision = false
       end
 
       return get_and_authorize_token()

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -258,43 +258,7 @@ return {
       return openai.handlers.form_parameters(self, params, messages)
     end,
     form_messages = function(self, messages)
-      -- Extract any images from the messages table
-      local images = {}
-      vim.iter(messages):each(function(m)
-        if m.opts and m.opts.tag == "image" and m.opts.base64 then
-          images[m.content] = {
-            base64 = m.opts.base64,
-            mimetype = m.opts.mimetype,
-          }
-        end
-      end)
-
-      messages = openai.handlers.form_messages(self, messages).messages
-
-      if vim.tbl_count(images) > 0 then
-        self.headers["Copilot-Vision-Request"] = "true"
-
-        -- Now replace the images to conform to the Copilot API
-        messages = vim
-          .iter(messages)
-          :map(function(m)
-            local image = images[m.content]
-            if image then
-              m.content = {
-                {
-                  type = "image_url",
-                  image_url = {
-                    url = string.format("data:%s;base64,%s", image.mimetype, image.base64),
-                  },
-                },
-              }
-            end
-            return m
-          end)
-          :totable()
-      end
-
-      return { messages = messages }
+      return openai.handlers.form_messages(self, messages)
     end,
     form_tools = function(self, tools)
       return openai.handlers.form_tools(self, tools)

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -258,28 +258,41 @@ return {
       return openai.handlers.form_parameters(self, params, messages)
     end,
     form_messages = function(self, messages)
-      local messages = openai.handlers.form_messages(self, messages).messages
+      -- Extract any images from the messages table
+      local images = {}
+      vim.iter(messages):each(function(m)
+        if m.opts and m.opts.tag == "image" and m.opts.base64 then
+          images[m.content] = {
+            base64 = m.opts.base64,
+            mimetype = m.opts.mimetype,
+          }
+        end
+      end)
 
-      -- Process any images
-      -- messages = vim
-      --   .iter(messages)
-      --   :map(function(m)
-      --     if m.opts and m.opts.tag == "image" then
-      --       self.headers["Copilot-Vision-Request"] = true
-      --       m.content = {
-      --         type = "image_url",
-      --         url = m.content,
-      --       }
-      --     end
-      --
-      --     return {
-      --       role = m.role,
-      --       content = m.content,
-      --       tool_calls = m.tool_calls,
-      --       tool_call_id = m.tool_call_id,
-      --     }
-      --   end)
-      --   :totable()
+      messages = openai.handlers.form_messages(self, messages).messages
+
+      if vim.tbl_count(images) > 0 then
+        self.headers["Copilot-Vision-Request"] = "true"
+
+        -- Now replace the images to conform to the Copilot API
+        messages = vim
+          .iter(messages)
+          :map(function(m)
+            local image = images[m.content]
+            if image then
+              m.content = {
+                {
+                  type = "image_url",
+                  image_url = {
+                    url = string.format("data:%s;base64,%s", image.mimetype, image.base64),
+                  },
+                },
+              }
+            end
+            return m
+          end)
+          :totable()
+      end
 
       return { messages = messages }
     end,

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -1,5 +1,5 @@
 local config = require("codecompanion.config")
-local curl = require("plenary.curl")
+local curl = require("codecompanion.http").curl --[[@type function]]
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.openai")
 local utils = require("codecompanion.utils.adapters")
@@ -93,7 +93,7 @@ local function authorize_token()
 
   log:debug("Authorizing GitHub Copilot token")
 
-  local request = curl.get("https://api.github.com/copilot_internal/v2/token", {
+  local request = curl().get("https://api.github.com/copilot_internal/v2/token", {
     headers = {
       Authorization = "Bearer " .. _oauth_token,
       ["Accept"] = "application/json",
@@ -155,7 +155,7 @@ local function get_models(self, opts)
   headers["Authorization"] = "Bearer " .. _github_token.token
 
   local ok, response = pcall(function()
-    return curl.get(url .. "/models", {
+    return curl().get(url .. "/models", {
       sync = true,
       headers = headers,
       insecure = config.adapters.opts.allow_insecure,

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -258,7 +258,30 @@ return {
       return openai.handlers.form_parameters(self, params, messages)
     end,
     form_messages = function(self, messages)
-      return openai.handlers.form_messages(self, messages)
+      local messages = openai.handlers.form_messages(self, messages).messages
+
+      -- Process any images
+      -- messages = vim
+      --   .iter(messages)
+      --   :map(function(m)
+      --     if m.opts and m.opts.tag == "image" then
+      --       self.headers["Copilot-Vision-Request"] = true
+      --       m.content = {
+      --         type = "image_url",
+      --         url = m.content,
+      --       }
+      --     end
+      --
+      --     return {
+      --       role = m.role,
+      --       content = m.content,
+      --       tool_calls = m.tool_calls,
+      --       tool_call_id = m.tool_call_id,
+      --     }
+      --   end)
+      --   :totable()
+
+      return { messages = messages }
     end,
     form_tools = function(self, tools)
       return openai.handlers.form_tools(self, tools)

--- a/lua/codecompanion/adapters/novita.lua
+++ b/lua/codecompanion/adapters/novita.lua
@@ -1,4 +1,4 @@
-local Curl = require("plenary.curl")
+local curl = require("codecompanion.http").curl --[[@type function]]
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.openai")
@@ -20,7 +20,7 @@ local function get_models(self, opts)
   local url = "https://api.novita.ai/v3/openai/models"
 
   local ok, response = pcall(function()
-    return Curl.get(url, {
+    return curl().get(url, {
       sync = true,
       insecure = config.adapters.opts.allow_insecure,
       proxy = config.adapters.opts.proxy,

--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -1,5 +1,5 @@
 local config = require("codecompanion.config")
-local curl = require("plenary.curl")
+local curl = require("codecompanion.http").curl --[[@type function]]
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.openai")
 
@@ -37,7 +37,7 @@ local function get_models(self, opts)
   end
 
   local ok, response = pcall(function()
-    return curl.get(url .. "/v1/models", {
+    return curl().get(url .. "/v1/models", {
       sync = true,
       headers = headers,
       insecure = config.adapters.opts.allow_insecure,

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -13,11 +13,11 @@ return {
   opts = {
     stream = true,
     tools = true,
+    vision = true,
   },
   features = {
     text = true,
     tokens = true,
-    vision = true,
   },
   url = "https://api.openai.com/v1/chat/completions",
   env = {
@@ -42,12 +42,17 @@ return {
 
       if choices and choices[model] and choices[model].opts then
         self.opts = vim.tbl_deep_extend("force", self.opts, choices[model].opts)
+
+        if not choices[model].opts.has_vision then
+          self.opts.vision = false
+        end
       end
 
       if self.opts and self.opts.stream then
         self.parameters.stream = true
         self.parameters.stream_options = { include_usage = true }
       end
+
       return true
     end,
 
@@ -92,7 +97,13 @@ return {
           end
 
           -- Process any images
-          if m.opts and m.opts.tag == "image" and m.opts.base64 then
+          if
+            (self.opts and self.opts.vision)
+            and m.opts
+            and m.opts.tag == "image"
+            and m.opts.base64
+            and m.opts.mimetype
+          then
             self.headers["Copilot-Vision-Request"] = "true"
             m.content = {
               {
@@ -318,14 +329,14 @@ return {
       ---@type string|fun(): string
       default = "gpt-4.1",
       choices = {
-        ["o4-mini-2025-04-16"] = { opts = { can_reason = true } },
+        ["o4-mini-2025-04-16"] = { opts = { has_vision = true, can_reason = true } },
         ["o3-mini-2025-01-31"] = { opts = { can_reason = true } },
-        ["o3-2025-04-16"] = { opts = { can_reason = true } },
-        ["o1-2024-12-17"] = { opts = { can_reason = true } },
-        "gpt-4.1",
-        "gpt-4o",
-        "gpt-4o-mini",
-        "gpt-4-turbo-preview",
+        ["o3-2025-04-16"] = { opts = { has_vision = true, can_reason = true } },
+        ["o1-2024-12-17"] = { opts = { has_vision = true, can_reason = true } },
+        ["gpt-4.1"] = { opts = { has_vision = true } },
+        ["gpt-4o"] = { opts = { has_vision = true } },
+        ["gpt-4o-mini"] = { opts = { has_vision = true } },
+        ["gpt-4-turbo-preview"] = { opts = { has_vision = true } },
         "gpt-4",
         "gpt-3.5-turbo",
       },

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -97,19 +97,13 @@ return {
           end
 
           -- Process any images
-          if
-            (self.opts and self.opts.vision)
-            and m.opts
-            and m.opts.tag == "image"
-            and m.opts.base64
-            and m.opts.mimetype
-          then
+          if (self.opts and self.opts.vision) and m.opts and m.opts.tag == "image" and m.opts.mimetype then
             self.headers["Copilot-Vision-Request"] = "true"
             m.content = {
               {
                 type = "image_url",
                 image_url = {
-                  url = string.format("data:%s;base64,%s", m.opts.mimetype, m.opts.base64),
+                  url = string.format("data:%s;base64,%s", m.opts.mimetype, m.content),
                 },
               },
             }

--- a/lua/codecompanion/adapters/openai_compatible.lua
+++ b/lua/codecompanion/adapters/openai_compatible.lua
@@ -1,5 +1,5 @@
 local config = require("codecompanion.config")
-local curl = require("plenary.curl")
+local curl = require("codecompanion.http").curl --[[@type function]]
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.openai")
 local utils = require("codecompanion.utils.adapters")
@@ -48,7 +48,7 @@ local function get_models(self, opts)
   local ok, response, json
 
   ok, response = pcall(function()
-    return curl.get(url .. models_endpoint, {
+    return curl().get(url .. models_endpoint, {
       sync = true,
       headers = headers,
       insecure = config.adapters.opts.allow_insecure,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -150,8 +150,8 @@ local defaults = {
           description = "Insert an image",
           opts = {
             dirs = {}, -- Directories to search for images
-            filetypes = { "png", "jpg", "jpeg", "gif", "webp" }, -- Images to search for
-            provider = providers.pickers, -- telescope|snacks|mini_pick|fzf_lua|default
+            filetypes = { "png", "jpg", "jpeg", "gif", "webp" }, -- Filetypes to search for
+            provider = providers.pickers, -- snacks|default
           },
         },
         ["now"] = {

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -145,6 +145,14 @@ local defaults = {
             provider = providers.help, -- telescope|snacks|mini_pick|fzf_lua
           },
         },
+        ["image"] = {
+          callback = "strategies.chat.slash_commands.image",
+          description = "Insert an image",
+          opts = {
+            image_dirs = {}, -- Directories on disk to search for images
+            provider = providers.pickers, -- telescope|snacks|mini_pick|fzf_lua|default
+          },
+        },
         ["now"] = {
           callback = "strategies.chat.slash_commands.now",
           description = "Insert the current date and time",

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -31,6 +31,7 @@ local defaults = {
     opts = {
       allow_insecure = false, -- Allow insecure connections?
       cache_models_for = 1800, -- Cache adapter models for this long (seconds)
+      curl = "plenary.curl", -- The Curl library to use
       proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
       show_defaults = true, -- Show default adapters
       show_model_choices = true, -- Show model choices when changing adapter

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -149,7 +149,8 @@ local defaults = {
           callback = "strategies.chat.slash_commands.image",
           description = "Insert an image",
           opts = {
-            image_dirs = {}, -- Directories on disk to search for images
+            dirs = {}, -- Directories to search for images
+            filetypes = { "png", "jpg", "jpeg", "gif", "webp" }, -- Images to search for
             provider = providers.pickers, -- telescope|snacks|mini_pick|fzf_lua|default
           },
         },

--- a/lua/codecompanion/health.lua
+++ b/lua/codecompanion/health.lua
@@ -32,10 +32,10 @@ M.libraries = {
   {
     name = "curl",
   },
-  -- {
-  --   name = "base64",
-  --   optional = true,
-  -- },
+  {
+    name = "base64",
+    optional = true,
+  },
 }
 
 M.adapters = {

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -260,6 +260,7 @@ CodeCompanion.has = function(feature)
     "prompt-library",
     "function-calling",
     "extensions",
+    "custom-http-clients",
   }
 
   if type(feature) == "string" then

--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -54,9 +54,20 @@ local function pick_providers()
   end
 end
 
+---Get the default image providers
+---@return string
+local function image_providers()
+  if pcall(require, "snacks") then
+    return "snacks"
+  else
+    return "default"
+  end
+end
+
 return {
   action_palette = action_palette_providers(),
   diff = diff_providers(),
   help = help_providers(),
+  images = image_providers(),
   pickers = pick_providers(),
 }

--- a/lua/codecompanion/strategies/chat/slash_commands/image.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/image.lua
@@ -161,7 +161,11 @@ local choice = {
       local loc = vim.fn.tempname()
       local response
       local curl_ok, curl_payload = pcall(function()
-        response = Curl.get(url, { output = loc })
+        response = Curl.get(url, {
+          insecure = config.adapters.opts.allow_insecure,
+          proxy = config.adapters.opts.proxy,
+          output = loc,
+        })
       end)
       if not curl_ok then
         vim.loop.fs_unlink(loc)

--- a/lua/codecompanion/strategies/chat/slash_commands/image.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/image.lua
@@ -1,12 +1,7 @@
-local path = require("plenary.path")
-
-local buf = require("codecompanion.utils.buffers")
+local Curl = require("plenary.curl")
+local Job = require("plenary.job")
 local config = require("codecompanion.config")
-local log = require("codecompanion.utils.log")
 local util = require("codecompanion.utils")
-
-local api = vim.api
-local fmt = string.format
 
 local CONSTANTS = {
   NAME = "Image",
@@ -132,11 +127,89 @@ local choice = {
   ---@return nil
   URL = function(SlashCommand)
     return vim.ui.input({ prompt = "Enter the URL: " }, function(input)
-      local selected = {
-        source = "image_url",
-        path = input,
-      }
-      return SlashCommand:output(selected)
+      if #vim.trim(input or "") == 0 then
+        return
+      end
+
+      if vim.fn.executable("base64") == 0 then
+        return util.notify("The `base64` command could not be found", vim.log.levels.ERROR)
+      end
+
+      -- Download the image to a temporary directory
+      local loc = vim.fn.tempname()
+      local response
+      local curl_ok, curl_payload = pcall(function()
+        response = Curl.get(input, { output = loc })
+      end)
+      if not curl_ok then
+        vim.loop.fs_unlink(loc) -- Clean up temp file if it was created
+        return util.notify("Failed to execute curl: " .. tostring(curl_payload), vim.log.levels.ERROR)
+      end
+
+      -- Check if the response is valid
+      if not response or (response.status and response.status >= 400) then
+        local err_msg = "Could not download the image."
+        if response and response.status then
+          err_msg = err_msg .. " HTTP Status: " .. response.status
+        end
+        if response and response.body and #response.body > 0 then
+          err_msg = err_msg .. "\nServer response: " .. response.body:sub(1, 200) -- Show a snippet
+        end
+        vim.loop.fs_unlink(loc) -- Clean up the downloaded file, as it might be an error page or empty
+        return util.notify(err_msg, vim.log.levels.ERROR)
+      end
+
+      -- Fetch the MIME type from headers
+      local mimetype = nil
+      if response.headers then
+        for _, header_line in ipairs(response.headers) do
+          local key, value = header_line:match("^([^:]+):%s*(.+)$")
+          if key and value and key:lower() == "content-type" then
+            mimetype = vim.trim(value:match("^([^;]+)")) -- Get part before any '; charset=...'
+            break
+          end
+        end
+      end
+
+      -- Determine the user's OS to set the correct args
+      local args
+      local uname_info = vim.loop.os_uname()
+      if uname_info and uname_info.sysname == "Darwin" then -- macOS
+        args = { "-i", loc }
+      elseif uname_info and uname_info.sysname == "Linux" then -- Linux
+        args = { "-w", "0", loc }
+      else
+        args = { loc }
+      end
+
+      -- Base64 encode the image
+      local job = Job:new({
+        command = "base64",
+        args = args,
+        on_exit = function(data, code)
+          vim.schedule(function()
+            if code == 0 then
+              local base64_content = nil
+              if data._stdout_results and #data._stdout_results > 0 then
+                base64_content = table.concat(data._stdout_results, "")
+                base64_content = vim.trim(base64_content)
+              end
+
+              local selected = {
+                source = "image_url",
+                path = input,
+                mimetype = mimetype,
+                base64 = base64_content,
+              }
+              return SlashCommand:output(selected)
+            else
+              util.notify("Could not base64 encode the image", vim.log.levels.ERROR)
+            end
+            vim.loop.fs_unlink(loc)
+          end)
+        end,
+      })
+      job:start()
     end)
   end,
 }
@@ -159,7 +232,7 @@ end
 ---@param SlashCommands CodeCompanion.SlashCommands
 ---@return nil
 function SlashCommand:execute(SlashCommands)
-  local choice = vim.ui.select({ "URL", "File" }, {
+  vim.ui.select({ "URL", "File" }, {
     prompt = "Select an image source",
   }, function(selected)
     if not selected then
@@ -175,14 +248,12 @@ end
 ---@return nil
 function SlashCommand:output(selected, opts)
   local id = "<image>" .. selected.path .. "</image>"
-
-  --TODO: base64 encode this if a file
   local image = selected.path
 
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = image,
-  }, { reference = id, tag = "image", visible = false })
+  }, { reference = id, base64 = selected.base64, mimetype = selected.mimetype, tag = "image", visible = false })
 
   self.Chat.references:add({
     bufnr = selected.bufnr,

--- a/lua/codecompanion/strategies/chat/slash_commands/image.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/image.lua
@@ -1,0 +1,195 @@
+local path = require("plenary.path")
+
+local buf = require("codecompanion.utils.buffers")
+local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
+local util = require("codecompanion.utils")
+
+local api = vim.api
+local fmt = string.format
+
+local CONSTANTS = {
+  NAME = "Image",
+  PROMPT = "Select an image(s)",
+}
+
+local providers = {
+  ---The default provider
+  ---@param SlashCommand CodeCompanion.SlashCommand
+  ---@return nil
+  default = function(SlashCommand)
+    local default = require("codecompanion.providers.slash_commands.default")
+    default = default
+      .new({
+        output = function(selection)
+          SlashCommand:output(selection)
+        end,
+        SlashCommand = SlashCommand,
+        title = CONSTANTS.PROMPT,
+      })
+      :buffers()
+      :display()
+  end,
+
+  ---The Snacks.nvim provider
+  ---@param SlashCommand CodeCompanion.SlashCommand
+  ---@return nil
+  snacks = function(SlashCommand)
+    local snacks = require("codecompanion.providers.slash_commands.snacks")
+    snacks = snacks.new({
+      title = CONSTANTS.PROMPT .. ": ",
+      output = function(selection)
+        return SlashCommand:output({
+          bufnr = selection.buf,
+          name = vim.fn.bufname(selection.buf),
+          path = selection.file,
+        })
+      end,
+    })
+
+    snacks.provider.picker.pick({
+      source = "buffers",
+      prompt = snacks.title,
+      confirm = snacks:display(),
+      main = { file = false, float = true },
+    })
+  end,
+
+  ---The Telescope provider
+  ---@param SlashCommand CodeCompanion.SlashCommand
+  ---@return nil
+  telescope = function(SlashCommand)
+    local telescope = require("codecompanion.providers.slash_commands.telescope")
+    telescope = telescope.new({
+      title = CONSTANTS.PROMPT,
+      output = function(selection)
+        return SlashCommand:output({
+          bufnr = selection.bufnr,
+          name = selection.filename,
+          path = selection.path,
+        })
+      end,
+    })
+
+    telescope.provider.buffers({
+      prompt_title = telescope.title,
+      ignore_current_buffer = true, -- Ignore the codecompanion buffer when selecting buffers
+      attach_mappings = telescope:display(),
+    })
+  end,
+
+  ---The Mini.Pick provider
+  ---@param SlashCommand CodeCompanion.SlashCommand
+  ---@return nil
+  mini_pick = function(SlashCommand)
+    local mini_pick = require("codecompanion.providers.slash_commands.mini_pick")
+    mini_pick = mini_pick.new({
+      title = CONSTANTS.PROMPT,
+      output = function(selected)
+        return SlashCommand:output(selected)
+      end,
+    })
+
+    mini_pick.provider.builtin.buffers(
+      { include_current = false },
+      mini_pick:display(function(selected)
+        return {
+          bufnr = selected.bufnr,
+          name = selected.text,
+          path = selected.text,
+        }
+      end)
+    )
+  end,
+
+  ---The fzf-lua provider
+  ---@param SlashCommand CodeCompanion.SlashCommand
+  ---@return nil
+  fzf_lua = function(SlashCommand)
+    local fzf = require("codecompanion.providers.slash_commands.fzf_lua")
+    fzf = fzf.new({
+      title = CONSTANTS.PROMPT,
+      output = function(selected)
+        return SlashCommand:output(selected)
+      end,
+    })
+
+    fzf.provider.buffers(fzf:display(function(selected, opts)
+      local file = fzf.provider.path.entry_to_file(selected, opts)
+      return {
+        bufnr = file.bufnr,
+        name = file.path,
+        path = file.bufname,
+      }
+    end))
+  end,
+}
+
+-- The different choices the user has to insert an image via a slash command
+local choice = {
+  ---Share the URL of an image
+  ---@param SlashCommand CodeCompanion.SlashCommand
+  ---@return nil
+  URL = function(SlashCommand)
+    return vim.ui.input({ prompt = "Enter the URL: " }, function(input)
+      local selected = {
+        source = "image_url",
+        path = input,
+      }
+      return SlashCommand:output(selected)
+    end)
+  end,
+}
+
+---@class CodeCompanion.SlashCommand.Image: CodeCompanion.SlashCommand
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommandArgs
+function SlashCommand.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+
+  return self
+end
+
+---Execute the slash command
+---@param SlashCommands CodeCompanion.SlashCommands
+---@return nil
+function SlashCommand:execute(SlashCommands)
+  local choice = vim.ui.select({ "URL", "File" }, {
+    prompt = "Select an image source",
+  }, function(selected)
+    if not selected then
+      return
+    end
+    return choice[selected](self)
+  end)
+end
+
+---Put a reference to the image in the chat buffer
+---@param selected table The selected image { source = string, path = string }
+---@param opts? table
+---@return nil
+function SlashCommand:output(selected, opts)
+  local id = "<image>" .. selected.path .. "</image>"
+
+  --TODO: base64 encode this if a file
+  local image = selected.path
+
+  self.Chat:add_message({
+    role = config.constants.USER_ROLE,
+    content = image,
+  }, { reference = id, tag = "image", visible = false })
+
+  self.Chat.references:add({
+    bufnr = selected.bufnr,
+    id = id,
+    path = selected.path,
+    source = "codecompanion.strategies.chat.slash_commands.image",
+  })
+end
+
+return SlashCommand

--- a/lua/codecompanion/strategies/chat/slash_commands/image.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/image.lua
@@ -3,9 +3,13 @@ local Job = require("plenary.job")
 local config = require("codecompanion.config")
 local util = require("codecompanion.utils")
 
+local dirs = { vim.fn.getcwd() } -- Always search the cwd for images
+
 local CONSTANTS = {
   NAME = "Image",
   PROMPT = "Select an image(s)",
+  IMAGE_DIRS = config.strategies.chat.slash_commands.image.opts.dirs,
+  IMAGE_TYPES = config.strategies.chat.slash_commands.image.opts.filetypes,
 }
 
 ---Encode a given file to base64
@@ -112,17 +116,13 @@ local providers = {
       end,
     })
 
-    local dirs = { vim.fn.getcwd() } -- Always search the current working directory
-
-    local image_dirs = config.strategies.chat.slash_commands.image.opts.dirs
-    if image_dirs and vim.tbl_count(image_dirs) > 0 then
-      vim.list_extend(dirs, image_dirs)
+    if CONSTANTS.IMAGE_DIRS and vim.tbl_count(CONSTANTS.IMAGE_DIRS) > 0 then
+      vim.list_extend(dirs, CONSTANTS.IMAGE_DIRS)
     end
 
     local ft = nil
-    local filetypes = config.strategies.chat.slash_commands.image.opts.filetypes
-    if filetypes and vim.tbl_count(filetypes) > 0 then
-      ft = filetypes
+    if CONSTANTS.IMAGE_TYPES and vim.tbl_count(CONSTANTS.IMAGE_TYPES) > 0 then
+      ft = CONSTANTS.IMAGE_TYPES
     end
 
     snacks.provider.picker.pick("files", {

--- a/tests/adapters/test_copilot.lua
+++ b/tests/adapters/test_copilot.lua
@@ -21,6 +21,62 @@ T["Copilot adapter"]["it can form messages to be sent to the API"] = function()
   h.eq({ messages = messages }, adapter.handlers.form_messages(adapter, messages))
 end
 
+T["Copilot adapter"]["it can form images to be sent to the API"] = function()
+  local messages = {
+    {
+      content = "How are you?",
+      role = "user",
+    },
+    {
+      content = "I am fine, thanks. How can I help?",
+      role = "assistant",
+    },
+    {
+      content = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+      role = "user",
+      opts = {
+        base64 = "abc123",
+        mimetype = "image/jpg",
+        reference = "<image>https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg</image>",
+        tag = "image",
+        visible = false,
+      },
+    },
+    {
+      content = "What is this an image of?",
+      role = "user",
+    },
+  }
+
+  local expected = {
+    {
+      content = "How are you?",
+      role = "user",
+    },
+    {
+      content = "I am fine, thanks. How can I help?",
+      role = "assistant",
+    },
+    {
+      content = {
+        {
+          type = "image_url",
+          image_url = {
+            url = "data:image/jpg;base64,abc123",
+          },
+        },
+      },
+      role = "user",
+    },
+    {
+      content = "What is this an image of?",
+      role = "user",
+    },
+  }
+
+  h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
+end
+
 T["Copilot adapter"]["it can form tools to be sent to the API"] = function()
   local weather = require("tests/strategies/chat/agents/tools/stubs/weather").schema
   local tools = { weather = { weather } }

--- a/tests/adapters/test_copilot.lua
+++ b/tests/adapters/test_copilot.lua
@@ -21,62 +21,6 @@ T["Copilot adapter"]["it can form messages to be sent to the API"] = function()
   h.eq({ messages = messages }, adapter.handlers.form_messages(adapter, messages))
 end
 
-T["Copilot adapter"]["it can form images to be sent to the API"] = function()
-  local messages = {
-    {
-      content = "How are you?",
-      role = "user",
-    },
-    {
-      content = "I am fine, thanks. How can I help?",
-      role = "assistant",
-    },
-    {
-      content = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
-      role = "user",
-      opts = {
-        base64 = "abc123",
-        mimetype = "image/jpg",
-        reference = "<image>https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg</image>",
-        tag = "image",
-        visible = false,
-      },
-    },
-    {
-      content = "What is this an image of?",
-      role = "user",
-    },
-  }
-
-  local expected = {
-    {
-      content = "How are you?",
-      role = "user",
-    },
-    {
-      content = "I am fine, thanks. How can I help?",
-      role = "assistant",
-    },
-    {
-      content = {
-        {
-          type = "image_url",
-          image_url = {
-            url = "data:image/jpg;base64,abc123",
-          },
-        },
-      },
-      role = "user",
-    },
-    {
-      content = "What is this an image of?",
-      role = "user",
-    },
-  }
-
-  h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
-end
-
 T["Copilot adapter"]["it can form tools to be sent to the API"] = function()
   local weather = require("tests/strategies/chat/agents/tools/stubs/weather").schema
   local tools = { weather = { weather } }

--- a/tests/adapters/test_openai.lua
+++ b/tests/adapters/test_openai.lua
@@ -32,10 +32,9 @@ T["OpenAI adapter"]["it can form messages with images"] = function()
       role = "assistant",
     },
     {
-      content = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+      content = "somefakebase64encoding",
       role = "user",
       opts = {
-        base64 = "abc123",
         mimetype = "image/jpg",
         reference = "<image>https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg</image>",
         tag = "image",
@@ -62,7 +61,7 @@ T["OpenAI adapter"]["it can form messages with images"] = function()
         {
           type = "image_url",
           image_url = {
-            url = "data:image/jpg;base64,abc123",
+            url = "data:image/jpg;base64,somefakebase64encoding",
           },
         },
       },

--- a/tests/adapters/test_openai.lua
+++ b/tests/adapters/test_openai.lua
@@ -21,7 +21,7 @@ T["OpenAI adapter"]["it can form messages"] = function()
   h.eq({ messages = messages }, adapter.handlers.form_messages(adapter, messages))
 end
 
-T["OpenAI adapter"]["it can form images to be sent to the API"] = function()
+T["OpenAI adapter"]["it can form messages with images"] = function()
   local messages = {
     {
       content = "How are you?",

--- a/tests/adapters/test_openai.lua
+++ b/tests/adapters/test_openai.lua
@@ -21,6 +21,62 @@ T["OpenAI adapter"]["it can form messages"] = function()
   h.eq({ messages = messages }, adapter.handlers.form_messages(adapter, messages))
 end
 
+T["OpenAI adapter"]["it can form images to be sent to the API"] = function()
+  local messages = {
+    {
+      content = "How are you?",
+      role = "user",
+    },
+    {
+      content = "I am fine, thanks. How can I help?",
+      role = "assistant",
+    },
+    {
+      content = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+      role = "user",
+      opts = {
+        base64 = "abc123",
+        mimetype = "image/jpg",
+        reference = "<image>https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg</image>",
+        tag = "image",
+        visible = false,
+      },
+    },
+    {
+      content = "What is this an image of?",
+      role = "user",
+    },
+  }
+
+  local expected = {
+    {
+      content = "How are you?",
+      role = "user",
+    },
+    {
+      content = "I am fine, thanks. How can I help?",
+      role = "assistant",
+    },
+    {
+      content = {
+        {
+          type = "image_url",
+          image_url = {
+            url = "data:image/jpg;base64,abc123",
+          },
+        },
+      },
+      role = "user",
+    },
+    {
+      content = "What is this an image of?",
+      role = "user",
+    },
+  }
+
+  h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
+end
+
 T["OpenAI adapter"]["it can form messages with tools"] = function()
   local messages = {
     {

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -53,6 +53,7 @@ return {
     },
     opts = {
       allow_insecure = false,
+      curl = "plenary.curl",
       proxy = nil,
     },
   },

--- a/tests/test_adapter.lua
+++ b/tests/test_adapter.lua
@@ -224,6 +224,7 @@ T["Adapter"]["can update a model on the adapter"] = function()
     name = "o4-mini-2025-04-16",
     opts = {
       can_reason = true,
+      has_vision = true,
     },
   }, result)
 end


### PR DESCRIPTION
## Description

Allow user's to provide custom http clients instead of `plenary.curl`. Update your config to be:

```lua
require("codecompanion").setup({
  adapters = {
    opts = {
      curl = "/Users/Oli/.dotfiles/.config/nvim/lua/curl.lua",
    },
  }
})
```

## Related Issue(s)

#1426

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied