### PR TITLE
fix: user-extended adapters inheriting name

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -178,25 +178,23 @@ follow the master branch:
 INSTALLING EXTENSIONS       *codecompanion-installation-installing-extensions*
 
 CodeCompanion supports extensions that add additional functionality to the
-plugin. For example, to install and set up the mcphub extension using
-lazy.nvim:
+plugin. Below is an example which installs and configures the
+|codecompanion-extensions-mcphub.html| extension:
 
-1. Install the extension:
+1. Install with:
 
 >lua
     {
       "olimorris/codecompanion.nvim",
       dependencies = {
-        -- Add mcphub.nvim as a dependency
         "ravitemer/mcphub.nvim" 
       }
     }
 <
 
-1. Add extension to your config with additional options:
+1. Configure with additional options:
 
 >lua
-    -- Configure in your setup
     require("codecompanion").setup({
       extensions = {
         mcphub = {
@@ -1592,7 +1590,7 @@ The plugin comes with the following system prompt:
 
 CHANGING THE SYSTEM PROMPT ~
 
-The default system prompt cant be changed with:
+The default system prompt can be changed with:
 
 >lua
     require("codecompanion").setup({

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -316,12 +316,14 @@ end
 ---@param adapter? CodeCompanion.Adapter|string|function
 ---@return CodeCompanion.Adapter
 function Adapter.resolve(adapter)
-  adapter = adapter or config.adapters[config.strategies.chat.adapter]
+  adapter = adapter or config.strategies.chat.adapter
 
   if type(adapter) == "table" then
     adapter = Adapter.new(adapter)
   elseif type(adapter) == "string" then
+    local name = adapter
     adapter = Adapter.extend(adapter)
+    adapter.name = name
   elseif type(adapter) == "function" then
     adapter = adapter()
   end


### PR DESCRIPTION
## Description

Related this issue comment: https://github.com/ravitemer/codecompanion-history.nvim/issues/9#issuecomment-2885801123

When user declares some custom adapters like below, 
```lua
return {
	adapters = {
		openrouter = function()
			return require("codecompanion.adapters").extend("openai_compatible", {
				env = {
					url = "https://openrouter.ai/api",
					api_key = "OPENROUTER_API_KEY",
					chat_url = "/v1/chat/completions",
				},
				schema = {
					model = {
						default = "google/gemini-2.5-flash-preview",
					},
				},
			})
		end,
	},
}
```

With `Chat:new()` the adapter is resolved. But the `adapter.name` will be `openai_compatible` instead of `openrouter`. Most users don't provide name or provide a different name from the `config.adapters.[adapter_name]`. This leads to an issue when we need to restore the chat with the saved adapter name. In the above case the Chat will be initialized with `openai_compatible` adapter.

Resetting `adapter.name` while resolving it ensures adapter's name will be one of the `config.adapters`


<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
