### PR TITLE
fix: adapters.resolve not using custom adapter, bug introduced with (#1459)

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -321,9 +321,8 @@ function Adapter.resolve(adapter)
   if type(adapter) == "table" then
     adapter = Adapter.new(adapter)
   elseif type(adapter) == "string" then
-    local name = adapter
-    adapter = Adapter.extend(adapter)
-    adapter.name = name
+    local user_adapter = config.adapters[adapter]
+    adapter = Adapter.extend(user_adapter or adapter, { name = adapter })
   elseif type(adapter) == "function" then
     adapter = adapter()
   end


### PR DESCRIPTION

## Description

Fixes bug as commented in https://github.com/olimorris/codecompanion.nvim/pull/1459#issuecomment-2892619215
 
![image](https://github.com/user-attachments/assets/d0fceff8-9940-46e7-9c82-a9a761b8129a)


<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
