### PR TITLE
fix(inline): keymap modes

### DIFF
--- a/lua/codecompanion/strategies/inline/keymaps.lua
+++ b/lua/codecompanion/strategies/inline/keymaps.lua
@@ -9,8 +9,8 @@ local M = {}
 local function clear_map(keymaps, bufnr)
   bufnr = bufnr or 0
   for _, map in pairs(keymaps) do
-    for _, key in pairs(map.modes) do
-      vim.keymap.del("n", key, { buffer = bufnr })
+    for mode, lhs in pairs(map.modes) do
+      vim.keymap.del(mode, lhs, { buffer = bufnr })
     end
   end
 end


### PR DESCRIPTION
## Description

Allows to add keymaps in visual mode for accept and reject changes.

Fixes an error if a visual mode mapping is added to the inline strategy.

Example: 

```lua
inline = {
  keymaps = {
    accept_change = {
      modes = {
        n = "<C-a>",
        x = "<C-a>"
      }
    },
    reject_change = {
      modes = {
        n = "<C-r>",
        x = "<C-r>"
      }
    }
  }
},
```

Error: 

```lua
Error  E5108: Error executing lua: vim/keymap.lua:0: E31: No such mapping
stack traceback:
	[C]: in function 'nvim_buf_del_keymap'
	vim/keymap.lua: in function 'del'
	...ion.nvim/lua/codecompanion/strategies/inline/keymaps.lua:13: in function 'clear_map'
	...ion.nvim/lua/codecompanion/strategies/inline/keymaps.lua:35: in function 'rhs'
	...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:80: in function <...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:77>
```

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
