### PR TITLE
set Adapter.opts.request to override Client.request

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -30,6 +30,7 @@ local log = require("codecompanion.utils.log")
 ---@field handlers.on_exit? fun(self: CodeCompanion.Adapter, data: table): table|nil
 ---@field handlers.teardown? fun(self: CodeCompanion.Adapter): any
 ---@field schema table Set of parameters for the generative AI service that the user can customise in the chat buffer
+---@field request? fun(self: CodeCompanion.Client, payload: { messages: table, tools: table|nil }, actions: CodeCompanion.Adapter.RequestActions, opts: table?) # Function to let and adapter completely override the above request handlers, and implement the request function itself.
 
 ---Check if a variable starts with "cmd:"
 ---@param var string

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -30,7 +30,6 @@ local log = require("codecompanion.utils.log")
 ---@field handlers.on_exit? fun(self: CodeCompanion.Adapter, data: table): table|nil
 ---@field handlers.teardown? fun(self: CodeCompanion.Adapter): any
 ---@field schema table Set of parameters for the generative AI service that the user can customise in the chat buffer
----@field request? fun(self: CodeCompanion.Client, payload: { messages: table, tools: table|nil }, actions: CodeCompanion.Adapter.RequestActions, opts: table?) # Function to let and adapter completely override the above request handlers, and implement the request function itself.
 
 ---Check if a variable starts with "cmd:"
 ---@param var string

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -59,6 +59,11 @@ end
 ---@param opts? table Options that can be passed to the request
 ---@return table|nil The Plenary job
 function Client:request(payload, actions, opts)
+  -- Check if the adapter has a custom request function and use it instead
+  if self.adapter and self.adapter.request and type(self.adapter.request) == "function" then
+    return self.adapter.request(self, payload, actions, opts)
+  end
+
   opts = opts or {}
   local cb = log:wrap_cb(actions.callback, "Response error: %s") --[[@type function]]
 

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -60,8 +60,13 @@ end
 ---@return table|nil The Plenary job
 function Client:request(payload, actions, opts)
   -- Check if the adapter has a custom request function and use it instead
-  if self.adapter and self.adapter.request and type(self.adapter.request) == "function" then
-    return self.adapter.request(self, payload, actions, opts)
+  if
+    self.adapter
+    and self.adapter.opts
+    and self.adapter.opts.request
+    and type(self.adapter.opts.request) == "function"
+  then
+    return self.adapter.opts.request(self, payload, actions, opts)
   end
 
   opts = opts or {}


### PR DESCRIPTION
## Description

Allows the adapter to implement a custom request protocol by overriding `Client:request`. Update the config to:

```lua
require("codecompanion").setup({
  adapters = {
    opts = {
      ---Send a HTTP request
      ---@param payload { messages: table, tools: table|nil } The payload to be sent to the endpoint
      ---@param actions CodeCompanion.Adapter.RequestActions
      ---@param opts? table Options that can be passed to the request
      ---@return table|nil The Plenary job
      request = function(client, payload, actions, opts)
          -- implement custom request logic here
      end
    },
  }
})
```

## Related Issue(s)

Above is another attempt at overriding the default http request logic - let me know what you think.

Here are the prior attempts for reference:
- #1457
- #1426 

## Screenshots

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
