### PR TITLE
Fix/vars not captured

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 19
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 21
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -10,7 +10,7 @@ Table of Contents                            *codecompanion-table-of-contents*
   - Requirements                     |codecompanion-installation-requirements|
   - Installation                     |codecompanion-installation-installation|
   - Installing Extensions   |codecompanion-installation-installing-extensions|
-  - Completion                         |codecompanion-installation-completion|
+  - Completion in the Chat Buffer|codecompanion-installation-completion-in-the-chat-buffer|
   - Help                                     |codecompanion-installation-help|
 3. Getting Started                             |codecompanion-getting-started|
   - With an Adapter            |codecompanion-getting-started-with-an-adapter|
@@ -187,7 +187,7 @@ plugin. Below is an example which installs and configures the
     {
       "olimorris/codecompanion.nvim",
       dependencies = {
-        "ravitemer/mcphub.nvim" 
+        "ravitemer/mcphub.nvim"
       }
     }
 <
@@ -200,9 +200,9 @@ plugin. Below is an example which installs and configures the
         mcphub = {
           callback = "mcphub.extensions.codecompanion",
           opts = {
-            make_vars = true,       
+            make_vars = true,
             make_slash_commands = true,
-            show_result_in_chat = true  
+            show_result_in_chat = true
           }
         }
       }
@@ -213,12 +213,15 @@ Visit the |codecompanion-extending-extensions| to learn more about available
 extensions and how to create your own.
 
 
-COMPLETION                             *codecompanion-installation-completion*
+COMPLETION IN THE CHAT BUFFER*codecompanion-installation-completion-in-the-chat-buffer*
 
-Out of the box, the plugin supports completion with both nvim-cmp
-<https://github.com/hrsh7th/nvim-cmp> and blink.cmp
-<https://github.com/Saghen/blink.cmp>. For the latter, on version <= 0.10.0,
-ensure that you’ve added `codecompanion` as a source:
+When in the |codecompanion-usage-chat-buffer-index|, completion can be used to
+more easily add |codecompanion-usage-chat-buffer-variables|,
+|codecompanion-usage-chat-buffer-slash-commands| and
+|codecompanion-usage-chat-buffer-agents|. Out of the box, the plugin supports
+completion with both nvim-cmp <https://github.com/hrsh7th/nvim-cmp> and
+blink.cmp <https://github.com/Saghen/blink.cmp>. For the latter, on version <=
+0.10.0, ensure that you’ve added `codecompanion` as a source:
 
 >lua
     sources = {
@@ -1840,21 +1843,22 @@ for sending a message (defaults: `<CR>` or `<C-s>`) can be used.
 
 SETTINGS ~
 
-An adapters settings can also be changed via the debug window (`gd`). This
+An adapter’s settings can also be changed via the debug window (`gd`). This
 allows you to modify an adapter’s schema, changing things like the specific
 model and the temperature etc. Be sure to save the changes to the debug window
 to persist them to the chat buffer.
 
 
-COMPLETION ~
+CHAT BUFFER COMPLETION ~
 
 
 
-The plugin supports multiple completion plugins out of the box. By default, the
-plugin will look to setup blink.cmp <https://github.com/Saghen/blink.cmp>
-before trying to setup nvim-cmp <https://github.com/hrsh7th/nvim-cmp>. If you
-don’t use a completion plugin, then you can use native completions with no
-setup, invoking them with `<C-_>` from within the chat buffer.
+The plugin supports multiple completion plugins out of the box, in the chat
+buffer. By default, the plugin will look to setup blink.cmp
+<https://github.com/Saghen/blink.cmp> before trying to setup nvim-cmp
+<https://github.com/hrsh7th/nvim-cmp>. If you don’t use a completion plugin,
+then you can use native completions with no setup, invoking them with `<C-_>`
+from within the chat buffer.
 
 
 KEYMAPS ~
@@ -1884,14 +1888,14 @@ The keymaps available to the user in normal mode are:
 - `}` to move to the next chat
 
 
-REFERENCES ~
+REFERENCES / CONTEXT ~
 
 
 
 Sharing context with an LLM is crucial in order to generate useful responses.
 In the plugin, references are defined as output that is shared with a chat
 buffer via a `Variable`, `Slash Command` or `Agent/Tool`. They appear in a
-blockquote entitled `Sharing`. In essence, this is context that you’re
+blockquote entitled `Context`. In essence, this is context that you’re
 sharing with an LLM.
 
 
@@ -1902,20 +1906,20 @@ files and buffers) or `watched` (for buffers).
 
 File and buffer references can be `pinned` to a chat buffer with the `gp`
 keymap (when your cursor is on the line of the shared buffer in the “>
-Sharing section). Pinning results in the content from the object being reloaded
+Context section). Pinning results in the content from the object being reloaded
 and shared with the LLM on every turn. The advantage of this is that the LLM
 will always receive a fresh copy of the source data regardless of any changes.
 This can be useful if you’re working with agents and tools. However, please
 note that this can consume a lot of tokens.
 
 Buffer references can be `watched` via the `gw` keymap (when your cursor is on
-the line of the shared buffer in the “> Sharing section). Watching, whilst
+the line of the shared buffer in the “> Context section). Watching, whilst
 similar to pinning, is a more token-conscious way of keeping the LLM up to date
 on the contents of a buffer. Watchers track changes (adds, edits, deletes) in
 the underlying buffer and update the LLM on each turn, with only those changes.
 
 If a reference is added by mistake, it can be removed from the chat buffer by
-simply deleting it from the `Sharing` blockquote. On the next turn, all context
+simply deleting it from the `Context` blockquote. On the next turn, all context
 related to that reference will be removed from the message history.
 
 Finally, it’s important to note that all LLM endpoints require the sending of

--- a/lua/codecompanion/strategies/chat/variables/init.lua
+++ b/lua/codecompanion/strategies/chat/variables/init.lua
@@ -79,7 +79,9 @@ function Variables:find(message)
 
   local found = {}
   for var, _ in pairs(self.vars) do
-    if message.content:match("%f[%w" .. CONSTANTS.PREFIX .. "]" .. CONSTANTS.PREFIX .. var .. "%f[%W]") then
+    -- Escape the special characters in var
+    local escaped_var = var:gsub("[%(%)%.%%%+%-%*%?%[%]%^%$%/:]", "%%%1")
+    if message.content:match("%f[%w" .. CONSTANTS.PREFIX .. "]" .. CONSTANTS.PREFIX .. escaped_var .. "%f[%W]") then
       table.insert(found, var)
     end
   end

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -174,6 +174,10 @@ return {
             has_params = true,
           },
         },
+        ["screenshot://screenshot-2025-05-21T11-17-45.440Z"] = {
+          callback = "tests.strategies.chat.variables.screenshot",
+          description = "Screenshot",
+        },
         ["baz"] = {
           callback = "tests.strategies.chat.variables.baz",
           description = "baz",

--- a/tests/strategies/chat/test_variables.lua
+++ b/tests/strategies/chat/test_variables.lua
@@ -64,6 +64,19 @@ T["Variables"][":parse"]["should parse a message with a variable and ignore para
   h.eq("baz", message.content)
 end
 
+T["Variables"][":parse"]["should parse a message with special characters in variable name"] = function()
+  table.insert(chat.messages, {
+    role = "user",
+    content = "#screenshot://screenshot-2025-05-21T11-17-45.440Z what does this do?",
+  })
+  local result = vars:parse(chat, chat.messages[#chat.messages])
+
+  h.eq(true, result)
+
+  local message = chat.messages[#chat.messages]
+  h.eq("Resolved screenshot variable", message.content)
+end
+
 T["Variables"][":replace"]["should replace the variable in the message"] = function()
   local message = "#foo #bar replace this var"
   local result = vars:replace(message, 0)

--- a/tests/strategies/chat/variables/screenshot.lua
+++ b/tests/strategies/chat/variables/screenshot.lua
@@ -1,0 +1,23 @@
+local Screenshot = {}
+
+---@param args CodeCompanion.Variable
+function Screenshot.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    params = args.params,
+  }, { __index = Screenshot })
+
+  return self
+end
+
+---Return the contents of the current buffer that the chat was initiated from
+---@return nil
+function Screenshot:output()
+  self.Chat:add_message({
+    role = "user",
+    content = "Resolved screenshot variable",
+  }, { tag = "variable", visible = false })
+end
+
+return Screenshot


### PR DESCRIPTION
## Description


Variables with special characters like `-`, `()` are not properly matched from the chat e.g:

```md
##   User

#screenshot://screenshot-2025-05-21T11-17-45.440Z what does this do?
```

The PR fixes it and adds a test for this.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
