### PR TITLE
docs: update history extension with title generation customization opts

### DIFF
--- a/doc/extensions/history.md
+++ b/doc/extensions/history.md
@@ -72,8 +72,14 @@ require("codecompanion").setup({
                 expiration_days = 0,
                 -- Picker interface ("telescope" or "snacks" or "fzf-lua" or "default")
                 picker = "telescope",
-                -- Automatically generate titles for new chats
+                ---Automatically generate titles for new chats
                 auto_generate_title = true,
+                title_generation_opts = {
+                    ---Adapter for generating titles (defaults to active chat's adapter) 
+                    adapter = nil, -- e.g "copilot"
+                    ---Model for generating titles (defaults to active chat's model)
+                    model = nil, -- e.g "gpt-4o"
+                },
                 ---On exiting and entering neovim, loads the last chat on opening chat
                 continue_last_chat = false,
                 ---When chat is cleared with `gx` delete the chat from history


### PR DESCRIPTION
## Description

Updates history extension docs with title generation customization options. Useful so that user can specify cheap and faster models for title generation. Fixes issues where thinking tags being present in the title



## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
