### PR TITLE
fix(providers): only use `mini.diff` if initialized

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -152,6 +152,23 @@ To enable you to copy images from your system clipboard into a chat buffer via `
 
 ```
 
+### [mini.diff](https://github.com/echasnovski/mini.diff)
+
+To render generated diffs inline, but keep `mini.diff` disabled for Git diffs:
+
+```lua
+ {
+    "echasnovski/mini.diff",
+    config = function()
+      local diff = require("mini.diff")
+      diff.setup({
+        -- Disabled by default
+        source = diff.gen_source.none(),
+      })
+    end,
+},
+```
+
 ## Completion
 
 When in the [Chat Buffer](usage/chat-buffer/index), completion can be used to more easily add [variables](usage/chat-buffer/variables), [slash commands](usage/chat-buffer/slash-commands) and [tools](usage/chat-buffer/agents). Out of the box, the plugin supports completion with both [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [blink.cmp](https://github.com/Saghen/blink.cmp). For the latter, on version <= 0.10.0, ensure that you've added `codecompanion` as a source:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -149,24 +149,6 @@ To enable you to copy images from your system clipboard into a chat buffer via `
     },
   },
 },
-
-```
-
-### [mini.diff](https://github.com/echasnovski/mini.diff)
-
-To render generated diffs inline, but keep `mini.diff` disabled for Git diffs:
-
-```lua
- {
-    "echasnovski/mini.diff",
-    config = function()
-      local diff = require("mini.diff")
-      diff.setup({
-        -- Disabled by default
-        source = diff.gen_source.none(),
-      })
-    end,
-},
 ```
 
 ## Completion

--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -17,7 +17,15 @@ local configs = {
       return snacks_module and snacks_module.config.picker.enabled
     end,
   },
-  mini_diff = { module = "mini.diff", name = "mini_diff" },
+  mini_diff = {
+    module = "mini.diff",
+    name = "mini_diff",
+    condition = function()
+      -- MiniDiff only works correctly if initialized,
+      -- which sets the global variable
+      return _G.MiniDiff ~= nil
+    end,
+  },
   fzf_lua = { module = "fzf-lua", name = "fzf_lua" },
 }
 


### PR DESCRIPTION
## Description

If `mini.nvim` is installed CodeCompanion will try to use `mini.diff`, but it only works if `setup()` was called.

This changes the default so it's only used if initialized, and updates the docs to share how to use MiniDiff only with CodeCompanion.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [-] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [-] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
