### PR TITLE
Fix/make params from schema on adapter resolve

### DIFF
--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -326,7 +326,7 @@ function Adapter.resolve(adapter)
   elseif type(adapter) == "function" then
     adapter = adapter()
   end
-
+  adapter:map_schema_to_params()
   return adapter.set_model(adapter)
 end
 

--- a/tests/strategies/inline/test_inline.lua
+++ b/tests/strategies/inline/test_inline.lua
@@ -10,7 +10,7 @@ T["Inline"] = new_set({
     pre_case = function()
       inline = h.setup_inline({
         adapters = {
-          fake_adapter = { name = "fake_adapter" },
+          fake_adapter = { name = "fake_adapter", schema = {} },
         },
       })
     end,

--- a/tests/test_adapter.lua
+++ b/tests/test_adapter.lua
@@ -252,6 +252,14 @@ T["Adapter"]["can resolve custom adapters"] = function()
   h.eq("abc_123", result)
 end
 
+T["Adapter"]["maps schema to params when resolving"] = function()
+  local result = child.lua([[
+    return require("codecompanion.adapters").resolve(_G.test_adapter).parameters.data.model
+  ]])
+
+  h.eq("gpt-4-0125-preview", result)
+end
+
 T["Adapter"]["utils"] = new_set()
 
 T["Adapter"]["utils"]["can consolidate consecutive messages"] = function()


### PR DESCRIPTION
## Description

When chat is initialized with some adapter, the adapter doesn't have parameters field on it as `map_schema_to_params` is not called until `Chat:submit()`. I don't know if this is intentional.

This leads to a minor bug when users have a dynamic llm role. 

```lua
		roles = {
			llm = function(adapter)
				return string.format(
					"  %s%s",
					adapter.formatted_name,
					adapter.parameters and (adapter.parameters.model and " (" .. adapter.parameters.model .. ")" or "")
						or ""
				)
			end,
``` 
This is not noticed during regular workflows as llm header is only render after `Chat:submit()` which is not the case when using with history extension where we render all the headers on `Chat:new()`. Related issue from history extension: https://github.com/ravitemer/codecompanion-history.nvim/issues/21

This PR calls `map_schema_to_params` on `adapter.resolve()` so that `adapter.parameters` becomes available. Adds a test and fixes a case in `test_inline.lua` file as described in the commit.

I am not sure if this leads to any side effects, feel free to discard it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
