### PR TITLE
fix: unlock buffer when adding reference after a tool output

### DIFF
--- a/lua/codecompanion/strategies/chat/references.lua
+++ b/lua/codecompanion/strategies/chat/references.lua
@@ -90,7 +90,14 @@ local function add(chat, ref, row)
     table.insert(lines, "")
   end
 
+  local was_locked = not vim.bo[chat.bufnr].modifiable
+  if was_locked then
+    chat.ui:unlock_buf()
+  end
   api.nvim_buf_set_lines(chat.bufnr, row, row, false, lines)
+  if was_locked then
+    chat.ui:lock_buf()
+  end
 end
 
 ---@class CodeCompanion.Chat.References


### PR DESCRIPTION
## Description

I have this following code in mcphub codecompanion success handler.

```lua
    if has_function_calling then
        chat:add_tool_output(
            tool,
            text,
            (user_msg or show_result_in_chat or is_error) and (user_msg or text)
                or string.format("**`%s` Tool**: Successfully finished", action_name)
        )
        for _, image in ipairs(images) do
            helpers.add_image(chat, image)
        end
    else
```

After adding tool output, If I try to add image, I get the following error:

```txt
   Error  05:06:46 msg_show.lua_error Error executing vim.schedule lua callback: ...on.nvim/lua/codecompanion/strategies/chat/references.lua:94: Buffer is not 'modifiable'
stack traceback:
	[C]: in function 'nvim_buf_set_lines'
	...on.nvim/lua/codecompanion/strategies/chat/references.lua:94: in function 'add'
	...on.nvim/lua/codecompanion/strategies/chat/references.lua:145: in function 'add'
	...anion.nvim/lua/codecompanion/strategies/chat/helpers.lua:79: in function 'add_image'
	...cphub.nvim/lua/mcphub/extensions/codecompanion/utils.lua:107: in function 'add_tool_output'
	...cphub.nvim/lua/mcphub/extensions/codecompanion/utils.lua:207: in function 'success'
	...a/codecompanion/strategies/chat/agents/executor/init.lua:69: in function 'success'
	...a/codecompanion/strategies/chat/agents/executor/init.lua:185: in function 'success'
	...a/codecompanion/strategies/chat/agents/executor/func.lua:83: in function 'output_handler'
	...cphub.nvim/lua/mcphub/extensions/codecompanion/utils.lua:51: in function 'original_callback'
	/home/ubuntu/mcp-hub/mcphub.nvim/lua/mcphub/hub.lua:437: in function 'callback'
	/home/ubuntu/mcp-hub/mcphub.nvim/lua/mcphub/hub.lua:669: in function 'process_response'
	/home/ubuntu/mcp-hub/mcphub.nvim/lua/mcphub/hub.lua:679: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

This PR unlocks the buffer before adding reference lines. Please let me know if there is any other way to add images along with the tool_output.

Edit:

If you want to test it with MCP Hub, please use the `image-support` branch of mcphub.nvim

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
