### PR TITLE
Update the default for GitHub Copilot to `gpt-4.1`

### DIFF
--- a/lua/codecompanion/adapters/githubmodels.lua
+++ b/lua/codecompanion/adapters/githubmodels.lua
@@ -136,12 +136,13 @@ return {
       type = "enum",
       desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
       ---@type string|fun(): string
-      default = "gpt-4o",
+      default = "gpt-4.1",
       choices = {
         ["o3-mini"] = { opts = { can_reason = true } },
         ["o1"] = { opts = { can_reason = true } },
         ["o1-mini"] = { opts = { can_reason = true } },
         "claude-3.5-sonnet",
+        "gpt-4.1",
         "gpt-4o",
         "gpt-4o-mini",
         "DeepSeek-R1",


### PR DESCRIPTION
## Description

Updating the default Github Copilot model to `gpt-4.1`.

> GPT-4o will remain available in the model picker, but it will be deprecated in 90 days.

https://github.blog/changelog/2025-05-08-openai-gpt-4-1-is-now-generally-available-in-github-copilot-as-the-new-default-model/

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
