### PR TITLE
feat(slash_commands): better caching and restoring of URLs

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -124,7 +124,9 @@ local defaults = {
           callback = "strategies.chat.slash_commands.fetch",
           description = "Insert URL contents",
           opts = {
-            adapter = "jina",
+            adapter = "jina", -- jina|tavily
+            cache_path = vim.fn.stdpath("data") .. "/codecompanion/urls",
+            provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
         },
         ["file"] = {

--- a/lua/codecompanion/providers/slash_commands/default.lua
+++ b/lua/codecompanion/providers/slash_commands/default.lua
@@ -72,6 +72,8 @@ function Default:buffers()
   return self
 end
 
+function Default:urls(urls) end
+
 ---Find images in a set of paths
 ---@param paths table
 ---@param filetypes table

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -143,4 +143,22 @@ function M.set_option(bufnr, opt, value)
   end
 end
 
+---Make a timestamp relative
+---@param timestamp number Unix timestamp
+---@return string Relative time string (e.g. "5m ago", "2h ago")
+function M.make_relative(timestamp)
+  local now = os.time()
+  local diff = now - timestamp
+
+  if diff < 60 then
+    return diff .. "s"
+  elseif diff < 3600 then
+    return math.floor(diff / 60) .. "m"
+  elseif diff < 86400 then
+    return math.floor(diff / 3600) .. "h"
+  else
+    return math.floor(diff / 86400) .. "d"
+  end
+end
+
 return M


### PR DESCRIPTION
## Description

It's currently impossible for a user to restore URLs from the cache unless they paste the exact same URL into the input box. This PR addresses that.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
