### PR TITLE
fix(slash_commands): update adapter reference

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -199,9 +199,9 @@ end
 ---@param opts? table
 ---@return nil
 function SlashCommand:output(url, opts)
-  local ok, adapter = pcall(require, "codecompanion.adapters.non_llm." .. self.config.opts.adapter)
+  local ok, adapter = pcall(require, "codecompanion.adapters." .. self.config.opts.adapter)
   if not ok then
-    ok, adapter = pcall(loadfile, self.config.opts.provider)
+    ok, adapter = pcall(loadfile, self.config.opts.adapter)
   end
   if not ok or not adapter then
     return log:error("Failed to load the adapter for the fetch Slash Command")


### PR DESCRIPTION
## Description

Fixes the reference to the adapter in the fetch slash command after #1279 was merged

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
