### PR TITLE
feat(ui): replace `vim.ui.select` with new util ui component

### DIFF
--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -251,4 +251,281 @@ function M.set_win_options(winnr, opts)
   end
 end
 
+---@class ConfirmDialogOpts
+---@field padding? number Content padding, default is 2
+---@field max_width? number Maximum width of dialog, default is 70
+---@field min_width? number Minimum width of dialog, default is 35
+---@field title? string Dialog title, default is "Confirm"
+---@field yes_icon? string YES button icon, default is " 󰄬 "
+---@field no_icon? string NO button icon, default is " 󰅖 "
+---@field yes_text? string YES button text, default is " 󰄬 YES"
+---@field no_text? string NO button text, default is " 󰅖 NO"
+---@field border? string|table Border style, default is "rounded"
+---@field zindex? number Window z-index, default is 100
+---@field relative? string Relative position, default is "editor"
+---@field highlights? table<string, table> Custom highlight group configuration
+---@field auto_close? boolean Whether to auto close when losing focus, default is true
+---@field timeout? number Auto close delay timeout (milliseconds), default is 10
+
+---Create a confirmation dialog floating window
+---@param content string Content to display
+---@param callback function Callback function that receives true/false/nil
+---@param opts? ConfirmDialogOpts Optional configuration
+---@return nil
+function M.create_confirm_dialog(content, callback, opts)
+  opts = opts or {}
+
+  -- Define highlight group configuration
+  local highlights = opts.highlights
+    or {
+      CodeCompanionConfirmYes = { fg = "#98c379", bg = "NONE", italic = false, bold = false },
+      CodeCompanionConfirmNo = { fg = "#61afef", bg = "NONE", italic = false, bold = false },
+      CodeCompanionConfirmSelected = { fg = "#e06c75", bg = "#3e4451", italic = false, bold = true },
+    }
+
+  -- Batch set highlight groups
+  for name, hl in pairs(highlights) do
+    vim.api.nvim_set_hl(0, name, hl)
+  end
+
+  -- Configuration parameters and theme
+  local config = {
+    padding = opts.padding or 2,
+    max_width = opts.max_width or 70,
+    min_width = opts.min_width or 35,
+    yes_icon = opts.yes_icon or " 󰄬 ",
+    no_icon = opts.no_icon or " 󰅖 ",
+    yes_text = opts.yes_text or " 󰄬 YES",
+    no_text = opts.no_text or " 󰅖 NO",
+    border = opts.border or "rounded",
+    zindex = opts.zindex or 100,
+    relative = opts.relative or "editor",
+    auto_close = opts.auto_close == nil and true or opts.auto_close,
+    timeout = opts.timeout or 10,
+  }
+
+  -- Smart text wrapping function
+  local function wrap_text(text, width)
+    local lines, current_line = {}, ""
+    for _, word in ipairs(vim.split(text, " ")) do
+      local test_line = current_line == "" and word or (current_line .. " " .. word)
+      if string.len(test_line) <= width then
+        current_line = test_line
+      else
+        if current_line ~= "" then
+          table.insert(lines, current_line)
+        end
+        current_line = word
+      end
+    end
+    if current_line ~= "" then
+      table.insert(lines, current_line)
+    end
+    return lines
+  end
+
+  -- Calculate dimensions
+  local content_width = math.min(
+    config.max_width - config.padding * 2,
+    math.max(config.min_width - config.padding * 2, string.len(content))
+  )
+  local content_lines = wrap_text(content, content_width)
+  local buttons_width = string.len(config.yes_text .. " " .. config.no_text) + 4
+  local actual_width = math.max(
+    math.max(unpack(vim.tbl_map(string.len, content_lines))) + config.padding * 2,
+    config.min_width,
+    buttons_width
+  )
+  local height = #content_lines + config.padding * 2
+
+  -- Create display content
+  local lines = {}
+  -- Add top padding
+  for i = 1, config.padding do
+    table.insert(lines, "")
+  end
+  -- Add content (center aligned)
+  for _, line in ipairs(content_lines) do
+    local content_padding = math.floor((actual_width - string.len(line)) / 2)
+    table.insert(lines, string.rep(" ", content_padding) .. line)
+  end
+  -- Add bottom padding
+  for i = 1, config.padding do
+    table.insert(lines, "")
+  end
+
+  -- Create buffer and window
+  local bufnr = api.nvim_create_buf(false, true)
+  local current_selection = 1
+
+  -- Batch set buffer options
+  local buffer_opts = {
+    modifiable = false,
+    bufhidden = "wipe",
+    filetype = "codecompanion",
+    buftype = "nofile",
+  }
+  for opt, value in pairs(buffer_opts) do
+    vim.bo[bufnr][opt] = value
+  end
+
+  -- Create footer text function
+  local function create_footer_text()
+    local yes_hl = current_selection == 1 and "CodeCompanionConfirmSelected" or "CodeCompanionConfirmYes"
+    local no_hl = current_selection == 2 and "CodeCompanionConfirmSelected" or "CodeCompanionConfirmNo"
+    return {
+      { config.yes_text, yes_hl },
+      { " ", "Normal" },
+      { config.no_text, no_hl },
+    }
+  end
+
+  -- Create window
+  local winnr = api.nvim_open_win(bufnr, true, {
+    relative = config.relative,
+    border = config.border,
+    width = actual_width,
+    height = height,
+    style = "minimal",
+    row = math.floor((vim.o.lines - height) / 2),
+    col = math.floor((vim.o.columns - actual_width) / 2),
+    title = opts.title or "Confirm",
+    title_pos = "center",
+    footer = create_footer_text(),
+    footer_pos = "right",
+    zindex = config.zindex,
+  })
+
+  -- Batch set window options
+  local window_opts = {
+    cursorline = false,
+    wrap = false,
+    spell = false,
+    number = false,
+    relativenumber = false,
+    signcolumn = "no",
+    foldcolumn = "0",
+  }
+  for opt, value in pairs(window_opts) do
+    vim.wo[winnr][opt] = value
+  end
+
+  -- Set window highlight
+  pcall(function()
+    vim.wo[winnr].winhl = "Normal:Normal,FloatBorder:FloatBorder,FloatTitle:FloatTitle"
+  end)
+
+  -- Set content
+  vim.bo[bufnr].modifiable = true
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].modifiable = false
+
+  -- Update footer and close dialog functions
+  local function update_footer()
+    api.nvim_win_set_config(winnr, { footer = create_footer_text(), footer_pos = "right" })
+  end
+
+  local function close_dialog(result)
+    if api.nvim_win_is_valid(winnr) then
+      pcall(api.nvim_win_close, winnr, true)
+    end
+    if callback then
+      callback(result)
+    end
+  end
+
+  local function switch_selection(new_selection)
+    if new_selection ~= current_selection then
+      current_selection = new_selection
+      update_footer()
+    end
+  end
+
+  -- Keymap configuration
+  local keymap_opts = { buffer = bufnr, silent = true, nowait = true }
+  local keymaps = {
+    -- Switch selection
+    {
+      { "<Tab>", "<S-Tab>" },
+      function()
+        switch_selection(current_selection == 1 and 2 or 1)
+      end,
+    },
+    {
+      { "<Left>", "h" },
+      function()
+        switch_selection(1)
+      end,
+    },
+    {
+      { "<Right>", "l" },
+      function()
+        switch_selection(2)
+      end,
+    },
+    -- Confirm selection
+    {
+      "<CR>",
+      function()
+        close_dialog(current_selection == 1)
+      end,
+    },
+    {
+      "y",
+      function()
+        close_dialog(true)
+      end,
+    },
+    {
+      "n",
+      function()
+        close_dialog(false)
+      end,
+    },
+    -- Cancel
+    {
+      { "<ESC>", "q" },
+      function()
+        close_dialog(nil)
+      end,
+    },
+  }
+
+  -- Batch set keymaps
+  for _, keymap in ipairs(keymaps) do
+    local keys, func = keymap[1], keymap[2]
+    if type(keys) == "table" then
+      for _, key in ipairs(keys) do
+        vim.keymap.set("n", key, func, keymap_opts)
+      end
+    else
+      vim.keymap.set("n", keys, func, keymap_opts)
+    end
+  end
+
+  -- Set autocommands
+  if config.auto_close then
+    local augroup = api.nvim_create_augroup("ConfirmDialogFocus", { clear = true })
+    api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
+      group = augroup,
+      buffer = bufnr,
+      callback = function()
+        vim.defer_fn(function()
+          if api.nvim_win_is_valid(winnr) and api.nvim_get_current_win() ~= winnr then
+            close_dialog(nil)
+          end
+        end, config.timeout)
+      end,
+    })
+
+    api.nvim_create_autocmd("WinClosed", {
+      group = augroup,
+      pattern = tostring(winnr),
+      callback = function()
+        pcall(api.nvim_del_augroup_by_id, augroup)
+      end,
+    })
+  end
+end
+
 return M


### PR DESCRIPTION
## Description

feat(ui): replace vim.ui.select with custom confirm dialog for tool approval

- Add create_confirm_dialog function to utils/ui.lua with enhanced features
- Replace vim.ui.select in executor with new confirm dialog
- Improve user experience with customizable styling, keyboard navigation, and auto-close behavior
- Add support for icons, custom text, and responsive layout

I don't think this PR requires additional testing, the current UI should be enough, if you think the UI can continue to be optimized, feel free to modify it

## Related PR

https://github.com/olimorris/codecompanion.nvim/pull/1354

## Screenshots

![image](https://github.com/user-attachments/assets/32a32734-6c26-49ed-8d52-1056bbca54ff)


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
