### PR TITLE
Reapply "Score based diff merges" (#1501)

### DIFF
--- a/tests/fixtures/files-diff-1.5.patch
+++ b/tests/fixtures/files-diff-1.5.patch
@@ -1,0 +1,10 @@
+*** Begin Patch
+@@ two
+three
+four
+five
+-five
++5
+six
+seven
+*** End Patch

--- a/tests/fixtures/files-output-1.5.html
+++ b/tests/fixtures/files-output-1.5.html
@@ -1,0 +1,10 @@
+one
+two
+three
+four
+5
+six
+seven
+eight
+nine
+ten


### PR DESCRIPTION
This reverts the revert in commit dbb287e1302563286870e72674f0b907c6db14f2.

This fixes the conflicts while reverting the revert discussed [here](https://github.com/olimorris/codecompanion.nvim/pull/1494#issuecomment-2909053308).

Basically `score-based-diff-merges` was built on top of `split-files-patch`. Merging `split-files-patch` was not needed if we merged `score-based-diff-merges` directly :).

This PR fixes them.