### PR TITLE
fix(workflows): successive prompts and tools now work

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/executor/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/init.lua
@@ -188,15 +188,9 @@ end
 ---Close the execution of the tool
 ---@return nil
 function Executor:close()
-  local chat = self.agent.chat
   log:debug("Executor:close")
   self.handlers.on_exit()
   util.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.agent.bufnr })
-
-  vim.schedule(function()
-    chat.subscribers:process(chat)
-    _G.codecompanion_current_tool = nil -- This must come last
-  end)
 end
 
 return Executor

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -204,10 +204,7 @@ local function ready_chat_buffer(chat)
     chat.ui:display_tokens(chat.parser, chat.header_line)
     chat.references:render()
 
-    -- If we're running any tooling, let them handle the subscriptions instead
-    if not chat.tools:loaded() then
-      chat.subscribers:process(chat)
-    end
+    chat.subscribers:process(chat)
   end
 
   log:info("Chat request finished")


### PR DESCRIPTION
## Description

Previously, workflows could be triggered via the chat buffer or when queued tools have finished executing. This lead to issues as per #1496.

## Related Issue(s)

#1496

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
