### PR TITLE
Change autcomplete from cmp to only trigger slash commands after a '/'

### DIFF
--- a/lua/codecompanion/providers/completion/cmp/slash_commands.lua
+++ b/lua/codecompanion/providers/completion/cmp/slash_commands.lua
@@ -17,7 +17,7 @@ function source:get_trigger_characters()
 end
 
 function source:get_keyword_pattern()
-  return [[\w\+]]
+  return [[/\w\+]]
 end
 
 function source:complete(params, callback)


### PR DESCRIPTION
## Description

By default, when using nvim-cmp, the `codecompanion_slash_commands` source is triggered
by the first character after a `/` instead of the slash itself.

This alters the default behavior to only trigger after a `/`, while also making it consistent
with how the `#` and `@`  completion triggers behave.

## Screenshots
Before:
![cmp-before](https://github.com/user-attachments/assets/2bd817a5-70a7-4952-b266-c44a153af419)

After:
![cmp-after](https://github.com/user-attachments/assets/78b8127e-0421-4987-8178-d5c73e9d7381)



## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
