### PR TITLE
feat(adapters): users can specify models for strategies

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 25
+*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 28
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -365,7 +365,9 @@ to make sure you’ve configured an adapter first:
 <
 
 In the example above, we’re using the Anthropic adapter for both the chat and
-inline strategies.
+inline strategies. Refer to the
+|codecompanion-configuration-adapters-changing-a-model| section to understand
+how to change the default model.
 
 Because most LLMs require an API key you’ll need to share that with the
 adapter. By default, adapters will look in your environment for a `*_API_KEY`
@@ -704,6 +706,44 @@ Environment variables can also be functions and as a parameter, they receive a
 copy of the adapter itself.
 
 
+CHANGING A MODEL ~
+
+To more easily change a model associated with a strategy you can pass in the
+`name` and `model` to the adapter:
+
+>lua
+    require("codecompanion").setup({
+      strategies = {
+        chat = {
+          adapter = {
+            name = "copilot",
+            model = "claude-sonnet-4-20250514",
+          },
+        },
+      },
+    }),
+<
+
+To change the default model on an adapter you can modify the
+`schema.model.default` property:
+
+>lua
+    require("codecompanion").setup({
+      adapters = {
+        openai = function()
+          return require("codecompanion.adapters").extend("openai", {
+            schema = {
+              model = {
+                default = "gpt-4.1",
+              },
+            },
+          })
+        end,
+      },
+    }),
+<
+
+
 ADAPTER SETTINGS ~
 
 LLMs have many settings such as model, temperature and max_tokens. In an
@@ -762,27 +802,6 @@ A proxy can be configured by utilising the `adapters.opts` table in the config:
           allow_insecure = true,
           proxy = "socks5://127.0.0.1:9999",
         },
-      },
-    }),
-<
-
-
-CHANGING A MODEL ~
-
-Many adapters allow model selection via the `schema.model.default` property:
-
->lua
-    require("codecompanion").setup({
-      adapters = {
-        openai = function()
-          return require("codecompanion.adapters").extend("openai", {
-            schema = {
-              model = {
-                default = "gpt-4",
-              },
-            },
-          })
-        end,
       },
     }),
 <
@@ -2105,12 +2124,8 @@ disk:
 
 - Creating a file
 - Reading a file
-- Reading lines from a file
 - Editing a file
 - Deleting a file
-- Renaming a file
-- Copying a file
-- Moving a file
 
 
 @WEB_SEARCH ~
@@ -2848,7 +2863,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI’S API OUTPUT
+OPENAI�S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -65,6 +65,42 @@ require("codecompanion").setup({
 
 Environment variables can also be functions and as a parameter, they receive a copy of the adapter itself.
 
+## Changing a Model
+
+To more easily change a model associated with a strategy you can pass in the `name` and `model` to the adapter:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      adapter = {
+        name = "copilot",
+        model = "claude-sonnet-4-20250514",
+      },
+    },
+  },
+}),
+
+```
+
+To change the default model on an adapter you can modify the `schema.model.default` property:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    openai = function()
+      return require("codecompanion.adapters").extend("openai", {
+        schema = {
+          model = {
+            default = "gpt-4.1",
+          },
+        },
+      })
+    end,
+  },
+}),
+```
+
 ## Configuring Adapter Settings
 
 LLMs have many settings such as model, temperature and max_tokens. In an adapter, these sit within a schema table and can be configured during setup:
@@ -120,26 +156,6 @@ require("codecompanion").setup({
       allow_insecure = true,
       proxy = "socks5://127.0.0.1:9999",
     },
-  },
-}),
-```
-
-## Changing a Model
-
-Many adapters allow model selection via the `schema.model.default` property:
-
-```lua
-require("codecompanion").setup({
-  adapters = {
-    openai = function()
-      return require("codecompanion.adapters").extend("openai", {
-        schema = {
-          model = {
-            default = "gpt-4",
-          },
-        },
-      })
-    end,
   },
 }),
 ```

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -25,7 +25,7 @@ require("codecompanion").setup({
 }),
 ```
 
-In the example above, we're using the Anthropic adapter for both the chat and inline strategies.
+In the example above, we're using the Anthropic adapter for both the chat and inline strategies. Refer to the [adapter](configuration/adapters#changing-a-model) section to understand how to change the default model.
 
 Because most LLMs require an API key you'll need to share that with the adapter. By default, adapters will look in your environment for a `*_API_KEY` where `*` is the name of the adapter such as `ANTHROPIC` or `OPENAI`. However, you can extend the adapter and change the API key like so:
 

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -330,13 +330,13 @@ function Adapter.resolve(adapter, opts)
   elseif type(adapter) == "string" then
     opts = vim.tbl_deep_extend("force", opts, { name = adapter })
     if opts.model then
-      opts = {
+      opts = vim.tbl_deep_extend("force", opts, {
         schema = {
           model = {
             default = opts.model,
           },
         },
-      }
+      })
     end
 
     local user_adapter = config.adapters[adapter]

--- a/lua/codecompanion/adapters/init.lua
+++ b/lua/codecompanion/adapters/init.lua
@@ -316,15 +316,31 @@ end
 
 ---Resolve an adapter from deep within the plugin...somewhere
 ---@param adapter? CodeCompanion.Adapter|string|function
+---@param opts? table
 ---@return CodeCompanion.Adapter
-function Adapter.resolve(adapter)
+function Adapter.resolve(adapter, opts)
   adapter = adapter or config.strategies.chat.adapter
+  opts = opts or {}
 
   if type(adapter) == "table" then
+    if adapter.name and adapter.model then
+      return Adapter.resolve(adapter.name, { model = adapter.model })
+    end
     adapter = Adapter.new(adapter)
   elseif type(adapter) == "string" then
+    opts = vim.tbl_deep_extend("force", opts, { name = adapter })
+    if opts.model then
+      opts = {
+        schema = {
+          model = {
+            default = opts.model,
+          },
+        },
+      }
+    end
+
     local user_adapter = config.adapters[adapter]
-    adapter = Adapter.extend(user_adapter or adapter, { name = adapter })
+    adapter = Adapter.extend(user_adapter or adapter, opts)
   elseif type(adapter) == "function" then
     adapter = adapter()
   end

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -565,7 +565,7 @@ function Chat.new(args)
     chat = self,
   }
 
-  self.adapter = adapters.resolve(args.adapter)
+  self.adapter = adapters.resolve(args.adapter or config.strategies.chat.adapter)
   if not self.adapter then
     return log:error("No adapter found")
   end

--- a/lua/codecompanion/strategies/cmd.lua
+++ b/lua/codecompanion/strategies/cmd.lua
@@ -15,7 +15,7 @@ function Cmd.new(args)
     opts = args.opts,
   }, { __index = Cmd })
 
-  self.adapter = adapters.resolve(config.adapters[config.strategies.cmd.adapter])
+  self.adapter = adapters.resolve(config.strategies.cmd.adapter)
   if not self.adapter then
     return log:error("No adapter found")
   end

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -204,7 +204,7 @@ function Inline.new(args)
     prompts = vim.deepcopy(args.prompts),
   }, { __index = Inline })
 
-  self:set_adapter(args.adapter or config.adapters[config.strategies.inline.adapter])
+  self:set_adapter(args.adapter or config.strategies.inline.adapter)
   if not self.adapter then
     return log:error("[Inline] No adapter found")
   end
@@ -223,7 +223,7 @@ function Inline.new(args)
 end
 
 ---Set the adapter for the inline prompt
----@param adapter CodeCompanion.Adapter
+---@param adapter CodeCompanion.Adapter|string|function
 ---@return nil
 function Inline:set_adapter(adapter)
   self.adapter = adapters.resolve(adapter)

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -222,7 +222,7 @@ return {
       },
     },
     inline = {
-      adapter = "foo",
+      adapter = "test_adapter",
       variables = {
         ["foo"] = {
           callback = vim.fn.getcwd() .. "/tests/strategies/inline/variables/foo.lua",

--- a/tests/test_adapter.lua
+++ b/tests/test_adapter.lua
@@ -253,6 +253,24 @@ T["Adapter"]["can resolve custom adapters"] = function()
   h.eq("abc_123", result)
 end
 
+T["Adapter"]["can pass in the name of the model"] = function()
+  local result = child.lua([[
+    require("codecompanion").setup({
+      strategies = {
+        chat = {
+          adapter = {
+            name = "copilot",
+            model = "some_made_up_model"
+          }
+        }
+      }
+    })
+    return require("codecompanion.adapters").resolve().model.name
+  ]])
+
+  h.eq("some_made_up_model", result)
+end
+
 T["Adapter"]["utils"] = new_set()
 
 T["Adapter"]["utils"]["can consolidate consecutive messages"] = function()


### PR DESCRIPTION
## Description

Before this PR, it was cumbersome for users to specify a different model for an adapter without creating a separate copy of an adapter.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
