### PR TITLE
Disable follow on toggle

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -204,7 +204,7 @@ CodeCompanion.toggle = function()
 
   chat.context = context_utils.get(api.nvim_get_current_buf())
   CodeCompanion.close_last_chat()
-  chat.ui:open(true)
+  chat.ui:open({ toggled = true })
 end
 
 ---Return a chat buffer

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -204,7 +204,7 @@ CodeCompanion.toggle = function()
 
   chat.context = context_utils.get(api.nvim_get_current_buf())
   CodeCompanion.close_last_chat()
-  chat.ui:open()
+  chat.ui:open(true)
 end
 
 ---Return a chat buffer

--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -65,9 +65,11 @@ function UI.new(args)
 end
 
 ---Open/create the chat window
----@param from_toggle? boolean
+---@param opts? table
 ---@return CodeCompanion.Chat.UI|nil
-function UI:open(from_toggle)
+function UI:open(opts)
+  opts = opts or {}
+
   if self:is_visible() then
     return
   end
@@ -139,7 +141,7 @@ function UI:open(from_toggle)
   ui.set_win_options(self.winnr, window.opts)
   vim.bo[self.bufnr].textwidth = 0
 
-  if not from_toggle then
+  if not opts.toggled then
     self:follow()
   end
 

--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -65,8 +65,9 @@ function UI.new(args)
 end
 
 ---Open/create the chat window
+---@param from_toggle? boolean
 ---@return CodeCompanion.Chat.UI|nil
-function UI:open()
+function UI:open(from_toggle)
   if self:is_visible() then
     return
   end
@@ -137,7 +138,10 @@ function UI:open()
 
   ui.set_win_options(self.winnr, window.opts)
   vim.bo[self.bufnr].textwidth = 0
-  self:follow()
+
+  if not from_toggle then
+    self:follow()
+  end
 
   log:trace("Chat opened with ID %d", self.id)
   util.fire("ChatOpened", { bufnr = self.bufnr })


### PR DESCRIPTION
## Description
Sometimes i like to toggle the chat window to reference my code,
but the cursor is always pushed back to the bottom, wich means
that i am forced to get back to where i was everytime i toggle.
This behavior can get particularlly annoying as the buffer grows in size.

I've hadled that by adding the `display.chat.follow_on_toggle` field, that when 
disabled, will keep the cursor where it was when using `:CodeCompanionChat Toggle`.

## Screenshots

Before (enabled)
![before](https://github.com/user-attachments/assets/6878865a-5f8e-4ead-8fc1-451f2430ee00)

After (disabled)
![after](https://github.com/user-attachments/assets/58f99aff-1221-4975-93c7-d6d4733451b4)


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
