### PR TITLE
refactor(core): Standardize model representation as an object #1521

### DIFF
--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -336,7 +336,7 @@ return {
         if type(model) == "function" then
           model = model()
         end
-        return not vim.startswith(model, "o1")
+        return not vim.startswith(model.name, "o1")
       end,
       desc = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
     },
@@ -358,7 +358,7 @@ return {
         if type(model) == "function" then
           model = model()
         end
-        return not vim.startswith(model, "o1")
+        return not vim.startswith(model.name, "o1")
       end,
       desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
     },
@@ -373,7 +373,7 @@ return {
         if type(model) == "function" then
           model = model()
         end
-        return not vim.startswith(model, "o1")
+        return not vim.startswith(model.name, "o1")
       end,
       desc = "How many chat completions to generate for each prompt.",
     },

--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -80,7 +80,7 @@ return {
       messages = vim
         .iter(messages)
         :map(function(m)
-          if vim.startswith(model, "o1") and m.role == "system" then
+          if vim.startswith(model.name, "o1") and m.role == "system" then
             m.role = self.roles.user
           end
 

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -86,18 +86,21 @@ function Client:request(payload, actions, opts)
 
   adapter:get_env_vars()
 
-  local body = self.opts.encode(
-    vim.tbl_extend(
-      "keep",
-      handlers.form_parameters
-          and handlers.form_parameters(adapter, adapter:set_env_vars(adapter.parameters), payload.messages)
-        or {},
-      handlers.form_messages and handlers.form_messages(adapter, payload.messages) or {},
-      handlers.form_tools and handlers.form_tools(adapter, payload.tools) or {},
-      adapter.body and adapter.body or {},
-      handlers.set_body and handlers.set_body(adapter, payload) or {}
-    )
+  local body_tbl = vim.tbl_extend(
+    "keep",
+    handlers.form_parameters
+        and handlers.form_parameters(adapter, adapter:set_env_vars(adapter.parameters), payload.messages)
+      or {},
+    handlers.form_messages and handlers.form_messages(adapter, payload.messages) or {},
+    handlers.form_tools and handlers.form_tools(adapter, payload.tools) or {},
+    adapter.body and adapter.body or {},
+    handlers.set_body and handlers.set_body(adapter, payload) or {}
   )
+  if body_tbl.model and type(body_tbl.model) == "table" then
+    body_tbl.model = body_tbl.model.name
+  end
+
+  local body = self.opts.encode(body_tbl)
 
   local body_file = Path.new(vim.fn.tempname() .. ".json")
   body_file:write(vim.split(body, "\n"), "w")


### PR DESCRIPTION
## Description

This commit refactors the handling of model identifiers to consistently support model objects. Previously, models were often treated as simple strings. This change ensures that if a model is represented as an object (e.g., `{ name = "model-id", ... }`), its `name` property is correctly used.

Key changes:
- In `http.lua`, the request building logic now explicitly extracts `model.name` if `model` is an object, ensuring the correct string identifier is sent in the API request.
- Adapters for Copilot and OpenAI have been updated to access `model.name` for internal logic that relies on the model identifier, such as conditional parameter availability or message role transformations.

This change improves the robustness and flexibility of model handling within the system, paving the way for more structured model metadata.

## Related Issue(s)
https://github.com/olimorris/codecompanion.nvim/issues/1521

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
