### PR TITLE
fix(adapters): resolving adapters from prompt library

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -565,7 +565,11 @@ function Chat.new(args)
     chat = self,
   }
 
-  self.adapter = adapters.resolve(args.adapter or config.strategies.chat.adapter)
+  if args.adapter and adapters.resolved(args.adapter) then
+    self.adapter = args.adapter
+  else
+    self.adapter = adapters.resolve(args.adapter or config.strategies.chat.adapter)
+  end
   if not self.adapter then
     return log:error("No adapter found")
   end

--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -9,10 +9,7 @@ local log = require("codecompanion.utils.log")
 ---@return nil
 local function add_adapter(strategy, opts)
   if opts.adapter and opts.adapter.name then
-    strategy.selected.adapter = adapters.resolve(config.adapters[opts.adapter.name])
-    if opts.adapter.model then
-      strategy.selected.adapter.schema.model.default = opts.adapter.model
-    end
+    strategy.selected.adapter = adapters.resolve(opts.adapter.name, { model = opts.adapter.model })
   end
 end
 

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -226,7 +226,9 @@ end
 ---@param adapter CodeCompanion.Adapter|string|function
 ---@return nil
 function Inline:set_adapter(adapter)
-  self.adapter = adapters.resolve(adapter)
+  if not self.adapter or not adapters.resolved(adapter) then
+    self.adapter = adapters.resolve(adapter)
+  end
 end
 
 ---Prompt the LLM

--- a/tests/test_prompt_library.lua
+++ b/tests/test_prompt_library.lua
@@ -1,19 +1,100 @@
-local new_set = MiniTest.new_set
 local h = require("tests.helpers")
+local new_set = MiniTest.new_set
+local T = new_set()
+local child = MiniTest.new_child_neovim()
 
-local T = MiniTest.new_set()
-
-local config
+T = new_set({
+  hooks = {
+    pre_case = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+      child.o.statusline = ""
+      child.o.laststatus = 0
+      child.lua([[
+        codecompanion = require("codecompanion")
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
 
 T["Prompt Library"] = new_set()
 
-T["Prompt Library"]["can add references"] = function()
-  require("codecompanion").prompt("test_ref")
+T["Prompt Library"]["can specify separate adapter and model"] = function()
+  local adapter = child.lua([[
+    codecompanion.setup({
+      prompt_library = {
+        ["Test Adapter"] = {
+          strategy = "chat",
+          description = "Testing that different adapters work",
+          opts = {
+            index = 1,
+            short_name = "test_adapters",
+            adapter = {
+              name = "copilot",
+              model = "gpt-4.1",
+            },
+          },
+          prompts = {
+            {
+              role = "foo",
+              content = "I can use different adapters",
+            },
+          },
+        },
+      }
+    })
+    require("tests.log")
+    codecompanion.prompt("test_adapters")
+    return {
+      name = codecompanion.last_chat().adapter.name,
+      model = codecompanion.last_chat().adapter.schema.model.default
+    }
+  ]])
 
-  local chat = require("codecompanion").buf_get_chat(0)
-  h.eq(2, #chat.refs)
-  h.eq("<file>lua/codecompanion/health.lua</file>", chat.refs[1].id)
-  h.eq("<file>lua/codecompanion/http.lua</file>", chat.refs[2].id)
+  h.eq("copilot", adapter.name)
+  h.eq("gpt-4.1", adapter.model)
+end
+
+T["Prompt Library"]["can add references"] = function()
+  local refs = child.lua([[
+    codecompanion.setup({
+      prompt_library = {
+        ["Test References"] = {
+          strategy = "chat",
+          description = "Add some references",
+          opts = {
+            index = 1,
+            is_default = true,
+            is_slash_cmd = false,
+            short_name = "test_ref",
+            auto_submit = false,
+          },
+          references = {
+            {
+              type = "file",
+              path = {
+                "lua/codecompanion/health.lua",
+                "lua/codecompanion/http.lua",
+              },
+            },
+          },
+          prompts = {
+            {
+              role = "foo",
+              content = "I need some references",
+            },
+          },
+        },
+      }
+    })
+    codecompanion.prompt("test_ref")
+    local chat = codecompanion.last_chat()
+    return chat.refs
+  ]])
+
+  h.eq(2, #refs)
+  h.eq("<file>lua/codecompanion/health.lua</file>", refs[1].id)
+  h.eq("<file>lua/codecompanion/http.lua</file>", refs[2].id)
 end
 
 return T


### PR DESCRIPTION
## Description

#1518 added the ability for users to specify models alongside their chosen adapter in a strategy. However, it caused issues for users who had custom prompts with adapter overrides (#1521).

This PR fixes #1521, adds test coverage and also makes the `adapters.resolve` function more efficient by detecting if an adapter has already been resolved. 

## Related Issue(s)

#1521

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
