### PR TITLE
refactor(completion): move into providers

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -370,6 +370,7 @@ local defaults = {
       },
       opts = {
         blank_prompt = "", -- The prompt to use when the user doesn't provide a prompt
+        completion_provider = providers.completion, -- blink|cmp|default
         register = "+", -- The register to use for yanking code
         yank_jump_delay_ms = 400, -- Delay in milliseconds before jumping back from the yanked code
       },

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -295,6 +295,12 @@ CodeCompanion.setup = function(opts)
     api.nvim_create_user_command(cmd.cmd, cmd.callback, cmd.opts)
   end
 
+  -- Set up completion
+  local completion = config.strategies.chat.opts.completion_provider
+  pcall(function()
+    return require("codecompanion.providers.completion." .. completion .. ".setup")
+  end)
+
   -- Set the log root
   log.set_root(log.new({
     handlers = {

--- a/lua/codecompanion/providers/completion/blink/setup.lua
+++ b/lua/codecompanion/providers/completion/blink/setup.lua
@@ -1,0 +1,14 @@
+local blink = require("blink.cmp")
+
+pcall(function()
+  local add_provider = blink.add_source_provider or blink.add_provider --[[@type function]]
+  add_provider("codecompanion", {
+    name = "CodeCompanion",
+    module = "codecompanion.providers.completion.blink",
+    enabled = true,
+    score_offset = 10,
+  })
+end)
+pcall(function()
+  blink.add_filetype_source("codecompanion", "codecompanion")
+end)

--- a/lua/codecompanion/providers/completion/cmp/setup.lua
+++ b/lua/codecompanion/providers/completion/cmp/setup.lua
@@ -1,0 +1,18 @@
+local config = require("codecompanion.config")
+
+local cmp = require("cmp")
+
+local completion = "codecompanion.providers.completion.cmp"
+cmp.register_source("codecompanion_models", require(completion .. ".models").new(config))
+cmp.register_source("codecompanion_slash_commands", require(completion .. ".slash_commands").new(config))
+cmp.register_source("codecompanion_tools", require(completion .. ".tools").new(config))
+cmp.register_source("codecompanion_variables", require(completion .. ".variables").new())
+cmp.setup.filetype("codecompanion", {
+  enabled = true,
+  sources = vim.list_extend({
+    { name = "codecompanion_models" },
+    { name = "codecompanion_slash_commands" },
+    { name = "codecompanion_tools" },
+    { name = "codecompanion_variables" },
+  }, cmp.get_config().sources),
+})

--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -7,16 +7,20 @@
 
 ---@type Providers<ProviderSpec>
 local configs = {
+  -- Pickers / Action Palette
   telescope = { module = "telescope", name = "telescope" },
   mini_pick = { module = "mini.pick", name = "mini_pick" },
+  fzf_lua = { module = "fzf-lua", name = "fzf_lua" },
   snacks = {
     module = "snacks",
     name = "snacks",
-    condition = function(snacks_module)
+    condition = function(snacks)
       -- Snacks can be installed but the Picker is disabled
-      return snacks_module and snacks_module.config.picker.enabled
+      return snacks and snacks.config.picker.enabled
     end,
   },
+
+  -- Diffs
   mini_diff = {
     module = "mini.diff",
     name = "mini_diff",
@@ -26,7 +30,18 @@ local configs = {
       return _G.MiniDiff ~= nil
     end,
   },
-  fzf_lua = { module = "fzf-lua", name = "fzf_lua" },
+
+  -- Completion
+  blink = { module = "blink.cmp", name = "blink" },
+  cmp = {
+    module = "cmp",
+    name = "cmp",
+    condition = function()
+      local has_cmp, _ = pcall(require, "cmp")
+      local has_blink, _ = pcall(require, "blink.cmp")
+      return has_cmp and not has_blink
+    end,
+  },
 }
 
 ---@param providers table<string> Provider names
@@ -66,6 +81,13 @@ local function diff_providers()
   return find_provider(providers, configs, "default")
 end
 
+---Get the default Completion provider
+---@return string
+local function completion_providers()
+  local providers = { "blink", "cmp", "default" }
+  return find_provider(providers, configs, "default")
+end
+
 ---Get the default Vim Help provider
 ---@return string
 local function help_providers()
@@ -90,6 +112,7 @@ end
 
 return {
   action_palette = action_palette_providers(),
+  completion = completion_providers(),
   diff = diff_providers(),
   help = help_providers(),
   images = image_providers(),

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -683,7 +683,7 @@ function Chat:apply_model(model)
   return self
 end
 
----The source to provide the model entries for completion
+---The source to provide the model entries for completion (cmp only)
 ---@param callback fun(request: table)
 ---@return nil
 function Chat:complete_models(callback)

--- a/plugin/codecompanion.lua
+++ b/plugin/codecompanion.lua
@@ -61,42 +61,6 @@ local diagnostic_config = {
 vim.diagnostic.config(diagnostic_config, config.INFO_NS)
 vim.diagnostic.config(diagnostic_config, config.ERROR_NS)
 
--- Setup completion for blink.cmp and cmp
-local has_cmp, cmp = pcall(require, "cmp")
-local has_blink, blink = pcall(require, "blink.cmp")
-if has_blink then
-  pcall(function()
-    local add_provider = blink.add_source_provider or blink.add_provider
-    add_provider("codecompanion", {
-      name = "CodeCompanion",
-      module = "codecompanion.providers.completion.blink",
-      enabled = true,
-      score_offset = 10,
-    })
-  end)
-  pcall(function()
-    blink.add_filetype_source("codecompanion", "codecompanion")
-  end)
-  -- We need to check for blink alongside cmp as blink.compat has a module that
-  -- is detected by a require("cmp") call and a lot of users have it installed
-  -- Reference: https://github.com/olimorris/codecompanion.nvim/discussions/501
-elseif has_cmp and not has_blink then
-  local completion = "codecompanion.providers.completion.cmp"
-  cmp.register_source("codecompanion_models", require(completion .. ".models").new(config))
-  cmp.register_source("codecompanion_slash_commands", require(completion .. ".slash_commands").new(config))
-  cmp.register_source("codecompanion_tools", require(completion .. ".tools").new(config))
-  cmp.register_source("codecompanion_variables", require(completion .. ".variables").new())
-  cmp.setup.filetype("codecompanion", {
-    enabled = true,
-    sources = vim.list_extend({
-      { name = "codecompanion_models" },
-      { name = "codecompanion_slash_commands" },
-      { name = "codecompanion_tools" },
-      { name = "codecompanion_variables" },
-    }, cmp.get_config().sources),
-  })
-end
-
 -- Capture the last terminal buffer
 _G.codecompanion_last_terminal = nil
 api.nvim_create_autocmd("TermEnter", {


### PR DESCRIPTION
## Description

This PR adds completion plugins into the providers stack as well as adding a config option.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
