### PR TITLE
fix(tools): auto submit sends updated buffer

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -851,6 +851,7 @@ function Chat:submit(opts)
   local bufnr = self.bufnr
 
   if opts.auto_submit then
+    self.watchers:check_for_changes(self)
     self:add_message({
       role = config.constants.USER_ROLE,
       content = "I've shared the output from the tool/function call with you.",
@@ -862,7 +863,6 @@ function Chat:submit(opts)
       return log:warn("No messages to submit")
     end
 
-    -- Check if any watched buffers have changes and add to the chat buffer before any user messages
     self.watchers:check_for_changes(self)
 
     -- Allow users to send a blank message to the LLM


### PR DESCRIPTION
## Description

Auto submitting a tool will now ensure that a watched buffer's content is added to the message history as context.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
