### PR TITLE
fix(providers): forgotten registration of coc execute function

### DIFF
--- a/lua/codecompanion/providers/completion/coc/init.lua
+++ b/lua/codecompanion/providers/completion/coc/init.lua
@@ -1,47 +1,75 @@
-local M = {}
-
-function M.init()
-  return {
-    priority = 9,
-    shortcut = "CodeCompanion",
-    filetypes = { "codecompanion" },
-    triggerCharacters = { "/", "#", "@" },
-  }
-end
+--- @module 'coc'
 
 local completion = require("codecompanion.providers.completion")
-local log = require("codecompanion.utils.log")
 
-local callbacks = {}
+--- @type table Cache for callback addresses that get lost (replaced by vim.Nil) during serialization.
+local callbacks_cache = {}
 
----Converts CodeCompanion completion items to coc.nvim-compatible completion items.
----@param opt table Table containing completion trigger context (buffer info, input, cursor position).
----@param complete_items table Array of original CodeCompanion completion items.
----@return table Array of formatted completion items compatible with coc.nvim.
-local function format_complete_items(opt, complete_items)
+--- Transforms CodeCompanion completion items into coc.nvim-compatible completion items.
+--- The completion items are modified in place!
+--- @param opt table Trigger context from coc.nvim.
+--- @param complete_items table CodeCompanion completion items.
+--- @return table coc.nvim-compatible completion items.
+local function transform_complete_items(opt, complete_items)
   for _, item in ipairs(complete_items) do
-    --Set standard Vim completion-items fields (see :h complete-items).
-    item.word = item.label:sub(2) --The text to insert after the trigger character.
-    item.abbr = item.label --The text to show in the completion menu.
-    item.info = item.detail --The details shown in the preview window.
+    -- Populate standard Vim completion-items fields (see :h complete-items).
+    item.word = item.label:sub(2) -- The text to insert after the trigger character
+    item.abbr = item.label -- The text to show in the completion menu
+    item.info = item.detail -- The details shown in the preview window
 
-    --Context to be used by CodeCompanion later.
+    -- Context to be used by CodeCompanion later
     item.context = {
       bufnr = opt.bufnr,
       input = opt.input,
       cursor = { row = opt.linenr, col = opt.colnr },
     }
 
-    --Store function pointers, as they are lost in serialization (replaced by vim.Nil).
+    -- Cache callback function pointers.
     if item.config and type(item.config.callback) == "function" then
-      callbacks[item.label] = item.config.callback
+      callbacks_cache[item.label] = item.config.callback
     end
 
-    --Remove label; otherwise coc.nvim adds an extra trigger character.
+    -- Remove label; otherwise coc.nvim adds an extra trigger character.
     item.label = nil
   end
 
   return complete_items
+end
+
+--- Deletes text from the start position to the cursor position.
+--- @param bufnr number Buffer number
+--- @param start table Start position
+--- @param start_offset number Start offset
+local function delete_text_to_cursor(bufnr, start, start_offset)
+  local cursor = vim.api.nvim_win_get_cursor(0)
+
+  -- Convert from 1-based to 0-based indices.
+  local range = {
+    start = {
+      line = start.row - 1,
+      character = start.col - 1 + start_offset,
+    },
+    ["end"] = {
+      line = cursor[1] - 1,
+      character = cursor[2], -- Cursor end position is exclusive.
+    },
+  }
+
+  vim.lsp.util.apply_text_edits({ { newText = "", range = range } }, bufnr, "utf-8")
+end
+
+--- @class coc.Source
+local M = {}
+
+---Returns coc.nvim source initialization parameters.
+---@return table
+function M.init()
+  return {
+    priority = 99,
+    shortcut = "CodeCompanion",
+    filetypes = { "codecompanion" },
+    triggerCharacters = { "/", "#", "@" },
+  }
 end
 
 ---Provides CodeCompanion completion items for coc.nvim-triggered completion.
@@ -51,38 +79,16 @@ function M.complete(opt)
   local complete_items
 
   if opt.triggerCharacter == "@" then
-    complete_items = format_complete_items(opt, completion.tools())
+    complete_items = transform_complete_items(opt, completion.tools())
   elseif opt.triggerCharacter == "#" then
-    complete_items = format_complete_items(opt, completion.variables())
+    complete_items = transform_complete_items(opt, completion.variables())
   elseif opt.triggerCharacter == "/" then
-    complete_items = format_complete_items(opt, completion.slash_commands())
+    complete_items = transform_complete_items(opt, completion.slash_commands())
   else
     complete_items = {}
   end
 
   return complete_items
-end
-
----Deletes text from the start position to the cursor position.
----@param bufnr number Buffer number
----@param start table Start position
----@param offset number
-local function delete_text_to_cursor(bufnr, start, offset)
-  local cursor = vim.api.nvim_win_get_cursor(0)
-
-  -- Convert from 1-based to 0-based indices.
-  local range = {
-    start = {
-      line = start.row - 1,
-      character = start.col - 1 + offset,
-    },
-    ["end"] = {
-      line = cursor[1] - 1,
-      character = cursor[2], --Cursor end position is exclusive.
-    },
-  }
-
-  vim.lsp.util.apply_text_edits({ { newText = "", range = range } }, bufnr, "utf-8")
 end
 
 ---Executes selected slash command on coc.nvim-triggered completion action.
@@ -99,59 +105,17 @@ function M.execute(opt)
   local start = opt.context.cursor
   delete_text_to_cursor(bufnr, start, -1)
 
-  opt.label = opt.abbr --Necessary for command execution.
-  opt.info = nil --No longer needed.
+  opt.label = opt.abbr -- Necessary for command execution
+  opt.info = nil -- No longer needed
 
-  --Restore the function callback.
-  if opt.config and callbacks[opt.label] then
-    opt.config.callback = callbacks[opt.label]
+  -- Restore the function callback.
+  if opt.config and callbacks_cache[opt.label] then
+    opt.config.callback = callbacks_cache[opt.label]
   end
 
   local chat = require("codecompanion").buf_get_chat(bufnr)
 
   completion.slash_commands_execute(opt, chat)
-end
-
----Activates coc for the current buffer.
----@return nil
-function M.ensure_buffer_attached()
-  vim.b.coc_force_attach = true
-end
-
----@type table The coc.nvim autoload file.
-local autoload_file = {
-  name = "codecompanion.vim",
-  path = vim.fn.stdpath("config") .. "/autoload/coc/source",
-  content = [[
-function! coc#source#codecompanion#init() abort
-  return v:lua.codecompanion_coc_init()
-endfunction
-
-function! coc#source#codecompanion#complete(opt, cb) abort
-  return a:cb(v:lua.codecompanion_coc_complete(a:opt))
-endfunction
-
-function! coc#source#codecompanion#on_complete(opt) abort
-  return a:cb(v:lua.codecompanion_coc_execute(a:opt))
-endfunction
-]],
-}
-
----Ensures that the coc.nvim autoload file exists in the expected path.
----@return nil
-function M.ensure_autoload_file()
-  if vim.fn.filereadable(autoload_file.path) == 1 then
-    return
-  end
-  vim.fn.mkdir(autoload_file.path, "p")
-  local file_name = autoload_file.path .. "/" .. autoload_file.name
-  local file = io.open(file_name, "w")
-  if file then
-    file:write(autoload_file.content)
-    file:close()
-  else
-    return log:error("Failed to create coc source autoload file: " .. file_name)
-  end
 end
 
 return M

--- a/lua/codecompanion/providers/completion/coc/setup.lua
+++ b/lua/codecompanion/providers/completion/coc/setup.lua
@@ -2,6 +2,8 @@ local cocCompletion = require("codecompanion.providers.completion.coc")
 
 _G.codecompanion_coc_init = cocCompletion.init
 _G.codecompanion_coc_complete = cocCompletion.complete
+_G.codecompanion_coc_execute = cocCompletion.execute
+
 vim.api.nvim_create_autocmd("VimEnter", {
   callback = cocCompletion.ensure_autoload_file,
 })

--- a/lua/codecompanion/providers/completion/coc/setup.lua
+++ b/lua/codecompanion/providers/completion/coc/setup.lua
@@ -1,13 +1,77 @@
-local cocCompletion = require("codecompanion.providers.completion.coc")
+local coc = require("codecompanion.providers.completion.coc")
+local log = require("codecompanion.utils.log")
 
-_G.codecompanion_coc_init = cocCompletion.init
-_G.codecompanion_coc_complete = cocCompletion.complete
-_G.codecompanion_coc_execute = cocCompletion.execute
+--coc.nvim currently requires new completion sources to be registered via a Vim autoload file.
+---@type table Specifies autoload file properties for coc.nvim.
+local autoload_file = {
+  name = "codecompanion.vim",
+  dir = vim.fn.stdpath("config") .. "/autoload/coc/source",
+  content = [[
+function! coc#source#codecompanion#init() abort
+  return v:lua.codecompanion_coc_init()
+endfunction
+
+function! coc#source#codecompanion#complete(opt, cb) abort
+  return a:cb(v:lua.codecompanion_coc_complete(a:opt))
+endfunction
+
+function! coc#source#codecompanion#on_complete(opt) abort
+  return a:cb(v:lua.codecompanion_coc_execute(a:opt))
+endfunction
+]],
+}
+
+-- Expose coc.nvim completion event handlers.
+_G.codecompanion_coc_init = coc.init
+_G.codecompanion_coc_complete = coc.complete
+_G.codecompanion_coc_execute = coc.execute
+
+---Ensures that the coc.nvim autoload file exists in the expected path, creating it if missing.
+---@return nil
+local function ensure_autoload_file_exists()
+  local dir = autoload_file.dir
+  local path = dir .. "/" .. autoload_file.name
+
+  -- Check if the file exists; if yes, do nothing.
+  if vim.fn.filereadable(path) == 1 then
+    return
+  end
+
+  -- Check if the directory exists; if no, create it.
+  if vim.fn.isdirectory(dir) ~= 1 then
+    if vim.fn.mkdir(dir, "p") ~= 1 then
+      log:error("Failed to create coc source directory: " .. dir)
+      return
+    end
+  end
+
+  -- Open the file for writing.
+  local file, err = io.open(path, "w")
+  if not file then
+    log:error('Failed to create coc source autoload file "' .. path .. '": ' .. err)
+    return
+  end
+
+  -- Write the content and close.
+  local ok, write_err = file:write(autoload_file.content)
+  file:close()
+  if not ok then
+    log:error('Failed to write to coc source autoload file "' .. path .. '": ' .. write_err)
+    return
+  end
+end
 
 vim.api.nvim_create_autocmd("VimEnter", {
-  callback = cocCompletion.ensure_autoload_file,
+  callback = ensure_autoload_file_exists,
 })
+
+---Activates coc for the current buffer.
+---@return nil
+local function ensure_buffer_attached()
+  vim.b.coc_force_attach = true
+end
+
 vim.api.nvim_create_autocmd("FileType", {
   pattern = "codecompanion",
-  callback = cocCompletion.ensure_buffer_attached,
+  callback = ensure_buffer_attached,
 })


### PR DESCRIPTION
## Description

* The first commit is a minimal fix of an error that slipped out from [feat(providers): provider for coc completion #1421](https://github.com/olimorris/codecompanion.nvim/pull/1421). Without this, slash commands for coc completion won't work!
* The second commit is my final refactor that I planned to include in [feat(providers): provider for coc completion #1421](https://github.com/olimorris/codecompanion.nvim/pull/1421), but it was merged earlier. It just moves relevant functions to `setup.lua` and improves file handling.

Feel free to merge both, or just the minimal fix. Thanks, and sorry for not communicating clearly [feat(providers): provider for coc completion #1421](https://github.com/olimorris/codecompanion.nvim/pull/1421).

## Related Issue(s)

Slash commands for coc copmletion.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
