### PR TITLE
Allow CodeCompanion chat buffer to act like a normal buffer

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -946,7 +946,7 @@ You must create or modify a workspace file through a series of prompts over mult
         position = nil, -- left|right|top|bottom (nil will default depending on vim.opt.splitright|vim.opt.splitbelow)
         border = "single",
         height = 0.8,
-        ---@type number|"auto" using "auto" will alow full_height buffers to act like normal buffers
+        ---@type number|"auto" using "auto" will allow full_height buffers to act like normal buffers
         width = 0.45,
         relative = "editor",
         full_height = true,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -946,6 +946,7 @@ You must create or modify a workspace file through a series of prompts over mult
         position = nil, -- left|right|top|bottom (nil will default depending on vim.opt.splitright|vim.opt.splitbelow)
         border = "single",
         height = 0.8,
+        ---@type number|"auto" using "auto" will alow full_height buffers to act like normal buffers
         width = 0.45,
         relative = "editor",
         full_height = true,

--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -78,7 +78,7 @@ function UI:open(opts)
   end
 
   local window = config.display.chat.window
-  local width  = math.floor(vim.o.columns * 0.45)
+  local width = math.floor(vim.o.columns * 0.45)
   if window.width ~= "auto" then
     width = window.width > 1 and window.width or math.floor(vim.o.columns * window.width)
   end

--- a/lua/codecompanion/strategies/chat/ui.lua
+++ b/lua/codecompanion/strategies/chat/ui.lua
@@ -78,7 +78,10 @@ function UI:open(opts)
   end
 
   local window = config.display.chat.window
-  local width = window.width > 1 and window.width or math.floor(vim.o.columns * window.width)
+  local width  = math.floor(vim.o.columns * 0.45)
+  if window.width ~= "auto" then
+    width = window.width > 1 and window.width or math.floor(vim.o.columns * window.width)
+  end
   local height = window.height > 1 and window.height or math.floor(vim.o.lines * window.height)
 
   if window.layout == "float" then
@@ -115,7 +118,9 @@ function UI:open(opts)
     if position == "right" and not vim.opt.splitright:get() then
       vim.cmd("wincmd l")
     end
-    vim.cmd("vertical resize " .. width)
+    if window.width ~= "auto" then
+      vim.cmd("vertical resize " .. width)
+    end
     self.winnr = api.nvim_get_current_win()
     api.nvim_win_set_buf(self.winnr, self.bufnr)
   elseif window.layout == "horizontal" then

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -10,7 +10,8 @@ local M = {}
 ---@return number,number The buffer and window numbers
 M.create_float = function(lines, opts)
   local window = opts.window
-  local width = window.width > 1 and window.width or opts.width or 85
+  local optsWidth = opts.width.width == "auto" and 0.45 or opts.window.width
+  local width = optsWidth > 1 and optsWidth or opts.width or 85
   local height = window.height > 1 and window.height or opts.height or 17
 
   local bufnr = opts.bufnr or api.nvim_create_buf(false, true)

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -10,7 +10,7 @@ local M = {}
 ---@return number,number The buffer and window numbers
 M.create_float = function(lines, opts)
   local window = opts.window
-  local optsWidth = opts.width.width == "auto" and 0.45 or opts.window.width
+  local optsWidth = opts.window.width == "auto" and 0.45 or opts.window.width
   local width = optsWidth > 1 and optsWidth or opts.width or 85
   local height = window.height > 1 and window.height or opts.height or 17
 


### PR DESCRIPTION
## Description

My vim workflow tends to rely a lot on the default split width behavior built into vim, and I found that the configuration of this plugin forces you to define a specific buffer/window width.

This is a quick pass at extending the existing configuration to allow a string value of `"auto"` to be passed to the window config that will disable the `vim.cmd("vertical resize " .. width)` call if the user sets `width` to auto. I kept the implementation as simple as possible for now since it doesn't really make sense as value for floating windows, so I fell back to 0.45 in those situations.

If this is something you're willing to accept, I can go ahead and add documentation if necessary, but figured this was a good spot to get a discussion going if it's something you're willing to accept.

## Screenshots

| before | after |
|---|---|
| <video controls width="400" src="https://github.com/user-attachments/assets/9e31cec2-29c9-458c-be3c-faa62e4d2a6a"></video> | <video controls width="400" src="https://github.com/user-attachments/assets/4774e2ee-3487-4af5-af03-766fb1258862"></video> |


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
