### PR TITLE
Register cmp completions when filetype is set.

### DIFF
--- a/lua/codecompanion/providers/completion/cmp/setup.lua
+++ b/lua/codecompanion/providers/completion/cmp/setup.lua
@@ -2,17 +2,25 @@ local config = require("codecompanion.config")
 
 local cmp = require("cmp")
 
-local completion = "codecompanion.providers.completion.cmp"
-cmp.register_source("codecompanion_models", require(completion .. ".models").new(config))
-cmp.register_source("codecompanion_slash_commands", require(completion .. ".slash_commands").new(config))
-cmp.register_source("codecompanion_tools", require(completion .. ".tools").new(config))
-cmp.register_source("codecompanion_variables", require(completion .. ".variables").new())
-cmp.setup.filetype("codecompanion", {
-  enabled = true,
-  sources = vim.list_extend({
-    { name = "codecompanion_models" },
-    { name = "codecompanion_slash_commands" },
-    { name = "codecompanion_tools" },
-    { name = "codecompanion_variables" },
-  }, cmp.get_config().sources),
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "codecompanion",
+  callback = function()
+    local completion = "codecompanion.providers.completion.cmp"
+    cmp.register_source("codecompanion_models", require(completion .. ".models").new(config))
+    cmp.register_source("codecompanion_slash_commands", require(completion .. ".slash_commands").new(config))
+    cmp.register_source("codecompanion_tools", require(completion .. ".tools").new(config))
+    cmp.register_source("codecompanion_variables", require(completion .. ".variables").new())
+    cmp.setup.filetype("codecompanion", {
+      enabled = true,
+      sources = vim.list_extend({
+        { name = "codecompanion_models" },
+        { name = "codecompanion_slash_commands" },
+        { name = "codecompanion_tools" },
+        { name = "codecompanion_variables" },
+      }, cmp.get_config().sources),
+    })
+    -- returning true will remove this autocmd
+    -- now that the completion sources are registered
+    return true
+  end,
 })


### PR DESCRIPTION
## Description

cmp.get_sources() is context dependent unfortunately so must be called in a context where the filetype is set in order to get all the correct sources.  This change delays initialization until the first codecompanion buffer is opened and avoids pulling the incorrect source list into the codecompanion buffers.

## Checklist

- [ x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature - Not applicable

- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature

not sure how to programmatically test this, but see cmp implementation here:

https://github.com/hrsh7th/nvim-cmp/blob/b5311ab3ed9c846b585c0c15b7559be131ec4be9/lua/cmp/config.lua#L110

- [ ] I've updated the README and/or relevant docs pages

have not done so but can do if desired.

- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied

no docs changed