### PR TITLE
fix(gemini): fix streaming for gemini adapter

### DIFF
--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -37,6 +37,12 @@ return {
         end
       end
 
+      if self.opts and self.opts.stream then
+        self.parameters = self.parameters or {}
+        self.parameters.stream = true
+        self.parameters.stream_options = { include_usage = true }
+      end
+
       return true
     end,
 

--- a/tests/adapters/test_gemini.lua
+++ b/tests/adapters/test_gemini.lua
@@ -57,6 +57,11 @@ end
 
 T["Gemini adapter"]["Streaming"] = new_set()
 
+T["Gemini adapter"]["Streaming"]["can build parameters"] = function()
+  adapter.handlers.setup(adapter)
+  h.eq({ stream = true, stream_options = { include_usage = true } }, adapter.parameters)
+end
+
 T["Gemini adapter"]["Streaming"]["can output streamed data into the chat buffer"] = function()
   local output = ""
   local lines = vim.fn.readfile("tests/adapters/stubs/gemini_streaming.txt")


### PR DESCRIPTION
## Description

Streaming response for gemini adapter was broken for me some time ago. I'm not sure whether it's their API changed or some changes in codecompanion caused this, but this patch fixes it.

## Details

Based on some testing in `curl` in the shell, I discovered that the Gemini API requires explicitly setting `stream` to true to enable streaming. This was missing from the `setup` handler in the gemini adapter.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
