### PR TITLE
Fix for extra blank lines in diffs

### DIFF
--- a/lua/codecompanion/providers/diff/default.lua
+++ b/lua/codecompanion/providers/diff/default.lua
@@ -74,7 +74,7 @@ function Diff.new(args)
     vim.api.nvim_set_option_value(opt, value, { win = diff.win })
   end
   -- Set the diff buffer to the contents, prior to any modifications
-  api.nvim_buf_set_lines(diff.buf, 0, 0, true, self.contents)
+  api.nvim_buf_set_lines(diff.buf, 0, -1, true, self.contents)
   if self.cursor_pos then
     api.nvim_win_set_cursor(diff.win, { self.cursor_pos[1], self.cursor_pos[2] })
   end


### PR DESCRIPTION
## Description

This is a fix for the extra newline appended to diffs generated from CodeCompanion.

A reference to the comment that found the fix:
https://github.com/olimorris/codecompanion.nvim/issues/1431#issuecomment-2921978498

## Related Issue(s)

#1431 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
