### PR TITLE
feat(keymaps): support `:map-arguments` in keymaps

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*         For NVIM v0.10.0         Last change: 2025 June 01
+*codecompanion.txt*         For NVIM v0.10.0         Last change: 2025 June 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1034,9 +1034,11 @@ to send messages, regenerate responses, close the buffer, etc. Example:
           keymaps = {
             send = {
               modes = { n = "<C-s>", i = "<C-s>" },
+              opts = {},
             },
             close = {
               modes = { n = "<C-c>", i = "<C-c>" },
+              opts = {},
             },
             -- Add further custom keymaps here
           },
@@ -1046,7 +1048,8 @@ to send messages, regenerate responses, close the buffer, etc. Example:
 <
 
 The keymaps are mapped to `<C-s>` for sending a message and `<C-c>` for closing
-in both normal and insert modes.
+in both normal and insert modes. To set other `:map-arguments`, you can use the
+optional `opts` table which will be fed to `vim.keymap.set`
 
 
 VARIABLES ~

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -32,8 +32,7 @@ require("codecompanion").setup({
 })
 ```
 
-The keymaps are mapped to `<C-s>` for sending a message and `<C-c>` for closing in both normal and insert modes.
-To set other `:map-arguments`, you can use the optional `opts` table which will be fed to `vim.keymap.set`
+The keymaps are mapped to `<C-s>` for sending a message and `<C-c>` for closing in both normal and insert modes. To set other `:map-arguments`, you can use the optional `opts` table which will be fed to `vim.keymap.set`.
 
 ## Variables
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -19,9 +19,11 @@ require("codecompanion").setup({
       keymaps = {
         send = {
           modes = { n = "<C-s>", i = "<C-s>" },
+          opts = {},
         },
         close = {
           modes = { n = "<C-c>", i = "<C-c>" },
+          opts = {},
         },
         -- Add further custom keymaps here
       },
@@ -31,6 +33,7 @@ require("codecompanion").setup({
 ```
 
 The keymaps are mapped to `<C-s>` for sending a message and `<C-c>` for closing in both normal and insert modes.
+To set other `:map-arguments`, you can use the optional `opts` table which will be fed to `vim.keymap.set`
 
 ## Variables
 

--- a/lua/codecompanion/utils/keymaps.lua
+++ b/lua/codecompanion/utils/keymaps.lua
@@ -71,7 +71,8 @@ function Keymaps:set()
       goto continue
     end
 
-    local opts = { desc = map.description or action_opts.desc, buffer = self.bufnr }
+    local default_opts = { desc = map.description or action_opts.desc, buffer = self.bufnr }
+    local opts = vim.tbl_deep_extend("force", default_opts, map.opts or {})
 
     if type(rhs) == "function" then
       callback = function()


### PR DESCRIPTION
## Description

Allow `opts` to keymap config option

I was a bit unsure where to potentially add the docs for this. Do you have any pointers on where you want it? I also wasn't able to run `make all` because I had some problems installing `pandoc`, but let's see if the pipeline succeeds.

I think the dedicated `description` option could be deprecated in favor or `opts.desc`, but it would be harsh to just remove it right away at least

## Related Issue(s)

Fixes https://github.com/olimorris/codecompanion.nvim/discussions/1537

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
