### PR TITLE
fire RequestFinished event after fetch slash cmd request completion

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -346,6 +346,8 @@ local function fetch(chat, adapter, url, opts)
               url = url,
             }, opts)
 
+            util.fire("RequestFinished")
+
             -- Cache the response
             -- TODO: Get an LLM to create summary
             vim.ui.select({ "Yes", "No" }, {


### PR DESCRIPTION
This is useful to clear a spinner indicator after a `/fetch` command fires a request.