### PR TITLE
feat(tools): auto_tool_mode now auto submits

### DIFF
--- a/doc/usage/chat-buffer/agents.md
+++ b/doc/usage/chat-buffer/agents.md
@@ -107,7 +107,7 @@ Consider combining tools for complex tasks:
 
 ### Automatic Tool Mode
 
-The plugin allows you to run tools on autopilot. This automatically approves any tool use instead of prompting the user, disables any diffs, and automatically saves any buffers that the agent has edited. Simply set the global variable `vim.g.codecompanion_auto_tool_mode` to enable this or set it to `nil` to undo this. Alternatively, the keymap `gta` will toggle  the feature whist from the chat buffer.
+The plugin allows you to run tools on autopilot. This automatically approves any tool use instead of prompting the user, disables any diffs, submits errors and success messages and automatically saves any buffers that the agent has edited. Simply set the global variable `vim.g.codecompanion_auto_tool_mode` to enable this or set it to `nil` to undo this. Alternatively, the keymap `gta` will toggle  the feature whist from the chat buffer.
 
 ## Compatibility
 

--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -76,22 +76,25 @@ function Agent:set_autocmds()
         )
       elseif request.match == "CodeCompanionAgentFinished" then
         return vim.schedule(function()
-          if self.status == CONSTANTS.STATUS_ERROR and self.tools_config.opts.auto_submit_errors then
+          local auto_submit = function()
             return self.chat:submit({
               auto_submit = true,
               callback = function()
                 self:reset({ auto_submit = true })
               end,
             })
+          end
+
+          if vim.g.codecompanion_auto_tool_mode then
+            return auto_submit()
+          end
+          if self.status == CONSTANTS.STATUS_ERROR and self.tools_config.opts.auto_submit_errors then
+            return auto_submit()
           end
           if self.status == CONSTANTS.STATUS_SUCCESS and self.tools_config.opts.auto_submit_success then
-            return self.chat:submit({
-              auto_submit = true,
-              callback = function()
-                self:reset({ auto_submit = true })
-              end,
-            })
+            return auto_submit()
           end
+
           self:reset({ auto_submit = false })
         end)
       end


### PR DESCRIPTION
## Description

If you set `vim.g.codecompanion_auto_tool_mode` (or use `gta` in the chat buffer), the plugin will now automatically submit error and success messages to the LLM.

## Related Issue(s)

Originally proposed in #1231

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
