### PR TITLE
feat(fetch): only show "Cache" option if cached files exist

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -414,7 +414,17 @@ end
 ---@param opts? table
 ---@return nil|string
 function SlashCommand:execute(SlashCommands, opts)
-  vim.ui.select({ "URL", "Cache" }, {
+  local cached_files = get_cached_files()
+  local options = { "URL" }
+  if #cached_files > 0 then
+    table.insert(options, "Cache")
+  end
+
+  if #options == 1 then
+    return choice[options[1]](self, SlashCommands)
+  end
+
+  vim.ui.select(options, {
     prompt = "Select link source",
     kind = "codecompanion.nvim",
   }, function(selected)


### PR DESCRIPTION
Previously, the "Cache" option was always shown in the selection menu, even when no cached files were available. Now, "Cache" is only included if there are cached files, improving the user experience and preventing invalid selections.

Personally I don't generally cache urls so this is a small QoL for me. Feel free to dismiss it :) 
