### PR TITLE
feat: simplify watchers to use unified diffs

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.10.0         Last change: 2025 May 28
+*codecompanion.txt*         For NVIM v0.10.0         Last change: 2025 June 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -42,20 +42,12 @@
 ---@field context table The context of the buffer that the chat was initiated from
 ---@field prompts table Any prompts to be sent to the LLM
 
----@class CodeCompanion.WatcherChange
----@field type "add"|"delete"|"modify" The type of change
----@field start number Starting line number
----@field end_line number Ending line number
----@field lines? string[] Added or deleted lines
----@field old_lines? string[] Original lines (for modify type)
----@field new_lines? string[] New lines (for modify type)
-
 ---@class CodeCompanion.Watchers
 ---@field buffers table<number, CodeCompanion.WatcherState> Map of buffer numbers to their states
 ---@field augroup integer The autocmd group ID
 ---@field watch fun(self: CodeCompanion.Watchers, bufnr: number): nil Start watching a buffer
 ---@field unwatch fun(self: CodeCompanion.Watchers, bufnr: number): nil Stop watching a buffer
----@field get_changes fun(self: CodeCompanion.Watchers, bufnr: number): CodeCompanion.WatcherChange[]|nil Get the latest changes in the buffer
+---@field get_changes fun(self: CodeCompanion.Watchers, bufnr: number): boolean, table
 
 ---@class CodeCompanion.WatcherState
 ---@field content string[] Complete buffer content


### PR DESCRIPTION
## Description

This PR refactors the existing buffer watcher system to use `vim.diff` for generating clean unified diffs instead of the previous custom diff format.

### What changed
- Replaced custom diff formatting with `vim.diff`.
- Updated diff output to standard **unified** diff format with proper context.
- Improved LLM comprehension of buffer changes through cleaner diff with context and a better wording.
- updated and simplified the tests as well.

### Code improvements
The refactor reduces the watchers module from 271 to 151 lines (**~45% reduction**) and (~30% reduction for tests) by removing complex custom diff logic and leveraging Neovim's built-in diff mechanism.


## Related Issue(s)

PR related #1506. Discussions happened in the PR [here](https://github.com/olimorris/codecompanion.nvim/pull/1494#issuecomment-2908074990)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
