### PR TITLE
refactor(tools): roll `@editor` functionality into `@insert_edit_into_file`

### DIFF
--- a/lua/codecompanion/strategies/chat/watchers.lua
+++ b/lua/codecompanion/strategies/chat/watchers.lua
@@ -133,11 +133,8 @@ function Watchers:check_for_changes(chat)
         local diff_content = format_changes_as_diff(old_content, current_content)
 
         if diff_content ~= "" then
-          local changes_text = string.format(
-            "The user has modified the watched file `%s`. Here are the changes:\n%s",
-            filename,
-            diff_content
-          )
+          local changes_text =
+            string.format("The watched file `%s`, has been modified. Here are the changes:\n%s", filename, diff_content)
           chat:add_message({
             role = config.constants.USER_ROLE,
             content = changes_text,

--- a/lua/codecompanion/utils/buffers.lua
+++ b/lua/codecompanion/utils/buffers.lua
@@ -76,6 +76,24 @@ function M.get_open(ft)
   return buffers
 end
 
+---Check if a filepath is open as a buffer and return the buffer number
+---@param filepath string The filepath to check
+---@return number|nil Buffer number if found, nil otherwise
+function M.get_bufnr_from_filepath(filepath)
+  local normalized_path = vim.fn.fnamemodify(filepath, ":p")
+
+  for _, bufnr in ipairs(api.nvim_list_bufs()) do
+    if api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].buflisted then
+      local buf_path = vim.fn.fnamemodify(api.nvim_buf_get_name(bufnr), ":p")
+      if buf_path == normalized_path then
+        return bufnr
+      end
+    end
+  end
+
+  return nil
+end
+
 ---Get the content of a given buffer
 ---@param bufnr number
 ---@param range? table


### PR DESCRIPTION
## Description

#1349 brought about some awesome changes which enabled LLMs to update files using diff patching. This PR looks to roll up the functionality and features of the `@editor` tool into the `@insert_edit_into_file` tool. With it, this will bring reliability, resiliency and a much simpler implementation.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
