### PR TITLE
refactor(slash_commands): improve fetch error messages

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/fetch.lua
@@ -366,7 +366,7 @@ local function fetch(chat, adapter, url, opts)
               end
             end)
           else
-            return log:error("Error %s - %s", data.status, body.data.text)
+            return log:error("Error %s - %s", data.status, body.message or "No message provided")
           end
         end
       end,


### PR DESCRIPTION
## Description

This makes the error messages from the fetch command more explicit.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
