### PR TITLE
Add `default_tools` option to chat strategy

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -224,12 +224,12 @@ require("codecompanion").setup({
     }
   }
 })
-
 ```
 
 ### Automatically Add Tools to Chat
 
-You can configure CodeCompanion to load tools to new chats by default:
+You can configure the plugin to automatically add tools to new chat buffers:
+
 ```lua
 require("codecompanion").setup({
   strategies = {
@@ -244,8 +244,7 @@ require("codecompanion").setup({
 })
 ```
 
-This works for both built-in tools and external tools configured by the users or
-[extensions](/configuration#extensions).
+This also works for [extensions](/configuration/extensions).
 
 ## Prompt Decorator
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -228,7 +228,7 @@ require("codecompanion").setup({
 
 ### Automatically Add Tools to Chat
 
-You can configure the plugin to automatically add tools to new chat buffers:
+You can configure the plugin to automatically add tools and tool groups to new chat buffers:
 
 ```lua
 require("codecompanion").setup({
@@ -236,7 +236,10 @@ require("codecompanion").setup({
     chat = {
       tools = {
         opts = {
-          default_tools = { "my_tool" }
+          default_tools = { 
+            "my_tool",
+            "my_tool_group"
+          }
         },
       }
     }

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -227,6 +227,26 @@ require("codecompanion").setup({
 
 ```
 
+### Automatically Add Tools to Chat
+
+You can configure CodeCompanion to load tools to new chats by default:
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      tools = {
+        opts = {
+          default_tools = { "my_tool" }
+        },
+      }
+    }
+  }
+})
+```
+
+This works for both built-in tools and external tools configured by the users or
+[extensions](/configuration#extensions).
+
 ## Prompt Decorator
 
 It can be useful to decorate your prompt, prior to sending to an LLM, with additional information. For example, the GitHub Copilot prompt in VS Code, wraps a user's prompt between `<prompt></prompt>` tags presumably to differentiate the user's ask from additional context. This can also be achieved in CodeCompanion:

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -123,6 +123,8 @@ local defaults = {
           auto_submit_errors = false, -- Send any errors to the LLM automatically?
           auto_submit_success = true, -- Send any successful output to the LLM automatically?
           wait_timeout = 30000, -- How long to wait for user input before timing out (milliseconds)
+          ---@type string[]
+          default_tools = {},
         },
       },
       variables = {

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -123,6 +123,7 @@ local defaults = {
           auto_submit_errors = false, -- Send any errors to the LLM automatically?
           auto_submit_success = true, -- Send any successful output to the LLM automatically?
           wait_timeout = 30000, -- How long to wait for user input before timing out (milliseconds)
+          ---Tools and/or groups that are always loaded in a chat buffer
           ---@type string[]
           default_tools = {},
         },

--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -265,6 +265,24 @@ function Agent:find(chat, message)
   return tools, groups
 end
 
+---@param chat CodeCompanion.Chat
+function Agent:add_tool_group(chat, group)
+  local schema = self.tools_config.groups[group]
+  local system_prompt = schema.system_prompt
+  if type(system_prompt) == "function" then
+    system_prompt = system_prompt(schema)
+  end
+  if system_prompt then
+    chat:add_message({
+      role = config.constants.SYSTEM_ROLE,
+      content = system_prompt,
+    }, { tag = "tool", visible = false })
+  end
+  for _, tool_name in pairs(schema.tools or {}) do
+    chat.tools:add(tool_name, self.tools_config[tool_name])
+  end
+end
+
 ---Parse a user message looking for a tool
 ---@param chat CodeCompanion.Chat
 ---@param message table
@@ -281,17 +299,7 @@ function Agent:parse(chat, message)
 
     if groups and not vim.tbl_isempty(groups) then
       for _, group in ipairs(groups) do
-        local schema = self.tools_config.groups[group]
-        local system_prompt = schema.system_prompt
-        if type(system_prompt) == "function" then
-          system_prompt = system_prompt(schema)
-        end
-        if system_prompt then
-          chat:add_message({
-            role = config.constants.SYSTEM_ROLE,
-            content = system_prompt,
-          }, { tag = "tool", visible = false })
-        end
+        self:add_tool_group(chat, group)
       end
     end
     return true

--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -265,7 +265,9 @@ function Agent:find(chat, message)
   return tools, groups
 end
 
+---Add a tool group to the chat buffer
 ---@param chat CodeCompanion.Chat
+---@param group string The group name to add
 function Agent:add_tool_group(chat, group)
   local schema = self.tools_config.groups[group]
   local system_prompt = schema.system_prompt

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -659,6 +659,8 @@ function Chat.new(args)
     local tool_config = config.strategies.chat.tools[tool_name]
     if tool_config ~= nil then
       self.tools:add(tool_name, tool_config)
+    elseif config.strategies.chat.tools.groups[tool_name] ~= nil and self.agents ~= nil then
+      self.agents:add_tool_group(self, tool_name)
     end
   end
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -655,6 +655,13 @@ function Chat.new(args)
     self:submit()
   end
 
+  for _, tool_name in pairs(config.strategies.chat.tools.opts.default_tools or {}) do
+    local tool_config = config.strategies.chat.tools[tool_name]
+    if tool_config ~= nil then
+      self.tools:add(tool_name, tool_config)
+    end
+  end
+
   return self ---@type CodeCompanion.Chat
 end
 

--- a/tests/strategies/chat/test_chat.lua
+++ b/tests/strategies/chat/test_chat.lua
@@ -172,4 +172,33 @@ T["Chat"]["can bring up keymap options in the chat buffer"] = function()
   h.eq(get_lines()[1], "### Keymaps")
 end
 
+T["Chat"]["can load default tools"] = function()
+  local loaded_tools = child.lua([[
+    codecompanion = require("codecompanion")
+    h = require('tests.helpers')
+    _G.chat, _G.agent = h.setup_chat_buffer({ 
+      strategies = { 
+        chat = {
+          tools = {
+            opts = {
+              default_tools = { "weather" }
+            }
+          }
+        } 
+      }
+    })
+
+    return _G.chat.refs
+  ]])
+  h.eq(
+    { "<tool>weather</tool>" },
+    vim
+      .iter(loaded_tools)
+      :map(function(item)
+        return item.id
+      end)
+      :totable()
+  )
+end
+
 return T

--- a/tests/strategies/chat/test_chat.lua
+++ b/tests/strategies/chat/test_chat.lua
@@ -173,7 +173,7 @@ T["Chat"]["can bring up keymap options in the chat buffer"] = function()
 end
 
 T["Chat"]["can load default tools"] = function()
-  local loaded_tools = child.lua([[
+  local refs = child.lua([[
     codecompanion = require("codecompanion")
     h = require('tests.helpers')
     _G.chat, _G.agent = h.setup_chat_buffer({ 
@@ -181,7 +181,7 @@ T["Chat"]["can load default tools"] = function()
         chat = {
           tools = {
             opts = {
-              default_tools = { "weather" }
+              default_tools = { "weather", "tool_group" }
             }
           }
         } 
@@ -191,9 +191,9 @@ T["Chat"]["can load default tools"] = function()
     return _G.chat.refs
   ]])
   h.eq(
-    { "<tool>weather</tool>" },
+    { "<tool>weather</tool>", "<tool>func</tool>", "<tool>cmd</tool>" },
     vim
-      .iter(loaded_tools)
+      .iter(refs)
       :map(function(item)
         return item.id
       end)


### PR DESCRIPTION
## Description

This PR adds the option to automatically load tools when opening a new chat.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
