### PR TITLE
fix: fallback to vim.highlight for nvim <0.12

### DIFF
--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -136,7 +136,7 @@ function M.show_buffer_notification(bufnr, opts)
   return api.nvim_buf_set_extmark(bufnr, ns_id, target_line, 0, {
     virt_lines = virt_lines,
     virt_lines_above = show_above,
-    priority = opts.priority or (vim.hl.priorities.user + 10),
+    priority = opts.priority or ((vim.hl or vim.highlight).priorities.user + 10),
   })
 end
 


### PR DESCRIPTION
## Description


https://neovim.io/doc/user/deprecated.html#vim.highlight

The `vim.hl` won't be available in versions older than 0.12. This PR fallbacks to `vim.highlight`.

## Related Issue(s)

```txt
 Error detected while processing User Autocommands for "CodeCompanionAgent*":

Error executing lua callback: ...ubuntu/codecompanion.nvim/lua/codecompanion/utils/ui.lua:139: attempt to index field 'hl' (a nil value)
stack traceback:
	...ubuntu/codecompanion.nvim/lua/codecompanion/utils/ui.lua:139: in function 'show_buffer_notification'
	...n.nvim/lua/codecompanion/strategies/chat/agents/init.lua:76: in function <...n.nvim/lua/codecompanion/strategies/chat/agents/init.lua:67>
	[C]: in function 'nvim_exec_autocmds'
	...untu/codecompanion.nvim/lua/codecompanion/utils/init.lua:10: in function 'fire'
	...n.nvim/lua/codecompanion/strategies/chat/agents/init.lua:201: in function 'done'
	...ompanion.nvim/lua/codecompanion/strategies/chat/init.lua:959: in function 'done'
	/home/ubuntu/codecompanion.nvim/lua/codecompanion/http.lua:155: in function </home/ubuntu/codecompanion.nvim/lua/codecompanion/http.lua:143>
```


## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
