### PR TITLE
feat(tools): add `file_search` tool

### DIFF
--- a/codecompanion-workspace.json
+++ b/codecompanion-workspace.json
@@ -67,7 +67,9 @@
         "executor-func",
         "executor-cmd",
         "executor-queue",
-        "queue-example"
+        "queue-example",
+        "read_file_tool",
+        "read_file_tool_test"
       ]
     }
   ],
@@ -203,6 +205,16 @@
       "type": "file",
       "path": "tests/stubs/queue.txt",
       "description": "This is how the queue object can look. This is an example of a function tool, a command tool, followed by a function tool:"
+    },
+    "read_file_tool": {
+      "type": "file",
+      "path": "lua/codecompanion/strategies/chat/agents/tools/read_file.lua",
+      "description": "This is an example of a tool in CodeCompanion that reads a file in the current working directory. It's a great example of a function tool."
+    },
+    "read_file_tool_test": {
+      "type": "file",
+      "path": "tests/strategies/chat/agents/tools/test_read_file.lua",
+      "description": "This is the corresponding test for the read file tool."
     }
   }
 }

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -60,6 +60,7 @@ local defaults = {
             tools = {
               "cmd_runner",
               "create_file",
+              "file_search",
               "read_file",
               "insert_edit_into_file",
             },
@@ -68,6 +69,7 @@ local defaults = {
             description = "Tools related to creating, reading and editing files",
             tools = {
               "create_file",
+              "file_search",
               "read_file",
               "insert_edit_into_file",
             },
@@ -80,6 +82,17 @@ local defaults = {
             requires_approval = true,
           },
         },
+        ["create_file"] = {
+          callback = "strategies.chat.agents.tools.create_file",
+          description = "Create a file in the current working directory",
+          opts = {
+            requires_approval = true,
+          },
+        },
+        ["file_search"] = {
+          callback = "strategies.chat.agents.tools.file_search",
+          description = "Search for files in the current working directory by glob pattern",
+        },
         ["insert_edit_into_file"] = {
           callback = "strategies.chat.agents.tools.insert_edit_into_file",
           description = "Insert code into an existing file",
@@ -89,13 +102,6 @@ local defaults = {
               file = true, -- For editing files in the current working directory
             },
             user_confirmation = true, -- Require confirmation from the user before moving on in the chat buffer?
-          },
-        },
-        ["create_file"] = {
-          callback = "strategies.chat.agents.tools.create_file",
-          description = "Create a file in the current working directory",
-          opts = {
-            requires_approval = true,
           },
         },
         ["read_file"] = {

--- a/lua/codecompanion/strategies/chat/agents/tools/file_search.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/file_search.lua
@@ -1,0 +1,163 @@
+local log = require("codecompanion.utils.log")
+
+local fmt = string.format
+
+---Search the current working directory for files matching the glob pattern.
+---@param action { query: string, max_results: number }
+---@return { status: "success"|"error", data: string }
+local function search(action)
+  local query = action.query
+  local max_results = action.max_results or 50 -- Default limit to prevent overwhelming results
+
+  if not query or query == "" then
+    return {
+      status = "error",
+      data = "**File Search Tool**: Query parameter is required and cannot be empty",
+    }
+  end
+
+  -- Get current working directory
+  local cwd = vim.fn.getcwd()
+
+  -- Convert glob pattern to lpeg pattern for matching
+  local ok, glob_pattern = pcall(vim.glob.to_lpeg, query)
+  if not ok then
+    return {
+      status = "error",
+      data = fmt("**File Search Tool**: Invalid glob pattern '%s': %s", query, glob_pattern),
+    }
+  end
+
+  local matches = {}
+
+  -- Use vim.fs.find with a custom function that matches the glob pattern
+  local found_files = vim.fs.find(function(name, path)
+    -- Create the full path and then get relative path from cwd for pattern matching
+    local full_path = vim.fs.joinpath(path, name)
+    local relative_path = vim.fs.relpath(cwd, full_path)
+
+    if not relative_path then
+      return false
+    end
+
+    -- Match against the glob pattern
+    return glob_pattern:match(relative_path) ~= nil
+  end, {
+    limit = max_results,
+    type = "file",
+    path = cwd,
+  })
+
+  -- Format the results
+  if #found_files == 0 then
+    return {
+      status = "success",
+      data = fmt("**File Search Tool**: No files found matching pattern '%s'", query),
+    }
+  end
+
+  -- Convert absolute paths to relative paths for cleaner output
+  local relative_files = {}
+  for _, file in ipairs(found_files) do
+    local rel_path = vim.fs.relpath(cwd, file)
+    if rel_path then
+      table.insert(relative_files, rel_path)
+    else
+      table.insert(relative_files, file)
+    end
+  end
+
+  return {
+    status = "success",
+    data = relative_files,
+  }
+end
+
+---@class CodeCompanion.Tool.FileSearch: CodeCompanion.Agent.Tool
+return {
+  name = "file_search",
+  cmds = {
+    ---Execute the search commands
+    ---@param self CodeCompanion.Tool.FileSearch
+    ---@param args table The arguments from the LLM's tool call
+    ---@param input? any The output from the previous function call
+    ---@return { status: "success"|"error", data: string }
+    function(self, args, input)
+      return search(args)
+    end,
+  },
+  schema = {
+    type = "function",
+    ["function"] = {
+      name = "file_search",
+      description = "Search for files in the workspace by glob pattern. This only returns the paths of matching files. Use this tool when you know the exact filename pattern of the files you're searching for. Glob patterns match from the root of the workspace folder. Examples:\n- **/*.{js,ts} to match all js/ts files in the workspace.\n- src/** to match all files under the top-level src folder.\n- **/foo/**/*.js to match all js files under any foo folder in the workspace.",
+      parameters = {
+        type = "object",
+        properties = {
+          query = {
+            type = "string",
+            description = "Search for files with names or paths matching this glob pattern.",
+          },
+          max_results = {
+            type = "number",
+            description = "The maximum number of results to return. Do not use this unless necessary, it can slow things down. By default, only some matches are returned. If you use this and don't see what you're looking for, you can try again with a more specific query or a larger max_results.",
+          },
+        },
+        required = {
+          "query",
+        },
+      },
+    },
+  },
+  handlers = {
+    ---@param agent CodeCompanion.Agent The tool object
+    ---@return nil
+    on_exit = function(agent)
+      log:trace("[File Search Tool] on_exit handler executed")
+    end,
+  },
+  output = {
+    ---The message which is shared with the user when asking for their approval
+    ---@param self CodeCompanion.Agent.Tool
+    ---@param agent CodeCompanion.Agent
+    ---@return nil|string
+    prompt = function(self, agent)
+      local args = self.args
+      local query = args.query or ""
+      return fmt("Search the cwd for %s?", query)
+    end,
+
+    ---@param self CodeCompanion.Tool.FileSearch
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table The command that was executed
+    ---@param stdout table The output from the command
+    success = function(self, agent, cmd, stdout)
+      local chat = agent.chat
+
+      local files = #stdout[1]
+      local output = vim.iter(stdout):flatten():join("\n")
+      local llm_output =
+        fmt("<fileSearchTool>Found the following files matching your query:\n\n%s</fileSearchTool>", output)
+      local user_message = fmt("**File Search Tool**: Returned %d files matching the query", files)
+
+      chat:add_tool_output(self, llm_output, user_message)
+    end,
+
+    ---@param self CodeCompanion.Tool.FileSearch
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table
+    ---@param stderr table The error output from the command
+    ---@param stdout? table The output from the command
+    error = function(self, agent, cmd, stderr, stdout) end,
+
+    ---Rejection message back to the LLM
+    ---@param self CodeCompanion.Tool.FileSearch
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table
+    ---@return nil
+    rejected = function(self, agent, cmd)
+      local chat = agent.chat
+      chat:add_tool_output(self, "**File Search Tool**: The user declined to execute")
+    end,
+  },
+}


### PR DESCRIPTION
## Description

Part of the plan to unify CodeCompanion's default tools with GitHub Copilot Chat

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
