### PR TITLE
fix(completion): always use latest completions in blink provider

### DIFF
--- a/lua/codecompanion/providers/completion/blink/init.lua
+++ b/lua/codecompanion/providers/completion/blink/init.lua
@@ -2,10 +2,6 @@
 
 local completion = require("codecompanion.providers.completion")
 
-local slash_commands = completion.slash_commands()
-local tools = completion.tools()
-local vars = completion.variables()
-
 --- @class blink.cmp.Source
 local M = {}
 
@@ -43,7 +39,7 @@ function M:get_completions(ctx, callback)
       is_incomplete_forward = false,
       is_incomplete_backward = false,
       items = vim
-        .iter(slash_commands)
+        .iter(completion.slash_commands())
         :map(function(item)
           return {
             kind = vim.lsp.protocol.CompletionItemKind.Function,
@@ -73,7 +69,7 @@ function M:get_completions(ctx, callback)
       is_incomplete_forward = false,
       is_incomplete_backward = false,
       items = vim
-        .iter(vars)
+        .iter(completion.variables())
         :map(function(item)
           return {
             kind = vim.lsp.protocol.CompletionItemKind.Variable,
@@ -99,7 +95,7 @@ function M:get_completions(ctx, callback)
       is_incomplete_forward = false,
       is_incomplete_backward = false,
       items = vim
-        .iter(tools)
+        .iter(completion.tools())
         :map(function(item)
           return {
             kind = vim.lsp.protocol.CompletionItemKind.Struct,


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

The `blink` provider stored the completions once when loaded, which meant that completions added later by extensions such as mcphub.nvim weren't included.

Fix this by always fetching the latest completions, like we already do in the `cmp` and `coc` providers:

- https://github.com/olimorris/codecompanion.nvim/blob/ba7bee5ce1883dd7585fc1f423f2bc82fbdf51a6/lua/codecompanion/providers/completion/cmp/variables.lua#L24
- https://github.com/olimorris/codecompanion.nvim/blob/ba7bee5ce1883dd7585fc1f423f2bc82fbdf51a6/lua/codecompanion/providers/completion/cmp/slash_commands.lua#L24
- https://github.com/olimorris/codecompanion.nvim/blob/ba7bee5ce1883dd7585fc1f423f2bc82fbdf51a6/lua/codecompanion/providers/completion/coc/init.lua#L82-L86

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

I saw this was discussed in https://github.com/olimorris/codecompanion.nvim/discussions/1474, but the workaround of adding `lazy = false` to both plugins didn't work for me.

Also because mcphub.nvim will dynamically add/remove variables and slash commands as servers are started/stopped, this change seems necessary anyway.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
