### PR TITLE
fix(inline): revert keymap changes

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -411,7 +411,7 @@ local defaults = {
       keymaps = {
         accept_change = {
           modes = {
-            n = "gda",
+            n = "ga",
           },
           index = 1,
           callback = "keymaps.accept_change",
@@ -419,7 +419,7 @@ local defaults = {
         },
         reject_change = {
           modes = {
-            n = "gdr",
+            n = "gr",
           },
           index = 2,
           callback = "keymaps.reject_change",


### PR DESCRIPTION
## Description

During testing I changed the inline diff keymaps. This reverts that.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
