### PR TITLE
Buffers: only pass relative paths to the llm

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -195,13 +195,13 @@ function SlashCommand:output(selected, opts)
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = fmt(
-      [[%s `%s` (which has a buffer number of _%d_ and a filepath of `%s`):
+      [[%s `%s` (which has a buffer number of _%d_ and a relative filepath of `%s`):
 
 %s]],
       message,
       filename,
       selected.bufnr,
-      selected.path,
+      selected.relative_path,
       content
     ),
   }, { reference = id, visible = false })
@@ -222,7 +222,7 @@ function SlashCommand:output(selected, opts)
   self.Chat.references:add({
     bufnr = selected.bufnr,
     id = id,
-    path = selected.path,
+    relative_path = selected.relative_path,
     opts = opts,
     source = "codecompanion.strategies.chat.slash_commands.buffer",
   })

--- a/lua/codecompanion/utils/buffers.lua
+++ b/lua/codecompanion/utils/buffers.lua
@@ -130,7 +130,7 @@ local function format(buffer, lines)
     [[
 Buffer Number: %d
 Name: %s
-Path: %s
+Relative Path: %s
 Filetype: %s
 Content:
 ```%s
@@ -139,7 +139,7 @@ Content:
 ]],
     buffer.number,
     buffer.name,
-    buffer.path,
+    buffer.relative_path,
     buffer.filetype,
     buffer.filetype,
     table.concat(formatted, "\n")


### PR DESCRIPTION
## Description

Makes @insert_edit_into_file using `/buffer` or `#buffer` more reliable by giving the LLM visibility of a buffer's relative filepath.
Stops publishing absolute buffer paths to the LLM.

## Related Issue(s)

- Fixes https://github.com/olimorris/codecompanion.nvim/issues/1631 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
