### PR TITLE
docs: link to examples to conceal tags with Markview

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -255,6 +255,10 @@ markdown in the chat buffer:
     },
 <
 
+You can also conceal the tags used in chat buffers, see
+<https://github.com/OXY2DEV/markview.nvim/wiki/HTML#container_elements>
+and <https://github.com/olimorris/codecompanion.nvim/discussions/1638> for
+examples.
 
 MINI.DIFF ~
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -131,6 +131,7 @@ Use [markview.nvim](https://github.com/OXY2DEV/markview.nvim) to render the mark
   },
 },
 ```
+You can also conceal the tags used in chat buffers, see [HTML options](https://github.com/OXY2DEV/markview.nvim/wiki/HTML#container_elements) and [this discussion](https://github.com/olimorris/codecompanion.nvim/discussions/1638) for examples.
 
 ### mini.diff
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

I wanted to share this configuration snippet to make the chat buffer look a bit nicer :grinning: If you think it's overkill to have it in the docs I'd also be happy to post it as a discussion instead.

This is based on the examples at https://github.com/OXY2DEV/markview.nvim/wiki/HTML#container_elements

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

![image](https://github.com/user-attachments/assets/2b473059-8783-4e8e-913f-48230357b632)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
