### PR TITLE
feat(tools): can be conditionally loaded

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -547,8 +547,9 @@ However, there are multiple options available:
 - `CodeCompanion /<prompt library>` - Call an item from the |codecompanion-configuration-prompt-library|
 - `CodeCompanionChat <prompt>` - Send a prompt to the LLM via a chat buffer
 - `CodeCompanionChat <adapter>` - Open a chat buffer with a specific adapter
-- `CodeCompanionChat Toggle` - Toggle a chat buffer
 - `CodeCompanionChat Add` - Add visually selected chat to the current chat buffer
+- `CodeCompanionChat RefreshCache` - Used to refresh conditional elements in the chat buffer
+- `CodeCompanionChat Toggle` - Toggle a chat buffer
 
 
 SUGGESTED WORKFLOW          *codecompanion-getting-started-suggested-workflow*
@@ -1251,6 +1252,32 @@ the `callback` option. The `callback` option can be a table itself or either a
 function or a string that points to a luafile that return the table.
 
 
+TOOL CONDITIONALS
+
+Tools can also be conditionally enabled:
+
+>lua
+    require("codecompanion").setup({
+      strategies = {
+        chat = {
+          tools = {
+            ["grep_search"] = {
+              ---@return boolean
+              enabled = function()
+                return vim.fn.executable("rg") == 1
+              end,
+            },
+          }
+        }
+      }
+    })
+<
+
+This is useful to ensure that a particular dependency is installed on the
+machine. After the user has installed the dependency, the `:CodeCompanionChat
+RefreshCache` command can be used to refresh the cache’s across chat buffers.
+
+
 APPROVALS
 
 Some tools, such as |codecompanion-usage-chat-buffer-agents.html-cmd-runner|,
@@ -1309,7 +1336,7 @@ chat buffers:
         chat = {
           tools = {
             opts = {
-              default_tools = { 
+              default_tools = {
                 "my_tool",
                 "my_tool_group"
               }
@@ -2633,7 +2660,7 @@ config, the plugin fires events at various points during its lifecycle.
 
 LIST OF EVENTS ~
 
-The events that you can access are:
+The events that are fired from within the plugin are:
 
 - `CodeCompanionChatCreated` - Fired after a chat has been created for the first time
 - `CodeCompanionChatOpened` - Fired after a chat has been opened
@@ -2659,6 +2686,11 @@ The events that you can access are:
 - `CodeCompanionDiffDetached` - Fired when exiting Diff mode
 - `CodeCompanionDiffAccepted` - Fired when a user accepts a change
 - `CodeCompanionDiffRejected` - Fired when a user rejects a change
+
+There are also events that can be utilized to trigger commands from within the
+plugin:
+
+- `CodeCompanionChatRefreshCache` - Used to refresh conditional elements in the chat buffer
 
 
 EVENT DATA ~
@@ -2706,6 +2738,14 @@ Events can be hooked into as follows:
           require("conform").format({ bufnr = request.buf })
         end
       end,
+    })
+<
+
+You can trigger an event with:
+
+>lua
+    vim.api.nvim_exec_autocmds("User", {
+      pattern = "CodeCompanionChatRefreshCache",
     })
 <
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -188,6 +188,29 @@ When users introduce the agent `@my_agent` in the chat buffer, it can call the t
 
 A tool is a [`CodeCompanion.Tool`](/extending/tools) table with specific keys that define the interface and workflow of the tool. The table can be resolved using the `callback` option. The `callback` option can be a table itself or either a function or a string that points to a luafile that return the table.
 
+### Tool Conditionals
+
+Tools can also be conditionally enabled:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      tools = {
+        ["grep_search"] = {
+          ---@return boolean
+          enabled = function()
+            return vim.fn.executable("rg") == 1
+          end,
+        },
+      }
+    }
+  }
+})
+```
+
+This is useful to ensure that a particular dependency is installed on the machine. After the user has installed the dependency, the `:CodeCompanionChat RefreshCache` command can be used to refresh the cache's across chat buffers.
+
 ### Approvals
 
 Some tools, such as [@cmd_runner](/usage/chat-buffer/agents.html#cmd-runner), require the user to approve any commands before they're executed. This can be changed by altering the config for each tool:
@@ -239,7 +262,7 @@ require("codecompanion").setup({
     chat = {
       tools = {
         opts = {
-          default_tools = { 
+          default_tools = {
             "my_tool",
             "my_tool_group"
           }

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -170,8 +170,9 @@ However, there are multiple options available:
 - `CodeCompanion /<prompt library>` - Call an item from the [prompt library](configuration/prompt-library)
 - `CodeCompanionChat <prompt>` - Send a prompt to the LLM via a chat buffer
 - `CodeCompanionChat <adapter>` - Open a chat buffer with a specific adapter
-- `CodeCompanionChat Toggle` - Toggle a chat buffer
 - `CodeCompanionChat Add` - Add visually selected chat to the current chat buffer
+- `CodeCompanionChat RefreshCache` - Used to refresh conditional elements in the chat buffer
+- `CodeCompanionChat Toggle` - Toggle a chat buffer
 
 ## Suggested Plugin Workflow
 

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -4,7 +4,7 @@ In order to enable a tighter integration between CodeCompanion and your Neovim c
 
 ## List of Events
 
-The events that you can access are:
+The events that are fired from within the plugin are:
 
 - `CodeCompanionChatCreated` - Fired after a chat has been created for the first time
 - `CodeCompanionChatOpened` - Fired after a chat has been opened
@@ -30,6 +30,10 @@ The events that you can access are:
 - `CodeCompanionDiffDetached` - Fired when exiting Diff mode
 - `CodeCompanionDiffAccepted` - Fired when a user accepts a change
 - `CodeCompanionDiffRejected` - Fired when a user rejects a change
+
+There are also events that can be utilized to trigger commands from within the plugin:
+
+- `CodeCompanionChatRefreshCache` - Used to refresh conditional elements in the chat buffer
 
 ## Event Data
 
@@ -74,6 +78,14 @@ vim.api.nvim_create_autocmd({ "User" }, {
       require("conform").format({ bufnr = request.buf })
     end
   end,
+})
+```
+
+You can trigger an event with:
+
+```lua
+vim.api.nvim_exec_autocmds("User", {
+  pattern = "CodeCompanionChatRefreshCache",
 })
 ```
 

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -35,6 +35,7 @@ end)
 local chat_subcommands = vim.deepcopy(adapters)
 table.insert(chat_subcommands, "Toggle")
 table.insert(chat_subcommands, "Add")
+table.insert(chat_subcommands, "RefreshCache")
 
 ---@type CodeCompanion.Command[]
 return {
@@ -91,7 +92,7 @@ return {
       codecompanion.chat(opts)
     end,
     opts = {
-      desc = "Open a CodeCompanion chat buffer",
+      desc = "Work with a CodeCompanion chat buffer",
       range = true,
       nargs = "*",
       -- Reference:

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -2,6 +2,7 @@ local _extensions = require("codecompanion._extensions")
 local config = require("codecompanion.config")
 local context_utils = require("codecompanion.utils.context")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local api = vim.api
 
@@ -133,6 +134,8 @@ CodeCompanion.chat = function(args)
         return CodeCompanion.add(args)
       elseif prompt == "toggle" then
         return CodeCompanion.toggle()
+      elseif prompt == "refreshcache" then
+        return CodeCompanion.refresh_cache()
       else
         table.insert(messages, {
           role = config.constants.USER_ROLE,
@@ -231,6 +234,14 @@ end
 CodeCompanion.actions = function(args)
   local context = context_utils.get(api.nvim_get_current_buf(), args)
   return require("codecompanion.actions").launch(context, args)
+end
+
+---Refresh any of the caches used by the plugin
+---@return nil
+CodeCompanion.refresh_cache = function()
+  local ToolFilter = require("codecompanion.strategies.chat.agents.tool_filter")
+  ToolFilter.refresh_cache()
+  utils.notify("Refreshed the cache for all chat buffers", vim.log.levels.INFO)
 end
 
 ---Return the JSON schema for the workspace file

--- a/lua/codecompanion/providers/completion/init.lua
+++ b/lua/codecompanion/providers/completion/init.lua
@@ -1,4 +1,5 @@
 local SlashCommands = require("codecompanion.strategies.chat.slash_commands")
+local ToolFilter = require("codecompanion.strategies.chat.agents.tool_filter")
 local config = require("codecompanion.config")
 local strategy = require("codecompanion.strategies")
 
@@ -72,9 +73,12 @@ end
 ---Return the tools to be used for completion
 ---@return table
 function M.tools()
+  -- Get filtered tools configuration (this uses the cache!)
+  local tools = ToolFilter.filter_enabled_tools(config.strategies.chat.tools)
+
   -- Add groups
   local items = vim
-    .iter(config.strategies.chat.tools.groups)
+    .iter(tools.groups)
     :filter(function(label)
       return label ~= "tools"
     end)
@@ -91,7 +95,7 @@ function M.tools()
 
   -- Add tools
   vim
-    .iter(config.strategies.chat.tools)
+    .iter(tools)
     :filter(function(label, value)
       return label ~= "opts" and label ~= "groups" and value.visible ~= false
     end)

--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -1,5 +1,5 @@
 ---@class CodeCompanion.Agent
----@field tools_config table The agent strategy from the config
+---@field tools_config table The available tools for the agent
 ---@field aug number The augroup for the tool
 ---@field bufnr number The buffer of the chat buffer
 ---@field constants table<string, string> The constants for the tool
@@ -13,6 +13,7 @@
 ---@field tools_ns integer The namespace for the virtual text that appears in the header
 
 local Executor = require("codecompanion.strategies.chat.agents.executor")
+local ToolFilter = require("codecompanion.strategies.chat.agents.tool_filter")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local regex = require("codecompanion.utils.regex")
@@ -50,7 +51,7 @@ function Agent.new(args)
     stdout = {},
     stderr = {},
     tool = {},
-    tools_config = config.strategies.chat.tools,
+    tools_config = ToolFilter.filter_enabled_tools(config.strategies.chat.tools), -- Filter here
     tools_ns = api.nvim_create_namespace(CONSTANTS.NS_TOOLS),
   }, { __index = Agent })
 

--- a/lua/codecompanion/strategies/chat/agents/tool_filter.lua
+++ b/lua/codecompanion/strategies/chat/agents/tool_filter.lua
@@ -1,0 +1,127 @@
+local log = require("codecompanion.utils.log")
+
+---@class CodeCompanion.Agent.ToolFilter
+local ToolFilter = {}
+
+local _enabled_cache = {}
+local _cache_timestamp = 0
+local CACHE_TTL = 30000
+
+---Clear the enabled tools cache
+---@return nil
+local function clear_cache()
+  _enabled_cache = {}
+  _cache_timestamp = 0
+  log:trace("[Tool Filter] Cache cleared")
+end
+
+---Check if the cache is valid
+---@return boolean
+local function is_cache_valid()
+  return vim.loop.now() - _cache_timestamp < CACHE_TTL
+end
+
+---Get enabled tools from the cache or compute them
+---@param tools_config table The tools configuration
+---@return table<string, boolean> Map of tool names to enabled status
+local function get_enabled_tools(tools_config)
+  if is_cache_valid() and next(_enabled_cache) then
+    log:trace("[Tool Filter] Using cached enabled tools")
+    return _enabled_cache
+  end
+
+  log:trace("[Tool Filter] Computing enabled tools")
+  _enabled_cache = {}
+  _cache_timestamp = vim.loop.now()
+
+  for tool_name, tool_config in pairs(tools_config) do
+    -- Skip special keys
+    if tool_name ~= "opts" and tool_name ~= "groups" then
+      local is_enabled = true
+
+      if tool_config.enabled ~= nil then
+        if type(tool_config.enabled) == "function" then
+          local ok, result = pcall(tool_config.enabled)
+          if ok then
+            is_enabled = result
+          else
+            log:error("[Tool Filter] Error evaluating enabled function for tool '%s': %s", tool_name, result)
+            is_enabled = false
+          end
+        elseif type(tool_config.enabled) == "boolean" then
+          is_enabled = tool_config.enabled
+        end
+      end
+
+      _enabled_cache[tool_name] = is_enabled
+      log:trace("[Tool Filter] Tool '%s' enabled: %s", tool_name, is_enabled)
+    end
+  end
+
+  return _enabled_cache
+end
+
+---Filter tools configuration to only include enabled tools
+---@param tools_config table The tools configuration
+---@return table The filtered tools configuration
+function ToolFilter.filter_enabled_tools(tools_config)
+  local enabled_tools = get_enabled_tools(tools_config)
+  local filtered_config = vim.deepcopy(tools_config)
+
+  -- Remove disabled tools
+  for tool_name, is_enabled in pairs(enabled_tools) do
+    if not is_enabled then
+      filtered_config[tool_name] = nil
+      log:trace("[Tool Filter] Filtered out disabled tool: %s", tool_name)
+    end
+  end
+
+  -- Filter groups to only include enabled tools
+  if filtered_config.groups then
+    for group_name, group_config in pairs(filtered_config.groups) do
+      if group_config.tools then
+        local enabled_group_tools = {}
+        for _, tool_name in ipairs(group_config.tools) do
+          if enabled_tools[tool_name] then
+            table.insert(enabled_group_tools, tool_name)
+          end
+        end
+        filtered_config.groups[group_name].tools = enabled_group_tools
+
+        -- Remove group if no tools are enabled
+        if #enabled_group_tools == 0 then
+          filtered_config.groups[group_name] = nil
+          log:trace("[Tool Filter] Filtered out group with no enabled tools: %s", group_name)
+        end
+      end
+    end
+  end
+
+  return filtered_config
+end
+
+---Check if a specific tool is enabled
+---@param tool_name string The name of the tool
+---@param tools_config table The tools configuration
+---@return boolean
+function ToolFilter.is_tool_enabled(tool_name, tools_config)
+  local enabled_tools = get_enabled_tools(tools_config)
+  return enabled_tools[tool_name] == true
+end
+
+---Force the cache to refresh (useful for testing or manual refresh)
+---@return nil
+function ToolFilter.refresh_cache()
+  clear_cache()
+  log:trace("[Tool Filter] Cache manually refreshed")
+end
+
+vim.api.nvim_create_autocmd("User", {
+  pattern = "CodeCompanionChatRefreshCache",
+  callback = function()
+    log:trace("[Tool Filter] Cache cleared via autocommand")
+    clear_cache()
+  end,
+})
+
+return ToolFilter

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -93,6 +93,14 @@ return {
             max_results = 500,
           },
         },
+        ["hidden_tool"] = {
+          callback = "strategies.chat.agents.tools.create_file",
+          ---@return boolean
+          enabled = function()
+            return false
+          end,
+          description = "A hidden tool that will not be shown in the tool list",
+        },
         ["read_file"] = {
           callback = "strategies.chat.agents.tools.read_file",
           description = "Read a file in the current working directory",
@@ -190,6 +198,24 @@ return {
               "func",
               "cmd",
             },
+          },
+          ["test_group"] = {
+            description = "Test Group",
+            system_prompt = "Test group system prompt",
+            tools = { "func", "weather" },
+            opts = { collapse_tools = true },
+          },
+          ["test_group2"] = {
+            description = "Group to be used for testing references",
+            system_prompt = "Individual tools system prompt",
+            tools = { "func", "weather" },
+            opts = { collapse_tools = false },
+          },
+          ["remove_group"] = {
+            description = "Group to be removed during testing of references",
+            system_prompt = "System prompt to be removed",
+            tools = { "func", "weather" },
+            opts = { collapse_tools = true },
           },
         },
         opts = {

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -93,14 +93,6 @@ return {
             max_results = 500,
           },
         },
-        ["hidden_tool"] = {
-          callback = "strategies.chat.agents.tools.create_file",
-          ---@return boolean
-          enabled = function()
-            return false
-          end,
-          description = "A hidden tool that will not be shown in the tool list",
-        },
         ["read_file"] = {
           callback = "strategies.chat.agents.tools.read_file",
           description = "Read a file in the current working directory",

--- a/tests/strategies/chat/agents/test_tool_filter.lua
+++ b/tests/strategies/chat/agents/test_tool_filter.lua
@@ -1,0 +1,69 @@
+local ToolFilter = require("codecompanion.strategies.chat.agents.tool_filter")
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      -- Clear cache before each test
+      ToolFilter.refresh_cache()
+    end,
+  },
+})
+
+T["filters out disabled tools"] = function()
+  local tools_config = {
+    enabled_tool = {
+      callback = "test",
+      enabled = true,
+    },
+    disabled_tool = {
+      callback = "test",
+      enabled = false,
+    },
+    function_disabled_tool = {
+      callback = "test",
+      enabled = function()
+        return false
+      end,
+    },
+    default_enabled_tool = {
+      callback = "test",
+      -- No enabled field means enabled by default
+    },
+    opts = {},
+  }
+
+  local filtered = ToolFilter.filter_enabled_tools(tools_config)
+
+  h.eq(filtered.enabled_tool ~= nil, true)
+  h.eq(filtered.default_enabled_tool ~= nil, true)
+  h.eq(filtered.disabled_tool, nil)
+  h.eq(filtered.function_disabled_tool, nil)
+  h.eq(filtered.opts ~= nil, true) -- opts should remain
+end
+
+T["filters disabled tools in groups"] = function()
+  local tools_config = {
+    tool1 = { callback = "test", enabled = true },
+    tool2 = { callback = "test", enabled = false },
+    tool3 = { callback = "test", enabled = true },
+    groups = {
+      mixed_group = {
+        tools = { "tool1", "tool2", "tool3" },
+      },
+      empty_group = {
+        tools = { "tool2" }, -- Only disabled tool
+      },
+    },
+    opts = {},
+  }
+
+  local filtered = ToolFilter.filter_enabled_tools(tools_config)
+
+  h.eq(#filtered.groups.mixed_group.tools, 2) -- Only tool1 and tool3
+  h.eq(filtered.groups.empty_group, nil) -- Empty group should be removed
+end
+
+return T

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -462,12 +462,6 @@ end
 
 T["References"]["Tool group with collapse_tools shows single group reference"] = function()
   child.lua([[
-    _G.agent.tools_config.groups.test_group = {
-      tools = { "func", "weather" },
-      system_prompt = "Test group system prompt",
-      opts = { collapse_tools = true }
-    }
-    
     local message = { role = "user", content = "@test_group help" }
     _G.chat:add_message(message)
     _G.chat:replace_vars_and_tools(message)
@@ -494,12 +488,6 @@ end
 
 T["References"]["Tool group without collapse_tools shows individual tools"] = function()
   child.lua([[
-    _G.agent.tools_config.groups.test_group2 = {
-      tools = { "func", "weather" },
-      system_prompt = "Individual tools system prompt",
-      opts = { collapse_tools = false }
-    }
-    
     local message = { role = "user", content = "@test_group2 help" }
     _G.chat:add_message(message)
     _G.chat:replace_vars_and_tools(message)
@@ -526,12 +514,6 @@ end
 
 T["References"]["Removing collapsed group removes all its tools and system message"] = function()
   child.lua([[
-    _G.agent.tools_config.groups.remove_group = {
-      tools = { "func", "weather" },
-      system_prompt = "System prompt to be removed",
-      opts = { collapse_tools = true }
-    }
-    
     local message = { role = "user", content = "@remove_group help" }
     _G.chat:add_message(message)
     _G.chat:replace_vars_and_tools(message)


### PR DESCRIPTION
## Description

Future tools will have dependencies and this PR enables them to be conditionally loaded.

For performance reasons, we cache their availability and add a command to refresh the cache, perhaps after a dependency has been installed.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
