### PR TITLE
add `grep_search` tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Prepare 🏗️
         run: |
+          apt-get install ripgrep
           test -d _neovim || {
             mkdir -p _neovim
             curl -sL ${{ matrix.url }} | tar xzf - --strip-components=1 -C "${PWD}/_neovim"

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -9,6 +9,7 @@
 - Neovim 0.11.0 or greater
 - _(Optional)_ An API key for your chosen LLM
 - _(Optional)_ The `base64` library for image/vision support
+- _(Optional)_ The `[ripgrep](https://github.com/BurntSushi/ripgrep)` library for the `grep_search` tool
 
 ## Installation
 
@@ -131,6 +132,7 @@ Use [markview.nvim](https://github.com/OXY2DEV/markview.nvim) to render the mark
   },
 },
 ```
+
 You can also conceal the tags used in chat buffers, see [HTML options](https://github.com/OXY2DEV/markview.nvim/wiki/HTML#container_elements) and [this discussion](https://github.com/olimorris/codecompanion.nvim/discussions/1638) for examples.
 
 ### mini.diff

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -56,13 +56,14 @@ local defaults = {
         groups = {
           ["full_stack_dev"] = {
             description = "Full Stack Developer - Can run code, edit code and modify files",
-            system_prompt = "**DO NOT** make any assumptions about the dependencies that a user has installed. If you need to install any dependencies to fulfil the user's request, do so via the Command Runner tool. If the user doesn't specify a path, use their current working directory.",
             tools = {
               "cmd_runner",
               "create_file",
               "file_search",
-              "read_file",
+              "grep_search",
               "insert_edit_into_file",
+              "read_file",
+              "web_search",
             },
             opts = {
               collapse_tools = true,
@@ -73,8 +74,8 @@ local defaults = {
             tools = {
               "create_file",
               "file_search",
-              "read_file",
               "insert_edit_into_file",
+              "read_file",
             },
             opts = {
               collapse_tools = true,
@@ -99,7 +100,19 @@ local defaults = {
           callback = "strategies.chat.agents.tools.file_search",
           description = "Search for files in the current working directory by glob pattern",
           opts = {
-            max_results = 500, -- Maximum number of results to return
+            max_results = 500,
+          },
+        },
+        ["grep_search"] = {
+          callback = "strategies.chat.agents.tools.grep_search",
+          enabled = function()
+            -- Currently this tool only supports ripgrep
+            return vim.fn.executable("rg") == 1
+          end,
+          description = "Search for text in the current working directory",
+          opts = {
+            max_results = 100,
+            respect_gitignore = true,
           },
         },
         ["insert_edit_into_file"] = {

--- a/lua/codecompanion/health.lua
+++ b/lua/codecompanion/health.lua
@@ -36,6 +36,10 @@ M.libraries = {
     name = "base64",
     optional = true,
   },
+  {
+    name = "rg",
+    optional = true,
+  },
 }
 
 M.adapters = {

--- a/lua/codecompanion/strategies/chat/agents/tools/grep_search.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/grep_search.lua
@@ -1,0 +1,276 @@
+local log = require("codecompanion.utils.log")
+
+local fmt = string.format
+
+---Search the current working directory for text using ripgrep
+---@param action { query: string, is_regexp: boolean?, include_pattern: string? }
+---@param opts table
+---@return { status: "success"|"error", data: string|table }
+local function grep_search(action, opts)
+  opts = opts or {}
+  local query = action.query
+
+  if not query or query == "" then
+    return {
+      status = "error",
+      data = "Query parameter is required and cannot be empty",
+    }
+  end
+
+  -- Check if ripgrep is available
+  if vim.fn.executable("rg") ~= 1 then
+    return {
+      status = "error",
+      data = "ripgrep (rg) is not installed or not in PATH",
+    }
+  end
+
+  local cmd = { "rg" }
+  local cwd = vim.fn.getcwd()
+  local max_results = opts.max_results or 100
+  local is_regexp = action.is_regexp or false
+  local respect_gitignore = opts.respect_gitignore
+  if respect_gitignore == nil then
+    respect_gitignore = opts.respect_gitignore ~= false
+  end
+
+  -- Use JSON output for structured parsing
+  table.insert(cmd, "--json")
+  table.insert(cmd, "--line-number")
+  table.insert(cmd, "--no-heading")
+  table.insert(cmd, "--with-filename")
+
+  -- Regex vs fixed string
+  if not is_regexp then
+    table.insert(cmd, "--fixed-strings")
+  end
+
+  -- Case sensitivity
+  table.insert(cmd, "--ignore-case")
+
+  -- Gitignore handling
+  if not respect_gitignore then
+    table.insert(cmd, "--no-ignore")
+  end
+
+  -- File pattern filtering
+  if action.include_pattern and action.include_pattern ~= "" then
+    table.insert(cmd, "--glob")
+    table.insert(cmd, action.include_pattern)
+  end
+
+  -- Limit results per file - we'll limit total results in post-processing
+  table.insert(cmd, "--max-count")
+  table.insert(cmd, tostring(math.min(max_results, 50)))
+
+  -- Add the query
+  table.insert(cmd, query)
+
+  -- Add the search path
+  table.insert(cmd, cwd)
+
+  log:debug("[Grep Search Tool] Running command: %s", table.concat(cmd, " "))
+
+  -- Execute
+  local result = vim
+    .system(cmd, {
+      text = true,
+      timeout = 30000, -- 30 second timeout
+    })
+    :wait()
+
+  if result.code ~= 0 then
+    local error_msg = result.stderr or "Unknown error"
+
+    if result.code == 1 then
+      -- No matches found - this is not an error for ripgrep
+      return {
+        status = "success",
+        data = "No matches found for the query",
+      }
+    elseif result.code == 2 then
+      log:warn("[Grep Search Tool] Invalid arguments or regex: %s", error_msg)
+      return {
+        status = "error",
+        data = fmt("Invalid search pattern or arguments: %s", error_msg:match("^[^\n]*") or "Unknown error"),
+      }
+    else
+      log:error("[Grep Search Tool] Command failed with code %d: %s", result.code, error_msg)
+      return {
+        status = "error",
+        data = fmt("Search failed: %s", error_msg:match("^[^\n]*") or "Unknown error"),
+      }
+    end
+  end
+
+  local output = result.stdout or ""
+  if output == "" then
+    return {
+      status = "success",
+      data = "No matches found for the query",
+    }
+  end
+
+  -- Parse JSON output from ripgrep
+  local matches = {}
+  local count = 0
+
+  for line in output:gmatch("[^\n]+") do
+    if count >= max_results then
+      break
+    end
+
+    local ok, json_data = pcall(vim.json.decode, line)
+    if ok and json_data.type == "match" then
+      local file_path = json_data.data.path.text
+      local line_number = json_data.data.line_number
+
+      -- Convert absolute path to relative path from cwd
+      local relative_path = vim.fs.relpath(cwd, file_path) or file_path
+
+      -- Extract just the filename and directory
+      local filename = vim.fn.fnamemodify(relative_path, ":t")
+      local dir_path = vim.fn.fnamemodify(relative_path, ":h")
+
+      -- Format: "filename:line directory_path"
+      local match_entry = fmt("%s:%d %s", filename, line_number, dir_path == "." and "" or dir_path)
+      table.insert(matches, match_entry)
+      count = count + 1
+    end
+  end
+
+  if #matches == 0 then
+    return {
+      status = "success",
+      data = "No matches found for the query",
+    }
+  end
+
+  return {
+    status = "success",
+    data = matches,
+  }
+end
+
+---@class CodeCompanion.Tool.GrepSearch: CodeCompanion.Agent.Tool
+return {
+  name = "grep_search",
+  cmds = {
+    ---Execute the search commands
+    ---@param self CodeCompanion.Tool.GrepSearch
+    ---@param args table The arguments from the LLM's tool call
+    ---@param input? any The output from the previous function call
+    ---@return { status: "success"|"error", data: string }
+    function(self, args, input)
+      return grep_search(args, self.tool.opts)
+    end,
+  },
+  schema = {
+    ["function"] = {
+      name = "grep_search",
+      description = "Do a text search in the workspace. Use this tool when you know the exact string you're searching for.",
+      parameters = {
+        type = "object",
+        properties = {
+          query = {
+            type = "string",
+            description = "The pattern to search for in files in the workspace. Can be a regex or plain text pattern",
+          },
+          is_regexp = {
+            type = "boolean",
+            description = "Whether the pattern is a regex. False by default.",
+          },
+          include_pattern = {
+            type = "string",
+            description = "Search files matching this glob pattern. Will be applied to the relative path of files within the workspace.",
+          },
+        },
+        required = {
+          "query",
+        },
+      },
+    },
+    type = "function",
+  },
+  handlers = {
+    ---@param agent CodeCompanion.Agent The tool object
+    ---@return nil
+    on_exit = function(agent)
+      log:trace("[Grep Search Tool] on_exit handler executed")
+    end,
+  },
+  output = {
+    ---The message which is shared with the user when asking for their approval
+    ---@param self CodeCompanion.Agent.Tool
+    ---@param agent CodeCompanion.Agent
+    ---@return nil|string
+    prompt = function(self, agent)
+      local args = self.args
+      local query = args.query or ""
+      return fmt("Perform a grep search for %s?", query)
+    end,
+
+    ---@param self CodeCompanion.Tool.GrepSearch
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table The command that was executed
+    ---@param stdout table The output from the command
+    success = function(self, agent, cmd, stdout)
+      local chat = agent.chat
+
+      local data = stdout[1]
+
+      local llm_output = [[<grepSearchTool>%s
+
+NOTE: The output format is {filename}:{line number} {filepath}. For example:
+init.lua:335 lua/codecompanion/strategies/chat/agents
+Refers to line 335 of the init.lua file in the lua/codecompanion/strategies/chat/agents directory.
+</grepSearchTool>]]
+      local user_message = "**Grep Search Tool**: %s"
+      local output = vim.iter(stdout):flatten():join("\n")
+
+      if type(data) == "table" then
+        -- Results were found - data is an array of file paths
+        local results = #data
+        chat:add_tool_output(
+          self,
+          fmt(llm_output, fmt("Returning %d results matching the query:\n%s", results, output)),
+          fmt(user_message, fmt("Returned %d results", results))
+        )
+      else
+        -- No results found - data is a string message
+        chat:add_tool_output(self, fmt(llm_output, "No results found"), fmt(user_message, "No results found"))
+      end
+    end,
+
+    ---@param self CodeCompanion.Tool.GrepSearch
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table
+    ---@param stderr table The error output from the command
+    ---@param stdout? table The output from the command
+    error = function(self, agent, cmd, stderr, stdout)
+      local chat = agent.chat
+      local errors = vim.iter(stderr):flatten():join("\n")
+      log:debug("[Grep Search Tool] Error output: %s", stderr)
+
+      local error_output = fmt(
+        [[**Grep Search Tool**: Ran with an error:
+
+```txt
+%s
+```]],
+        errors
+      )
+      chat:add_tool_output(self, error_output)
+    end,
+
+    ---Rejection message back to the LLM
+    ---@param self CodeCompanion.Tool.GrepSearch
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table
+    ---@return nil
+    rejected = function(self, agent, cmd)
+      local chat = agent.chat
+      chat:add_tool_output(self, "**Grep Search Tool**: The user declined to execute")
+    end,
+  },
+}

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -93,6 +93,10 @@ return {
             max_results = 500,
           },
         },
+        ["grep_search"] = {
+          callback = "strategies.chat.agents.tools.grep_search",
+          description = "Search for text in the current working directory",
+        },
         ["read_file"] = {
           callback = "strategies.chat.agents.tools.read_file",
           description = "Read a file in the current working directory",

--- a/tests/strategies/chat/agents/tools/test_grep_search.lua
+++ b/tests/strategies/chat/agents/tools/test_grep_search.lua
@@ -1,0 +1,151 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+
+local child = MiniTest.new_child_neovim()
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        -- Setup test directory structure
+        _G.TEST_DIR = 'tests/stubs/grep_search'
+        _G.TEST_DIR_ABSOLUTE = vim.fs.joinpath(vim.fn.tempname(), _G.TEST_DIR)
+
+        -- Create test directory structure
+        vim.fn.mkdir(_G.TEST_DIR_ABSOLUTE .. '/src/components', 'p')
+        vim.fn.mkdir(_G.TEST_DIR_ABSOLUTE .. '/src/utils', 'p')
+        vim.fn.mkdir(_G.TEST_DIR_ABSOLUTE .. '/tests', 'p')
+        vim.fn.mkdir(_G.TEST_DIR_ABSOLUTE .. '/docs', 'p')
+
+        -- Create test files with actual content to search
+        local test_files = {
+          {
+            path = 'src/components/Button.js',
+            content = {
+              'import React from "react";',
+              '',
+              'function Button({ onClick, children }) {',
+              '  return (',
+              '    <button className="btn-primary" onClick={onClick}>',
+              '      {children}',
+              '    </button>',
+              '  );',
+              '}',
+              '',
+              'export default Button;'
+            }
+          },
+          {
+            path = 'src/components/Modal.ts',
+            content = {
+              'interface ModalProps {',
+              '  isOpen: boolean;',
+              '  onClose: () => void;',
+              '  children: React.ReactNode;',
+              '}',
+              '',
+              'export function Modal({ isOpen, onClose, children }: ModalProps) {',
+              '  if (!isOpen) return null;',
+              '',
+              '  return (',
+              '    <div className="modal-overlay">',
+              '      <div className="modal-content">',
+              '        <button onClick={onClose}>Close</button>',
+              '        {children}',
+              '      </div>',
+              '    </div>',
+              '  );',
+              '}'
+            }
+          },
+          {
+            path = 'src/utils/helpers.js',
+            content = {
+              '// Utility functions',
+              'export function formatDate(date) {',
+              '  return date.toLocaleDateString();',
+              '}',
+              '',
+              'export function debounce(func, delay) {',
+              '  let timeoutId;',
+              '  return function(...args) {',
+              '    clearTimeout(timeoutId);',
+              '    timeoutId = setTimeout(() => func.apply(this, args), delay);',
+              '  };',
+              '}'
+            }
+          },
+          {
+            path = 'tests/button.test.js',
+            content = {
+              'import { render, screen } from "@testing-library/react";',
+              'import Button from "../src/components/Button";',
+              '',
+              'test("renders button with text", () => {',
+              '  render(<Button>Click me</Button>);',
+              '  const button = screen.getByRole("button");',
+              '  expect(button).toBeInTheDocument();',
+              '});'
+            }
+          },
+          {
+            path = 'package.json',
+            content = {
+              '{',
+              '  "name": "test-project",',
+              '  "version": "1.0.0",',
+              '  "scripts": {',
+              '    "test": "jest",',
+              '    "build": "webpack"',
+              '  }',
+              '}'
+            }
+          }
+        }
+
+        for _, file in ipairs(test_files) do
+          local filepath = vim.fs.joinpath(_G.TEST_DIR_ABSOLUTE, file.path)
+          vim.fn.writefile(file.content, filepath)
+        end
+
+        h = require('tests.helpers')
+        chat, agent = h.setup_chat_buffer()
+
+        -- Change to test directory for relative path testing
+        vim.cmd('cd ' .. _G.TEST_DIR_ABSOLUTE)
+      ]])
+    end,
+    post_case = function()
+      child.lua([[
+        h.teardown_chat_buffer()
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["can find basic text matches"] = function()
+  child.lua([[
+    local tool = {
+      {
+        ["function"] = {
+          name = "grep_search",
+          arguments = '{"query": "Button"}'
+        },
+      },
+    }
+    agent:execute(chat, tool)
+    vim.wait(200)
+  ]])
+
+  local output = child.lua_get("chat.messages[#chat.messages].content")
+
+  -- Should find matches in multiple files
+  h.expect_contains("Button.js:3 src/components", output) -- function Button declaration
+  h.expect_contains("Button.js:11 src/components", output) -- export default Button
+  h.expect_contains("button.test.js:3 tests", output) -- import Button
+  h.expect_contains("button.test.js:5 tests", output) -- render(<Button>
+end
+
+return T


### PR DESCRIPTION
## Description

Part of the plan to unify CodeCompanion's default tools with GitHub Copilot Chat.

This tool uses [ripgrep](https://github.com/BurntSushi/ripgrep) to search for files containing specific text.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
