### PR TITLE
refactor(tools): simply various logic

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/file_search.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/file_search.lua
@@ -10,8 +10,7 @@ local function search(action, opts)
   opts = opts or {}
   local query = action.query
 
-  local tool_config = opts.config and opts.config[opts.name] or {}
-  local max_results = action.max_results or tool_config.opts.max_results or 500 -- Default limit to prevent overwhelming results
+  local max_results = action.max_results or opts.max_results or 500 -- Default limit to prevent overwhelming results
 
   if not query or query == "" then
     return {
@@ -81,7 +80,7 @@ return {
     ---@param input? any The output from the previous function call
     ---@return { status: "success"|"error", data: string }
     function(self, args, input)
-      return search(args, { name = self.tool.name, config = self.tools_config })
+      return search(args, self.tool.opts)
     end,
   },
   schema = {

--- a/lua/codecompanion/strategies/chat/agents/tools/grep_search.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/grep_search.lua
@@ -160,7 +160,7 @@ return {
     ---@param self CodeCompanion.Tool.GrepSearch
     ---@param args table The arguments from the LLM's tool call
     ---@param input? any The output from the previous function call
-    ---@return { status: "success"|"error", data: string }
+    ---@return { status: "success"|"error", data: string|table }
     function(self, args, input)
       return grep_search(args, self.tool.opts)
     end,

--- a/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
@@ -122,9 +122,7 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
     data = fmt("**Insert Edit Into File Tool**: `%s` - %s", action.filepath, action.explanation),
   }
 
-  local tool_config = opts.config and opts.config[opts.name] or {}
-
-  if should_diff and tool_config.opts.user_confirmation then
+  if should_diff and opts.user_confirmation then
     local accept = config.strategies.inline.keymaps.accept_change.modes.n
     local reject = config.strategies.inline.keymaps.reject_change.modes.n
 
@@ -162,13 +160,7 @@ return {
     function(self, args, input, output_handler)
       local bufnr = buffers.get_bufnr_from_filepath(args.filepath)
       if bufnr then
-        return edit_buffer(
-          bufnr,
-          self.chat.bufnr,
-          args,
-          output_handler,
-          { name = self.tool.name, config = self.tools_config }
-        )
+        return edit_buffer(bufnr, self.chat.bufnr, args, output_handler, self.tool.opts)
       else
         local ok, outcome = pcall(edit_file, args)
         if not ok then

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -115,6 +115,7 @@
 ---@field output.error? fun(self: CodeCompanion.Agent.Tool, agent: CodeCompanion.Agent, cmd: table, stderr: table, stdout?: table): any The function to call if an error occurs
 ---@field output.success? fun(self: CodeCompanion.Agent.Tool, agent: CodeCompanion.Agent, cmd: table, stdout: table): any Function to call if the tool is successful
 ---@field args table The arguments sent over by the LLM when making the request
+---@field tool table The tool configuration from the config file
 
 ---@class CodeCompanion.SlashCommand.Provider
 ---@field output function The function to call when a selection is made


### PR DESCRIPTION
## Description

Simplifies the way methods in the tool receive the config from `config.lua`.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
