### PR TITLE
Try merging the patch even if the LLMs miss the BEGIN and END markers

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
@@ -36,7 +36,7 @@ local function edit_file(action)
 
   -- 1. extract list of changes from the code
   local raw = action.code or ""
-  local changes = patch.parse_changes(raw)
+  local changes, had_begin_end_markers = patch.parse_changes(raw)
 
   -- 2. read file into lines
   local content = p:read()
@@ -46,7 +46,11 @@ local function edit_file(action)
   for _, change in ipairs(changes) do
     local new_lines = patch.apply_change(lines, change)
     if new_lines == nil then
-      error(fmt("Bad/Incorrect diff:\n\n%s\n\nNo changes were applied", patch.get_change_string(change)))
+      if had_begin_end_markers then
+        error(fmt("Bad/Incorrect diff:\n\n%s\n\nNo changes were applied", patch.get_change_string(change)))
+      else
+        error("Invalid patch format: missing Begin/End markers")
+      end
     else
       lines = new_lines
     end
@@ -82,7 +86,7 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
 
   -- Parse and apply patches to buffer
   local raw = action.code or ""
-  local changes = patch.parse_changes(raw)
+  local changes, had_begin_end_markers = patch.parse_changes(raw)
 
   -- Get current buffer content as lines
   local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -92,7 +96,11 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
   for _, change in ipairs(changes) do
     local new_lines = patch.apply_change(lines, change)
     if new_lines == nil then
-      error(fmt("Bad/Incorrect diff:\n\n%s\n\nNo changes were applied", patch.get_change_string(change)))
+      if had_begin_end_markers then
+        error(fmt("Bad/Incorrect diff:\n\n%s\n\nNo changes were applied", patch.get_change_string(change)))
+      else
+        error("Invalid patch format: missing Begin/End markers")
+      end
     else
       if not start_line then
         start_line = patch.get_change_location(lines, change)

--- a/tests/fixtures/files-diff-1.5.patch
+++ b/tests/fixtures/files-diff-1.5.patch
@@ -1,10 +1,12 @@
-*** Begin Patch
 @@ two
 three
 four
-five
 -five
 +5
 six
 seven
-*** End Patch
+
+@@
+seven
+eight
+-nine

--- a/tests/fixtures/files-output-1.5.html
+++ b/tests/fixtures/files-output-1.5.html
@@ -6,5 +6,4 @@ four
 six
 seven
 eight
-nine
 ten

--- a/tests/strategies/chat/agents/tools/test_insert_edit_into_file.lua
+++ b/tests/strategies/chat/agents/tools/test_insert_edit_into_file.lua
@@ -189,6 +189,34 @@ T["File"]["insert_edit_into_file tool multiple patches"] = function()
   h.eq_info(output, expected, child.lua_get("chat.messages[#chat.messages].content"))
 end
 
+T["File"]["insert_edit_into_file tool multiple patches"] = function()
+  child.lua([[
+      -- read initial file from fixture
+      local initial = vim.fn.readfile("tests/fixtures/files-input-1.html")
+      local ok = vim.fn.writefile(initial, _G.TEST_TMPFILE_ABSOLUTE)
+      assert(ok == 0)
+
+      -- read contents for the tool from fixtures
+      local content = table.concat(vim.fn.readfile("tests/fixtures/files-diff-1.5.patch"), "\n")
+      local arguments = vim.json.encode({ filepath = _G.TEST_TMPFILE, explanation = "...", code = content })
+      local tool = {
+        {
+          ["function"] = {
+            name = "insert_edit_into_file",
+            arguments = arguments
+          },
+        },
+      }
+      agent:execute(chat, tool)
+      vim.wait(200)
+    ]])
+
+  -- Test that the file was updated as per the output fixture
+  local output = child.lua_get("vim.fn.readfile(_G.TEST_TMPFILE_ABSOLUTE)")
+  local expected = child.lua_get("vim.fn.readfile('tests/fixtures/files-output-1.5.html')")
+  h.eq_info(output, expected, child.lua_get("chat.messages[#chat.messages].content"))
+end
+
 T["File"]["insert_edit_into_file tool multiple continuation"] = function()
   child.lua([[
       -- read initial file from fixture


### PR DESCRIPTION
## Description

LLMs sometimes miss the BEGIN and END wrapping for the patches. This fails the merge.

Making the algorithm lax to allow and handle these misses confidently.

## Related Issue(s)

Handles a partial fix for https://github.com/olimorris/codecompanion.nvim/discussions/1619.

Even good models, such as `gpt-4.1` miss the `BEGIN` and `END` markers sometimes. This happens especially when the context is very large.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
