### PR TITLE
Use the same diff format as in patch

### DIFF
--- a/lua/codecompanion/strategies/chat/watchers.lua
+++ b/lua/codecompanion/strategies/chat/watchers.lua
@@ -105,7 +105,7 @@ end
 ---@param old_content table
 ---@param new_content table
 ---@return string
-local function format_changes_as_diff(old_content, new_content)
+function Watchers:format_changes_as_diff(old_content, new_content)
   -- Convert line arrays to strings for vim.diff
   local old_str = table.concat(old_content, "\n") .. "\n"
   local new_str = table.concat(new_content, "\n") .. "\n"
@@ -116,7 +116,9 @@ local function format_changes_as_diff(old_content, new_content)
     algorithm = "myers",
   })
   if diff_result and diff_result ~= "" then
-    return fmt("```diff\n%s```", diff_result)
+    -- replace line numbers in diff to keep a common format
+    diff_result = diff_result:gsub("^@@ .+ @@\n", "@@\n")
+    return fmt("```\n%s```", diff_result)
   end
 
   return ""
@@ -132,7 +134,7 @@ function Watchers:check_for_changes(chat)
       if has_changed and old_content then
         local filename = vim.fn.fnamemodify(api.nvim_buf_get_name(ref.bufnr), ":.")
         local current_content = api.nvim_buf_get_lines(ref.bufnr, 0, -1, false)
-        local diff_content = format_changes_as_diff(old_content, current_content)
+        local diff_content = self:format_changes_as_diff(old_content, current_content)
 
         if diff_content ~= "" then
           local delta = fmt("The file `%s`, has been modified. Here are the changes:\n%s", filename, diff_content)

--- a/tests/strategies/chat/test_watcher.lua
+++ b/tests/strategies/chat/test_watcher.lua
@@ -310,4 +310,12 @@ T["Watchers"]["doesn't watch invalid buffers"] = function()
   h.eq(old_content, nil)
 end
 
+T["Watchers"]["format_changes_as_diff returns correct unified diff"] = function()
+  local old = { "one", "two", "three" }
+  local new = { "one", "TWO", "three", "four" }
+  local watcher = Watcher.new()
+  local diff = watcher:format_changes_as_diff(old, new)
+  h.eq(diff, "```\n@@\n one\n-two\n+TWO\n three\n+four\n```")
+end
+
 return T


### PR DESCRIPTION
## Description

It is highly recommended to not use line-numbers for diffs in LLMs. The diffs generated in watched files used line numbers. This can confuse the LLMs.

This PR fixes that by using a common format.

## Related Issue(s)

It addresses some of the issues mentioned here: https://github.com/olimorris/codecompanion.nvim/discussions/1619#discussioncomment-13473490

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
