### PR TITLE
feat(chat): add_buffer

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -154,45 +154,11 @@ function SlashCommand:output(selected, opts)
   if not config.can_send_code() and (self.config.opts and self.config.opts.contains_code) then
     return log:warn("Sending of code has been disabled")
   end
-  opts = opts or {}
 
-  local message = "Here is the content from a file (including line numbers)"
-  if opts.pin then
-    message = "Here is the updated content from a file (including line numbers)"
-  end
-
-  local ok, content, id, filename = pcall(buf.format_for_llm, selected, { message = message })
-  if not ok then
-    return log:warn(content)
-  end
-
-  self.Chat:add_message({
-    role = config.constants.USER_ROLE,
-    content = content,
-  }, { reference = id, visible = false })
-
-  if opts.pin then
-    return
-  end
-
-  local slash_command_opts = self.config.opts and self.config.opts.default_params or nil
-  if slash_command_opts then
-    if slash_command_opts == "pin" then
-      opts.pinned = true
-    elseif slash_command_opts == "watch" then
-      opts.watched = true
-    end
-  end
-
-  self.Chat.references:add({
-    bufnr = selected.bufnr,
-    id = id,
-    path = selected.path,
-    opts = opts,
+  local opts_with_source = vim.tbl_deep_extend("force", opts or {}, {
     source = "codecompanion.strategies.chat.slash_commands.buffer",
   })
-
-  util.notify(fmt("Added buffer `%s` to the chat", filename))
+  self.Chat:add_buffer(selected, opts_with_source)
 end
 
 return SlashCommand


### PR DESCRIPTION

## Description

This is feature to expose `add_buffer` as public API. E.g. it can be
used to add current buffer to the most recent chat like this:

```lua
function()
  local bufnr = vim.api.nvim_get_current_buf()
  require('codecompanion').last_chat():add_buffer({ bufnr = bufnr })
end
```

Change itself is quite simple. I simply moved code from
`slash_commands/buffer.lua` to `init.lua`, added path resolution in case
it is not supplied and documented it in comments. As well moved code is
called in `slash_commands/buffers.lua` output. Path resolution was
added to make `add_buffer` usage simpler.

This is part of functionality discussed here:
https://github.com/olimorris/codecompanion.nvim/discussions/1546

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
