### PR TITLE
Fix: require tool module path correctly

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/init.lua
+++ b/lua/codecompanion/strategies/chat/agents/init.lua
@@ -365,7 +365,7 @@ function Agent.resolve(tool)
   end
 
   -- Try loading the tool from the user's config using a module path
-  ok, module = pcall(require)
+  ok, module = pcall(require, callback)
   if ok then
     log:debug("[Tools] %s identified", callback)
     return module


### PR DESCRIPTION
## Description
This fixes an error I made in this PR: https://github.com/olimorris/codecompanion.nvim/pull/1552

I mis-typed [this](https://github.com/olimorris/codecompanion.nvim/pull/1552/files#diff-9cbd4b342833a2597fc285c8b38bb5f46c086dd4a675aeddb7a7da387f6623baR361) line, which doesn't do anything.

I'm sorry for the mistake!

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
