### PR TITLE
Add tool support to azure_openai adapter

### DIFF
--- a/lua/codecompanion/adapters/azure_openai.lua
+++ b/lua/codecompanion/adapters/azure_openai.lua
@@ -10,6 +10,7 @@ return {
   },
   opts = {
     stream = true,
+    tools = true,
     vision = true,
   },
   features = {
@@ -41,12 +42,23 @@ return {
     form_messages = function(self, messages)
       return openai.handlers.form_messages(self, messages)
     end,
-    chat_output = function(self, data)
-      return openai.handlers.chat_output(self, data)
+    form_tools = function(self, tools)
+      return openai.handlers.form_tools(self, tools)
+    end,
+    chat_output = function(self, data, tools)
+      return openai.handlers.chat_output(self, data, tools)
     end,
     inline_output = function(self, data, context)
       return openai.handlers.inline_output(self, data, context)
     end,
+    tools = {
+      format_tool_calls = function(self, tools)
+        return openai.handlers.tools.format_tool_calls(self, tools)
+      end,
+      output_response = function(self, tool_call, output)
+        return openai.handlers.tools.output_response(self, tool_call, output)
+      end,
+    },
     on_exit = function(self, data)
       return openai.handlers.on_exit(self, data)
     end,


### PR DESCRIPTION
## Description

First off, thank you for this plugin, clearly lots of effort has gone into building it. This PR adds tool support the the azure adapter, as they are now supported in their chat completions api https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions. I used the same implementation for tools support as openai_compatible.lua has.

As a side note, I spent quite a bit of time trying to diagnose this issue (thinking the problem could be with azure, or the model I was selecting or not setting up mini diff correctly, etc.). How do you feel about notifying the user if their LLM does not support tool use, but they requested it? It gets silently dropped [here](https://github.com/olimorris/codecompanion.nvim/blob/229ca916ed0c9cfb5d97a06b61bd7ebb69f5d63e/lua/codecompanion/http.lua#L96) if the adapter doesn't support it, so that's one spot a message could be added. Another option is when they add the tool [here](https://github.com/olimorris/codecompanion.nvim/blob/229ca916ed0c9cfb5d97a06b61bd7ebb69f5d63e/lua/codecompanion/strategies/chat/agents/init.lua#L222-L222), we could check if `chat.adapter.opts.tools == true` somewhere & log.

## Related Issue(s)

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
