### PR TITLE
Add Copilot Usage Statistics Feature with `gS` as default keymap

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 17
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 20
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1947,7 +1947,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -2144,6 +2144,7 @@ The keymaps available to the user in normal mode are:
 - `gR` to go to the file under cursor. If the file is already opened, it’ll jump
     to the existing window. Otherwise, it’ll be opened in a new tab.
 - `gs` to toggle the system prompt on/off
+- `gS` to show copilot usage stats
 - `gta` to toggle auto tool mode
 - `gx` to clear the chat buffer’s contents
 - `gy` to yank the last codeblock in the chat buffer
@@ -3139,7 +3140,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI’S API OUTPUT
+OPENAI�S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/usage/chat-buffer/index.md
+++ b/doc/usage/chat-buffer/index.md
@@ -85,6 +85,7 @@ The keymaps available to the user in normal mode are:
 - `gR` to go to the file under cursor. If the file is already opened, it'll jump
   to the existing window. Otherwise, it'll be opened in a new tab.
 - `gs` to toggle the system prompt on/off
+- `gS` to show copilot usage stats
 - `gta` to toggle auto tool mode
 - `gx` to clear the chat buffer's contents
 - `gy` to yank the last codeblock in the chat buffer
@@ -92,4 +93,3 @@ The keymaps available to the user in normal mode are:
 - `]]` to move to the next header
 - `{` to move to the previous chat
 - `}` to move to the next chat
-

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -345,16 +345,12 @@ local function show_copilot_stats()
   end
   vim.api.nvim_win_call(winnr, function()
     -- Usage percentages with color coding
-    if stats.premium_interactions and not stats.premium_interactions.unlimited then
-      local used = stats.premium_interactions.entitlement - stats.premium_interactions.remaining
-      local usage_percent = stats.premium_interactions.entitlement > 0
-          and (used / stats.premium_interactions.entitlement * 100)
-        or 0
+    local premium = stats.quota_snapshots.premium_interactions
+    if premium and not premium.unlimited then
+      local used = premium.entitlement - premium.remaining
+      local usage_percent = premium.entitlement > 0 and (used / premium.entitlement * 100) or 0
       local highlight = get_usage_highlight(usage_percent)
-      vim.fn.matchadd(
-        highlight,
-        string.format("Used: %d / %d (%.1f%%)", used, stats.premium_interactions.entitlement, usage_percent)
-      )
+      vim.fn.matchadd(highlight, string.format("   - Used: %d / %d (%.1f%%)", used, premium.entitlement, usage_percent))
     end
   end)
 end

--- a/lua/codecompanion/adapters/copilot.lua
+++ b/lua/codecompanion/adapters/copilot.lua
@@ -259,7 +259,7 @@ local function get_copilot_stats()
     return nil
   end
 
-  return json.quota_snapshots
+  return json
 end
 
 ---Show Copilot usage statistics in a floating window
@@ -275,45 +275,50 @@ local function show_copilot_stats()
   table.insert(lines, "# 󰾞  GitHub Copilot Usage Statistics 󰾞 ")
   table.insert(lines, "")
 
-  if stats.premium_interactions then
-    local premium = stats.premium_interactions
+  if stats.quota_snapshots.premium_interactions then
+    local premium = stats.quota_snapshots.premium_interactions
     table.insert(lines, "##  Premium Interactions")
     local used = premium.entitlement - premium.remaining
     local usage_percent = premium.entitlement > 0 and (used / premium.entitlement * 100) or 0
-    table.insert(lines, string.format("   Used: %d / %d (%.1f%%)", used, premium.entitlement, usage_percent))
-    table.insert(lines, string.format("   Remaining: %d", premium.remaining))
-    table.insert(lines, string.format("   Percentage: %.1f%%", premium.percent_remaining))
+    table.insert(lines, string.format("   - Used: %d / %d (%.1f%%)", used, premium.entitlement, usage_percent))
+    table.insert(lines, string.format("   - Remaining: %d", premium.remaining))
+    table.insert(lines, string.format("   - Percentage: %.1f%%", premium.percent_remaining))
     if premium.unlimited then
-      table.insert(lines, "   Status: Unlimited ✨")
+      table.insert(lines, "   - Status: Unlimited ✨")
     else
-      table.insert(lines, "   Status: Limited")
+      table.insert(lines, "   - Status: Limited")
     end
     table.insert(lines, "")
   end
 
-  if stats.chat then
-    local chat = stats.chat
+  if stats.quota_snapshots.chat then
+    local chat = stats.quota_snapshots.chat
     table.insert(lines, "## 󰭹 Chat")
     if chat.unlimited then
-      table.insert(lines, "   Status: Unlimited ✨")
+      table.insert(lines, "   - Status: Unlimited ✨")
     else
       local used = chat.entitlement - chat.remaining
       local usage_percent = chat.entitlement > 0 and (used / chat.entitlement * 100) or 0
-      table.insert(lines, string.format("   Used: %d / %d (%.1f%%)", used, chat.entitlement, usage_percent))
+      table.insert(lines, string.format("   - Used: %d / %d (%.1f%%)", used, chat.entitlement, usage_percent))
     end
     table.insert(lines, "")
   end
 
-  if stats.completions then
-    local completions = stats.completions
-    table.insert(lines, "##   Completions")
+  if stats.quota_snapshots.completions then
+    local completions = stats.quota_snapshots.completions
+    table.insert(lines, "##  Completions")
     if completions.unlimited then
-      table.insert(lines, "   Status: Unlimited ✨")
+      table.insert(lines, "   - Status: Unlimited ✨")
     else
       local used = completions.entitlement - completions.remaining
       local usage_percent = completions.entitlement > 0 and (used / completions.entitlement * 100) or 0
-      table.insert(lines, string.format("   Used: %d / %d (%.1f%%)", used, completions.entitlement, usage_percent))
+      table.insert(lines, string.format("   - Used: %d / %d (%.1f%%)", used, completions.entitlement, usage_percent))
     end
+  end
+  if stats.quota_reset_date then
+    table.insert(lines, "")
+    table.insert(lines, string.format("> Quota resets on: %s", stats.quota_reset_date))
+    table.insert(lines, "")
   end
 
   -- Create floating window

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -433,6 +433,12 @@ local defaults = {
           callback = "keymaps.goto_file_under_cursor",
           description = "Open the file under cursor in a new tab.",
         },
+        copilot_stats = {
+          modes = { n = "gS" },
+          index = 20,
+          callback = "keymaps.copilot_stats",
+          description = "Show Copilot usage statistics",
+        },
       },
       opts = {
         blank_prompt = "", -- The prompt to use when the user doesn't provide a prompt

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -641,4 +641,18 @@ M.goto_file_under_cursor = {
   end,
 }
 
+M.copilot_stats = {
+  desc = "Show Copilot usage statistics",
+  callback = function(chat)
+    if chat.adapter.name ~= "copilot" then
+      return util.notify("Copilot stats are only available when using the Copilot adapter", vim.log.levels.WARN)
+    end
+    if chat.adapter.show_copilot_stats then
+      chat.adapter.show_copilot_stats()
+    else
+      util.notify("Copilot stats function not available", vim.log.levels.ERROR)
+    end
+  end,
+}
+
 return M

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -17,15 +17,25 @@ M.create_float = function(lines, opts)
   local bufnr = opts.bufnr or api.nvim_create_buf(false, true)
 
   require("codecompanion.utils").set_option(bufnr, "filetype", opts.filetype or "codecompanion")
+  -- Calculate center position if not specified
+  local row = opts.row or window.row or 10
+  local col = opts.col or window.col or 0
+  if row == "center" then
+    row = math.floor((vim.o.lines - height) / 2)
+  end
+  if col == "center" then
+    col = math.floor((vim.o.columns - width) / 2)
+  end
 
   local winnr = api.nvim_open_win(bufnr, true, {
     relative = opts.relative or "cursor",
-    border = "single",
+    -- thanks to @mini.nvim for this, it's for >= 0.11, to respect users winborder style
+    border = (vim.fn.exists("+winborder") == 1 and vim.o.winborder ~= "") and vim.o.winborder or "single",
     width = width,
     height = height,
     style = "minimal",
-    row = 10,
-    col = 0,
+    row = row,
+    col = col,
     title = opts.title or "Options",
     title_pos = "center",
   })

--- a/tests/adapters/test_copilot.lua
+++ b/tests/adapters/test_copilot.lua
@@ -127,4 +127,47 @@ T["Copilot adapter"]["No Streaming"]["can output for the inline assistant"] = fu
   )
 end
 
+T["Stats"] = new_set()
+
+T["Stats"]["can calculate usage percentages correctly"] = function()
+  local entitlement, remaining = 300, 250
+  local used = entitlement - remaining
+  local usage_percent = entitlement > 0 and (used / entitlement * 100) or 0
+  h.eq(50, used)
+  -- 50/300 * 100 = 16.666... so we need to check the rounded value
+  h.eq(16.7, math.floor(usage_percent * 10 + 0.5) / 10)
+
+  local zero_entitlement = 0
+  local zero_percent = zero_entitlement > 0 and (0 / zero_entitlement * 100) or 0
+  h.eq(0, zero_percent)
+
+  -- Test full usage
+  local full_entitlement, no_remaining = 100, 0
+  local full_used = full_entitlement - no_remaining
+  local full_percent = full_entitlement > 0 and (full_used / full_entitlement * 100) or 0
+  h.eq(100, full_used)
+  h.eq(100.0, full_percent)
+end
+
+T["Stats"]["can determine correct highlight colors based on usage"] = function()
+  local function get_usage_highlight(usage_percent)
+    if usage_percent >= 80 then
+      return "Error"
+    else
+      return "MoreMsg"
+    end
+  end
+
+  -- Test low usage (green)
+  h.eq("MoreMsg", get_usage_highlight(16.7))
+  h.eq("MoreMsg", get_usage_highlight(50))
+  h.eq("MoreMsg", get_usage_highlight(79.9))
+  -- Test high usage (red)
+  h.eq("Error", get_usage_highlight(80))
+  h.eq("Error", get_usage_highlight(85))
+  h.eq("Error", get_usage_highlight(100))
+
+  h.eq("MoreMsg", get_usage_highlight(0))
+end
+
 return T


### PR DESCRIPTION
## Description

This PR adds a feature to display GitHub Copilot [usage statistics](https://docs.github.com/en/copilot/managing-copilot/understanding-and-managing-copilot-usage/monitoring-your-copilot-usage-and-entitlements), similar to what's available in VSCode, JetBrains IDEs, and other editors. Users can now check their quota usage directly within CodeCompanion without switching to other tools or waiting an email from GitHub (when requesting usage data).

**Note**: Premium interactions quota applies to all models except `gpt-4.1` and `gpt-4o`.

## Usage

Press `gS` in any Copilot chat buffer to display a centered floating window showing:
- Premium interactions usage with percentage and color coding
- Chat quota status (those added for users uses free copilot)
- Completions quota status (those added for users uses free copilot)

Usage above 80% is highlighted in red (`Error`), below 80% in green (`MoreMsg`).

## Implementation Changes

### Existing Code Changes
- **UI enhancement**: Added `row="center"` and `col="center"` support to `create_float()` for window centering
- **Neovim 0.11 compatibility**: Added `winborder` option support to respect user's border preferences (inspired by mini.nvim)


If this doesn't fit the core, that's completely fine. Happy to maintain it as a separate extension.
However, I feel it’s essential now, especially since they’ve started counting premium requests. :(


## Related Issue(s)

This PR is related to the discussion in #1667. Instead of calculating usages locally, it’s better to rely on GitHub for that, as I believe this is essential now, and I haven’t seen any Neovim plugin implement it yet.

## Notes:  
~~I’m thinking of adding the Neovim version to the header tomorrow.~~
~~Also, I believe the reset date should be added now after adding the vscode screenshot.~~

## Screenshots
<img width="451" alt="Screenshot 2025-06-20 at 10 28 41 AM" src="https://github.com/user-attachments/assets/3f14d66e-22b9-419a-ba0e-a53418be57cf" />


in Vscode:
<img width="248" alt="Screenshot 2025-06-20 at 1 00 34 AM" src="https://github.com/user-attachments/assets/f82ac76e-b178-4e98-8e89-b0869b33309e" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
