### PR TITLE
feat: add gemini-2.5-flash and set as new default

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 17
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 20
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1947,7 +1947,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -2440,7 +2440,7 @@ Below is the tool use status of various adapters and models in CodeCompanion:
   DeepSeek      deepseek-reasoner                         Doesn’t support function
                                                           calling
 
-  Gemini        Gemini-2.0-flash                          
+  Gemini        Gemini-2.5-flash                          
 
   Gemini        Gemini-2.5-pro-exp-03-25                  
 
@@ -3139,7 +3139,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI’S API OUTPUT
+OPENAI�S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/usage/chat-buffer/agents.md
+++ b/doc/usage/chat-buffer/agents.md
@@ -207,7 +207,7 @@ Below is the tool use status of various adapters and models in CodeCompanion:
 | Copilot           | gemini-2.5-pro             | :white_check_mark: |                                  |
 | DeepSeek          | deepseek-chat              | :white_check_mark: |                                  |
 | DeepSeek          | deepseek-reasoner          | :x:                | Doesn't support function calling |
-| Gemini            | Gemini-2.0-flash           | :white_check_mark: |                                  |
+| Gemini            | Gemini-2.5-flash           | :white_check_mark: |                                  |
 | Gemini            | Gemini-2.5-pro-exp-03-25   | :white_check_mark: |                                  |
 | Gemini            | gemini-2.5-flash-preview   | :white_check_mark: |                                  |
 | GitHub Models     | All                        | :x:                | Not supported yet                |

--- a/lua/codecompanion/adapters/gemini.lua
+++ b/lua/codecompanion/adapters/gemini.lua
@@ -84,10 +84,11 @@ return {
       mapping = "parameters",
       type = "enum",
       desc = "The model that will complete your prompt. See https://ai.google.dev/gemini-api/docs/models/gemini#model-variations for additional details and options.",
-      default = "gemini-2.5-flash-preview-05-20",
+      default = "gemini-2.5-flash",
       choices = {
         ["gemini-2.5-pro-preview-06-05"] = { opts = { can_reason = true, has_vision = true } },
         ["gemini-2.5-pro-preview-05-06"] = { opts = { can_reason = true, has_vision = true } },
+        ["gemini-2.5-flash"] = { opts = { can_reason = true, has_vision = true } },
         ["gemini-2.5-flash-preview-05-20"] = { opts = { can_reason = true, has_vision = true } },
         ["gemini-2.0-flash"] = { opts = { has_vision = true } },
         ["gemini-2.0-flash-lite"] = { opts = { has_vision = true } },


### PR DESCRIPTION
## Description

- Add `gemini-2.5-flash` to Gemini model choices
- Set `gemini-2.5-flash` as new default Gemini model

## Related Issue(s)

- Fixes #1683 

## Screenshots

NA

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
