### PR TITLE
fix(inline): user_prompt mode with dressing and telescope

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -294,15 +294,17 @@ function Inline:prompt(user_prompt)
   -- From the prompt library, user's can explicitly ask to be prompted for input
   if self.opts and self.opts.user_prompt then
     local title = string.gsub(self.context.filetype, "^%l", string.upper)
-    vim.ui.input({ prompt = title .. " " .. config.display.action_palette.prompt }, function(input)
-      if not input then
-        return
-      end
+    vim.schedule(function()
+      vim.ui.input({ prompt = title .. " " .. config.display.action_palette.prompt }, function(input)
+        if not input then
+          return
+        end
 
-      log:info("[Inline] User input received: %s", input)
-      add_prompt("<prompt>" .. input .. "</prompt>", user_role)
-      self.prompts = prompts
-      return self:submit(vim.deepcopy(prompts))
+        log:info("[Inline] User input received: %s", input)
+        add_prompt("<prompt>" .. input .. "</prompt>", user_role)
+        self.prompts = prompts
+        return self:submit(vim.deepcopy(prompts))
+      end)
     end)
   else
     self.prompts = prompts


### PR DESCRIPTION
## Description

I suppose there is a conflict between telescope and dressing triggered by switching from Action Palette (telescope) to "Custom Prompt" (dressing). The "Custom Prompt" so far is the only inline prompt with `user_prompt = true`, so it triggers `vim.ui.input()` right after leaving telescope selection menu. Telescope selection menu was in INSERT mode, and I think it tries to leave it on exiting from menu. Dressing in turn tries to enable INSERT mode on showing `vim.ui.input` - and fails (it calls `vim.cmd("startinsert!")` without any effect).

If I disable any one of telescope or dressing this issue disappears.

Adding `vim.schedule` fixes the issue. But I didn't checked the whole codebase - there are may be other similar issues somewhere too.

I've no idea is it possible to write a test for the fix.

## Screenshots

Pressing enter here:
![изображение](https://github.com/user-attachments/assets/faddec82-f9b0-4584-8b83-f16b2b364f5f)
result in this (note **block** cursor meaning NORMAL mode):
![изображение](https://github.com/user-attachments/assets/08b421e1-eee2-4373-991c-776d992d6bc1)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
