### PR TITLE
files can be opened as buffers in a workspace

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 17
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 23
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1947,7 +1947,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -3139,7 +3139,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI’S API OUTPUT
+OPENAI�S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>
@@ -5067,6 +5067,9 @@ FILES
 When `files` are defined, their entire content is shared with the LLM alongside
 the description. This is useful for files where a deep understanding of how
 they function is required. Of course, this can consume significant tokens.
+CodeCompanion will automatically detect if a file is open in Neovim, as a
+buffer, and load it as such. This makes it more convenient to leverage watchers
+and pins and keep an LLM updated when you modify the contents.
 
 
 SYMBOLS
@@ -5080,14 +5083,14 @@ symbolic outline of files, capturing:
 - File/library imports
 - Start/end lines for each symbol
 
-By tagging the `files` tool, the LLM can request specific line ranges from
-these symbols - a cost-effective alternative to sharing entire files.
+Alongside the `@files` tool group, the LLM can request specific line ranges
+from these symbols - a cost-effective alternative to sharing entire files.
 
 
 URLS
 
 Workspace files also support the loading of data from URLs. When loading a URL,
-the `fetch` slash command adapter retrieves the data. The plugin:
+the `/fetch` slash command adapter retrieves the data. The plugin:
 
 - Caches URL data to disk by default
 - Prompts before restoring from cache

--- a/doc/extending/workspace.md
+++ b/doc/extending/workspace.md
@@ -93,7 +93,7 @@ Let's also explore one of the `data` objects in detail:
 
 ### Files
 
-When _files_ are defined, their entire content is shared with the LLM alongside the description. This is useful for files where a deep understanding of how they function is required. Of course, this can consume significant tokens.
+When _files_ are defined, their entire content is shared with the LLM alongside the description. This is useful for files where a deep understanding of how they function is required. Of course, this can consume significant tokens. CodeCompanion will automatically detect if a file is open in Neovim, as a buffer, and load it as such. This makes it more convenient to leverage watchers and pins and keep an LLM updated when you modify the contents.
 
 ### Symbols
 
@@ -104,11 +104,11 @@ The plugin uses Tree-sitter [queries](https://github.com/olimorris/codecompanion
 - File/library imports
 - Start/end lines for each symbol
 
-By tagging the `files` tool, the LLM can request specific line ranges from these symbols - a cost-effective alternative to sharing entire files.
+Alongside the `@files` tool group, the LLM can request specific line ranges from these symbols - a cost-effective alternative to sharing entire files.
 
 ### URLs
 
-Workspace files also support the loading of data from URLs. When loading a URL, the `fetch` slash command adapter retrieves the data. The plugin:
+Workspace files also support the loading of data from URLs. When loading a URL, the `/fetch` slash command adapter retrieves the data. The plugin:
 
 - Caches URL data to disk by default
 - Prompts before restoring from cache

--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -192,7 +192,9 @@ function SlashCommand:output(selected, opts)
     source = "codecompanion.strategies.chat.slash_commands.buffer",
   })
 
-  util.notify(fmt("Added buffer `%s` to the chat", filename))
+  if not opts.silent then
+    util.notify(fmt("Added buffer `%s` to the chat", filename))
+  end
 end
 
 return SlashCommand

--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -1,3 +1,4 @@
+local buf_utils = require("codecompanion.utils.buffers")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 
@@ -90,6 +91,10 @@ end
 ---@return nil
 function SlashCommands.references(chat, slash_command, opts)
   local slash_commands = {
+    buffer = require("codecompanion.strategies.chat.slash_commands.buffer").new({
+      Chat = chat,
+      config = config.strategies.chat.slash_commands["buffer"],
+    }),
     file = require("codecompanion.strategies.chat.slash_commands.file").new({
       Chat = chat,
     }),
@@ -101,6 +106,24 @@ function SlashCommands.references(chat, slash_command, opts)
       config = config.strategies.chat.slash_commands["fetch"],
     }),
   }
+
+  -- Check if the file is already open as a buffer
+  if slash_command == "file" then
+    local buffer = {}
+    for _, buf in ipairs(buf_utils.get_open()) do
+      if buf.relative_path == opts.path then
+        buffer = {
+          bufnr = buf.bufnr,
+          name = buf.path,
+          path = buf.path,
+        }
+        break
+      end
+    end
+    if not vim.tbl_isempty(buffer) then
+      return slash_commands["buffer"]:output(buffer, { silent = true })
+    end
+  end
 
   if slash_command == "file" or slash_command == "symbols" then
     return slash_commands[slash_command]:output({ description = opts.description, path = opts.path }, { silent = true })

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -11,33 +11,6 @@ local CONSTANTS = {
   WORKSPACE_FILE = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json"),
 }
 
----Output a list of files in the group
----@param group table
----@param workspace table
----@return string
-local function get_file_list(group, workspace)
-  local items = {}
-
-  if group.data and workspace and workspace.data then
-    for _, item in ipairs(group.data) do
-      local resource = workspace.data[item]
-      if resource and resource.path then
-        table.insert(items, "- " .. resource.path)
-      end
-    end
-  end
-
-  if vim.tbl_count(items) == 0 then
-    return ""
-  end
-
-  if group.vars then
-    util.replace_placeholders(items, group.vars)
-  end
-
-  return table.concat(items, "\n")
-end
-
 ---Replace variables in a string
 ---@param workspace table
 ---@param group table

--- a/tests/strategies/chat/slash_commands/test_workspace.lua
+++ b/tests/strategies/chat/slash_commands/test_workspace.lua
@@ -97,6 +97,20 @@ T["Workspace"]["files and symbols are added to the chat"] = function()
   )
 end
 
+T["Workspace"]["can open a file as a buffer if it's already open"] = function()
+  child.lua([[
+    -- Comment this out and see that it's loaded as a file instead
+    vim.cmd("edit tests/stubs/stub.go")
+
+    _G.set_workspace()
+    _G.wks:output("Test")
+  ]])
+
+  local messages = child.lua_get([[_G.chat.messages]])
+
+  h.expect_starts_with('<attachment filepath="tests/stubs/stub.go" buffer_number=', messages[5].content)
+end
+
 T["Workspace"]["top-level prompts are not duplicated and are ordered correctly"] = function()
   workspace_json = vim.json.decode(table.concat(vim.fn.readfile("tests/stubs/workspace_multiple.json"), ""))
 


### PR DESCRIPTION
## Description

When opening a workspace file, CodeCompanion will now detect if a file in a group is open as a buffer in Neovim. If so, then it will add that the file as a buffer in the chat buffer, automatically watching it in the process (if the user hasn't changed the defaults)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
