### PR TITLE
rename buffer pin and watch icons

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -156,13 +156,13 @@ VIM-PLUG ~
 
 >vim
     call plug#begin()
-    
+
     Plug 'nvim-lua/plenary.nvim'
     Plug 'nvim-treesitter/nvim-treesitter'
     Plug 'olimorris/codecompanion.nvim'
-    
+
     call plug#end()
-    
+
     lua << EOF
       require("codecompanion").setup()
     EOF
@@ -561,7 +561,7 @@ For an optimum plugin workflow, I recommend the following:
     vim.keymap.set({ "n", "v" }, "<C-a>", "<cmd>CodeCompanionActions<cr>", { noremap = true, silent = true })
     vim.keymap.set({ "n", "v" }, "<LocalLeader>a", "<cmd>CodeCompanionChat Toggle<cr>", { noremap = true, silent = true })
     vim.keymap.set("v", "ga", "<cmd>CodeCompanionChat Add<cr>", { noremap = true, silent = true })
-    
+
     -- Expand 'cc' into 'CodeCompanion' in the command line
     vim.cmd([[cab cc CodeCompanion]])
 <
@@ -1397,10 +1397,10 @@ configuration:
         chat = {
           -- Change the default icons
           icons = {
-            pinned_buffer = " ",
-            watched_buffer = "👀 ",
+            buffer_pin = " ",
+            buffer_watch = "👀 ",
           },
-    
+
           -- Alter the sizing of the debug window
           debug_window = {
             ---@return number|fun(): number
@@ -1408,7 +1408,7 @@ configuration:
             ---@return number|fun(): number
             height = vim.o.lines - 2,
           },
-    
+
           -- Options to customize the UI of the chat buffer
           window = {
             layout = "vertical", -- float|vertical|horizontal|buffer
@@ -1431,7 +1431,7 @@ configuration:
               wrap = true,
             },
           },
-    
+
           ---Customize how tokens are displayed
           ---@param tokens number
           ---@param adapter CodeCompanion.Adapter
@@ -1492,7 +1492,7 @@ customized in the configuration:
             llm = function(adapter)
               return "CodeCompanion (" .. adapter.formatted_name .. ")"
             end,
-    
+
             ---The header name for your messages
             ---@type string
             user = "Me",
@@ -1723,9 +1723,9 @@ Custom prompts can be added as follows:
             {
               role = "user",
               content = [[I'm rewriting the documentation for my plugin CodeCompanion.nvim, as I'm moving to a vitepress website. Can you help me rewrite it?
-    
+
     I'm sharing my vitepress config file so you have the context of how the documentation website is structured in the `sidebar` section of that file.
-    
+
     I'm also sharing my `config.lua` file which I'm mapping to the `configuration` section of the sidebar.
     ]],
             },
@@ -1760,7 +1760,7 @@ The plugin comes with the following system prompt:
 
 >txt
     You are an AI programming assistant named "CodeCompanion". You are currently plugged in to the Neovim text editor on a user's machine.
-    
+
     Your core tasks include:
     - Answering general programming questions.
     - Explaining how the code in a Neovim buffer works.
@@ -1772,7 +1772,7 @@ The plugin comes with the following system prompt:
     - Proposing fixes for test failures.
     - Answering questions about Neovim.
     - Running tools.
-    
+
     You must:
     - Follow the user's requirements carefully and to the letter.
     - Keep your answers short and impersonal, especially if the user responds with context outside of your tasks.
@@ -1785,7 +1785,7 @@ The plugin comes with the following system prompt:
     - Use actual line breaks instead of '\n' in your response to begin new lines.
     - Use '\n' only when you want a literal backslash followed by a character 'n'.
     - All non-code responses must be in %s.
-    
+
     When given a task:
     1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.
     2. Output the code in a single code block, being careful to only return relevant code.
@@ -1833,7 +1833,7 @@ lazy.nvim:
       "olimorris/codecompanion.nvim",
       dependencies = {
         -- Add mcphub.nvim as a dependency
-        "ravitemer/mcphub.nvim" 
+        "ravitemer/mcphub.nvim"
       }
     }
 <
@@ -1847,9 +1847,9 @@ lazy.nvim:
         mcphub = {
           callback = "mcphub.extensions.codecompanion",
           opts = {
-            make_vars = true,       
+            make_vars = true,
             make_slash_commands = true,
-            show_result_in_chat = true  
+            show_result_in_chat = true
           }
         }
       }
@@ -2406,45 +2406,45 @@ Below is the tool use status of various adapters and models in CodeCompanion:
   --------------------------------------------------------------------------------
   Adapter       Model                         Supported   Notes
   ------------- ---------------------------- ------------ ------------------------
-  Anthropic     claude-3-opus-20240229                    
+  Anthropic     claude-3-opus-20240229
 
-  Anthropic     claude-3-5-haiku-20241022                 
+  Anthropic     claude-3-5-haiku-20241022
 
-  Anthropic     claude-3-5-sonnet-20241022                
+  Anthropic     claude-3-5-sonnet-20241022
 
-  Anthropic     claude-3-7-sonnet-20250219                
+  Anthropic     claude-3-7-sonnet-20250219
 
-  Copilot       gpt-4o                                    
+  Copilot       gpt-4o
 
-  Copilot       gpt-4.1                                   
+  Copilot       gpt-4.1
 
-  Copilot       o1                                        
+  Copilot       o1
 
-  Copilot       o3-mini                                   
+  Copilot       o3-mini
 
-  Copilot       o4-mini                                   
+  Copilot       o4-mini
 
-  Copilot       claude-3-5-sonnet                         
+  Copilot       claude-3-5-sonnet
 
-  Copilot       claude-3-7-sonnet                         
+  Copilot       claude-3-7-sonnet
 
   Copilot       claude-3-7-sonnet-thought                 Doesn’t support function
                                                           calling
 
-  Copilot       gemini-2.0-flash-001                      
+  Copilot       gemini-2.0-flash-001
 
-  Copilot       gemini-2.5-pro                            
+  Copilot       gemini-2.5-pro
 
-  DeepSeek      deepseek-chat                             
+  DeepSeek      deepseek-chat
 
   DeepSeek      deepseek-reasoner                         Doesn’t support function
                                                           calling
 
-  Gemini        Gemini-2.0-flash                          
+  Gemini        Gemini-2.0-flash
 
-  Gemini        Gemini-2.5-pro-exp-03-25                  
+  Gemini        Gemini-2.5-pro-exp-03-25
 
-  Gemini        gemini-2.5-flash-preview                  
+  Gemini        gemini-2.5-flash-preview
 
   GitHub Models All                                       Not supported yet
 
@@ -2459,22 +2459,22 @@ Below is the tool use status of various adapters and models in CodeCompanion:
   OpenAI        All                                       Dependent on the model
   Compatible                                              and provider
 
-  OpenAI        gpt-3.5-turbo                             
+  OpenAI        gpt-3.5-turbo
 
-  OpenAI        gpt-4.1                                   
+  OpenAI        gpt-4.1
 
-  OpenAI        gpt-4                                     
+  OpenAI        gpt-4
 
-  OpenAI        gpt-4o                                    
+  OpenAI        gpt-4o
 
-  OpenAI        gpt-4o-mini                               
+  OpenAI        gpt-4o-mini
 
-  OpenAI        o1-2024-12-17                             
+  OpenAI        o1-2024-12-17
 
   OpenAI        o1-mini-2024-09-12                        Doesn’t support function
                                                           calling
 
-  OpenAI        o3-mini-2025-01-31                        
+  OpenAI        o3-mini-2025-01-31
 
   xAI           All                                       Not supported yet
   --------------------------------------------------------------------------------
@@ -2743,7 +2743,7 @@ Events can be hooked into as follows:
 
 >lua
     local group = vim.api.nvim_create_augroup("CodeCompanionHooks", {})
-    
+
     vim.api.nvim_create_autocmd({ "User" }, {
       pattern = "CodeCompanionInline*",
       group = group,
@@ -2872,10 +2872,10 @@ statusline when a request is being sent to an LLM:
 
 >lua
     local M = require("lualine.component"):extend()
-    
+
     M.processing = false
     M.spinner_index = 1
-    
+
     local spinner_symbols = {
       "⠋",
       "⠙",
@@ -2889,13 +2889,13 @@ statusline when a request is being sent to an LLM:
       "⠏",
     }
     local spinner_symbols_len = 10
-    
+
     -- Initializer
     function M:init(options)
       M.super.init(self, options)
-    
+
       local group = vim.api.nvim_create_augroup("CodeCompanionHooks", {})
-    
+
       vim.api.nvim_create_autocmd({ "User" }, {
         pattern = "CodeCompanionRequest*",
         group = group,
@@ -2908,7 +2908,7 @@ statusline when a request is being sent to an LLM:
         end,
       })
     end
-    
+
     -- Function that runs every time statusline is updated
     function M:update_status()
       if self.processing then
@@ -2918,7 +2918,7 @@ statusline when a request is being sent to an LLM:
         return nil
       end
     end
-    
+
     return M
 <
 
@@ -3168,7 +3168,7 @@ The chat buffer, which is structured like:
 
 >markdown
     ## Me
-    
+
     Explain Ruby in two words
 <
 
@@ -3233,7 +3233,7 @@ comes with some handy utility functions to work with this:
 >lua
     -- Put this at the top of your adapter
     local utils = require("codecompanion.utils.adapters")
-    
+
     handlers = {
       chat_output = function(self, data)
         data = utils.clean_streamed_data(data)
@@ -3278,7 +3278,7 @@ chat buffer, with:
         local output = {}
         ---
         local delta = json.choices[1].delta
-    
+
         if delta.content then
           output.content = delta.content
           output.role = delta.role or nil
@@ -3308,17 +3308,17 @@ we have data in our response:
     handlers = {
       chat_output = function(self, data)
         local output = {}
-    
+
         if data and data ~= "" then
           data = utils.clean_streamed_data(data)
           local ok, json = pcall(vim.json.decode, data, { luanil = { object = true } })
-    
+
           local delta = json.choices[1].delta
-    
+
           if delta.content then
             output.content = delta.content
             output.role = delta.role or nil
-    
+
             return {
               status = "success",
               output = output,
@@ -3683,7 +3683,7 @@ builtin to the plugin as the `Code Advisor` action:
               role = "user",
               content = function(context)
                 local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
-    
+
                 return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
               end,
               opts = {
@@ -3744,7 +3744,7 @@ advice on the code:
         role = "user",
         content = function(context)
           local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
-    
+
           return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
         end,
         opts = {
@@ -3799,7 +3799,7 @@ Lets now take a look at the second prompt:
       role = "user",
       content = function(context)
         local text = require("codecompanion.helpers.actions").get_code(context.start_line, context.end_line)
-    
+
         return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
       end,
       opts = {
@@ -4024,32 +4024,32 @@ please see the diagram below:
         participant A as Agent
         participant E as Tool Executor
         participant T as Tool
-    
+
         C->>L: Prompt
         L->>C: Response with Tool(s) request
-    
+
         C->>A: Parse response
-    
+
         loop For each detected tool
             A<<->>T: Resolve Tool config
             A->>A: Add Tool to queue
         end
-    
+
         A->>E: Begin executing Tools
-    
+
         loop While queue not empty
             E<<->>T: Fetch Tool implementation
-    
+
             E->>E: Setup handlers and output functions
             T<<->>E: handlers.setup()
-    
+
             alt
             Note over C,E: Some Tools require human approvals
                 E->>C: Prompt for approval
                 C->>E: User decision
             end
-    
-    
+
+
             alt
             Note over E,T: If Tool runs with success
                 T-->>A: Update stdout
@@ -4059,13 +4059,13 @@ please see the diagram below:
                 T-->>A: Update stderr
                 E<<->>T: output.error()
             end
-    
+
             Note over E,T: When Tool completes
             E<<->>T: handlers.on_exit()
         end
-    
+
         E-->>A: Fire autocmd
-    
+
         A->>A: reset()
 <
 
@@ -4175,7 +4175,7 @@ by use of ${} brackets. The now removed `@code_runner` tool used them as below:
       local temp_dir = temp_input:match("(.*/)")
       local lang = self.args.lang
       local code = self.args.code
-    
+
       return {
         code = code,
         lang = lang,
@@ -4209,20 +4209,20 @@ you can ignore it. For the purpose of our calculator example:
         local num1 = tonumber(args.num1)
         local num2 = tonumber(args.num2)
         local operation = args.operation
-    
+
         -- Validate input
         if not num1 then
           return { status = "error", data = "First number is missing or invalid" }
         end
-    
+
         if not num2 then
           return { status = "error", data = "Second number is missing or invalid" }
         end
-    
+
         if not operation then
           return { status = "error", data = "Operation is missing" }
         end
-    
+
         -- Perform the calculation
         local result
         if operation == "add" then
@@ -4239,7 +4239,7 @@ you can ignore it. For the purpose of our calculator example:
         else
           return { status = "error", data = "Invalid operation: must be add, subtract, multiply, or divide" }
         end
-    
+
         return { status = "success", data = result }
       end,
     },
@@ -4349,14 +4349,14 @@ For our calculator tool, our `system_prompt` could look something like:
 
 >lua
     system_prompt = [[## Calculator Tool (`calculator`)
-    
+
     ## CONTEXT
     - You have access to a calculator tool running within CodeCompanion, in Neovim.
     - You can use it to add, subtract, multiply or divide two numbers.
-    
+
     ### OBJECTIVE
     - Do a mathematical operation on two numbers when the user asks
-    
+
     ### RESPONSE
     - Always use the structure above for consistency.
     ]],
@@ -4471,20 +4471,20 @@ If we put this all together in our config:
                     local num1 = tonumber(args.num1)
                     local num2 = tonumber(args.num2)
                     local operation = args.operation
-    
+
                     -- Validate input
                     if not num1 then
                       return { status = "error", data = "First number is missing or invalid" }
                     end
-    
+
                     if not num2 then
                       return { status = "error", data = "Second number is missing or invalid" }
                     end
-    
+
                     if not operation then
                       return { status = "error", data = "Operation is missing" }
                     end
-    
+
                     -- Perform the calculation
                     local result
                     if operation == "add" then
@@ -4504,23 +4504,23 @@ If we put this all together in our config:
                         data = "Invalid operation: must be add, subtract, multiply, or divide",
                       }
                     end
-    
+
                     return { status = "success", data = result }
                   end,
                 },
                 system_prompt = [[## Calculator Tool (`calculator`)
-    
+
     ## CONTEXT
     - You have access to a calculator tool running within CodeCompanion, in Neovim.
     - You can use it to add, subtract, multiply or divide two numbers.
-    
+
     ### OBJECTIVE
     - Do a mathematical operation on two numbers when the user asks
-    
+
     ### RESPONSE
     - Always use the structure above for consistency.
     ]],
-    
+
                 schema = {
                   type = "function",
                   ["function"] = {
@@ -4637,7 +4637,7 @@ To account for the user being prompted for an approval, we can add a
 >lua
     output = {
       -- success and error functions remain the same ...
-    
+
       ---The message which is shared with the user when asking for their approval
       ---@param self CodeCompanion.Tool.Calculator
       ---@param agent CodeCompanion.Agent
@@ -4660,7 +4660,7 @@ You can also customize the output if a user rejects the approval:
 >lua
     output = {
       -- success, error and prompt functions remain the same ...
-    
+
       ---Rejection message back to the LLM
       ---@param self CodeCompanion.Tool.Calculator
       ---@param agent CodeCompanion.Agent
@@ -4824,20 +4824,20 @@ Let’s breakdown the prompts in that workflow:
           content = function()
             -- Leverage auto_tool_mode which disables the requirement of approvals and automatically saves any edited buffer
             vim.g.codecompanion_auto_tool_mode = true
-    
+
             -- Some clear instructions for the LLM to follow
             return [[### Instructions
-    
+
     Your instructions here
-    
+
     ### Steps to Follow
-    
+
     You are required to write code following the instructions provided above and test the correctness by running the designated test suite. Follow these steps exactly:
-    
+
     1. Update the code in #buffer{watch} using the @insert_edit_into_file tool
     2. Then use the @cmd_runner tool to run the test suite with `<test_cmd>` (do this after you have updated the code)
     3. Make sure you trigger both tools in the same response
-    
+
     We'll repeat this cycle until the tests pass. Ensure no deviations from these steps.]]
           end,
         },
@@ -5191,7 +5191,7 @@ Extensions are configured in your CodeCompanion setup:
         "author/codecompanion_history.nvim" -- history extension
       }
     }
-    
+
     -- Configure in your setup
     require("codecompanion").setup({
       extensions = {
@@ -5230,19 +5230,19 @@ exports:
     ---@field setup fun(opts: table) Function called when extension is loaded
     ---@field exports? table Functions exposed via codecompanion.extensions.your_extension
     local Extension = {}
-    
+
     ---Setup the extension
-    ---@param opts table Configuration options 
+    ---@param opts table Configuration options
     function Extension.setup(opts)
       -- Initialize extension
       -- Add actions, keymaps etc.
     end
-    
+
     -- Optional: Functions exposed via codecompanion.extensions.your_extension
     Extension.exports = {
       clear_history = function() end
     }
-    
+
     return Extension
 <
 
@@ -5258,10 +5258,10 @@ codecompanion.config object inside setup function.
     function Extension.setup(opts)
       -- Add action to chat keymaps
       local chat_keymaps = require("codecompanion.config").strategies.chat.keymaps
-      
+
       chat_keymaps.open_saved_chats = {
         modes = {
-          n = opts.keymap or "gh", 
+          n = opts.keymap or "gh",
         },
         description = "Open Saved Chats",
         callback = function(chat)
@@ -5307,12 +5307,12 @@ cases:
                   vim.notify("Editor opened for chat " .. chat.id)
                 end,
               }
-    
+
               -- Add the action to chat keymaps config
               local chat_keymaps = require("codecompanion.config").strategies.chat.keymaps
               chat_keymaps.open_editor = open_editor
             end,
-    
+
             -- Optional: Expose functions
             exports = {
               is_editor_open = function()

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -310,8 +310,8 @@ require("codecompanion").setup({
     chat = {
       -- Change the default icons
       icons = {
-        pinned_buffer = " ",
-        watched_buffer = "👀 ",
+        buffer_pin = " ",
+        buffer_watch = "👀 ",
       },
 
       -- Alter the sizing of the debug window

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1000,8 +1000,8 @@ You must create or modify a workspace file through a series of prompts over mult
     },
     chat = {
       icons = {
-        pinned_buffer = " ",
-        watched_buffer = "󰂥 ",
+        buffer_pin = " ",
+        buffer_watch = "󰂥 ",
       },
       debug_window = {
         ---@return number|fun(): number

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -307,7 +307,7 @@ M.pin_reference = {
       return
     end
 
-    local icon = config.display.chat.icons.pinned_buffer
+    local icon = config.display.chat.icons.pinned_buffer or config.display.chat.icons.buffer_pin
     local id = line:gsub("^> %- ", "")
 
     if not chat.references:can_be_pinned(id) then
@@ -355,7 +355,8 @@ M.toggle_watch = {
 
     -- Find the reference and toggle watch state
     for _, ref in ipairs(chat.refs) do
-      local clean_id = id:gsub(icons.pinned_buffer, ""):gsub(icons.watched_buffer, "")
+      local clean_id = id:gsub(icons.pinned_buffer or icons.buffer_pin, "")
+        :gsub(icons.watched_buffer or icons.buffer_watch, "")
       if ref.id == clean_id then
         if not ref.opts then
           ref.opts = {}
@@ -368,7 +369,7 @@ M.toggle_watch = {
           -- Check if buffer is still valid before watching
           if vim.api.nvim_buf_is_valid(ref.bufnr) and vim.api.nvim_buf_is_loaded(ref.bufnr) then
             chat.watchers:watch(ref.bufnr)
-            new_line = string.format("> - %s%s", icons.watched_buffer, clean_id)
+            new_line = string.format("> - %s%s", icons.watched_buffer or icons.buffer_watch, clean_id)
           else
             -- Buffer is invalid, can't watch it
             ref.opts.watched = false

--- a/lua/codecompanion/strategies/chat/references.lua
+++ b/lua/codecompanion/strategies/chat/references.lua
@@ -10,8 +10,8 @@ local api = vim.api
 local user_role = config.strategies.chat.roles.user
 local icons_path = config.display.chat.icons
 local icons = {
-  pinned = icons_path.pinned_buffer,
-  watched = icons_path.watched_buffer,
+  pinned = icons_path.pinned_buffer or icons_path.buffer_pin,
+  watched = icons_path.watched_buffer or icons_path.buffer_watch,
 }
 
 local allowed_pins = {

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -364,8 +364,8 @@ return {
   display = {
     chat = {
       icons = {
-        pinned_buffer = " ",
-        watched_buffer = "👀 ",
+        buffer_pin = " ",
+        buffer_watch = "👀 ",
       },
       show_references = true,
       show_settings = false,

--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -218,7 +218,7 @@ T["References"]["Can be pinned"] = function()
 
   h.eq("> Context:", buffer[15])
   h.eq(
-    string.format("> - %s<buf>pinned example</buf>", child.lua_get([[config.display.chat.icons.pinned_buffer]])),
+    string.format("> - %s<buf>pinned example</buf>", child.lua_get([[config.display.chat.icons.buffer_pin]])),
     buffer[16]
   )
   h.eq("> - <buf>unpinned example</buf>", buffer[17])
@@ -446,13 +446,13 @@ T["References"]["Show icons immediately when added with default parameters"] = f
 
   -- Check that watched reference shows with icon immediately
   h.eq(
-    string.format("> - %s<buf>watched_file.lua</buf>", child.lua_get([[config.display.chat.icons.watched_buffer]])),
+    string.format("> - %s<buf>watched_file.lua</buf>", child.lua_get([[config.display.chat.icons.buffer_watch]])),
     lines[4]
   )
 
   -- Check that pinned reference shows with icon immediately
   h.eq(
-    string.format("> - %s<buf>pinned_file.lua</buf>", child.lua_get([[config.display.chat.icons.pinned_buffer]])),
+    string.format("> - %s<buf>pinned_file.lua</buf>", child.lua_get([[config.display.chat.icons.buffer_pin]])),
     lines[5]
   )
 


### PR DESCRIPTION
## Description

Simple refactor to unify how icons are named in the buffer. Non-breaking.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
