### PR TITLE
add description to buffer content in workspace

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/buffer.lua
@@ -166,6 +166,10 @@ function SlashCommand:output(selected, opts)
     return log:warn(content)
   end
 
+  if opts.description then
+    content = opts.description .. "\n\n" .. content
+  end
+
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = content,

--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -121,7 +121,7 @@ function SlashCommands.references(chat, slash_command, opts)
       end
     end
     if not vim.tbl_isempty(buffer) then
-      return slash_commands["buffer"]:output(buffer, { silent = true })
+      return slash_commands["buffer"]:output(buffer, { description = opts.description, silent = true })
     end
   end
 

--- a/tests/strategies/chat/slash_commands/test_workspace.lua
+++ b/tests/strategies/chat/slash_commands/test_workspace.lua
@@ -108,7 +108,7 @@ T["Workspace"]["can open a file as a buffer if it's already open"] = function()
 
   local messages = child.lua_get([[_G.chat.messages]])
 
-  h.expect_starts_with('<attachment filepath="tests/stubs/stub.go" buffer_number=', messages[5].content)
+  h.expect_starts_with([[Test description for the file stub.go located at tests/stubs/stub.go]], messages[5].content)
 end
 
 T["Workspace"]["top-level prompts are not duplicated and are ordered correctly"] = function()


### PR DESCRIPTION
## Description

If a file is added as a buffer, the description from the workspace file is now incorporated with it.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
