### PR TITLE
fix(inline): skip think tags output by qwen3

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -523,6 +523,9 @@ end
 ---@param output string
 ---@return table|nil
 function Inline:parse_output(output)
+  -- Remove any think tags that may have been added by the LLM (e.g. qwen3).
+  output = output:gsub("<think>.-</think>", "")
+
   -- Try parsing as plain JSON first
   output = output:gsub("^```json", ""):gsub("```$", "")
   local _, json = pcall(vim.json.decode, output)

--- a/tests/strategies/inline/test_inline.lua
+++ b/tests/strategies/inline/test_inline.lua
@@ -28,6 +28,23 @@ T["Inline"]["can parse json output correctly"] = function()
   h.eq("add", json.placement)
 end
 
+T["Inline"]["can parse output with think tags correctly"] = function()
+  local json = inline:parse_output([[
+<think>
+Cogito,
+ergo sum.
+</think>
+
+{
+  "code": "function test() end",
+  "placement": "add"
+}
+]])
+
+  h.eq("function test() end", json.code)
+  h.eq("add", json.placement)
+end
+
 T["Inline"]["can parse markdown output correctly"] = function()
   local json = inline:parse_output([[```json
 {


### PR DESCRIPTION
## Description

LLM qwen3:8b running using Ollama always return `<think>...</think>` at beginning of the response. Even if prompt includes `/no_think` instruction (in this case there will be no content between the tags, but tags are still present).

This breaks inline strategy parser.

Example output when using `/no_think` in the prompt:

```text
<think>

</think>

{
  "code": "This is my Neovim config.\n",
  "language": "markdown"
}
```

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
