### PR TITLE
refactor anthropic and remove auto-submit user prompt

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -861,10 +861,6 @@ function Chat:submit(opts)
 
   if opts.auto_submit then
     self.watchers:check_for_changes(self)
-    self:add_message({
-      role = config.constants.USER_ROLE,
-      content = "I've shared the output from the tool/function call with you.",
-    }, { visible = false })
   else
     local message = ts_parse_messages(self, self.header_line)
 


### PR DESCRIPTION
## Description

This PR removes the unnecessary user prompt from the chat buffer when an auto-submit was triggered. This also removes the blank user prompt that _could_ occur in the Anthropic adapter.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
