### PR TITLE
enable domain specific web search for tavily adapter and `@web_search` tool

### DIFF
--- a/doc/usage/chat-buffer/agents.md
+++ b/doc/usage/chat-buffer/agents.md
@@ -138,6 +138,11 @@ Can you use the @web_search tool to tell me the latest version of Neovim?
 
 Currently, the tool uses [tavily](https://www.tavily.com) and you'll need to ensure that an API key has been set accordingly, as per the [adapter](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/adapters/tavily.lua).
 
+You can also ask it to search under a specific domain:
+```
+Using the @web_search tool to search from `https://neovim.io` and explain how I can configure a new language server.
+```
+
 ## Tool Groups
 
 CodeCompanion comes with two built-in tool groups:

--- a/lua/codecompanion/adapters/tavily.lua
+++ b/lua/codecompanion/adapters/tavily.lua
@@ -40,6 +40,7 @@ return {
         time_range = adapter.opts.time_range or nil, -- day, week, month, year
         include_answer = adapter.opts.include_answer or false,
         include_raw_content = adapter.opts.include_raw_content or false,
+        include_domains = data.include_domains,
       }
 
       if adapter.opts.topic == "news" then

--- a/lua/codecompanion/strategies/chat/agents/tools/web_search.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/web_search.lua
@@ -47,6 +47,7 @@ return {
         :request({
           url = adapter.url,
           query = args.query,
+          include_domains = args.include_domains,
         }, {
           callback = function(err, data)
             if err then
@@ -90,8 +91,16 @@ return {
             type = "string",
             description = "Search query optimized for keyword searching.",
           },
+          include_domains = {
+            type = "array",
+            items = {
+              type = "string",
+              description = "Each string should be a url, like `https://github.com/` or `https://neovim.io/`",
+            },
+            description = "When there's a specific site that you want to search from, add the url to the sites here. They must be from user input or from a previous search result. Otherwise, leave this field empty.",
+          },
         },
-        required = { "query" },
+        required = { "query", "include_domains" },
         additionalProperties = false,
       },
       strict = true,

--- a/tests/adapters/test_tavily.lua
+++ b/tests/adapters/test_tavily.lua
@@ -14,7 +14,7 @@ T["Tavily adapter"] = new_set({
 })
 
 T["Tavily adapter"]["should return properly formatted body with default options"] = function()
-  local data = { query = "test query" }
+  local data = { query = "test query", include_domains = { "https://github.com" } }
   local body = adapter.handlers.set_body(adapter, data)
 
   h.eq(body.query, data.query)
@@ -25,6 +25,7 @@ T["Tavily adapter"]["should return properly formatted body with default options"
   h.eq(body.max_results, 3)
   h.eq(body.include_answer, false)
   h.eq(body.include_raw_content, false)
+  h.eq(body.include_domains, { "https://github.com" })
 end
 
 T["Tavily adapter"]["should use adapter options if provided"] = function()


### PR DESCRIPTION
## Description

This allows the LLM to search from a (or some) specific websites, similar to the `site:` trick for Google search. This makes it easier if you know _just_ where to look for the correct info, but the LLM don't.

Ref: https://docs.tavily.com/documentation/api-reference/endpoint/search#body-include-domains

## Screenshots

![image](https://github.com/user-attachments/assets/202523ed-63ad-4fcd-836f-6e21c34aff75)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
