### PR TITLE
Ensure chat buffers gracefully handle buffer deletion

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1203,7 +1203,7 @@ function Chat:close()
     end)
   )
   chatmap[self.bufnr] = nil
-  api.nvim_buf_delete(self.bufnr, { force = true })
+  pcall(api.nvim_buf_delete, self.bufnr, { force = true })
   if self.aug then
     api.nvim_clear_autocmds({ group = self.aug })
   end
@@ -1422,6 +1422,12 @@ end
 ---@return CodeCompanion.Chat|nil
 function Chat.last_chat()
   if not last_chat or vim.tbl_isempty(last_chat) then
+    return nil
+  end
+  -- if last_chat buffer was deleted, we need to clean it out
+  if last_chat and not api.nvim_buf_is_loaded(last_chat.bufnr) then
+    last_chat:close()
+    last_chat = nil
     return nil
   end
   return last_chat


### PR DESCRIPTION
## Description

Harden `Chat.last_chat` to validate whether the buffer was deleted or not, and if it was, clean it up with `:close()` and return `nil`. The net result of this required wrapping the deleted buffer call in `close` with a pcall just in case.

Hopefully I'm not coming across as annoying, but I do think it's good to gracefully handle buffer deletion cases since they can come in many forms (from other plugins or various work flows) 😬

## Related Issue(s)

Fixes #1744

## Screenshots

The original issue has an example broken case when using the Toggle API. However there was an additional case if you use CodeCompanion History extension and you did `:bd` on an existing chat buffer, you could never access that particular history item again until you restarted neovim. Here's a video showing those flows being fixed with these changes:

https://github.com/user-attachments/assets/02b22a53-050d-4bd1-a744-a26dc1cc4844

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
