### PR TITLE
docs: fix markdown for ripgrep link

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 June 30
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 03
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -114,7 +114,7 @@ REQUIREMENTS                         *codecompanion-installation-requirements*
 - Neovim 0.11.0 or greater
 - `(Optional)` An API key for your chosen LLM
 - `(Optional)` The `base64` library for image/vision support
-- `(Optional)` The `[ripgrep](https://github.com/BurntSushi/ripgrep)` library for the `grep_search` tool
+- `(Optional)` The ripgrep <https://github.com/BurntSushi/ripgrep> library for the `grep_search` tool
 
 
 INSTALLATION                         *codecompanion-installation-installation*
@@ -1959,7 +1959,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -3123,7 +3123,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -9,7 +9,7 @@
 - Neovim 0.11.0 or greater
 - _(Optional)_ An API key for your chosen LLM
 - _(Optional)_ The `base64` library for image/vision support
-- _(Optional)_ The `[ripgrep](https://github.com/BurntSushi/ripgrep)` library for the `grep_search` tool
+- _(Optional)_ The [ripgrep](https://github.com/BurntSushi/ripgrep) library for the `grep_search` tool
 
 ## Installation
 


### PR DESCRIPTION
The link to ripgrep was not showing as a link because was inside a inline block code.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
