### PR TITLE
docs(contributing): missing prerequirement pandoc.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,8 @@ CodeCompanion.nvim is organized into several key directories:
 
 - Neovim 0.10.0+
 - [lua-language-server](https://github.com/LuaLS/lua-language-server) for LSP support and type annotations
-- [stylua](https://github.com/JohnnyMorganz/StyLua) for Lua formatting
+- [stylua](https://github.com/JohnnyMorganz/StyLua) for Lua formatting (Install it with feature `lua54`)
+- [pandoc](https://pandoc.org/installing.html) for generate docs.
 
 ### Setting Up for Development
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
