### PR TITLE
Don't remove custom system prompts when using `gs`

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -539,10 +539,6 @@ local defaults = {
               context.filetype
             )
           end,
-          opts = {
-            visible = false,
-            tag = "system_tag",
-          },
         },
       },
     },
@@ -566,9 +562,6 @@ local defaults = {
                 context.filetype
               )
             end,
-            opts = {
-              visible = false,
-            },
           },
           {
             role = constants.USER_ROLE,
@@ -676,9 +669,6 @@ We'll repeat this cycle until the tests pass. Ensure no deviations from these st
 3. Explain each function or significant block of code, including parameters and return values.
 4. Highlight any specific functions or methods used and their roles.
 5. Provide context on how the code fits into a larger application if applicable.]],
-          opts = {
-            visible = false,
-          },
         },
         {
           role = constants.USER_ROLE,
@@ -731,9 +721,6 @@ We'll repeat this cycle until the tests pass. Ensure no deviations from these st
       - Edge cases
       - Error handling (if applicable)
 6. Provide the generated unit tests in a clear and organized manner without additional explanations or chat.]],
-          opts = {
-            visible = false,
-          },
         },
         {
           role = constants.USER_ROLE,
@@ -791,9 +778,6 @@ Ensure the fixed code:
 - Is formatted correctly.
 
 Use Markdown formatting and include the programming language name at the start of the code block.]],
-          opts = {
-            visible = false,
-          },
         },
         {
           role = constants.USER_ROLE,
@@ -835,9 +819,6 @@ Use Markdown formatting and include the programming language name at the start o
         {
           role = constants.SYSTEM_ROLE,
           content = [[You are an expert coder and helpful assistant who can help debug code diagnostics, such as warning and error messages. When appropriate, give solutions with code snippets as fenced codeblocks with a language identifier to enable syntax highlighting.]],
-          opts = {
-            visible = false,
-          },
         },
         {
           role = constants.USER_ROLE,
@@ -951,7 +932,6 @@ This is the code, for context:
       prompts = {
         {
           role = constants.SYSTEM_ROLE,
-          opts = { visible = false },
           content = function()
             local schema = require("codecompanion").workspace_schema()
             return fmt(

--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -158,6 +158,9 @@ function Strategies:workflow()
           if type(p.content) == "function" then
             p.content = p.content(self.context)
           end
+          if p.role == config.constants.SYSTEM_ROLE and not p.opts then
+            p.opts = { visible = false, tags = { "from_custom_prompt" } }
+          end
           return p
         end)
         :totable()
@@ -254,7 +257,7 @@ function Strategies.evaluate_prompts(prompts, context)
     :map(function(prompt)
       local content = type(prompt.content) == "function" and prompt.content(context) or prompt.content
       if prompt.role == config.constants.SYSTEM_ROLE and not prompt.opts then
-        prompt.opts = { visible = false }
+        prompt.opts = { visible = false, tags = { "from_custom_prompt" } }
       end
       return {
         role = prompt.role or "",


### PR DESCRIPTION
## Description

When a prompt from the prompt library was used to open a chat and a user pressed `gs` (to clear the default system prompt), the system prompt from the library would also be removed.

## Related Issue(s)

#1749

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
