### PR TITLE
fix Anthropic reasoning models and tool use

### DIFF
--- a/tests/strategies/chat/test_references.lua
+++ b/tests/strategies/chat/test_references.lua
@@ -208,7 +208,7 @@ T["References"]["Can be pinned"] = function()
     })
     _G.chat:submit()
     _G.chat.status = "success"
-    _G.chat:done({ content = "This is a mocked response" })
+    _G.chat:done({{ content = "This is a mocked response" }})
   ]])
 
   h.eq(child.lua_get([[#_G.chat.messages]]), 4, "There are four messages")


### PR DESCRIPTION
## Description

This PR will add reasoning output into the messages stack making which is a requirement for Anthropic's reasoning models and their tool use

## Related Issue(s)

#1752

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
