### PR TITLE
Fix: copilot adapter unauthorized token expired

### DIFF
--- a/lua/codecompanion/adapters/copilot/init.lua
+++ b/lua/codecompanion/adapters/copilot/init.lua
@@ -300,7 +300,7 @@ return {
             return { ["gpt-4.1"] = { opts = {} } } -- fallback
           end
         end
-        return copilot_helper.get_models(self, get_and_authorize_token, _github_token)
+        return copilot_helper.get_models(self, get_and_authorize_token, _oauth_token)
       end,
     },
     ---@type CodeCompanion.Schema


### PR DESCRIPTION
## Description
Fix `Unauthorized: token expired` error after prompting inactivity.

The issue seems to be caused by [models cache](https://github.com/olimorris/codecompanion.nvim/blob/3527a9c85b58a8db2fee6d7dcde72077ba790a4a/lua/codecompanion/config.lua#L33) refresh after some time. The copilot adapter function [is given a _github_token](https://github.com/olimorris/codecompanion.nvim/blob/3527a9c85b58a8db2fee6d7dcde72077ba790a4a/lua/codecompanion/adapters/copilot/init.lua#L303C48-L303C71) but that token can be outdated and refreshed by `get_and_authorize_token` call inside the function. Despite this the function would still use the outdated token from input when calling the models endpoint.

## Related Issue(s)

- Fixes #1052

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
