### PR TITLE
fix: add chat ID to chat opened/hidden events

### DIFF
--- a/lua/codecompanion/strategies/chat/ui/init.lua
+++ b/lua/codecompanion/strategies/chat/ui/init.lua
@@ -148,7 +148,7 @@ function UI:open(opts)
   end
 
   log:trace("Chat opened with ID %d", self.chat_id)
-  util.fire("ChatOpened", { bufnr = self.chat_bufnr })
+  util.fire("ChatOpened", { bufnr = self.chat_bufnr, id = self.chat_id })
 
   self.tools = require("codecompanion.strategies.chat.ui.tools").new({
     chat_bufnr = self.chat_bufnr,
@@ -176,7 +176,7 @@ function UI:hide()
     vim.cmd("buffer " .. vim.fn.bufnr("#"))
   end
 
-  util.fire("ChatHidden", { bufnr = self.chat_bufnr })
+  util.fire("ChatHidden", { bufnr = self.chat_bufnr, id = self.chat_id })
 end
 
 ---Follow the cursor in the chat buffer


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

As mentioned in #1791, the `CodeCompanionChatOpened` and `CodeCompanionChatHidden` events currently do not provide the chat ID in the event data. This PR adds that.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

Implements #1791 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

<img width="1713" alt="image" src="https://github.com/user-attachments/assets/9283f1f7-a63e-4ff0-8d0f-118af26f5d3b" />

Note the `id` is set.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
