### PR TITLE
feat: Add versioning User-Agent to HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Thank you to the following people:
 - :books: Have [multiple chats](https://codecompanion.olimorris.dev/usage/introduction.html#quickly-accessing-a-chat-buffer) open at the same time
 - :art: Support for [vision and images](https://codecompanion.olimorris.dev/usage/chat-buffer/#images-vision) as input
 - :muscle: Async execution for fast performance
+- :identification_card: Automatic User-Agent headers for better API compliance and debugging
 
 <!-- panvimdoc-ignore-start -->
 
@@ -79,6 +80,23 @@ require("codecompanion").setup({
   opts = {
     log_level = "DEBUG", -- or "TRACE"
   }
+})
+```
+
+**User-Agent Headers**
+
+CodeCompanion automatically adds a User-Agent header (e.g., `CodeCompanion/17.6.0`) to all HTTP requests for better API compliance and debugging. You can control this behavior:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    opts = {
+      add_user_agent = true, -- Default: true, set to false to disable
+      default_headers = {
+        ["X-Custom-Header"] = "value", -- Add custom headers to all adapters
+      },
+    },
+  },
 })
 ```
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 03
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 07
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/lua/codecompanion/adapters/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/copilot/helpers.lua
@@ -2,6 +2,7 @@ local config = require("codecompanion.config")
 local curl = require("plenary.curl")
 local log = require("codecompanion.utils.log")
 local utils = require("codecompanion.utils.adapters")
+local version = require("codecompanion.utils.version")
 local M = {}
 
 -- Cache variables
@@ -111,7 +112,7 @@ function M.get_copilot_stats(get_and_authorize_token_fn, oauth_token)
       headers = {
         Authorization = "Bearer " .. oauth_token,
         Accept = "*/*",
-        ["User-Agent"] = "CodeCompanion.nvim",
+        ["User-Agent"] = version.get_user_agent(),
       },
       insecure = config.adapters.opts.allow_insecure,
       proxy = config.adapters.opts.proxy,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -34,6 +34,8 @@ local defaults = {
       proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
       show_defaults = true, -- Show default adapters
       show_model_choices = true, -- Show model choices when changing adapter
+      add_user_agent = true, -- Add User-Agent header to all adapters (e.g. "CodeCompanion/17.6.0")
+      default_headers = {}, -- Default headers to add to all adapters
     },
   },
   constants = constants,

--- a/lua/codecompanion/utils/version.lua
+++ b/lua/codecompanion/utils/version.lua
@@ -1,0 +1,42 @@
+---@class CodeCompanion.Version
+local M = {}
+
+---Get the version of the CodeCompanion plugin
+---@return string The version string in format "v17.6.0" or "unknown"
+function M.get_version()
+  local plugin_path = debug.getinfo(1, "S").source:match("@(.*/)")
+
+  if plugin_path then
+    -- Navigate to plugin root (go up from lua/codecompanion/utils/)
+    local root_path = plugin_path:gsub("/lua/codecompanion/utils/$", "")
+
+    -- Get version using git describe
+    local cmd = string.format("cd '%s' && git describe --tags --always --dirty 2>/dev/null", root_path)
+    local handle = io.popen(cmd)
+    if handle then
+      local result = handle:read("*a")
+      handle:close()
+      if result and result ~= "" then
+        local version = result:gsub("%s+$", "")
+        return version
+      end
+    end
+  end
+
+  return "unknown"
+end
+
+---Get the User-Agent string for HTTP requests
+---@return string The User-Agent string in format "CodeCompanion/v17.6.0"
+function M.get_user_agent()
+  local version = M.get_version()
+  if version == "unknown" then
+    return "CodeCompanion"
+  else
+    -- Remove 'v' prefix if present for consistency
+    local clean_version = version:gsub("^v", "")
+    return string.format("CodeCompanion/%s", clean_version)
+  end
+end
+
+return M

--- a/tests/test_adapter.lua
+++ b/tests/test_adapter.lua
@@ -9,6 +9,7 @@ T = new_set({
       h.child_start(child)
       child.lua([[
         utils = require("codecompanion.utils.adapters")
+        version = require("codecompanion.utils.version")
 
         _G.test_adapter = {
           name = "TestAdapter",
@@ -164,7 +165,9 @@ T["Adapter"]["can set environment variables in the adapter"] = function()
     return adapter:set_env_vars(adapter.headers)
   ]])
 
+  local expected_user_agent = child.lua_get("version.get_user_agent()")
   h.eq({
+    ["User-Agent"] = expected_user_agent,
     content_type = "application/json",
     home = os.getenv("HOME"),
   }, headers)

--- a/tests/test_adapter_user_agent.lua
+++ b/tests/test_adapter_user_agent.lua
@@ -1,0 +1,175 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        config = require("codecompanion.config")
+        Adapter = require("codecompanion.adapters.init")
+        version = require("codecompanion.utils.version")
+        
+        -- Mock version module
+        _G.original_get_user_agent = version.get_user_agent
+        version.get_user_agent = function()
+          return "CodeCompanion/1.2.3"
+        end
+      ]])
+    end,
+    post_once = function()
+      child.stop()
+    end,
+  },
+})
+
+T["User-Agent header"] = new_set({
+  hooks = {
+    pre_case = function()
+      child.lua([[
+        -- Reset config to default state
+        config.adapters = {
+          opts = {}
+        }
+      ]])
+    end,
+    post_case = function()
+      child.lua([[
+        -- Restore original function
+        version.get_user_agent = _G.original_get_user_agent
+      ]])
+    end,
+  },
+})
+
+T["User-Agent header"]["is added by default"] = function()
+  child.lua([[
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  h.eq(user_agent, "CodeCompanion/1.2.3")
+end
+
+T["User-Agent header"]["can be disabled"] = function()
+  child.lua([[
+    config.adapters.opts.add_user_agent = false
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  h.eq(user_agent, vim.NIL)
+end
+
+T["User-Agent header"]["merges with existing headers"] = function()
+  child.lua([[
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+      headers = {
+        ["Authorization"] = "Bearer token123",
+        ["Content-Type"] = "application/json",
+      }
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  local auth = child.lua_get("test_adapter.headers['Authorization']")
+  local content_type = child.lua_get("test_adapter.headers['Content-Type']")
+
+  h.eq(user_agent, "CodeCompanion/1.2.3")
+  h.eq(auth, "Bearer token123")
+  h.eq(content_type, "application/json")
+end
+
+T["User-Agent header"]["adapter headers take precedence"] = function()
+  child.lua([[
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+      headers = {
+        ["User-Agent"] = "CustomAgent/1.0",
+      }
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  h.eq(user_agent, "CustomAgent/1.0")
+end
+
+T["User-Agent header"]["merges with custom default headers"] = function()
+  child.lua([[
+    config.adapters.opts.default_headers = {
+      ["X-Custom-Header"] = "custom-value",
+      ["Authorization"] = "Bearer default-token",
+    }
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+      headers = {
+        ["Authorization"] = "Bearer override-token",
+      }
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  local custom_header = child.lua_get("test_adapter.headers['X-Custom-Header']")
+  local auth = child.lua_get("test_adapter.headers['Authorization']")
+
+  h.eq(user_agent, "CodeCompanion/1.2.3")
+  h.eq(custom_header, "custom-value")
+  h.eq(auth, "Bearer override-token")
+end
+
+T["User-Agent header"]["works with no custom headers"] = function()
+  child.lua([[
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  h.eq(user_agent, "CodeCompanion/1.2.3")
+end
+
+T["User-Agent header"]["handles unknown version"] = function()
+  child.lua([[
+    version.get_user_agent = function()
+      return "CodeCompanion"
+    end
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  h.eq(user_agent, "CodeCompanion")
+end
+
+T["User-Agent header"]["does not contain newlines"] = function()
+  child.lua([[
+    version.get_user_agent = function()
+      return "CodeCompanion/1.2.3-dirty"
+    end
+    test_adapter = Adapter.new({
+      name = "test",
+      url = "https://example.com",
+    })
+  ]])
+
+  local user_agent = child.lua_get("test_adapter.headers['User-Agent']")
+  h.eq(user_agent:find("\n"), nil)
+  h.eq(user_agent:find("\r"), nil)
+end
+
+return T

--- a/tests/utils/test_version.lua
+++ b/tests/utils/test_version.lua
@@ -1,0 +1,188 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        version = require("codecompanion.utils.version")
+      ]])
+    end,
+    post_once = function()
+      child.stop()
+    end,
+  },
+})
+
+T["get_version"] = new_set({
+  hooks = {
+    pre_case = function()
+      -- Mock io.popen for testing
+      child.lua([[
+        _G.original_io_popen = io.popen
+        _G.mock_git_result = nil
+        _G.mock_git_error = false
+        
+        io.popen = function(cmd)
+          if _G.mock_git_error then
+            return nil
+          end
+          
+          local handle = {
+            read = function(self, format)
+              return _G.mock_git_result or ""
+            end,
+            close = function(self)
+              return true
+            end
+          }
+          return handle
+        end
+      ]])
+    end,
+    post_case = function()
+      -- Restore original io.popen
+      child.lua([[
+        io.popen = _G.original_io_popen
+      ]])
+    end,
+  },
+})
+
+T["get_version"]["returns version from git describe"] = function()
+  child.lua([[
+    _G.mock_git_result = "v1.2.3-4-g1234567"
+  ]])
+
+  local version = child.lua_get("version.get_version()")
+  h.eq(version, "v1.2.3-4-g1234567")
+end
+
+T["get_version"]["strips whitespace from git result"] = function()
+  child.lua([[
+    _G.mock_git_result = "v1.2.3-dirty\n"
+  ]])
+
+  local version = child.lua_get("version.get_version()")
+  h.eq(version, "v1.2.3-dirty")
+end
+
+T["get_version"]["returns unknown when git command fails"] = function()
+  child.lua([[
+    _G.mock_git_error = true
+  ]])
+
+  local version = child.lua_get("version.get_version()")
+  h.eq(version, "unknown")
+end
+
+T["get_version"]["returns unknown when git result is empty"] = function()
+  child.lua([[
+    _G.mock_git_result = ""
+  ]])
+
+  local version = child.lua_get("version.get_version()")
+  h.eq(version, "unknown")
+end
+
+T["get_version"]["returns unknown when plugin path cannot be determined"] = function()
+  child.lua([[
+    -- Mock debug.getinfo to return nil
+    _G.original_debug_getinfo = debug.getinfo
+    debug.getinfo = function(level, what)
+      return { source = "@" }
+    end
+  ]])
+
+  local version = child.lua_get("version.get_version()")
+  h.eq(version, "unknown")
+
+  child.lua([[
+    debug.getinfo = _G.original_debug_getinfo
+  ]])
+end
+
+T["get_user_agent"] = new_set({
+  hooks = {
+    pre_case = function()
+      -- Use the same io.popen mocking
+      child.lua([[
+        _G.original_io_popen = io.popen
+        _G.mock_git_result = nil
+        _G.mock_git_error = false
+        
+        io.popen = function(cmd)
+          if _G.mock_git_error then
+            return nil
+          end
+          
+          local handle = {
+            read = function(self, format)
+              return _G.mock_git_result or ""
+            end,
+            close = function(self)
+              return true
+            end
+          }
+          return handle
+        end
+      ]])
+    end,
+    post_case = function()
+      child.lua([[
+        io.popen = _G.original_io_popen
+      ]])
+    end,
+  },
+})
+
+T["get_user_agent"]["returns CodeCompanion with version"] = function()
+  child.lua([[
+    _G.mock_git_result = "v1.2.3"
+  ]])
+
+  local user_agent = child.lua_get("version.get_user_agent()")
+  h.eq(user_agent, "CodeCompanion/1.2.3")
+end
+
+T["get_user_agent"]["removes v prefix from version"] = function()
+  child.lua([[
+    _G.mock_git_result = "v17.6.0-1-g1234567"
+  ]])
+
+  local user_agent = child.lua_get("version.get_user_agent()")
+  h.eq(user_agent, "CodeCompanion/17.6.0-1-g1234567")
+end
+
+T["get_user_agent"]["returns CodeCompanion when version is unknown"] = function()
+  child.lua([[
+    _G.mock_git_error = true
+  ]])
+
+  local user_agent = child.lua_get("version.get_user_agent()")
+  h.eq(user_agent, "CodeCompanion")
+end
+
+T["get_user_agent"]["handles version without v prefix"] = function()
+  child.lua([[
+    _G.mock_git_result = "1.2.3-dirty"
+  ]])
+
+  local user_agent = child.lua_get("version.get_user_agent()")
+  h.eq(user_agent, "CodeCompanion/1.2.3-dirty")
+end
+
+T["get_user_agent"]["does not contain newlines"] = function()
+  child.lua([[
+    _G.mock_git_result = "v1.2.3\n"
+  ]])
+
+  local user_agent = child.lua_get("version.get_user_agent()")
+  h.eq(user_agent, "CodeCompanion/1.2.3")
+  h.eq(user_agent:find("\n"), nil)
+end
+
+return T


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

Add versioning User-Agent to HTTP headers

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/olimorris/codecompanion.nvim/discussions/1773

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

![image](https://github.com/user-attachments/assets/fc9ec654-a923-4ca4-9bca-80851e592bae)
![image](https://github.com/user-attachments/assets/0f1e31f4-5e2f-4822-9bf8-066b46a246d5)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
