### PR TITLE
feat(keymaps): sort options

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -64,6 +64,22 @@ M.options = {
       return desc
     end
 
+    local function sorted_pairs(tbl, comp)
+      local keys = {}
+      for k in pairs(tbl) do
+        table.insert(keys, k)
+      end
+      table.sort(keys, comp)
+      local i = 0
+      return function()
+        i = i + 1
+        local key = keys[i]
+        if key ~= nil then
+          return key, tbl[key]
+        end
+      end
+    end
+
     -- Workout the column spacing
     local keymaps = config.strategies.chat.keymaps
     local keymaps_max = max("description", keymaps)
@@ -108,7 +124,11 @@ M.options = {
     -- Keymaps
     table.insert(lines, "### Keymaps")
 
-    for _, map in pairs(keymaps) do
+    local function compare_keymaps(a, b)
+      return (keymaps[a].description or "") < (keymaps[b].description or "")
+    end
+
+    for _, map in sorted_pairs(keymaps, compare_keymaps) do
       if type(map.condition) == "function" and not map.condition() then
         goto continue
       end
@@ -142,7 +162,7 @@ M.options = {
     table.insert(lines, "")
     table.insert(lines, "### Variables")
 
-    for key, val in pairs(vars) do
+    for key, val in sorted_pairs(vars) do
       local desc = clean_and_truncate(val.description)
       table.insert(lines, indent .. pad("#" .. key, max_length, 4) .. " " .. desc)
     end
@@ -151,7 +171,7 @@ M.options = {
     table.insert(lines, "")
     table.insert(lines, "### Tools")
 
-    for key, val in pairs(tools) do
+    for key, val in sorted_pairs(tools) do
       if key ~= "opts" then
         local desc = clean_and_truncate(val.description)
         table.insert(lines, indent .. pad("@" .. key, max_length, 4) .. " " .. desc)


### PR DESCRIPTION
## Description

Amount of keymaps is increasing with time (I've 26 now), and using Options window (`?`) became complicated because the order is different on each Neovim run. This PR adds basic sorting to keymaps/vars/tools.

## Screenshots

![изображение](https://github.com/user-attachments/assets/b11a3a7d-891d-435c-9bca-e68da186ea45)
![изображение](https://github.com/user-attachments/assets/0e424909-58db-476f-8b90-d5d682850eb9)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
