### PR TITLE
Fix/watcher on unlisted buffer deletion

### DIFF
--- a/lua/codecompanion/strategies/chat/watchers.lua
+++ b/lua/codecompanion/strategies/chat/watchers.lua
@@ -80,6 +80,9 @@ end
 ---@param bufnr number
 ---@return boolean, table|nil
 function Watchers:get_changes(bufnr)
+  if not api.nvim_buf_is_valid(bufnr) then
+    self:unwatch(bufnr)
+  end
   if not self.buffers[bufnr] then
     return false, nil
   end

--- a/lua/codecompanion/strategies/chat/watchers.lua
+++ b/lua/codecompanion/strategies/chat/watchers.lua
@@ -80,11 +80,13 @@ end
 ---@param bufnr number
 ---@return boolean, table|nil
 function Watchers:get_changes(bufnr)
-  if not api.nvim_buf_is_valid(bufnr) then
-    self:unwatch(bufnr)
-  end
   if not self.buffers[bufnr] then
     return false, nil
+  end
+  if not api.nvim_buf_is_valid(bufnr) then
+    -- special case for unlisted buffers
+    self:unwatch(bufnr)
+    return true, nil
   end
   local buffer = self.buffers[bufnr]
   local current_content = api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -144,6 +146,12 @@ function Watchers:check_for_changes(chat)
             content = fmt([[<attachment filepath="%s" buffer_number="%s">%s</attachment>]], filename, ref.bufnr, delta),
           }, { visible = false })
         end
+      elseif has_changed then
+        -- buffer is now invalid
+        chat:add_message({
+          role = config.constants.USER_ROLE,
+          content = fmt([[buffer %d has been removed.]], ref.bufnr),
+        }, { visible = false })
       end
     end
   end

--- a/tests/strategies/chat/test_watcher.lua
+++ b/tests/strategies/chat/test_watcher.lua
@@ -187,6 +187,20 @@ T["Watchers"]["ignores changes after unwatching"] = function()
   h.eq(old_content, nil)
 end
 
+T["Watchers"]["handles changes after buffer removal"] = function()
+  local watcher = Watcher.new()
+  local bufnr = vim.api.nvim_create_buf(false, true)
+
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "line 1" })
+  watcher:watch(bufnr)
+
+  vim.api.nvim_buf_delete(bufnr, {})
+
+  local has_changed, old_content = watcher:get_changes(bufnr)
+  h.eq(has_changed, false)
+  h.eq(old_content, nil)
+end
+
 T["Watchers"]["handles prepending to start of buffer"] = function()
   local watcher = Watcher.new()
   local bufnr = vim.api.nvim_get_current_buf()

--- a/tests/strategies/chat/test_watcher.lua
+++ b/tests/strategies/chat/test_watcher.lua
@@ -197,7 +197,7 @@ T["Watchers"]["handles changes after buffer removal"] = function()
   vim.api.nvim_buf_delete(bufnr, {})
 
   local has_changed, old_content = watcher:get_changes(bufnr)
-  h.eq(has_changed, false)
+  h.eq(has_changed, true)
   h.eq(old_content, nil)
 end
 


### PR DESCRIPTION
## Description

The deletion of unlisted buffers doesn't seem to trigger `BufDelete`, and therefore doesn't trigger `watchers:unwatch(bufnr)`.

I use the watchers to track _unlisted_ scratch buffers that contain information generated from the [dap extension](https://github.com/Davidyz/codecompanion-dap.nvim), so that when the tools are called and the results are mostly the same, only the diffs are sent to the LLM.

When I delete the scratch buffers following the termination of a DAP session, the watchers don't unwatch them due to the aforementioned reason.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
