### PR TITLE
fix tool folding

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -966,13 +966,11 @@ function Chat:submit(opts)
                 { type = self.MESSAGE_TYPES.REASONING_MESSAGE }
               )
             end
-            if result.output.content then
-              table.insert(output, result.output.content)
-              self:add_buf_message(
-                { role = result.output.role, content = result.output.content },
-                { type = self.MESSAGE_TYPES.LLM_MESSAGE }
-              )
-            end
+            table.insert(output, result.output.content)
+            self:add_buf_message(
+              { role = result.output.role, content = result.output.content },
+              { type = self.MESSAGE_TYPES.LLM_MESSAGE }
+            )
           elseif self.status == CONSTANTS.STATUS_ERROR then
             log:error("Error: %s", result.output)
             return self:done(output)


### PR DESCRIPTION
## Description

In the UI Builder, a new section and a new header are triggered when the `add_buf_message` method is called. Because I'd been so strict about when that method was called in `Chat:submit`, this meant that any tool output wasn't triggering the builder. So we would see tool output being written into the user header.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
