### PR TITLE
save buffer after `insert_edit_into_file` tool

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
@@ -149,8 +149,10 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
     return wait.for_decision(diff_id, { "CodeCompanionDiffAccepted", "CodeCompanionDiffRejected" }, function(result)
       if result.accepted then
         -- Save the buffer
-        vim.api.nvim_buf_call(bufnr, function()
-          vim.cmd("silent! w")
+        pcall(function()
+          api.nvim_buf_call(bufnr, function()
+            vim.cmd("silent! w")
+          end)
         end)
         return output_handler(success)
       end


### PR DESCRIPTION
## Description

This automatically saves the buffer after a user accepts the LLM's edits via the `insert_edit_into_file` tool

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
