### PR TITLE
add restore function to ensure a chat buffer can be made visible

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -209,6 +209,25 @@ CodeCompanion.toggle = function()
   chat.ui:open({ toggled = true })
 end
 
+---Make a previously hidden chat buffer, visible again
+---@param bufnr integer
+---@return nil
+CodeCompanion.restore = function(bufnr)
+  if not bufnr or not api.nvim_buf_is_valid(bufnr) then
+    return log:error("Chat buffer %d is not valid", bufnr)
+  end
+
+  local chat = require("codecompanion.strategies.chat").buf_get_chat(bufnr)
+  if not chat then
+    return log:error("Could not restore the chat buffer")
+  end
+
+  if chat.ui:is_visible() then
+    return
+  end
+  chat.ui:open()
+end
+
 ---Return a chat buffer
 ---@param bufnr? integer
 ---@return CodeCompanion.Chat|table

--- a/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
@@ -156,7 +156,9 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
             vim.cmd("silent! w")
           end)
         end)
+        -- NOTE: This is required to ensure folding works for chat buffers that aren't visible
         codecompanion.restore(chat_bufnr)
+
         return output_handler(success)
       end
       return output_handler({

--- a/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
@@ -1,11 +1,13 @@
-local Path = require("plenary.path")
 local buffers = require("codecompanion.utils.buffers")
+local codecompanion = require("codecompanion")
 local config = require("codecompanion.config")
 local diff = require("codecompanion.strategies.chat.agents.tools.helpers.diff")
 local log = require("codecompanion.utils.log")
 local patch = require("codecompanion.strategies.chat.agents.tools.helpers.patch")
 local ui = require("codecompanion.utils.ui")
 local wait = require("codecompanion.strategies.chat.agents.tools.helpers.wait")
+
+local Path = require("plenary.path")
 
 local api = vim.api
 local fmt = string.format
@@ -154,6 +156,7 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
             vim.cmd("silent! w")
           end)
         end)
+        codecompanion.restore(chat_bufnr)
         return output_handler(success)
       end
       return output_handler({


### PR DESCRIPTION
## Description

This ensures that the chat buffer is visible after a user accepts an edit with the `insert_edit_into_file` tool.

## Related Issue(s)

#1788

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
