### PR TITLE
patching algorithm can be swapped out

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 03
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 11
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -476,8 +476,9 @@ actions:
 
 - `cmd_runner` - The LLM will run shell commands (subject to approval)
 - `create_file` - The LLM will create a file in the current working directory (subject to approval)
-- `file_search` - The LLM can search for a file in the current working directory
-- `grep_search` - The LLM can search within files in the current working directory
+- `file_search` - The LLM can search for a file in the CWD
+- `get_changed_files` - The LLM can get git diffs for any changed files in the CWD
+- `grep_search` - The LLM can search within files in the CWD
 - `insert_edit_into_file` - The LLM will edit code in a Neovim buffer or on the file system (subject to approval)
 - `next_edit_suggestion` - The LLM can show the user where the next edit is
 - `read_file` - The LLM can read a specific file
@@ -485,7 +486,7 @@ actions:
 
 Tools can also be grouped together, also accessible via `@` in the chat buffer:
 
-- `files` - Contains the `create_file`, `file_search`, `grep_search`, `insert_edit_into_file` and `read_file` tools
+- `files` - Contains the `create_file`, `file_search`, `get_changed_files`, `grep_search`, `insert_edit_into_file` and `read_file` tools
 
 
   [!TIP] Use them in your prompt like: `Can you use the @{grep_search} tool to
@@ -1959,7 +1960,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -2246,6 +2247,9 @@ and if so, to insert a flag in its request. This is then detected and the
 outcome of the test is stored in the corresponding flag on the chat buffer.
 This makes it ideal for |codecompanion-extending-workflows| to hook into.
 
+**Options:** - `requires_approval` require approval before running a command?
+(Default: true)
+
 
 CREATE_FILE ~
 
@@ -2257,6 +2261,9 @@ Create a file within the current working directory:
     Can you create some test fixtures using the @{create_file} tool?
 <
 
+**Options:** - `requires_approval` require approval before creating a file?
+(Default: true)
+
 
 FILE_SEARCH ~
 
@@ -2267,6 +2274,23 @@ files.
 >md
     Use the @{file_search} tool to list all the lua files in my project
 <
+
+**Options:** - `max_results` limits the amount of results that can be sent to
+the LLM in the response (Default: 500)
+
+
+GET_CHANGED_FILES ~
+
+This tool enables an LLM to get git diffs of any file changes in the current
+working directory. It will return a diff which can contain `staged`, `unstaged`
+and `merge-conflicts`.
+
+>md
+    Use the @{get_changed_files} tool see what's changed
+<
+
+**Options:** - `max_lines` limits the amount of lines that can be sent to the
+LLM in the response (Default: 1000)
 
 
 GREP_SEARCH ~
@@ -2281,6 +2305,10 @@ working directory. For every match, the output (`{filename}:{line number}
 >md
     Use the @{grep_search} tool to find all occurrences of `buf_add_message`?
 <
+
+**Options:** - `max_files` (number) limits the amount of files that can be sent
+to the LLM in the response (Default: 100) - `respect_gitignore` (boolean)
+(Default: true)
 
 
 INSERT_EDIT_INTO_FILE ~
@@ -2298,40 +2326,24 @@ This tool can edit buffers and files for code changes from an LLM:
     Can you apply the suggested changes to the buffer with the @{insert_edit_into_file} tool?
 <
 
+**Options:** - `patching_algorithm` (string|table|function) The algorithm to
+use to determine how to edit files and buffers - `requires_approval.buffer`
+(boolean) Require approval before editng a buffer? (Default: false) -
+`requires_approval.file` (boolean) Require approval before editng a file?
+(Default: true) - `user_confirmation` (boolean) require confirmation from the
+user before moving on in the chat buffer? (Default: true)
+
 
 NEXT_EDIT_SUGGESTION ~
 
 Inspired by Copilot Next Edit Suggestion
 <https://code.visualstudio.com/blogs/2025/02/12/next-edit-suggestions>, the
-`@next_edit_suggestion` tool gives the LLM the ability to show the user where
-the next edit is. The LLM can only suggest edits in files or buffers that have
-been shared with it as context.
+tool gives the LLM the ability to show the user where the next edit is. The LLM
+can only suggest edits in files or buffers that have been shared with it as
+context.
 
-The jump action can be customised in the `opts` table:
-
->lua
-    require("codecompanion").setup({
-      strategies = {
-        chat = {
-          tools = {
-            ["next_edit_suggestion"] = {
-              opts = {
-                --- the default is to open in a new tab, and reuse existing tabs
-                --- where possible
-                ---@type string|fun(path: string):integer?
-                jump_action = 'tabnew',
-              },
-            }
-          }
-        }
-      }
-    })
-<
-
-The `jump_action` can be a VimScript command (as a string), or a lua function
-that accepts the path to the file and optionally returns the |window ID|. The
-window ID is needed if you want the LLM to point you to a specific line in the
-file.
+**Options:** - `jump_action` (string|function) Determines how a jump to the
+next edit is made (Default: `tabnew`)
 
 
 READ_FILE ~
@@ -2366,33 +2378,15 @@ TOOL GROUPS ~
 
 CodeCompanion comes with two built-in tool groups:
 
-- `full_stack_dev` - Contains `cmd_runner`, `create_file`, `read_file`, and `insert_edit_into_file` tools
-- `files` - Contains `create_file`, `read_file`, and `insert_edit_into_file` tools
+- `full_stack_dev` - Containing all of the tools
+- `files` - Containing `create_file`, `file_search`, `get_changed_files`, `grep_search`, `insert_edit_into_file` and `read_file` tools
 
 When you include a tool group in your chat (e.g., `@{files}`), all tools within
 that group become available to the LLM. By default, all the tools in the group
 will be shown as a single `<group>name</group>` reference in the chat buffer.
 
 If you want to show all tools as references in the chat buffer, set the
-`collapse_tools` option to `false`:
-
->lua
-    require("codecompanion").setup({
-      strategies = {
-        chat = {
-          tools = {
-            groups = {
-              ["files"] = {
-                opts = {
-                  collapse_tools = false, -- Shows all tools in the group as individual references
-                },
-              },
-            },
-          }
-        }
-      }
-    })
-<
+`opts.collapse_tools` option to `false` on the group itself.
 
 
 APPROVALS ~
@@ -3123,7 +3117,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI’S API OUTPUT
+OPENAI�S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/usage/chat-buffer/agents.md
+++ b/doc/usage/chat-buffer/agents.md
@@ -125,36 +125,17 @@ Can you apply the suggested changes to the buffer with the @{insert_edit_into_fi
 ```
 
 **Options:**
+- `patching_algorithm` (string|table|function) The algorithm to use to determine how to edit files and buffers
 - `requires_approval.buffer` (boolean) Require approval before editng a buffer? (Default: false)
 - `requires_approval.file` (boolean) Require approval before editng a file? (Default: true)
 - `user_confirmation` (boolean) require confirmation from the user before moving on in the chat buffer? (Default: true)
 
 ## next_edit_suggestion
 
-Inspired by [Copilot Next Edit Suggestion](https://code.visualstudio.com/blogs/2025/02/12/next-edit-suggestions), the `@next_edit_suggestion` tool gives the LLM the ability to show the user where the next edit is. The LLM can only suggest edits in files or buffers that have been shared with it as context.
+Inspired by [Copilot Next Edit Suggestion](https://code.visualstudio.com/blogs/2025/02/12/next-edit-suggestions), the tool gives the LLM the ability to show the user where the next edit is. The LLM can only suggest edits in files or buffers that have been shared with it as context.
 
-The jump action can be customised in the `opts` table:
-
-```lua
-require("codecompanion").setup({
-  strategies = {
-    chat = {
-      tools = {
-        ["next_edit_suggestion"] = {
-          opts = {
-            --- the default is to open in a new tab, and reuse existing tabs
-            --- where possible
-            ---@type string|fun(path: string):integer?
-            jump_action = 'tabnew',
-          },
-        }
-      }
-    }
-  }
-})
-```
-
-The `jump_action` can be a VimScript command (as a string), or a lua function that accepts the path to the file and optionally returns the [window ID](https://neovim.io/doc/user/windows.html#window-ID). The window ID is needed if you want the LLM to point you to a specific line in the file.
+**Options:**
+- `jump_action` (string|function) Determines how a jump to the next edit is made (Default: `tabnew`)
 
 ## read_file
 
@@ -184,25 +165,7 @@ CodeCompanion comes with two built-in tool groups:
 
 When you include a tool group in your chat (e.g., `@{files}`), all tools within that group become available to the LLM. By default, all the tools in the group will be shown as a single `<group>name</group>` reference in the chat buffer.
 
-If you want to show all tools as references in the chat buffer, set the `collapse_tools` option to `false`:
-
-```lua
-require("codecompanion").setup({
-  strategies = {
-    chat = {
-      tools = {
-        groups = {
-          ["files"] = {
-            opts = {
-              collapse_tools = false, -- Shows all tools in the group as individual references
-            },
-          },
-        },
-      }
-    }
-  }
-})
-```
+If you want to show all tools as references in the chat buffer, set the `opts.collapse_tools` option to `false` on the group itself.
 
 ## Approvals
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -129,6 +129,7 @@ local defaults = {
           callback = "strategies.chat.agents.tools.insert_edit_into_file",
           description = "Insert code into an existing file",
           opts = {
+            patching_algorithm = "strategies.chat.agents.tools.helpers.patch",
             requires_approval = { -- Require approval before the tool is executed?
               buffer = false, -- For editing buffers in Neovim
               file = true, -- For editing files in the current working directory

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -81,6 +81,9 @@ return {
         ["insert_edit_into_file"] = {
           callback = "strategies.chat.agents.tools.insert_edit_into_file",
           description = "Insert code into an existing file",
+          opts = {
+            patching_algorithm = "strategies.chat.agents.tools.helpers.patch",
+          },
         },
         ["create_file"] = {
           callback = "strategies.chat.agents.tools.create_file",

--- a/tests/strategies/chat/agents/tools/helpers/test_patch.lua
+++ b/tests/strategies/chat/agents/tools/helpers/test_patch.lua
@@ -10,14 +10,14 @@ end
 
 local function apply_patch(input_str, patch_str)
   -- 1. parse changes
-  local changes, had_begin_end_markers = patch.parse_changes(patch_str)
+  local changes, had_begin_end_markers = patch.parse_edits(patch_str)
 
   -- 2. read file into lines
   local lines = vim.split(input_str, "\n", { plain = true })
 
   -- 3. apply changes
   for _, change in ipairs(changes) do
-    local new_lines = patch.apply_change(lines, change)
+    local new_lines = patch.apply(lines, change)
     if new_lines == nil then
       if had_begin_end_markers then
         error(string.format("Bad/Incorrect diff:\n\n%s\n\nNo changes were applied", patch.get_change_string(change)))

--- a/tests/strategies/chat/agents/tools/helpers/test_patch.lua
+++ b/tests/strategies/chat/agents/tools/helpers/test_patch.lua
@@ -9,18 +9,18 @@ local function readfile(path)
 end
 
 local function apply_patch(input_str, patch_str)
-  -- 1. parse changes
-  local changes, had_begin_end_markers = patch.parse_edits(patch_str)
+  -- 1. parse edits
+  local edits, had_begin_end_markers = patch.parse_edits(patch_str)
 
   -- 2. read file into lines
   local lines = vim.split(input_str, "\n", { plain = true })
 
-  -- 3. apply changes
-  for _, change in ipairs(changes) do
-    local new_lines = patch.apply(lines, change)
+  -- 3. apply edits
+  for _, edit in ipairs(edits) do
+    local new_lines = patch.apply(lines, edit)
     if new_lines == nil then
       if had_begin_end_markers then
-        error(string.format("Bad/Incorrect diff:\n\n%s\n\nNo changes were applied", patch.get_change_string(change)))
+        error(string.format("Bad/Incorrect diff:\n\n%s\n\nNo edits were applied", patch.get_change_string(edit)))
       else
         error("Invalid patch format: missing Begin/End markers")
       end


### PR DESCRIPTION
## Description

This PR allows users to specify their own patching algorithm for the `insert_edit_into_file` tool. Also swaps out the word `changes` for `edits` in the default algorithm.

## Related Issue(s)

#1619

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
