### PR TITLE
fix(read_file): read entire file, when end_line is greater than file

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
@@ -90,7 +90,7 @@ Invalid line range - start_line_number_base_zero (%d) comes after end_line_numbe
   if not error_msg and end_line_zero ~= -1 and end_line_zero >= #lines then
     end_line_zero = math.max(0, #lines - 1)
   end
-  
+
   -- Convert to 1-based indexing
   local start_line = start_line_zero + 1
   local end_line = end_line_zero == -1 and #lines or end_line_zero + 1

--- a/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
@@ -64,16 +64,6 @@ start_line_number_base_zero (%d) is beyond file length. File `%s` has %d lines (
       #lines,
       math.max(0, #lines - 1)
     )
-  elseif end_line_zero ~= -1 and end_line_zero >= #lines then
-    error_msg = fmt(
-      [[Error reading `%s`
-end_line_number_base_zero (%d) is beyond file length. File `%s` has %d lines (0-%d)]],
-      action.filepath,
-      end_line_zero,
-      action.filepath,
-      #lines,
-      math.max(0, #lines - 1)
-    )
   elseif end_line_zero ~= -1 and start_line_zero > end_line_zero then
     error_msg = fmt(
       [[Error reading `%s`
@@ -96,6 +86,11 @@ Invalid line range - start_line_number_base_zero (%d) comes after end_line_numbe
     }
   end
 
+  -- Clamp end_line_zero to the last valid line if it exceeds file length (unless -1)
+  if not error_msg and end_line_zero ~= -1 and end_line_zero >= #lines then
+    end_line_zero = math.max(0, #lines - 1)
+  end
+  
   -- Convert to 1-based indexing
   local start_line = start_line_zero + 1
   local end_line = end_line_zero == -1 and #lines or end_line_zero + 1


### PR DESCRIPTION
## Description

The "read_file" tools currently throws, when the LLM what's to read a file until a line, which is greater than the actual file length. This PR removes the error and replaces the to high end_line with the actual last line.

## Related Issue(s)

#1819

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
