### PR TITLE
fix(symbols): also use file contents to detect filetype

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/symbols.lua
@@ -172,8 +172,7 @@ function SlashCommand:output(selected, opts)
   end
   opts = opts or {}
 
-  local ft = vim.filetype.match({ filename = selected.path })
-  local symbols, content = helpers.extract_file_symbols(selected.path)
+  local symbols, content, ft = helpers.extract_file_symbols(selected.path)
 
   if not symbols then
     return no_query(ft)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

This makes the `/symbols` slash command work with files that don't have an extension, e.g. a Python script without `.py`.

Since we already load the file contents to get the symbols we can just pass it to `vim.filetype.match` to improve the detection.

Use `unpack()` in the tests to get multiple return values through `lua_get()`, which only seems to support returning a single value.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->



## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
