### PR TITLE
improve read_file tool error messages

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
@@ -77,12 +77,7 @@ Invalid line range - start_line_number_base_zero (%d) comes after end_line_numbe
   if error_msg then
     return {
       status = "error",
-      data = fmt(
-        [["Error reading `%s`
-%s]],
-        action.filename,
-        error_msg
-      ),
+      data = fmt([[%s]], error_msg),
     }
   end
 


### PR DESCRIPTION
## Description

Improves the error messages that are sent from the `read_file` tool

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
