### PR TITLE
better handle reasoning output if a tool response follows

### DIFF
--- a/lua/codecompanion/strategies/chat/ui/formatters/tools.lua
+++ b/lua/codecompanion/strategies/chat/ui/formatters/tools.lua
@@ -17,6 +17,13 @@ end
 function Tools:format(message, opts, state)
   local lines = {}
 
+  if state.has_reasoning_output then
+    state:mark_reasoning_complete()
+    table.insert(lines, "")
+    table.insert(lines, "")
+    table.insert(lines, "### Response")
+  end
+
   if state.is_new_section then
     table.insert(lines, "")
   end


### PR DESCRIPTION
## Description

If an LLM went from reasoning->tool output, the `response` header would not be output in the chat buffer.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
