### PR TITLE
fix(chat): also restore the chat buffer on edit changes rejection. This fix the folding error also on change rejection.

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/insert_edit_into_file.lua
@@ -149,6 +149,7 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
 
     -- Wait for the user to accept or reject the edit
     return wait.for_decision(diff_id, { "CodeCompanionDiffAccepted", "CodeCompanionDiffRejected" }, function(result)
+      local response
       if result.accepted then
         -- Save the buffer
         pcall(function()
@@ -156,15 +157,16 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
             vim.cmd("silent! w")
           end)
         end)
-        -- NOTE: This is required to ensure folding works for chat buffers that aren't visible
-        codecompanion.restore(chat_bufnr)
-
-        return output_handler(success)
+        response = success
+      else
+        response = {
+          status = "error",
+          data = result.timeout and "User failed to accept the changes in time" or "User rejected the changes",
+        }
       end
-      return output_handler({
-        status = "error",
-        data = result.timeout and "User failed to accept the changes in time" or "User rejected the changes",
-      })
+      -- NOTE: This is required to ensure folding works for chat buffers that aren't visible
+      codecompanion.restore(chat_bufnr)
+      return output_handler(response)
     end, wait_opts)
   end
 


### PR DESCRIPTION

## Description

This is a fix for #1816 which fixed #1788 and #1823 but only when user accepted the proposed edit changes.
I believe that it make sense to also restore the chat buffer on change rejection.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
