### PR TITLE
add `fetch_webpage` tool

### DIFF
--- a/lua/codecompanion/adapters/jina.lua
+++ b/lua/codecompanion/adapters/jina.lua
@@ -1,10 +1,10 @@
+local log = require("codecompanion.utils.log")
+
 ---@class CodeCompanion.AdapterArgs
 return {
   name = "jina",
-  opts = {
-    stream = false,
-  },
   url = "",
+  env = {},
   headers = {},
   schema = {
     model = {
@@ -36,6 +36,42 @@ return {
           })
         end
       end,
+    },
+    tools = {
+      fetch_webpage = {
+        ---Setup the adapter for the fetch webpage tool
+        ---@param self CodeCompanion.Adapter
+        ---@param data table The data from the LLM's tool call
+        ---@return nil
+        setup = function(self, data)
+          self.methods.slash_commands.fetch(self, data)
+        end,
+
+        ---Process the output from the fetch webpage tool
+        ---@param self CodeCompanion.Adapter
+        ---@param data table The data returned from the fetch
+        ---@return table{status: string, content: string}|nil
+        callback = function(self, data)
+          local ok, data = pcall(vim.json.decode, data)
+          if not ok then
+            return {
+              status = "error",
+              output = "Failed to decode JSON content",
+            }
+          end
+          if data.status ~= 200 then
+            log:error("[Jina Adapter] Error: %s", data)
+            return {
+              status = "error",
+              content = data.message or data.body or "Unknown error occurred",
+            }
+          end
+          return {
+            success = "success",
+            content = data.body.content,
+          }
+        end,
+      },
     },
   },
 }

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -99,6 +99,13 @@ local defaults = {
             requires_approval = true,
           },
         },
+        ["fetch_webpage"] = {
+          callback = "strategies.chat.agents.tools.fetch_webpage",
+          description = "Fetches content from a webpage",
+          opts = {
+            adapter = "jina",
+          },
+        },
         ["file_search"] = {
           callback = "strategies.chat.agents.tools.file_search",
           description = "Search for files in the current working directory by glob pattern",

--- a/lua/codecompanion/strategies/chat/agents/tools/fetch_webpage.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/fetch_webpage.lua
@@ -1,0 +1,128 @@
+local adapters = require("codecompanion.adapters")
+local client = require("codecompanion.http")
+local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
+
+local fmt = string.format
+
+---@class CodeCompanion.Tool.FetchWebpage: CodeCompanion.Agent.Tool
+return {
+  name = "fetch_webpage",
+  cmds = {
+    ---Execute the fetch_webpage tool
+    ---@param self CodeCompanion.Agent
+    ---@param args table The arguments from the LLM's tool call
+    ---@param cb function Async callback for completion
+    ---@return nil
+    function(self, args, _, cb)
+      local opts = self.tool.opts
+      local url = args.url
+
+      if not opts or not opts.adapter then
+        log:error("Error - no adapter for `fetch_webpage`")
+        return cb({ status = "error" })
+      end
+      if not args then
+        log:error("Error - no args for `fetch_webpage` tool")
+        return cb({ status = "error" })
+      end
+
+      local tool_adapter = config.strategies.chat.tools.fetch_webpage.opts.adapter
+      local adapter = vim.deepcopy(adapters.resolve(config.adapters[tool_adapter]))
+
+      if not adapter then
+        log:error("Error - Failed to load the adapter for the `fetch_webpage` tool")
+        return cb({ status = "error" })
+      end
+
+      adapter.methods.tools.fetch_webpage.setup(adapter, args)
+
+      if not url:match("^https?://") then
+        log:error("Invalid URL: `%s`", url)
+        return cb({ status = "error", data = fmt("Invalid URL: `%s`", url) })
+      end
+
+      client
+        .new({
+          adapter = adapter,
+        })
+        :request(_, {
+          callback = function(err, data)
+            if err then
+              log:error("[Fetch Webpage Tool] Error fetching `%s`: %s", url, err)
+              return cb({ status = "error", data = fmt("Error fetching `%s`\n%s", url, err) })
+            end
+
+            if data then
+              local output = adapter.methods.tools.fetch_webpage.callback(adapter, data)
+              if output.status == "error" then
+                log:error("[Fetch Webpage Tool] Error processing data for `%s`: %s", url, output.content)
+                return cb({ status = "error", data = fmt("Error fetching `%s`\n%s", url, output.content) })
+              end
+
+              return cb({ status = "success", data = output.content })
+            end
+          end,
+        })
+    end,
+  },
+  schema = {
+    type = "function",
+    ["function"] = {
+      name = "fetch_webpage",
+      description = "Fetches the main content from a web page. You should use this tool when you think the user is looking for information from a specific webpage.",
+      parameters = {
+        type = "object",
+        properties = {
+          url = {
+            type = "string",
+            description = "The URL of the webpage to fetch content from",
+          },
+        },
+        required = { "url" },
+      },
+    },
+  },
+  output = {
+    ---@param self CodeCompanion.Tool.FetchWebpage
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table The command that was executed
+    ---@param stdout table The output from the command
+    success = function(self, agent, cmd, stdout)
+      local args = self.args
+      local chat = agent.chat
+
+      local llm_output = "<fetchWebpageTool>%s</fetchWebpageTool>"
+      local user_output = fmt("Fetched content from `%s`", args.url)
+
+      local content = ""
+      if type(stdout[1]) == "table" then
+        content = table.concat(stdout[1], "")
+      end
+
+      chat:add_tool_output(self, fmt(llm_output, content), user_output)
+    end,
+
+    ---@param self CodeCompanion.Tool.FetchWebpage
+    ---@param agent CodeCompanion.Agent
+    ---@param cmd table
+    ---@param stderr table The error output from the command
+    ---@param stdout? table The output from the command
+    error = function(self, agent, cmd, stderr, stdout)
+      local args = self.args
+      local chat = agent.chat
+      local errors = vim.iter(stderr):flatten():join("\n")
+      log:debug("[Fetch Webpage Tool] Error output: %s", stderr)
+
+      local error_output = fmt(
+        [[Error fetching content from `%s`:
+```txt
+%s
+```]],
+        args.url,
+        errors
+      )
+      chat:add_tool_output(self, error_output)
+    end,
+  },
+}


### PR DESCRIPTION
## Description

This will add a new `fetch_webpage` tool.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
