### PR TITLE
wrap tool folding in pcall

### DIFF
--- a/lua/codecompanion/strategies/chat/ui/tools.lua
+++ b/lua/codecompanion/strategies/chat/ui/tools.lua
@@ -1,4 +1,5 @@
 local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
 
 ---@class CodeCompanion.Chat.UI.Tools
 ---@field chat_bufnr number The buffer number of the chat
@@ -125,9 +126,15 @@ function Tools:create_fold(start_line, end_line, foldtext)
   self.fold_summaries[self.chat_bufnr] = self.fold_summaries[self.chat_bufnr] or {}
   self.fold_summaries[self.chat_bufnr][start_line] = foldtext
 
-  api.nvim_buf_call(self.chat_bufnr, function()
-    vim.cmd(string.format("%d,%dfold", start_line + 1, end_line + 1))
+  local fold, fold_err = pcall(function()
+    api.nvim_buf_call(self.chat_bufnr, function()
+      vim.cmd(string.format("%d,%dfold", start_line + 1, end_line + 1))
+    end)
   end)
+
+  if not fold then
+    log:trace("[Tools] Failed to create fold: %s", fold_err)
+  end
 end
 
 return Tools


### PR DESCRIPTION
## Description

Wraps the tool folding in a pcall.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
