### PR TITLE
Sticky chat window

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -331,6 +331,7 @@ require("codecompanion").setup({
         width = 0.45,
         relative = "editor",
         full_height = true, -- when set to false, vsplit will be used to open the chat buffer vs. botright/topleft vsplit
+        sticky = false, -- when set to true and `layout` is not `"buffer"`, the chat buffer will remain opened when switching tabs
         opts = {
           breakindent = true,
           cursorcolumn = false,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1027,6 +1027,7 @@ You must create or modify a workspace file through a series of prompts over mult
         width = 0.45,
         relative = "editor",
         full_height = true,
+        sticky = false,
         opts = {
           breakindent = true,
           cursorcolumn = false,

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -12,6 +12,25 @@ local CodeCompanion = {
   extensions = _extensions.manager,
 }
 
+local function setup_sticky_chat_buffer()
+  local window_config = config.display.chat.window
+  if window_config.sticky and (window_config.layout ~= "buffer") then
+    api.nvim_create_autocmd("TabEnter", {
+      group = api.nvim_create_augroup("CodeCompanionStickyWindow", { clear = true }),
+      callback = function(args)
+        local chat = CodeCompanion.last_chat()
+        if chat and chat.ui:is_visible_non_curtab() then
+          chat.context = context_utils.get(args.buf)
+          vim.schedule(function()
+            CodeCompanion.close_last_chat()
+            chat.ui:open({ toggled = true })
+          end)
+        end
+      end,
+    })
+  end
+end
+
 ---Register an extension with setup and exports
 ---@param name string The name of the extension
 ---@param extension CodeCompanion.Extension The extension implementation
@@ -360,6 +379,7 @@ CodeCompanion.setup = function(opts)
       end
     end
   end
+  setup_sticky_chat_buffer()
 end
 
 return CodeCompanion

--- a/tests/test_cmds.lua
+++ b/tests/test_cmds.lua
@@ -39,4 +39,27 @@ T["cmds"][":CodeCompanionChat Toggle"] = function()
   expect.reference_screenshot(child.get_screenshot())
 end
 
+T["cmds"]["sticky chat window"] = function()
+  child.lua([[
+    require('codecompanion').setup({
+      display = {
+        chat = {
+          window = {
+            layout = "vertical",
+            sticky = true
+          }
+        }
+      }
+    })
+    vim.cmd("CodeCompanionChat")
+    vim.cmd("tabnew")
+  ]])
+
+  -- expect.reference_screenshot(child.get_screenshot())
+  -- window opened
+  h.eq(true, child.lua_get("require('codecompanion').last_chat().ui:is_visible()"))
+  -- window opened in the current tab (in other words, NOT in NON_CURRENT tab)
+  h.eq(false, child.lua_get("require('codecompanion').last_chat().ui:is_visible_non_curtab()"))
+end
+
 return T


### PR DESCRIPTION
## Description

This PR adds an option to make the chat window stay there when the layout is "vertical", "horizontal" or "float".
This option would be useful when the user is using [tools that could make the "focus" jump between tabs](https://github.com/Davidyz/codecompanion-dap.nvim).

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
