### PR TITLE
fix custom prompts containing URLs

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -136,8 +136,8 @@ function SlashCommands.references(chat, slash_command, opts)
     opts.silent = true
     opts.url = opts.url or opts.path
     opts.description = opts.description
-    opts.auto_restore_cache = opts.opts.auto_restore_cache
-    opts.ignore_cache = opts.opts.ignore_cache
+    opts.auto_restore_cache = opts.opts and opts.opts.auto_restore_cache
+    opts.ignore_cache = opts.opts and opts.opts.ignore_cache
 
     return slash_commands[slash_command]:output(opts.url, opts)
   end


### PR DESCRIPTION
## Description

Custom prompts which had a URL would fail

## Related Issue(s)

#1843

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
