### PR TITLE
fix(tools): handle missing action in get_changed_files

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/get_changed_files.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/get_changed_files.lua
@@ -40,6 +40,12 @@ end
 ---@param opts {max_lines: number}
 ---@return {status: "success"|"error", data: string}
 local function get_changed_files(action, opts)
+  if not action then
+    return {
+      status = "error",
+      data = "Invalid arguments provided to get_changed_files tool",
+    }
+  end
   local states = action.source_control_state or { "unstaged", "staged", "merge-conflicts" }
   local output = {}
 

--- a/lua/codecompanion/strategies/chat/agents/tools/get_changed_files.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/get_changed_files.lua
@@ -43,7 +43,7 @@ local function get_changed_files(action, opts)
   if not action then
     return {
       status = "error",
-      data = "Invalid arguments provided to get_changed_files tool",
+      data = "Missing required parameter 'action' for get_changed_files tool",
     }
   end
   local states = action.source_control_state or { "unstaged", "staged", "merge-conflicts" }


### PR DESCRIPTION
I meet this error, this maybe fix it ?

```
You made an error in calling the get_changed_files tool: "...n.nvim/lua/codecompanion/strategies/chat/agents/init.lua:173: Expected value but found T_END at character 1"

...anion/strategies/chat/agents/tools/get_changed_files.lua:43: attempt to index local 'action' (a nil value)
```

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
