### PR TITLE
refactor autocmd names

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/helpers/wait.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/helpers/wait.lua
@@ -20,7 +20,7 @@ function M.for_decision(id, events, callback, opts)
     return callback({ accepted = true })
   end
 
-  local aug = api.nvim_create_augroup("codecompanion_wait_" .. tostring(id), { clear = true })
+  local aug = api.nvim_create_augroup("codecompanion.agent.tools.wait_" .. tostring(id), { clear = true })
 
   -- Show waiting indicator in the chat buffer
   local chat_extmark_id = nil

--- a/lua/codecompanion/strategies/chat/watchers.lua
+++ b/lua/codecompanion/strategies/chat/watchers.lua
@@ -15,7 +15,7 @@ local Watchers = {}
 function Watchers.new()
   return setmetatable({
     buffers = {},
-    augroup = api.nvim_create_augroup("CodeCompanionWatcher", { clear = true }),
+    augroup = api.nvim_create_augroup("codecompanion.watchers", { clear = true }),
   }, { __index = Watchers })
 end
 

--- a/tests/strategies/chat/agents/tools/helpers/test_wait.lua
+++ b/tests/strategies/chat/agents/tools/helpers/test_wait.lua
@@ -162,7 +162,7 @@ T["for_decision()"]["cleans up autocmds after decision"] = function()
   local augroups_before = child.lua([[
     local groups = {}
     for _, group in ipairs(vim.api.nvim_get_autocmds({})) do
-      if group.group_name and group.group_name:match("codecompanion_wait_") then
+      if group.group_name and group.group_name:match("codecompanion.agent.tools.wait_") then
         table.insert(groups, group.group_name)
       end
     end
@@ -181,7 +181,7 @@ T["for_decision()"]["cleans up autocmds after decision"] = function()
   local augroups_after = child.lua([[
     local groups = {}
     for _, group in ipairs(vim.api.nvim_get_autocmds({})) do
-      if group.group_name and group.group_name:match("codecompanion_wait_test_cleanup") then
+      if group.group_name and group.group_name:match("codecompanion.agent.tools.wait_") then
         table.insert(groups, group.group_name)
       end
     end


### PR DESCRIPTION
## Description

Minor PR ensuring that autocmd's are uniformly named.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
