### PR TITLE
refactor(tools): read_file error message

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/read_file.lua
@@ -16,7 +16,7 @@ local function read(action)
   if not exists then
     return {
       status = "error",
-      data = fmt("Error reading `%s`, does not exist", filepath),
+      data = fmt("Error reading `%s`, does not exist", action.filepath),
     }
   end
 


### PR DESCRIPTION
## Description

Clean up the error messages on the read_file tool

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
