### PR TITLE
refactor(chat): support separate options for message and reference in…

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1049,12 +1049,16 @@ end
 ---@param data { role: string, content: string }
 ---@param source string
 ---@param id string
----@param opts? table Options for the message
-function Chat:add_reference(data, source, id, opts)
-  opts = opts or { reference = id, visible = false }
+---@param msg_opts? table Options for the message
+---@param ref_opts? table Options for the reference
+function Chat:add_reference(data, source, id, msg_opts, ref_opts)
+  if not msg_opts or vim.tbl_isempty(msg_opts) then
+    msg_opts = { reference = id, visible = false }
+  end
+  ref_opts = ref_opts or {}
 
-  self.references:add({ source = source, id = id })
-  self:add_message(data, opts)
+  self.references:add({ source = source, id = id, opts = ref_opts })
+  self:add_message(data, msg_opts)
 end
 
 ---Check if there are any images in the chat buffer


### PR DESCRIPTION
… add_reference

Allow add_reference to accept distinct options for the message and the reference, improving flexibility for custom slash commands and reference handling.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

This PR updates the `Chat:add_reference` method in `lua/codecompanion/strategies/chat/init.lua` to support separate options for the message (`msg_opts`) and the reference (`ref_opts`). The method signature and internal logic are adjusted to handle these two sets of options independently, allowing for more granular control when adding references and their associated messages.

## Related Issue(s)

Essentially I wanted to be able to pass watched (or pinned) to `self.references:add` while currently the opts table was only propagated to `add_message`

## Screenshots

None

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
