### PR TITLE
fix(huggingface): update to use new HuggingFace API endpoint

### DIFF
--- a/lua/codecompanion/adapters/huggingface.lua
+++ b/lua/codecompanion/adapters/huggingface.lua
@@ -2,12 +2,10 @@ local config = require("codecompanion.config")
 local curl = require("plenary.curl")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.openai")
-local utils = require("codecompanion.utils.adapters")
 
 -- Cache variables for models
 local _cached_models
 local _cache_expires
-local _cache_file = vim.fn.tempname()
 
 ---Get a list of available Hugging Face models from inference providers
 ---@param adapter CodeCompanion.Adapter
@@ -33,12 +31,12 @@ local function get_models(adapter)
     })
   end)
   if not ok then
-    log:error("Could not get Hugging Face models from %s.\nError: %s", url, response)
+    log:error("Could not get Hugging Face models from %s. Error: %s", url, response)
     return {}
   end
-  local ok, models_data = pcall(vim.json.decode, response.body)
-  if not ok then
-    log:error("Error parsing Hugging Face models response: %s", response.body)
+  local ok2, models_data = pcall(vim.json.decode, response.body)
+  if not ok2 then
+    log:error("Error parsing Hugging Face models response from %s", url)
     return {}
   end
   local models = {}
@@ -57,7 +55,7 @@ local function get_models(adapter)
     }
   end
   _cached_models = models
-  _cache_expires = utils.refresh_cache(_cache_file, config.adapters.opts.cache_models_for)
+  _cache_expires = os.time() + (config.adapters.opts.cache_models_for or 1800)
   log:debug("Found %d Hugging Face models", vim.tbl_count(models))
   return models
 end


### PR DESCRIPTION
## Description

This PR updates the Hugging Face adapter to fix HuggingFace API endpoint and model selection.


**Key changes:**
- Updates the API endpoint for chat completions to `https://router.huggingface.co/v1/chat/completions`.
- Adds a `get_models` function to dynamically fetch available models from the new Hugging Face API endpoint (`/api/models?inference_provider=all`), with caching and fallback support.

some source for anyone to read more about how new API works:
[Inference Provider](https://huggingface.co/docs/inference-providers/index?python-clients=requests&javascript-clients=huggingface.js)
[Hub API](https://huggingface.co/docs/inference-providers/hub-api?code=curl)


## Related Issue(s)
Fix #1864 


## NOTE  
It’s worth mentioning that we currently have several different versions of the `get_models` function across multiple adapters (copilot, openai_compatible, ollama, novita, huggingface). These could be consolidated into a single function, at least for novita, huggingface, and openai_compatible, but I believe it’s better to address this in a new PR.

Thank you

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
