### PR TITLE
Add support for GitHub Copilot Enterprise API

### DIFF
--- a/lua/codecompanion/adapters/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/copilot/helpers.lua
@@ -48,7 +48,7 @@ function M.get_models(adapter, get_and_authorize_token_fn, oauth_token)
     return {}
   end
 
-  local url = "https://api.githubcopilot.com/models"
+  local url = adapter.api .. "/models"
   local headers = vim.deepcopy(_cached_adapter.headers)
   headers["Authorization"] = "Bearer " .. oauth_token
 


### PR DESCRIPTION
## Description

In the Copilot adapter code, the URL `github.com` is hardcoded in a few places. This makes it possible to use the plugin with other providers, namely Github Copilot Enterprise instances.

The only required configuration is the following:

```lua
local p = require 'codecompanion'
p.setup {
  adapters = {
    copilot = function()
      return require("codecompanion.adapters").extend("copilot", {
        opts = {
          provider_url = "acme.ghe.com",            -- defaults to 'github.com'
        },
      })
    end,
  },
}
```

The `provider_url` is used for token retrieval from `$XDG_CONFIG_HOME/github-copilot/{apps,hosts}.json` and authentication.
Thanks to #1533 other queries should be correctly redirected to the (possibly custom) API endpoint.

## Related Issue(s)

N.A.

## Screenshots

N.A.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied

## Notes

I'm still testing this and might have missed something.
Also, there are some parts of the code that need to be parametric on user options, but I'm not sure what is the best way to inject them. Maybe you can help me with that.