### PR TITLE
feat: add ChatDone event

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -2660,6 +2660,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionChatHidden` - Fired after a chat has been hidden
 - `CodeCompanionChatClosed` - Fired after a chat has been permanently closed
 - `CodeCompanionChatSubmitted` - Fired after a chat has been submitted
+- `CodeCompanionChatDone` - Fired after a chat has received the response
 - `CodeCompanionChatStopped` - Fired after a chat has been stopped
 - `CodeCompanionChatCleared` - Fired after a chat has been cleared
 - `CodeCompanionChatAdapter` - Fired after the adapter has been set in the chat

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -11,6 +11,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionChatHidden` - Fired after a chat has been hidden
 - `CodeCompanionChatClosed` - Fired after a chat has been permanently closed
 - `CodeCompanionChatSubmitted` - Fired after a chat has been submitted
+- `CodeCompanionChatDone` - Fired after a chat has received the response
 - `CodeCompanionChatStopped` - Fired after a chat has been stopped
 - `CodeCompanionChatCleared` - Fired after a chat has been cleared
 - `CodeCompanionChatAdapter` - Fired after the adapter has been set in the chat
@@ -88,4 +89,3 @@ vim.api.nvim_exec_autocmds("User", {
   pattern = "CodeCompanionChatRefreshCache",
 })
 ```
-

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1043,6 +1043,8 @@ function Chat:done(output, reasoning, tools)
   end
 
   ready_chat_buffer(self)
+
+  util.fire("ChatDone", { bufnr = self.bufnr, id = self.id })
 end
 
 ---Add a reference to the chat buffer (Useful for user's adding custom Slash Commands)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

This PR adds the `ChatDone` event as a "stop" counterpart for the existing `ChatSubmitted` event. The result is:
- Consistency with the other events, which always come in pairs ("start" and "stop").
- The ability for extensions to use the `ChatSubmitted` and `ChatDone` events as hooks for chat operations.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Resolves #1878 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
