### PR TITLE
Feature: Unified Inline Diff Mechanism (No External Dependencies)

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1073,7 +1073,7 @@ You must create or modify a workspace file through a series of prompts over mult
         "followwrap",
         "linematch:120",
       },
-      provider = providers.diff, -- mini_diff|default
+      provider = providers.diff, -- inline|mini_diff|default
     },
     inline = {
       -- If the inline prompt creates a new buffer, how should we display this?

--- a/lua/codecompanion/providers/diff/inline.lua
+++ b/lua/codecompanion/providers/diff/inline.lua
@@ -1,0 +1,159 @@
+local log = require("codecompanion.utils.log")
+local util = require("codecompanion.utils")
+
+local api = vim.api
+local diff_fn = vim.text.diff or vim.diff
+
+---@class InlineDiffArgs
+---@field bufnr integer Buffer number to apply diff to
+---@field contents string[] Original content lines
+---@field id string Unique identifier for this diff
+
+---@class InlineDiff
+---@field bufnr integer
+---@field contents string[]
+---@field id string
+---@field ns_id integer
+---@field extmark_ids integer[]
+---@field has_changes boolean
+local InlineDiff = {}
+
+---Creates a new InlineDiff instance and applies diff highlights
+---@param args InlineDiffArgs
+---@return InlineDiff
+function InlineDiff.new(args)
+  log:debug("[InlineDiff] Version 4 test - with virtual text")
+  local self = setmetatable({
+    bufnr = args.bufnr,
+    contents = args.contents,
+    id = args.id,
+    ns_id = api.nvim_create_namespace("codecompanion_inline_diff_" .. args.id),
+    extmark_ids = {},
+    has_changes = false,
+  }, { __index = InlineDiff })
+  ---@cast self InlineDiff
+
+  local current_content = api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
+  if self:contents_equal(self.contents, current_content) then
+    log:debug("[InlineDiff] No changes detected")
+    util.fire("DiffAttached", { diff = "inline", bufnr = self.bufnr, id = self.id })
+    return self
+  end
+  log:debug("[InlineDiff] Changes detected - applying diff highlights")
+  self.has_changes = true
+  self:apply_diff_highlights(self.contents, current_content)
+  util.fire("DiffAttached", { diff = "inline", bufnr = self.bufnr, id = self.id })
+  return self
+end
+
+---Compares two content arrays for equality
+---@param content1 string[] First content array
+---@param content2 string[] Second content array
+---@return boolean equal True if contents are identical
+function InlineDiff:contents_equal(content1, content2)
+  if #content1 ~= #content2 then
+    return false
+  end
+  for i = 1, #content1 do
+    if content1[i] ~= content2[i] then
+      return false
+    end
+  end
+  return true
+end
+
+---Applies visual diff highlights using extmarks and virtual text
+---@param old_lines string[] Original content lines
+---@param new_lines string[] New content lines
+function InlineDiff:apply_diff_highlights(old_lines, new_lines)
+  local old_text = table.concat(old_lines, "\n")
+  local new_text = table.concat(new_lines, "\n")
+  log:debug("[InlineDiff] Generating diff between %d and %d chars", #old_text, #new_text)
+  local ok, diff_result = pcall(diff_fn, old_text, new_text, {
+    result_type = "indices",
+    algorithm = "histogram",
+  })
+  ---@cast diff_result integer[][]?
+  if not ok or not diff_result or #diff_result == 0 then
+    log:debug("[InlineDiff] No diff result generated")
+    return
+  end
+  log:debug("[InlineDiff] Processing %d diff hunks", #diff_result)
+  -- Process each hunk
+  for hunk_idx, hunk in ipairs(diff_result) do
+    local old_start, old_count, new_start, new_count = unpack(hunk)
+    log:debug("[InlineDiff] Hunk %d: old(%d,%d) new(%d,%d)", hunk_idx, old_start, old_count, new_start, new_count)
+    -- Handle removed lines (show as virtual text with full line highlight)
+    if old_count > 0 then
+      for i = 0, old_count - 1 do
+        local old_line_idx = old_start + i
+        if old_line_idx <= #old_lines then
+          local line_content = old_lines[old_line_idx]
+          -- Place virtual text strategically
+          local attach_line = math.max(0, new_start - 1)
+          if attach_line >= api.nvim_buf_line_count(self.bufnr) then
+            attach_line = api.nvim_buf_line_count(self.bufnr) - 1
+          end
+          -- Create full-width virtual line
+          local padding = math.max(0, vim.o.columns - #line_content - 2) -- Leave some margin
+          local extmark_id = api.nvim_buf_set_extmark(self.bufnr, self.ns_id, attach_line, 0, {
+            virt_lines = { { { line_content .. string.rep(" ", padding), "DiffDelete" } } },
+            virt_lines_above = true,
+            priority = 100,
+          })
+          table.insert(self.extmark_ids, extmark_id)
+        end
+      end
+    end
+
+    -- Handle added/modified lines (highlight in green)
+    if new_count > 0 then
+      for i = 0, new_count - 1 do
+        local new_line_idx = new_start + i - 1 -- Convert to 0-based indexing
+        if new_line_idx >= 0 and new_line_idx < api.nvim_buf_line_count(self.bufnr) then
+          log:debug("[InlineDiff] Adding green highlight at line %d", new_line_idx)
+          local extmark_id = api.nvim_buf_set_extmark(self.bufnr, self.ns_id, new_line_idx, 0, {
+            line_hl_group = "DiffAdd",
+            priority = 100,
+          })
+          table.insert(self.extmark_ids, extmark_id)
+        end
+      end
+    end
+  end
+  log:debug("[InlineDiff] Applied %d extmarks for diff visualization", #self.extmark_ids)
+end
+
+---Clears all diff highlights and extmarks
+function InlineDiff:clear_highlights()
+  if api.nvim_buf_is_valid(self.bufnr) then
+    api.nvim_buf_clear_namespace(self.bufnr, self.ns_id, 0, -1)
+  end
+  self.extmark_ids = {}
+end
+
+---Accepts the diff changes and clears highlights
+function InlineDiff:accept()
+  log:debug("[InlineDiff] Accept called")
+  util.fire("DiffAccepted", { diff = "inline", bufnr = self.bufnr, id = self.id, accept = true })
+  self:clear_highlights()
+end
+
+---Rejects the diff changes, restores original content, and clears highlights
+function InlineDiff:reject()
+  util.fire("DiffRejected", { diff = "inline", bufnr = self.bufnr, id = self.id, accept = false })
+  log:debug("[InlineDiff] Reject called")
+  if api.nvim_buf_is_valid(self.bufnr) then
+    api.nvim_buf_set_lines(self.bufnr, 0, -1, true, self.contents)
+  end
+  self:clear_highlights()
+end
+
+---Cleans up the diff instance and fires detachment event
+function InlineDiff:teardown()
+  log:debug("[InlineDiff] Teardown called")
+  self:clear_highlights()
+  util.fire("DiffDetached", { diff = "inline", bufnr = self.bufnr, id = self.id })
+end
+
+return InlineDiff

--- a/lua/codecompanion/providers/diff/inline.lua
+++ b/lua/codecompanion/providers/diff/inline.lua
@@ -27,7 +27,9 @@ function InlineDiff.new(args)
     bufnr = args.bufnr,
     contents = args.contents,
     id = args.id,
-    ns_id = api.nvim_create_namespace("codecompanion_inline_diff_" .. args.id),
+    ns_id = api.nvim_create_namespace(
+      "codecompanion_inline_diff_" .. (args.id ~= nil and args.id or math.random(1, 100000))
+    ),
     extmark_ids = {},
     has_changes = false,
   }, { __index = InlineDiff })

--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -21,6 +21,11 @@ local configs = {
   },
 
   -- Diffs
+  inline = {
+    module = "codecompanion.providers.diff.inline", -- Internal module path
+    name = "inline",
+    -- No condition needed - always available since it's internal
+  },
   mini_diff = {
     module = "mini.diff",
     name = "mini_diff",
@@ -87,7 +92,7 @@ end
 ---Get the default Diff provider
 ---@return string
 local function diff_providers()
-  local providers = { "mini_diff" }
+  local providers = { "inline", "mini_diff" }
   return find_provider(providers, configs, "default")
 end
 

--- a/lua/codecompanion/strategies/chat/agents/tools/helpers/diff.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/helpers/diff.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local keymaps = require("codecompanion.utils.keymaps")
+local log = require("codecompanion.utils.log")
 local ui = require("codecompanion.utils.ui")
 local api = vim.api
 
@@ -9,42 +10,84 @@ local M = {}
 ---@param bufnr number The buffer to create diff for
 ---@param diff_id number|string Unique identifier for this diff
 ---@param opts? table Optional configuration
+---@original_content: string[] The original buffer content before changes (optional)
 ---@return table|nil diff The diff object, or nil if no diff was created
 function M.create(bufnr, diff_id, opts)
   opts = opts or {}
 
+  log:debug("[Diff] create() called - bufnr=%d, diff_id=%s", bufnr, tostring(diff_id))
+
   -- Skip if in auto mode or diff disabled
   if vim.g.codecompanion_auto_tool_mode or not config.display.diff.enabled then
+    log:debug(
+      "[Diff] Skipping diff - auto_mode=%s, enabled=%s",
+      tostring(vim.g.codecompanion_auto_tool_mode),
+      tostring(config.display.diff.enabled)
+    )
     return nil
   end
 
   -- Skip for terminal buffers
   if vim.bo[bufnr].buftype == "terminal" then
+    log:debug("[Diff] Skipping diff - terminal buffer")
     return nil
   end
 
   local provider = config.display.diff.provider
+  log:debug("[Diff] Using provider: %s", provider)
+
   local ok, diff_module = pcall(require, "codecompanion.providers.diff." .. provider)
   if not ok then
+    log:error("[Diff] Failed to load provider '%s': %s", provider, diff_module)
     return nil
   end
+  log:debug("[Diff] Successfully loaded provider module")
 
   local winnr = ui.buf_get_win(bufnr)
   if not winnr then
+    log:debug("[Diff] No window found for buffer %d", bufnr)
     return nil
+  end
+
+  -- Use provided original content or fallback to current buffer content
+  local original_content = opts.original_content or api.nvim_buf_get_lines(bufnr, 0, -1, true)
+  local current_content = api.nvim_buf_get_lines(bufnr, 0, -1, true)
+
+  log:debug("[Diff] Original content lines: %d", #original_content)
+  log:debug("[Diff] Current content lines: %d", #current_content)
+  log:debug("[Diff] Using provided original_content: %s", opts.original_content and "YES" or "NO")
+
+  if #original_content > 0 then
+    log:debug("[Diff] Original first line: %s", original_content[1])
+  end
+  if #current_content > 0 then
+    log:debug("[Diff] Current first line: %s", current_content[1])
   end
 
   local diff_args = {
     bufnr = bufnr,
-    contents = api.nvim_buf_get_lines(bufnr, 0, -1, true),
-    filetype = api.nvim_buf_get_option(bufnr, "filetype"),
+    contents = original_content,
+    filetype = api.nvim_get_option_value("filetype", { buf = bufnr }),
     id = diff_id,
     winnr = winnr,
   }
 
+  log:debug(
+    "[Diff] Creating diff with args: bufnr=%d, contents_lines=%d, filetype=%s",
+    diff_args.bufnr,
+    #diff_args.contents,
+    diff_args.filetype
+  )
+
   local diff = diff_module.new(diff_args)
 
-  M.setup_keymaps(diff, opts)
+  if diff then
+    log:debug("[Diff] Successfully created diff object")
+    M.setup_keymaps(diff, opts)
+    log:debug("[Diff] Keymaps setup complete")
+  else
+    log:error("[Diff] Failed to create diff object")
+  end
 
   return diff
 end

--- a/lua/codecompanion/strategies/chat/agents/tools/helpers/wait.lua
+++ b/lua/codecompanion/strategies/chat/agents/tools/helpers/wait.lua
@@ -21,11 +21,24 @@ function M.for_decision(id, events, callback, opts)
   end
 
   local aug = api.nvim_create_augroup("codecompanion.agent.tools.wait_" .. tostring(id), { clear = true })
+  local decision_made = false
 
   -- Show waiting indicator in the chat buffer
   local chat_extmark_id = nil
   if opts.chat_bufnr then
     chat_extmark_id = M.show_waiting_indicator(opts.chat_bufnr, opts)
+  end
+
+  local function cleanup_and_callback(result)
+    if decision_made then
+      return -- Prevent double execution
+    end
+    decision_made = true
+    if chat_extmark_id and opts.chat_bufnr then
+      M.clear_waiting_indicator(opts.chat_bufnr)
+    end
+    api.nvim_clear_autocmds({ group = aug })
+    callback(result)
   end
 
   api.nvim_create_autocmd("User", {
@@ -38,13 +51,7 @@ function M.for_decision(id, events, callback, opts)
       end
 
       local accepted = (event.match == events[1])
-
-      if chat_extmark_id and opts.chat_bufnr then
-        M.clear_waiting_indicator(opts.chat_bufnr)
-      end
-
-      api.nvim_clear_autocmds({ group = aug })
-      callback({
+      cleanup_and_callback({
         accepted = accepted,
         event = event.match,
         data = event_data,
@@ -58,12 +65,7 @@ function M.for_decision(id, events, callback, opts)
 
   opts.timeout = opts.timeout or config.strategies.chat.tools.opts.wait_timeout or 30000
   vim.defer_fn(function()
-    if chat_extmark_id and opts.chat_bufnr then
-      M.clear_waiting_indicator(opts.chat_bufnr)
-    end
-
-    api.nvim_clear_autocmds({ group = aug })
-    callback({
+    cleanup_and_callback({
       accepted = false,
       timeout = true,
     })

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -461,13 +461,19 @@ function Inline:done(output)
     self:reset()
     return self:to_chat()
   end
-  self:place(placement)
 
   vim.schedule(function()
-    self:start_diff()
+    local original_content = api.nvim_buf_get_lines(self.context.bufnr, 0, -1, true)
+    log:debug("[Inline] Captured %d lines of original content", #original_content)
+    self:place(placement)
     pcall(vim.cmd.undojoin)
     self:output(json.code)
-    self:reset()
+    log:debug("[Inline] Code output applied")
+    if config.display.diff.enabled and self.classification.placement ~= "new" then
+      self:start_diff(original_content)
+    else
+      self:reset()
+    end
   end)
 end
 
@@ -675,14 +681,16 @@ function Inline:to_chat()
 end
 
 ---Start the diff process
+---@param original_content string[] The original buffer content before changes
 ---@return nil
-function Inline:start_diff()
+function Inline:start_diff(original_content)
+  log:debug("[Inline] Starting diff with provider: %s", config.display.diff.provider)
   if config.display.diff.enabled == false then
-    return
+    return self:reset()
   end
 
   if self.classification.placement == "new" then
-    return
+    return self:reset()
   end
 
   keymaps
@@ -697,17 +705,20 @@ function Inline:start_diff()
   local provider = config.display.diff.provider
   local ok, diff = pcall(require, "codecompanion.providers.diff." .. provider)
   if not ok then
-    return log:error("[Inline] Diff provider not found: %s", provider)
+    log:error("[Inline] Diff provider not found: %s", provider)
+    return self:reset()
   end
 
-  ---@type CodeCompanion.Diff
   self.diff = diff.new({
     bufnr = self.context.bufnr,
     cursor_pos = self.context.cursor_pos,
     filetype = self.context.filetype,
-    contents = self.lines,
+    contents = original_content,
+    id = self.id,
     winnr = self.context.winnr,
   })
+
+  log:debug("[Inline] Diff created with id=%d, provider=%s", self.id, provider)
 end
 
 return Inline

--- a/lua/codecompanion/strategies/inline/keymaps.lua
+++ b/lua/codecompanion/strategies/inline/keymaps.lua
@@ -19,9 +19,11 @@ M.accept_change = {
   desc = "Accept the change from the LLM",
   callback = function(inline)
     if inline.diff then
-      log:trace("[Inline] Accepting diff")
+      log:trace("[Inline] Accepting diff for id=%s", tostring(inline.id))
       inline.diff:accept()
       clear_map(config.strategies.inline.keymaps, inline.diff.bufnr)
+    else
+      log:warn("[Inline] No diff found to accept")
     end
   end,
 }
@@ -30,9 +32,12 @@ M.reject_change = {
   desc = "Reject the change from the LLM",
   callback = function(inline)
     if inline.diff then
-      log:trace("[Inline] Rejecting diff")
+      log:trace("[Inline] Rejecting diff for id=%s", tostring(inline.id))
       inline.diff:reject()
       clear_map(config.strategies.inline.keymaps, inline.diff.bufnr)
+      inline:reset()
+    else
+      log:warn("[Inline] No diff found to reject")
     end
   end,
 }


### PR DESCRIPTION
## Description

This PR introduces a new **inline diff mechanism** for codecompanion, implemented in the simplest way possible to maximize readability and maintainability. The diffing logic is based on the ZED style of diff, and is rendered in a unified inline style directly within the buffer. No external dependencies are required; the implementation uses only built-in Neovim APIs and Lua.

- **Unified Inline Diff**: Shows changes (additions and deletions including modified) inline, using extmarks and virtual text, similar to ZED's approach.
- **No Dependencies**: All logic is internal, avoiding any third-party libraries.
- **Simplicity**: The code is intentionally kept minimal and straightforward to ease future maintenance and reduce complexity.

### Notable Implementation Details (this WIP and could change a lot)

- **Diff Provider**: A new provider (`inline`) is added and set as the default. It can be toggled in the config.
- **Diff Logic**: The diff is calculated using Neovim's built-in `vim.diff` or `vim.text.diff` (if available with nvim 0.12), and visualized using extmarks for highlights and virtual lines for deletions.
- **Buffer Safety**: The diff is only shown if there are actual changes between the original and current buffer content.
- **Minimal State**: The diff object tracks only what is necessary (namespace, extmarks, etc.) for clarity and maintainability.

#### Notable Changes in `wait.lua`

- **Race Condition Fix**: The callback logic in `wait.lua` is now guarded by a `decision_made` flag and a `cleanup_and_callback` function. This ensures the callback is only executed once, preventing race conditions where both an autocmd and a timeout could trigger the callback.

---

> **Warning**
>
> This is a draft PR. The inline diff mechanism is working, but expect bugs and rough edges. The feature still needs significant work to be considered reliable and production-ready.

---

### TODO


- [ ] Make the inline diff mechanism more reliable and robust.
- [ ] Improve workflow predictability, especially reconciling differences between chat-based diffs (with tools) and the inline strategy.
- [ ] Refactor and improve highlight groups for better visual clarity.
- [ ] Implement a **"super diff buffer"** (inspired by ZED) that accumulates all changes, allowing users to view and revert all changes in a single clean diff buffer.
- [ ] Add a keymap to send all changes to the quickfix list (with line numbers).
- [ ] Tweak the visual appearance; optionally add a **"GitHub style"** diff if it can be done in under 10 lines of code.
- [ ] Add comprehensive tests for all diff scenarios and edge cases.
- [ ] Clean up the codebase, especially removing or reducing excessive logging.


## Related Issue(s)

[Here](https://github.com/olimorris/codecompanion.nvim/discussions/1607#discussioncomment-13436914) #1607

## Screenshots


<img width="1692" height="1764" alt="Screenshot 2025-07-21 at 11 02 05 PM" src="https://github.com/user-attachments/assets/6d673cc5-67a3-43a3-a39c-5746423c7a6e" />

### Comparing with Mini.diff

<details><summary>Screenshots</summary>
<p>



cc Inline mode:
<img width="2384" height="1364" alt="Screenshot_inline" src="https://github.com/user-attachments/assets/58175bf2-5dda-4358-a1b4-726b14fef05d" />

Mini.diff style (this can looks way messier but this is just a simple example:
<img width="2616" height="1322" alt="Screenshot_mini_diff" src="https://github.com/user-attachments/assets/88d13af4-7648-4c75-85e3-99977876d85c" />


</p>
</details> 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
