### PR TITLE
fix(ollama): ensure default model returns

### DIFF
--- a/lua/codecompanion/adapters/ollama.lua
+++ b/lua/codecompanion/adapters/ollama.lua
@@ -85,8 +85,9 @@ local function get_models(self, opts)
     job:wait()
   end
 
-  if opts and opts.last then
-    return models[1]
+  local latest_model = json.models[1]
+  if opts and opts.last and latest_model then
+    return latest_model.name
   end
   return models
 end


### PR DESCRIPTION
## Description

With the change to using Ollama's native API in #1829, returning of the default model broke, as models are now stored in a table by name. This meant that the model selection list was empty, as `change_adapter` in `strategies/chat/keymaps.lua` ended up creating a table of models that `vim.ui.select` could not render.

This PR uses the underlying API response to return the first-returned (newest) available model _name_ as the default.

It wasn't obvious where test coverage could be added for this, as it looked like adapter schema is mocked in `test_ollama.lua`. 

## Screenshots

### Model selection before
<img width="1203" height="722" alt="before" src="https://github.com/user-attachments/assets/7de48514-f66b-4218-aa19-ed59a6bf252b" />

### Model selection after
<img width="1203" height="722" alt="after" src="https://github.com/user-attachments/assets/682f9bac-0953-46cf-a08e-f9fc3d8cc509" />


## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
