### PR TITLE
fix(commands): CodeCompanion complete from prompt library.

### DIFF
--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -75,11 +75,19 @@ return {
       -- Reference:
       -- https://github.com/nvim-neorocks/nvim-best-practices?tab=readme-ov-file#speaking_head-user-commands
       complete = function(arg_lead, cmdline, _)
-        if cmdline:match("^['<,'>]*CodeCompanion[!]*%s+%w*$") then
+        if cmdline:match("^['<,'>]*CodeCompanion[!]*%s+/?%w*$") then
           return vim
             .iter(inline_subcommands)
             :filter(function(key)
               return key:find(arg_lead) ~= nil
+            end)
+            :map(function(key)
+              -- Remove the leading "/" if it has already been typed.
+              -- This allows matching on /<prompt library> without placing "//".
+              if arg_lead:sub(1, 1) == "/" and key:sub(1, 1) == "/" then
+                return key:sub(2)
+              end
+              return key
             end)
             :totable()
         end


### PR DESCRIPTION
## Description

The regex in the complete function did not match on the "/" needed to reference elements from the prompt library. Prompt library elements would appear only if "/" was not used.

## Related Issue(s)

Fixes #1885

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
