### PR TITLE
fix error outputting tool name when completed

### DIFF
--- a/lua/codecompanion/strategies/chat/agents/executor/func.lua
+++ b/lua/codecompanion/strategies/chat/agents/executor/func.lua
@@ -72,7 +72,7 @@ function FuncExecutor:run(func, action, input, callback)
   ---@param msg {status:"success"|"error", data:any}
   local function output_handler(msg)
     if tool_finished then
-      return log:info("output_handler for tool %s called more than once", self.executor.tool.name)
+      return
     end
     tool_finished = true
     if msg.status == self.executor.agent.constants.STATUS_ERROR then


### PR DESCRIPTION
## Description

Prevents the issue when trying to log a nonexistent tool in `func.lua`

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
