### PR TITLE
fix(copilot): correctly retrieve token in get_models

### DIFF
--- a/lua/codecompanion/adapters/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/copilot/helpers.lua
@@ -30,7 +30,7 @@ end
 ---Get a list of available Copilot models
 ---@param adapter CodeCompanion.Adapter
 ---@param get_and_authorize_token_fn function Function to get and authorize token
----@param authorize_token_fn function Function to get fresh github token
+---@param authorize_token_fn function Function to get fresh Github token
 ---@return table
 function M.get_models(adapter, get_and_authorize_token_fn, authorize_token_fn)
   if _cached_models and _cache_expires and _cache_expires > os.time() then

--- a/lua/codecompanion/adapters/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/copilot/helpers.lua
@@ -55,7 +55,8 @@ function M.get_models(adapter, get_and_authorize_token_fn, authorize_token_fn)
     return {}
   end
 
-  local url = "https://api.githubcopilot.com/models"
+  local base_url = (fresh_token.endpoints and fresh_token.endpoints.api) or "https://api.githubcopilot.com"
+  local url = base_url .. "/models"
   local headers = vim.deepcopy(_cached_adapter.headers)
   headers["Authorization"] = "Bearer " .. fresh_token.token
 

--- a/lua/codecompanion/adapters/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/copilot/helpers.lua
@@ -30,9 +30,9 @@ end
 ---Get a list of available Copilot models
 ---@param adapter CodeCompanion.Adapter
 ---@param get_and_authorize_token_fn function Function to get and authorize token
----@param oauth_token string The oauth token
+---@param authorize_token_fn function Function to get fresh github token
 ---@return table
-function M.get_models(adapter, get_and_authorize_token_fn, oauth_token)
+function M.get_models(adapter, get_and_authorize_token_fn, authorize_token_fn)
   if _cached_models and _cache_expires and _cache_expires > os.time() then
     return _cached_models
   end
@@ -47,10 +47,17 @@ function M.get_models(adapter, get_and_authorize_token_fn, oauth_token)
   if not get_and_authorize_token_fn(adapter) then
     return {}
   end
+  -- Get a fresh token (authorize_token_fn handles expiry automatically)
+  local fresh_token = authorize_token_fn()
+  -- Ensure we have a fresh GitHub token
+  if not fresh_token or not fresh_token.token then
+    log:error("Could not get valid GitHub Copilot token")
+    return {}
+  end
 
   local url = "https://api.githubcopilot.com/models"
   local headers = vim.deepcopy(_cached_adapter.headers)
-  headers["Authorization"] = "Bearer " .. oauth_token
+  headers["Authorization"] = "Bearer " .. fresh_token.token
 
   local ok, response = pcall(function()
     return curl.get(url, {

--- a/lua/codecompanion/adapters/copilot/init.lua
+++ b/lua/codecompanion/adapters/copilot/init.lua
@@ -300,7 +300,7 @@ return {
             return { ["gpt-4.1"] = { opts = {} } } -- fallback
           end
         end
-        return copilot_helper.get_models(self, get_and_authorize_token, _oauth_token)
+        return copilot_helper.get_models(self, get_and_authorize_token, authorize_token)
       end,
     },
     ---@type CodeCompanion.Schema

--- a/tests/adapters/copilot/test_helpers.lua
+++ b/tests/adapters/copilot/test_helpers.lua
@@ -162,10 +162,13 @@ T["Copilot Helper Get Models"]["retrieves models with correct structure"] = func
   local mock_get_and_authorize_token = function()
     return true -- Simulate successful token retrieval
   end
-  local mock_oauth_token = "mock_oauth_token"
-
-  local models = copilot_helper.get_models(mock_adapter, mock_get_and_authorize_token, mock_oauth_token)
-
+  local mock_authorize_token = function()
+    return {
+      token = "mock_github_token",
+      expires_at = os.time() + 3600, -- Expires in 1 hour
+    }
+  end
+  local models = copilot_helper.get_models(mock_adapter, mock_get_and_authorize_token, mock_authorize_token)
   h.eq(2, vim.tbl_count(models), "Expected two models to be returned")
   h.eq({
     opts = {


### PR DESCRIPTION
## Description

There’s an issue where Copilot doesn’t retrieve models correctly because the `get_models` GitHub endpoint expects a GitHub token rather than an OAuth token. It’s still surprising that the API didn’t return any errors when we used the wrong token.

This PR addresses the issue, but I would appreciate it if you could test it before merging to ensure everything is working smoothly.

Thank you

## Related Issue(s)

#1874

## Screenshots


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
