### PR TITLE
fix(openai): handle choices as function in reasoning format

### DIFF
--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -350,8 +350,12 @@ return {
         if type(model) == "function" then
           model = model()
         end
-        if self.schema.model.choices[model] and self.schema.model.choices[model].opts then
-          return self.schema.model.choices[model].opts.can_reason
+        local choices = self.schema.model.choices
+        if type(choices) == "function" then
+          choices = choices(self)
+        end
+        if choices and choices[model] and choices[model].opts then
+          return choices[model].opts.can_reason
         end
         return false
       end,


### PR DESCRIPTION
## Description

This PR updates the `condition` function for the `reasoning_effort` schema field to correctly handle cases where `self.schema.model.choices` is a function. Previously, attempting to index `choices` when it was a function resulted in an error:

```lua
attempt to index field 'choices' (a function value)
```

The fix ensures that if `choices` is a function, it is called with `self` to obtain the actual choices table before indexing. This prevents runtime errors when evaluating the condition for showing the `reasoning_effort` option.



### Reason:
The reason is that I’m trying to make the choices dynamic to support extending certain adapters like Huggingface and OpenRouter. (I’m extending the OpenAI adapter directly rather than the openai_compatible one because of  the function calls are supported there.)
Also, this is simply a similar version of what already existed in the `setup()` function.


## Related Issue(s)

Error message when we have function for the choices:

```lua
vim.schedule callback: ...codecompanion.nvim/lua/codecompanion/adapters/openai.lua:353: attempt to index field 'choices' (a function value)
stack traceback:
	...codecompanion.nvim/lua/codecompanion/adapters/openai.lua:353: in function 'condition'
	...am/repos/codecompanion.nvim/lua/codecompanion/schema.lua:23: in function 'get_default'
	...codecompanion.nvim/lua/codecompanion/strategies/chat.lua:679: in function 'apply_settings'
	...anion.nvim/lua/codecompanion/strategies/chat/keymaps.lua:545: in function 'on_choice'
	.../bassam/repos/namu.nvim/lua/namu/ui_select/ui_select.lua:210: in function <.../bassam/repos/namu.nvim/lua/namu/ui_select/ui_select.lua:209>
```

Thank you

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
