### PR TITLE
feat: configurable workspace file path; context path functions

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 27
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 28
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -3991,9 +3991,12 @@ This can now accomplished, as per the example below:
       context = {
         {
           type = "file",
-          path = { -- This can be a string or a table of values
+          path = { -- This can be a string, a function, or a table of strings or functions
             "lua/codecompanion/health.lua",
             "lua/codecompanion/http.lua",
+            function() -- must return a path string
+              return vim.fs.normalize(vim.fs.joinpath(vim.fn.getcwd(), 'some/other/path.lua'))
+            end,
           },
         },
         {
@@ -5009,6 +5012,15 @@ For the origin of workspaces in CodeCompanion, and why I settled on this
 design, please see the original
 <https://github.com/olimorris/codecompanion.nvim/discussions/705> announcement.
 
+
+  [!NOTE] You can customize the name and location (relative to your current
+  working directory) of the workspace file by setting the `workspace_file`
+  configuration option. For example:
+  >lua
+      require('codecompanion').setup({
+        workspace_file = '.ai/workspace.json', -- relative to cwd
+      })
+  <
 
 STRUCTURE ~
 

--- a/doc/configuration/workspace.md
+++ b/doc/configuration/workspace.md
@@ -1,0 +1,13 @@
+# Configuring the Workspace File
+
+Workspaces act as a context management system for your project. This context sits in a `codecompanion-workspace.json` file in the root of the current working directory. For the purposes of this guide, the file will be referred to as the _workspace file_.
+
+You can customize the name and location of the workspace file by setting the `workspace_file` configuration option. For example:
+
+```lua
+require('codecompanion').setup({
+  workspace_file = '.ai/workspace.json' -- relative to cwd
+})
+```
+
+To learn more about the workspace file, please see the [Creating Workspaces](/extending/workspace) guide.

--- a/doc/extending/prompts.md
+++ b/doc/extending/prompts.md
@@ -362,9 +362,12 @@ It can be useful to pre-load a chat buffer with context from _files_, _symbols_ 
   context = {
     {
       type = "file",
-      path = { -- This can be a string or a table of values
+      path = { -- This can be a string, a function, or a table of strings or functions
         "lua/codecompanion/health.lua",
         "lua/codecompanion/http.lua",
+        function() -- must return a path string
+          return vim.fs.normalize(vim.fs.joinpath(vim.fn.getcwd(), 'some/other/path.lua'))
+        end,
       },
     },
     {
@@ -395,4 +398,3 @@ It can be useful to pre-load a chat buffer with context from _files_, _symbols_ 
 ## Conclusion
 
 Hopefully this serves as a useful introduction on how you can expand CodeCompanion to create prompts that suit your workflow. It's worth checking out [config.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua) files for more complex examples.
-

--- a/doc/extending/workspace.md
+++ b/doc/extending/workspace.md
@@ -4,6 +4,15 @@ Workspaces act as a context management system for your project. This context sit
 
 For the origin of workspaces in CodeCompanion, and why I settled on this design, please see the [original](https://github.com/olimorris/codecompanion.nvim/discussions/705) announcement.
 
+> [!NOTE]
+> You can customize the name and location (relative to your current working directory) of the workspace file by setting the `workspace_file` configuration option. For example:
+>
+> ```lua
+> require('codecompanion').setup({
+>   workspace_file = '.ai/workspace.json', -- relative to cwd
+> })
+> ```
+
 ## Structure
 
 The workspace file primarily consists of a groups array and data objects. A group defines a specific feature or functionality within the code base, which is made up of a number of individual data objects. These objects are simply a reference to code, which could be in the form of a file, a symbolic outline, or a URL.
@@ -130,7 +139,6 @@ An example of using the configuration options:
   }
 }
 ```
-
 
 ## Variables
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -37,6 +37,7 @@ local defaults = {
     },
   },
   constants = constants,
+  workspace_file = "codecompanion-workspace.json", -- Relative to cwd
   strategies = {
     -- CHAT STRATEGY ----------------------------------------------------------
     chat = {
@@ -952,9 +953,9 @@ This is the code, for context:
       context = {
         {
           type = "file",
-          path = {
-            vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json"),
-          },
+          path = function()
+            return require("codecompanion.utils.files").get_workspace_file_path()
+          end,
         },
       },
       prompts = {
@@ -994,7 +995,8 @@ You must create or modify a workspace file through a series of prompts over mult
           role = constants.USER_ROLE,
           content = function()
             local prompt = ""
-            if vim.fn.filereadable(vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json")) == 1 then
+            local path = require("codecompanion.utils.files").get_workspace_file_path()
+            if vim.fn.filereadable(path) == 1 then
               prompt = [[Can you help me add a group to an existing workspace file?]]
             else
               prompt = [[Can you help me create a workspace file?]]

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -5,12 +5,6 @@ local util = require("codecompanion.utils")
 
 local fmt = string.format
 
-local CONSTANTS = {
-  NAME = "Workspace",
-  PROMPT = "Select a workspace group",
-  WORKSPACE_FILE = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json"),
-}
-
 ---Replace variables in a string
 ---@param workspace table
 ---@param group table
@@ -72,11 +66,7 @@ end
 ---@return table
 function SlashCommand:read_workspace_file(path)
   if not path then
-    path = CONSTANTS.WORKSPACE_FILE
-  end
-  if not path then
-    path = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json")
-    CONSTANTS.WORKSPACE_FILE = vim.fs.joinpath(vim.fn.getcwd(), "codecompanion-workspace.json")
+    path = require("codecompanion.utils.files").get_workspace_file_path()
   end
 
   if not vim.uv.fs_stat(path) then

--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -66,9 +66,15 @@ function Strategies.add_context(prompt, chat)
     if item.type == "file" or item.type == "symbols" then
       if type(item.path) == "string" then
         return slash_commands.context(chat, item.type, { path = item.path })
+      elseif type(item.path) == "function" then
+        return slash_commands.context(chat, item.type, { path = item.path() })
       elseif type(item.path) == "table" then
         for _, path in ipairs(item.path) do
-          slash_commands.context(chat, item.type, { path = path })
+          if type(path) == "string" then
+            slash_commands.context(chat, item.type, { path = path })
+          elseif type(path) == "function" then
+            slash_commands.context(chat, item.type, { path = path() })
+          end
         end
       end
     elseif item.type == "url" then

--- a/lua/codecompanion/utils/files.lua
+++ b/lua/codecompanion/utils/files.lua
@@ -32,4 +32,18 @@ function M.create_dir_recursive(path)
   return true, nil
 end
 
+---Resolves a path relative to the current working directory.
+---@param path string? The path to resolve
+---@return string resolved_path The resolved absolute path
+M.resolve_path_relative_to_cwd = function(path)
+  return vim.fs.normalize(vim.fs.joinpath(vim.fn.getcwd(), path))
+end
+
+---Resolves the workspace path relative to the current working directory.
+---@return string workspace_file_path The resolved absolute path to the workspace file.
+M.get_workspace_file_path = function()
+  local config_file_name = require("codecompanion.config").workspace_file
+  return M.resolve_path_relative_to_cwd(config_file_name or "codecompanion-workspace.json")
+end
+
 return M

--- a/tests/stubs/workspace_custom.json
+++ b/tests/stubs/workspace_custom.json
@@ -1,0 +1,21 @@
+{
+  "name": "Custom Workspace",
+  "version": "1.0.0",
+  "workspace_spec": "1.0",
+  "system_prompt": "Custom workspace system prompt",
+  "groups": [
+    {
+      "name": "Custom Test",
+      "description": "This is a custom test group",
+      "system_prompt": "Custom test group system prompt",
+      "data": ["custom-stub-go"]
+    }
+  ],
+  "data": {
+    "custom-stub-go": {
+      "type": "file",
+      "path": "tests/stubs/stub.go",
+      "description": "Custom test description for the file ${filename} located at ${path}"
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR:

- Adds a `workspace_file` configuration option to customize location/name
- Add helper functions for resolving workspace file paths
- Adds support for function type in context path objects for dynamic paths resolution
- Refactors workspace file path resolution to use utility functions
- Updates documentation with examples

## Related Issue(s)

N/A

## Screenshots

### After updating config, prior to moving my workspace file

<img width="1818" height="2247" alt="Screenshot 2025-07-27 at 23 19 35" src="https://github.com/user-attachments/assets/aca88c21-c4c9-4be0-be6d-b168c370b241" />

### After moving my config file and running `/workspace`

<img width="1818" height="2247" alt="Screenshot 2025-07-28 at 00 13 22" src="https://github.com/user-attachments/assets/c3cf3912-578b-4a5d-89d3-bc0caa08d4ee" />


## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
