### PR TITLE
feat(HuggingFace): add support for function calling

### DIFF
--- a/lua/codecompanion/adapters/huggingface.lua
+++ b/lua/codecompanion/adapters/huggingface.lua
@@ -71,7 +71,7 @@ return {
   },
   opts = {
     stream = true,
-    vision = true,
+    vision = false,
     tools = true,
   },
   features = {


### PR DESCRIPTION
## Description

This PR enables tool support for HuggingFace adapter.  
- Adds `tools` role and enables `tools` and `vision` options by default.
- Checks model capabilities to disable tools if unsupported.
- Implements tool-related handler functions by delegating to existing OpenAI handlers.

Thank you

## Related Issue(s)

There’s no function call for Hugging Face inference.

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
