### PR TITLE
Change the githubmodels url to use the GitHub Rest API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ CodeCompanion.nvim is organized into several key directories:
 - Neovim 0.10.0+
 - [lua-language-server](https://github.com/LuaLS/lua-language-server) for LSP support and type annotations
 - [stylua](https://github.com/JohnnyMorganz/StyLua) for Lua formatting
+- [pandoc](https://pandoc.org/) for doc generation
 
 ### Setting Up for Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ CodeCompanion.nvim is organized into several key directories:
 - Neovim 0.10.0+
 - [lua-language-server](https://github.com/LuaLS/lua-language-server) for LSP support and type annotations
 - [stylua](https://github.com/JohnnyMorganz/StyLua) for Lua formatting
-- [pandoc](https://pandoc.org/) for doc generation
+- [pandoc](https://pandoc.org) for doc generation
 
 ### Setting Up for Development
 

--- a/lua/codecompanion/adapters/githubmodels.lua
+++ b/lua/codecompanion/adapters/githubmodels.lua
@@ -53,7 +53,7 @@ return {
     text = true,
     tokens = true,
   },
-  url = "https://models.inference.ai.azure.com/chat/completions",
+  url = "https://models.github.ai/inference/chat/completions",
   env = {
     ---@return string|nil
     api_key = function()


### PR DESCRIPTION
## Description

This changes the url for the `githubmodels` adapter from a [deprecated one](https://github.blog/changelog/2025-07-17-deprecation-of-azure-endpoint-for-github-models/) to the supported [GitHub Models REST API](https://docs.github.com/en/rest/models).

NOTE: There are some existing bugs, that I did not fix in this PR. In testing different models I found that `o3-mini` fails on both the old endpoint and the new. There may be others, but I chose not to expand the scope of this PR as the default option **does** work.

## Related Issue(s)

For: https://github.com/olimorris/codecompanion.nvim/discussions/1909

## Screenshots

<details>
<summary>o3-mini max tokens error message</summary>

<img width="668" height="409" alt="Screenshot 2025-07-29 at 6 59 21 PM" src="https://github.com/user-attachments/assets/852851e2-9e82-4c20-9b99-6bc08b267560" />

</details>

<details>
<summary>Error message from manually testing a url with a typo</summary>

<img width="692" height="243" alt="Screenshot 2025-07-29 at 6 58 25 PM" src="https://github.com/user-attachments/assets/85c1f0fd-daa5-44a3-b8a0-4fdc00926b2c" />

</details>

<details>
<summary>make all works</summary>

<img width="125" height="39" alt="Screenshot 2025-07-29 at 7 38 56 PM" src="https://github.com/user-attachments/assets/41d51e45-bb06-4851-a5aa-a38ba01698fb" />


<img width="725" height="805" alt="Screenshot 2025-07-29 at 7 23 27 PM" src="https://github.com/user-attachments/assets/4ce9a91d-fcb0-4019-b52c-adabc0b2b919" />


</details>

<details>
<summary>A successful request to the new endpoint</summary>

<img width="681" height="212" alt="Screenshot 2025-07-29 at 7 48 33 PM" src="https://github.com/user-attachments/assets/a55f9ad4-1823-483f-a986-bda42047fdfa" />



</details>

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
