### PR TITLE
fix: handle custom winborder characters

### DIFF
--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -30,7 +30,7 @@ M.create_float = function(lines, opts)
   local winnr = api.nvim_open_win(bufnr, true, {
     relative = opts.relative or "cursor",
     -- thanks to @mini.nvim for this, it's for >= 0.11, to respect users winborder style
-    border = (vim.fn.exists("+winborder") == 1 and vim.o.winborder ~= "") and vim.o.winborder or "single",
+    border = (vim.fn.exists("+winborder") == 0 or vim.o.winborder == "") and "single" or nil,
     width = width,
     height = height,
     style = "minimal",


### PR DESCRIPTION
## Description

`vim.o.winborder` returns a comma separated string for custom border characters. `nvim_open_win` does not support this. It only supports either one of the known string values or a table with the border characters.

It is unnecessary to set border explicitly to the users winborder option, as it will default to that when border is nil.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
