### PR TITLE
Fix codeblock formatting in chat buffer

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -304,7 +304,7 @@ M.codeblock = {
     local cursor_pos = api.nvim_win_get_cursor(0)
     local line = cursor_pos[1]
 
-    local ft = chat.context.filetype or ""
+    local ft = chat.buffer_context.filetype or ""
 
     local codeblock = {
       "```" .. ft,


### PR DESCRIPTION
## Description

Whilst refactoring the context in the chat buffer, I forgot to update the codeblock callback that formats code in the chat buffer

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
