### PR TITLE
fix: set nowait as default for reject

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 29
+*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 31
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1643,6 +1643,7 @@ The inline assistant supports keymaps for accepting or rejecting changes:
             },
             reject_change = {
               modes = { n = "gr" },
+              opts = { nowait = true },
               description = "Reject the suggested change",
             },
           },

--- a/doc/configuration/inline-assistant.md
+++ b/doc/configuration/inline-assistant.md
@@ -21,6 +21,7 @@ require("codecompanion").setup({
         },
         reject_change = {
           modes = { n = "gr" },
+          opts = { nowait = true },
           description = "Reject the suggested change",
         },
       },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -503,6 +503,7 @@ local defaults = {
           modes = {
             n = "gr",
           },
+          opts = { nowait = true },
           index = 2,
           callback = "keymaps.reject_change",
           description = "Reject change",


### PR DESCRIPTION
## Description

Following up on this https://github.com/olimorris/codecompanion.nvim/pull/1572. I think it makes sense to set this as default to make rejection of a diff happen immediately. By default this conflicts with the builtin lsp mappings which have `gr` as prefix. Therefore it waits for if a third keypress happens or not.

Probably doesn't make sense to wait for a third keypress while in diff mode? So I think it will enhance the experience of not "lagging" when rejecting changes

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
