### PR TITLE
fix(ui): Debug Chat: allow `q` and `<Esc>` to be able to close the window

### DIFF
--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -227,7 +227,6 @@ function Debug:render()
   ui.create_float(lines, {
     bufnr = self.bufnr,
     filetype = "lua",
-    ignore_keymaps = true,
     relative = "editor",
     title = "Debug Chat",
     window = window,


### PR DESCRIPTION
## Description

When I want to quit from Debug Chat, it is tedious to have to do `:q<return>` (three keypresses). It should be possible to just quit using `q` or `Esc`. That feature exists but `ignore_keymaps` is set to `true` when creating the floating window. Set `ignore_keymaps` to false. 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
