### PR TITLE
Prompt Library: Allow custom intro message and now don't require a user prompt

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2025 July 31
+*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 03
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -3986,6 +3986,22 @@ system prompt with the request:
       description = "Your Special New Prompt",
       opts = {
         ignore_system_prompt = true,
+      },
+      -- Your prompts here
+    }
+<
+
+
+SETTING A CUSTOM INTRO MESSAGE
+
+To customize the chat buffer UI, you can set a custom intro message:
+
+>lua
+    ["Your_New_Prompt"] = {
+      strategy = "chat",
+      description = "Your Special New Prompt",
+      opts = {
+        intro_message = "Welcome to your Special New Prompt"
       },
       -- Your prompts here
     }

--- a/doc/extending/prompts.md
+++ b/doc/extending/prompts.md
@@ -343,6 +343,21 @@ It may also be useful to create custom prompts that do not send the default syst
 }
 ```
 
+### Setting a custom intro message
+
+To customize the chat buffer UI, you can set a custom intro message:
+
+```lua
+["Your_New_Prompt"] = {
+  strategy = "chat",
+  description = "Your Special New Prompt",
+  opts = {
+    intro_message = "Welcome to your Special New Prompt"
+  },
+  -- Your prompts here
+}
+```
+
 ### Prompts with Context
 
 It can be useful to pre-load a chat buffer with context from _files_, _symbols_ or even _urls_. This makes conversing with an LLM that much more productive. This can now accomplished, as per the example below:

--- a/lua/codecompanion/strategies/chat/helpers.lua
+++ b/lua/codecompanion/strategies/chat/helpers.lua
@@ -83,4 +83,13 @@ function M.add_image(Chat, image, opts)
   })
 end
 
+---Check if the messages contain any user messages
+---@param messages table The list of messages to check
+---@return boolean
+function M.has_user_messages(messages)
+  return vim.iter(messages):any(function(msg)
+    return msg.role == config.constants.USER_ROLE
+  end)
+end
+
 return M

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -28,6 +28,7 @@
 ---@field ui CodeCompanion.Chat.UI The UI of the chat buffer
 ---@field variables? CodeCompanion.Variables The variables available to the user
 ---@field watchers CodeCompanion.Watchers The buffer watcher instance
+---@field intro_message? string The welcome message that is displayed in the chat buffer
 ---@field yaml_parser vim.treesitter.LanguageTree The Yaml Tree-sitter parser for the chat buffer
 ---@field _last_role string The last role that was rendered in the chat buffer
 
@@ -43,6 +44,7 @@
 ---@field status? string The status of any running jobs in the chat buffe
 ---@field stop_context_insertion? boolean Stop any visual selection from being automatically inserted into the chat buffer
 ---@field tokens? table Total tokens spent in the chat buffer so far
+---@field intro_message? string The welcome message that is displayed in the chat buffer
 
 local adapters = require("codecompanion.adapters")
 local client = require("codecompanion.http")
@@ -536,6 +538,7 @@ function Chat.new(args)
     messages = args.messages or {},
     opts = args,
     status = "",
+    intro_message = args.intro_message or config.display.chat.intro_message,
     create_buf = function()
       local bufnr = api.nvim_create_buf(false, true)
       api.nvim_buf_set_name(bufnr, string.format("[CodeCompanion] %d", id))
@@ -622,8 +625,8 @@ function Chat.new(args)
     self.header_line = header_line and (header_line + 1) or 1
   end
 
-  if vim.tbl_isempty(self.messages) then
-    self.ui:set_intro_msg()
+  if vim.tbl_isempty(self.messages) or not helpers.has_user_messages(args.messages) then
+    self.ui:set_intro_msg(self.intro_message)
   end
 
   if config.strategies.chat.keymaps then

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1346,7 +1346,7 @@ function Chat:clear()
   self.tool_registry:clear()
 
   log:trace("Clearing chat buffer")
-  self.ui:render(self.buffer_context, self.messages, self.opts):set_intro_msg()
+  self.ui:render(self.buffer_context, self.messages, self.opts):set_intro_msg(self.intro_message)
   self:add_system_prompt()
   util.fire("ChatCleared", { bufnr = self.bufnr, id = self.id })
 end

--- a/lua/codecompanion/strategies/chat/ui/init.lua
+++ b/lua/codecompanion/strategies/chat/ui/init.lua
@@ -3,6 +3,7 @@ Manages the UI for the chat buffer such as opening and closing splits/windows,
 parsing settings and rendering extmarks.
 --]]
 local config = require("codecompanion.config")
+local helpers = require("codecompanion.strategies.chat.helpers")
 local log = require("codecompanion.utils.log")
 local schema = require("codecompanion.schema")
 local ui = require("codecompanion.utils.ui")
@@ -310,7 +311,7 @@ function UI:render(context, messages, opts)
     spacer()
   end
 
-  if vim.tbl_isempty(messages) then
+  if vim.tbl_isempty(messages) or not helpers.has_user_messages(messages) then
     log:trace("Setting the header for the chat buffer")
     self:set_header(lines, self.roles.user)
     spacer()
@@ -370,14 +371,15 @@ function UI:render_headers()
 end
 
 ---Set the welcome message in the chat buffer
+---@param message string The intro message to display
 ---@return CodeCompanion.Chat.UI|nil
-function UI:set_intro_msg()
+function UI:set_intro_msg(message)
   if self.intro_message then
     return self
   end
 
   if not config.display.chat.start_in_insert_mode then
-    local extmark_id = self:set_virtual_text(config.display.chat.intro_message, "eol")
+    local extmark_id = self:set_virtual_text(message, "eol")
     api.nvim_create_autocmd("InsertEnter", {
       buffer = self.chat_bufnr,
       callback = function()

--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -121,6 +121,7 @@ function Strategies:chat()
       auto_submit = (opts and opts.auto_submit) or false,
       stop_context_insertion = (opts and self.selected.opts.stop_context_insertion) or false,
       ignore_system_prompt = (opts and opts.ignore_system_prompt) or false,
+      intro_message = (opts and opts.intro_message) or nil,
     })
   end
 


### PR DESCRIPTION
## Description

- This PR allows users to alter the intro message in the chat buffer for their custom prompts
- It also removes the requirement for users to supply an empty `user` message in their prompt library items

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
