### PR TITLE
refactor(chat): do not redefine schema

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1161,9 +1161,9 @@ function Chat:check_context()
   -- Clear any tool's schemas
   local schemas_to_keep = {}
   local tools_in_use_to_keep = {}
-  for id, schema in pairs(self.tool_registry.schemas) do
+  for id, tool_schemas in pairs(self.tool_registry.schemas) do
     if not vim.tbl_contains(to_remove, id) then
-      schemas_to_keep[id] = schema
+      schemas_to_keep[id] = tool_schemas
       local tool_name = id:match("<tool>(.*)</tool>")
       if tool_name and self.tool_registry.in_use[tool_name] then
         tools_in_use_to_keep[tool_name] = true

--- a/tests/adapters/test_tools_in_chat_buffer.lua
+++ b/tests/adapters/test_tools_in_chat_buffer.lua
@@ -40,6 +40,12 @@ T["Test tools in chat buffer"]["with different adapters"] = function(adapter, fi
   local response = "tests/adapters/stubs/" .. file .. "_streaming.txt"
   local output = "tests/adapters/stubs/output/" .. file .. ".txt"
 
+  child.lua([[
+    local ollama = require("codecompanion.adapters.ollama")
+    ollama.schema.model.default = function() return "mock-model" end
+    ollama.schema.model.choices = function() return { ["mock-model"] = { opts = {} } } end
+  ]])
+
   -- Setup the chat with the specified adapter
   child.lua(string.format(
     [[


### PR DESCRIPTION
## Description

Don't redefine the schema variable in the chat buffer

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
