### PR TITLE
fix(cmd): CodeCompanion Add

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -113,7 +113,7 @@ CodeCompanion.add = function(args)
   local chat = CodeCompanion.last_chat()
 
   if not chat then
-    chat = CodeCompanion.chat()
+    chat = CodeCompanion.chat({ stop_context_insertion = true })
 
     if not chat then
       return log:warn("Could not create chat buffer")
@@ -170,6 +170,7 @@ CodeCompanion.chat = function(args)
     buffer_context = context,
     messages = has_messages and messages or nil,
     auto_submit = has_messages,
+    stop_context_insertion = args and args.stop_context_insertion,
   })
 end
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -602,6 +602,10 @@ function Chat.new(args)
   self.close_last_chat()
   self.ui:open():render(self.buffer_context, self.messages, args)
 
+  if args.stop_context_insertion then
+    self.opts.stop_context_insertion = true
+  end
+
   -- Set the header line for the chat buffer
   if args.messages and vim.tbl_count(args.messages) > 0 then
     ---@cast self CodeCompanion.Chat


### PR DESCRIPTION
## Description

fix duplicate text when using `<cmd>CodeCompanionChat Add<cr>` to add text when **no chat buffer created**

## Related Issue(s)

Fixes #1658

## Screenshots

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
