### PR TITLE
feat(ui): add picker prompt option

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 03
+*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -625,6 +625,7 @@ You can change the appearance of the chat buffer by changing the
           opts = {
             show_default_actions = true, -- Show the default actions in the action palette?
             show_default_prompt_library = true, -- Show the default prompt library in the action palette?
+            prompt = "CodeCompanion Action ", -- Prompt used for the action palette picker.
           },
         },
       },
@@ -1973,7 +1974,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-tools-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -3181,7 +3182,7 @@ OpenAI adapter.
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>

--- a/doc/configuration/action-palette.md
+++ b/doc/configuration/action-palette.md
@@ -24,6 +24,7 @@ require("codecompanion").setup({
       opts = {
         show_default_actions = true, -- Show the default actions in the action palette?
         show_default_prompt_library = true, -- Show the default prompt library in the action palette?
+        prompt = "CodeCompanion Action ", -- Prompt used for the action palette picker.
       },
     },
   },

--- a/lua/codecompanion/actions/init.lua
+++ b/lua/codecompanion/actions/init.lua
@@ -87,6 +87,10 @@ function Actions.launch(context, args)
     provider_opts = args.provider.opts or {}
   end
 
+  if config.display.action_palette.opts then
+    provider_opts.prompt = config.display.action_palette.opts.prompt
+  end
+
   return require("codecompanion.providers.actions." .. provider)
     .new({ context = context, validate = Actions.validate, resolve = Actions.resolve })
     :picker(items, provider_opts)


### PR DESCRIPTION
## Description

Added a `prompt` option so users can change the picker's UI prompt as needed.

## Related Discussion

[Is there any way change action palette's prompt?](https://github.com/olimorris/codecompanion.nvim/discussions/1935)

## Screenshots

<img width="3072" height="1824" alt="image" src="https://github.com/user-attachments/assets/d62ca7f2-3f64-4186-961e-d09ffdc0402f" />
<img width="634" height="349" alt="image" src="https://github.com/user-attachments/assets/84f5aa52-a086-4c76-adb9-cefb727fb1af" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
