### PR TITLE
Patch mini_pick provider to handle picker actions

### DIFF
--- a/lua/codecompanion/providers/actions/mini_pick.lua
+++ b/lua/codecompanion/providers/actions/mini_pick.lua
@@ -50,12 +50,7 @@ function Provider:picker(items, opts)
 
         -- Switch to target window and perform selection
         vim.api.nvim_win_call(win_target, function()
-          if provider.resolve then
-            -- Try direct resolution if select fails
-            provider.resolve(chosen_item.item, provider.context)
-          else
-            provider:select(chosen_item.item)
-          end
+          provider:select(chosen_item.item)
           MiniPick.set_picker_target_window(vim.api.nvim_get_current_win())
         end)
         return false -- Close picker after selection
@@ -111,7 +106,17 @@ function Provider:select(item)
       name = item.picker.prompt or item.name,
       choose = function(chosen_item)
         if chosen_item and chosen_item.item and chosen_item.item.callback then
-          chosen_item.item.callback()
+          -- Get the target window before closing the picker
+          local win_target = MiniPick.get_picker_state().windows.target
+          if not vim.api.nvim_win_is_valid(win_target) then
+            win_target = vim.api.nvim_get_current_win()
+          end
+
+          -- Switch to target window and perform callback
+          vim.api.nvim_win_call(win_target, function()
+            chosen_item.item.callback()
+            MiniPick.set_picker_target_window(vim.api.nvim_get_current_win())
+          end)
         end
         return false -- Close picker
       end,


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

When using `provider = "mini_pick"` for the action palette, selecting "Open chats ..." throws an error:

```
Error executing vim.schedule lua callback: (mini.pick) Error during choose:
...n.nvim/lua/codecompanion/providers/actions/mini_pick.lua:52: Error executing lua: ...codecompanion.nvim/lua/codecompanion/strategies/init.lua:38: attemp
t to call a nil value
stack traceback:
        ...codecompanion.nvim/lua/codecompanion/strategies/init.lua:38: in function 'resolve'
        ...n.nvim/lua/codecompanion/providers/actions/mini_pick.lua:55: in function <...n.nvim/lua/codecompanion/providers/actions/mini_pick.lua:52>
        [C]: in function 'nvim_win_call'
        ...n.nvim/lua/codecompanion/providers/actions/mini_pick.lua:52: in function <...n.nvim/lua/codecompanion/providers/actions/mini_pick.lua:43>
        [C]: in function 'pcall'
        ...esktop/.repro/data/nvim/lazy/mini.pick/lua/mini/pick.lua:2761: in function 'picker_query_add'
        ...esktop/.repro/data/nvim/lazy/mini.pick/lua/mini/pick.lua:2208: in function 'start'
        ...n.nvim/lua/codecompanion/providers/actions/mini_pick.lua:86: in function 'actions'
        ...m/lazy/codecompanion.nvim/lua/codecompanion/commands.lua:135: in function <...m/lazy/codecompanion.nvim/lua/codecompanion/commands.lua:134>
stack traceback:
        [C]: in function 'error'
        ...esktop/.repro/data/nvim/lazy/mini.pick/lua/mini/pick.lua:3486: in function 'error'
        ...esktop/.repro/data/nvim/lazy/mini.pick/lua/mini/pick.lua:2763: in function <...esktop/.repro/data/nvim/lazy/mini.pick/lua/mini/pick.lua:2763>
```

Replicated with a minimal config. 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
