### PR TITLE
feat(adapter): Add Support for Gitlab Duo

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -62,7 +62,7 @@ LLMs, in Neovim.
 FEATURES                                      *codecompanion-welcome-features*
 
 -  Copilot Chat <https://github.com/features/copilot> meets Zed AI <https://zed.dev/blog/zed-ai>, in Neovim
--  Support for Anthropic, Copilot, GitHub Models, DeepSeek, Gemini, Mistral AI, Novita, Ollama, OpenAI, Azure OpenAI, HuggingFace and xAI LLMs out of the box (or bring your own!)
+-  Support for Anthropic, Copilot, GitHub Models, DeepSeek, Gemini, Mistral AI, Novita, Ollama, OpenAI, Azure OpenAI, HuggingFace, xAI and Gitlab Dui LLMs out of the box (or bring your own!)
 -  User contributed and supported |codecompanion-configuration-adapters-community-adapters|
 -  |codecompanion-usage-inline-assistant.html|, code creation and refactoring
 -  |codecompanion-usage-chat-buffer-variables|, |codecompanion-usage-chat-buffer-slash-commands|, |codecompanion-usage-chat-buffer-tools| and |codecompanion-usage-workflows| to improve LLM output
@@ -90,6 +90,7 @@ of the box, the plugin supports:
 - OpenAI (`openai`) - Requires an API key
 - Azure OpenAI (`azure_openai`) - Requires an Azure OpenAI service with a model deployment
 - xAI (`xai`) - Requires an API key
+- Gitlab Duo (gitlab_duo) - Requires and API key
 
 The plugin utilises objects called `strategies`. These are the different ways
 that a user can interact with the plugin. The `chat` strategy harnesses a
@@ -2515,6 +2516,8 @@ Below is the tool use status of various adapters and models in CodeCompanion:
   OpenAI                                      Dependent on the model
 
   xAI            All                          Not supported yet
+
+  Gitlab Dui                                  Not supported yet
   ------------------------------------------------------------------------
 
 SLASH COMMANDS                            *codecompanion-usage-slash-commands*

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -35,7 +35,7 @@ return {
             return { content = merged_content }
         end,
         chat_output = function(self, data, tools)
-            vim.prinT(data.body)
+            vim.print(data.body)
             local ok, body = pcall(vim.json.decode, data.body)
             if not ok then
                 return {

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -35,7 +35,7 @@ return {
             return { content = merged_content }
         end,
         chat_output = function(self, data, tools)
-            vim.print(data.body)
+            vim.print(data)
             local ok, body = pcall(vim.json.decode, data.body)
             if not ok then
                 return {

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -56,5 +56,10 @@ return {
                 }
             }
         end,
-    }
+    },
+    schema = {
+        model = {
+            default = "gitlab_duo",
+        },
+    },
 }

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -1,0 +1,60 @@
+---@class GitlabDuo.Adapter: CodeCompanion.Adapter
+return {
+    name = "gitlab_duo",
+    formatted_name = "Gitlab Duo",
+    roles = {
+        llm = "assistant",
+        user = "user",
+    },
+    opts = {
+        stream = true,
+        vision = false,
+    },
+    features = {
+        text = true,
+        tokens = false,
+    },
+    url = "${url}${chat_url}",
+    env = {
+        api_key = "GITLAB_API_KEY",
+        url = "GITLAB_URL",
+        chat_url = "/api/v4/chat/completions",
+    },
+    headers = {
+        Authorization = "Bearer ${api_key}",
+        ["Content-Type"] = "application/json",
+    },
+    handlers = {
+        form_messages = function(self, messages)
+            -- messages must be shorter than 1000 characters.
+            -- This issues with the default system_prompt.
+            local merged_content = "";
+            for _, message in ipairs(messages) do
+                merged_content = merged_content .. message.content
+            end
+            return { content = merged_content }
+        end,
+        chat_output = function(self, data, tools)
+            local ok, body = pcall(vim.json.decode, data.body)
+            if not ok then
+                return {
+                    status = "error",
+                    output = "Could not parse JSON response",
+                }
+            end
+            if data and data.status >= 400 then
+                return {
+                    status = "error",
+                    output = body.error,
+                }
+            end
+            return {
+                status = "success",
+                output = {
+                    role = "assistant",
+                    content = body,
+                }
+            }
+        end,
+    }
+}

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -21,8 +21,8 @@ return {
         chat_url = "/api/v4/chat/completions",
     },
     headers = {
-        Authorization = "Bearer ${api_key}",
         ["Content-Type"] = "application/json",
+        ["Authorization"] = "Bearer ${api_key}",
     },
     handlers = {
         form_messages = function(self, messages)

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -35,6 +35,7 @@ return {
             return { content = merged_content }
         end,
         chat_output = function(self, data, tools)
+            vim.prinT(data.body)
             local ok, body = pcall(vim.json.decode, data.body)
             if not ok then
                 return {

--- a/lua/codecompanion/adapters/gitlab_duo.lua
+++ b/lua/codecompanion/adapters/gitlab_duo.lua
@@ -7,8 +7,6 @@ return {
         user = "user",
     },
     opts = {
-        stream = true,
-        vision = false,
     },
     features = {
         text = true,
@@ -35,7 +33,6 @@ return {
             return { content = merged_content }
         end,
         chat_output = function(self, data, tools)
-            vim.print(data)
             local ok, body = pcall(vim.json.decode, data.body)
             if not ok then
                 return {


### PR DESCRIPTION
## Description

I recently discovered that I have [Gitlab Duo](https://docs.gitlab.com/api/chat/) access and as a CodeCompletaion.nvim user, I felt it necessary to add support for it in my workflow.

I'm relatively new to this, so if there's anything else that needs to be added I'm willing to do it. Just provide me any guidance for anything you're unsatisfied with.

Also, currently  Gitlab Duo has a 1000 character limit per message so the default system prompt does not work so I set it to an empty string in my CodeCompanion config. Any thoughts on how to
work around this (Maybe allowing for a smaller default prompt)?

Gitlab Duo API Reference: https://docs.gitlab.com/api/chat/

Additional Context is interesting. I don't know how this could be integrated into the workflow, but it provides for Agentic coding.

I'm also thinking that concatenating the message list is a god idea, maybe I should always submit the most recent message?

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/discussions/1947

## Screenshots

<img width="960" height="1080" alt="image" src="https://github.com/user-attachments/assets/a9e31762-9d2c-471c-bc31-e1fc36fd53a3" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
