### PR TITLE
fix(inline): replacement broken when user switched buffer in meantime

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -169,6 +169,7 @@ local function overwrite_selection(context)
     context.end_col,
     { "" }
   )
+  vim.api.nvim_set_current_buf(context.bufnr) -- in case user switched buffer in the meantime
   api.nvim_win_set_cursor(context.winnr, { context.start_line, context.start_col })
 end
 

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -161,6 +161,8 @@ local function overwrite_selection(context)
     context.end_col = line_length
   end
 
+  -- NOTE: Ensure that focus is set to the correct buffer in case the user has navigated away
+  api.nvim_set_current_buf(context.bufnr)
   api.nvim_buf_set_text(
     context.bufnr,
     context.start_line - 1,
@@ -169,7 +171,6 @@ local function overwrite_selection(context)
     context.end_col,
     { "" }
   )
-  vim.api.nvim_set_current_buf(context.bufnr) -- in case user switched buffer in the meantime
   api.nvim_win_set_cursor(context.winnr, { context.start_line, context.start_col })
 end
 


### PR DESCRIPTION
## Bug description
When you switch the buffer after triggering the inline strategy, the [cursor movement](https://github.com/olimorris/codecompanion.nvim/blob/19d665a9b13c0b05652c359c4302465b8b2543be/lua/codecompanion/strategies/inline/init.lua#L172) results in various issues:
- If the current buffer has more rows than the row at the buffer where the request was made, the cursor moves in the current buffer. Somewhat negligible, but nonetheless irritating to move to a random, unrelated location.
- If the current buffer has fewer rows than the buffer where the request was made, the cursor cannot be moved following error is thrown:

```
Error executing vim.schedule lua callback: ...panion.nvim/lua/codecompanion/strategies/inline/init.lua:172: Cursor position outside buffer
stack traceback:
	[C]: in function 'nvim_win_set_cursor'
	...panion.nvim/lua/codecompanion/strategies/inline/init.lua:172: in function 'overwrite_selection'
	...panion.nvim/lua/codecompanion/strategies/inline/init.lua:585: in function 'place'
	...panion.nvim/lua/codecompanion/strategies/inline/init.lua:464: in function 'cb'
	.../nvim/lazy/codecompanion.nvim/lua/codecompanion/http.lua:146: in function <.../nvim/lazy/codecompanion.nvim/lua/codecompanion/http.lua:143>
```

At this point, the old text has been removed, but the new text not inserted yet, actually leaving you with lost data if you don't pay attention. 

## Fix by this PR
This PR addresses this issue by ensuring we are at the correct buffer before triggering the cursor movement.
