### PR TITLE
fix(chat): improve Copilot stats keymap logic and error handling

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -693,14 +693,13 @@ M.goto_file_under_cursor = {
 M.copilot_stats = {
   desc = "Show Copilot usage statistics",
   callback = function(chat)
-    if chat.adapter.name ~= "copilot" then
-      return util.notify("Copilot stats are only available when using the Copilot adapter", vim.log.levels.WARN)
+    if not chat.adapter.show_copilot_stats then
+      return util.notify(
+        "Copilot stats are only available when using the Copilot adapter",
+        vim.log.levels.WARN
+      )
     end
-    if chat.adapter.show_copilot_stats then
-      chat.adapter.show_copilot_stats()
-    else
-      util.notify("Copilot stats function not available", vim.log.levels.ERROR)
-    end
+    chat.adapter.show_copilot_stats()
   end,
 }
 


### PR DESCRIPTION
## Description

I have two copilot adapter, one for the default model, one for premium model. Before this fix, it won't show stats for the `copilot_premium` adapter.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
