### PR TITLE
use api = vim.api throughout the plugin

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/code_extractor.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/code_extractor.lua
@@ -1,6 +1,8 @@
 local Utils = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.utils")
 local log = require("codecompanion.utils.log")
 
+local api = vim.api
+
 ---@class ListCodeUsages.CodeExtractor
 local CodeExtractor = {}
 
@@ -231,7 +233,7 @@ function CodeExtractor.get_fallback_code_block(bufnr, row, col)
 
   -- Find end of block (going downward)
   local end_row = row
-  local total_lines = vim.api.nvim_buf_line_count(bufnr)
+  local total_lines = api.nvim_buf_line_count(bufnr)
   for i = row + 1, math.min(row + CONSTANTS.MAX_BLOCK_SCAN_LINES, total_lines - 1) do
     local curr_lines = Utils.safe_get_lines(bufnr, i, i + 1)
     local curr_line = curr_lines[1]

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
@@ -3,6 +3,7 @@ local ResultProcessor = require("codecompanion.strategies.chat.tools.catalog.lis
 local SymbolFinder = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.symbol_finder")
 local Utils = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.utils")
 
+local api = vim.api
 local fmt = string.format
 
 ---@class CodeCompanion.Tool.ListCodeUsages: CodeCompanion.Tools.Tool
@@ -52,7 +53,7 @@ local function process_lsp_symbols_async(symbols, state, callback)
       if edit_success then
         Utils.async_set_cursor(line, col, function(cursor_success)
           if cursor_success then
-            local current_bufnr = vim.api.nvim_get_current_buf()
+            local current_bufnr = api.nvim_get_current_buf()
             local methods_to_process = {}
 
             -- Collect all methods to process
@@ -121,7 +122,7 @@ local function process_grep_results_async(grep_result, state, callback)
     if edit_success then
       Utils.async_set_cursor(grep_result.line, grep_result.col, function(cursor_success)
         if cursor_success then
-          local current_bufnr = vim.api.nvim_get_current_buf()
+          local current_bufnr = api.nvim_get_current_buf()
           local methods_to_process = {}
 
           -- Collect all methods to process
@@ -204,14 +205,14 @@ return {
       -- Save current state of view
       local context_winnr = self.chat.context.winnr
       local context_bufnr = self.chat.context.bufnr
-      local chat_winnr = vim.api.nvim_get_current_win()
+      local chat_winnr = api.nvim_get_current_win()
 
       -- Get file extension from context buffer if available
       local file_extension = get_file_extension(context_bufnr)
 
       -- Exit insert mode and switch focus to context window
       vim.cmd("stopinsert")
-      vim.api.nvim_set_current_win(context_winnr)
+      api.nvim_set_current_win(context_winnr)
 
       -- Start async processing
       SymbolFinder.find_with_lsp_async(symbol_name, file_paths, function(all_lsp_symbols)
@@ -227,7 +228,7 @@ return {
 
             -- Handle case where we have no results
             if total_results == 0 then
-              vim.api.nvim_set_current_win(chat_winnr)
+              api.nvim_set_current_win(chat_winnr)
               local filetype_msg = file_extension and (" in " .. file_extension .. " files") or ""
               output_handler(
                 Utils.create_result(
@@ -241,8 +242,8 @@ return {
             end
 
             -- Restore original state of view
-            vim.api.nvim_set_current_buf(context_bufnr)
-            vim.api.nvim_set_current_win(chat_winnr)
+            api.nvim_set_current_buf(context_bufnr)
+            api.nvim_set_current_win(chat_winnr)
 
             -- Store state for output handler
             ListCodeUsagesTool.symbol_data = state.symbol_data

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/result_processor.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/result_processor.lua
@@ -2,6 +2,8 @@ local CodeExtractor = require("codecompanion.strategies.chat.tools.catalog.list_
 local Utils = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.utils")
 local log = require("codecompanion.utils.log")
 
+local api = vim.api
+
 ---@class ListCodeUsages.ResultProcessor
 local ResultProcessor = {}
 
@@ -199,7 +201,7 @@ function ResultProcessor.process_quickfix_references(qflist, symbol_data)
       local col = qfitem.col - 1 -- Convert to 0-indexed
 
       -- Load buffer if needed
-      if not vim.api.nvim_buf_is_loaded(target_bufnr) then
+      if not api.nvim_buf_is_loaded(target_bufnr) then
         vim.fn.bufload(target_bufnr)
       end
 

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/utils.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/utils.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+
 ---@class ListCodeUsages.Utils
 local Utils = {}
 
@@ -52,7 +54,7 @@ end
 ---@param bufnr number|nil The buffer number to validate
 ---@return boolean True if the buffer is valid and exists
 function Utils.is_valid_buffer(bufnr)
-  return bufnr and vim.api.nvim_buf_is_valid(bufnr)
+  return bufnr and api.nvim_buf_is_valid(bufnr)
 end
 
 ---@param bufnr number The buffer number to get filetype from
@@ -62,7 +64,7 @@ function Utils.safe_get_filetype(bufnr)
     return ""
   end
 
-  local success, filetype = pcall(vim.api.nvim_get_option_value, "filetype", { buf = bufnr })
+  local success, filetype = pcall(api.nvim_get_option_value, "filetype", { buf = bufnr })
   return success and filetype or ""
 end
 
@@ -73,7 +75,7 @@ function Utils.safe_get_buffer_name(bufnr)
     return ""
   end
 
-  local success, name = pcall(vim.api.nvim_buf_get_name, bufnr)
+  local success, name = pcall(api.nvim_buf_get_name, bufnr)
   return success and name or ""
 end
 
@@ -87,7 +89,7 @@ function Utils.safe_get_lines(bufnr, start_row, end_row, strict_indexing)
     return {}
   end
 
-  local success, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, start_row, end_row, strict_indexing or false)
+  local success, lines = pcall(api.nvim_buf_get_lines, bufnr, start_row, end_row, strict_indexing or false)
   return success and lines or {}
 end
 
@@ -105,7 +107,7 @@ end
 ---@param callback function Callback function called with success boolean
 function Utils.async_set_cursor(line, col, callback)
   vim.schedule(function()
-    local success = pcall(vim.api.nvim_win_set_cursor, 0, { line, col })
+    local success = pcall(api.nvim_win_set_cursor, 0, { line, col })
     if success then
       pcall(vim.cmd, "normal! zz")
     end

--- a/lua/codecompanion/strategies/chat/tools/catalog/next_edit_suggestion.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/next_edit_suggestion.lua
@@ -1,5 +1,7 @@
 local log = require("codecompanion.utils.log")
 
+local api = vim.api
+
 ---@class CodeCompanion.Tool.NextEditSuggestion.Args
 ---@field filepath string
 ---@field line integer
@@ -78,19 +80,19 @@ When you suggest a change to the codebase, you may call this tool to jump to the
         ---@type jump_action
         self.tool.opts.jump_action = function(path)
           vim.cmd(action_command .. " " .. path)
-          return vim.api.nvim_get_current_win()
+          return api.nvim_get_current_win()
         end
       end
       local winnr = self.tool.opts.jump_action(args.filepath)
       if args.line >= 0 and winnr then
-        local ok = pcall(vim.api.nvim_win_set_cursor, winnr, { args.line + 1, 0 })
+        local ok = pcall(api.nvim_win_set_cursor, winnr, { args.line + 1, 0 })
         if not ok then
-          local bufnr = vim.api.nvim_win_get_buf(winnr)
+          local bufnr = api.nvim_win_get_buf(winnr)
           return {
             status = "error",
             data = string.format(
               "The jump to the file was successful, but This file only has %d lines. Unable to jump to line %d",
-              vim.api.nvim_buf_line_count(bufnr),
+              api.nvim_buf_line_count(bufnr),
               args.line
             ),
           }

--- a/lua/codecompanion/strategies/chat/ui/builder.lua
+++ b/lua/codecompanion/strategies/chat/ui/builder.lua
@@ -4,6 +4,8 @@ local Reasoning = require("codecompanion.strategies.chat.ui.formatters.reasoning
 local Standard = require("codecompanion.strategies.chat.ui.formatters.standard")
 local Tools = require("codecompanion.strategies.chat.ui.formatters.tools")
 
+local api = vim.api
+
 ---@class CodeCompanion.Chat.UI.Builder
 ---@field chat CodeCompanion.Chat
 ---@field state table
@@ -188,8 +190,8 @@ function Builder:_write_to_buffer(lines, opts, fold_info, state)
     last_column = 0
   end
 
-  local cursor_moved = vim.api.nvim_win_get_cursor(0)[1] == line_count
-  vim.api.nvim_buf_set_text(self.chat.bufnr, last_line, last_column, last_line, last_column, lines)
+  local cursor_moved = api.nvim_win_get_cursor(0)[1] == line_count
+  api.nvim_buf_set_text(self.chat.bufnr, last_line, last_column, last_line, last_column, lines)
 
   -- Handle folding
   if fold_info and opts.type == self.chat.MESSAGE_TYPES.TOOL_MESSAGE and #lines > 1 then

--- a/lua/codecompanion/strategies/chat/ui/init.lua
+++ b/lua/codecompanion/strategies/chat/ui/init.lua
@@ -505,7 +505,7 @@ function UI:add_line_break()
   local _, _, line_count = self:last()
 
   self:unlock_buf()
-  vim.api.nvim_buf_set_lines(self.chat_bufnr, line_count, line_count, false, { "" })
+  api.nvim_buf_set_lines(self.chat_bufnr, line_count, line_count, false, { "" })
   self:lock_buf()
 
   self:move_cursor(true)

--- a/lua/codecompanion/utils/treesitter.lua
+++ b/lua/codecompanion/utils/treesitter.lua
@@ -81,7 +81,7 @@ function M.goto_node(node, goto_end, avoid_set_jump)
 
   -- Enter visual mode if we are in operator pending mode
   -- If we don't do this, it will miss the last character.
-  local mode = vim.api.nvim_get_mode()
+  local mode = api.nvim_get_mode()
 
   if mode.mode == "no" then
     vim.cmd("normal! v")


### PR DESCRIPTION
## Description

Minor refactor to ensure that `vim.api` is in a variable.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
