### PR TITLE
fix(ui): tool spacing in chat buffer

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -879,6 +879,7 @@ function Chat:submit(opts)
         message.content =
           chat_opts.prompt_decorator(message.content, adapters.make_safe(self.adapter), self.buffer_context)
       end
+      self.builder.state.last_type = "user_message"
       self:add_message({
         role = config.constants.USER_ROLE,
         content = (message and message.content or config.strategies.chat.opts.blank_prompt),


### PR DESCRIPTION
## Description

Previously, for models like `gpt-4.1`, there would be no space between the header and the tool output. This was caused by the LLM responding with just the tool output and no message. This resulted in the `state.last_type` in the UI Builder being left as `tool_message` from one response to the next.

This PR changes that by adding the notion of `user_message` if the user submits a message.

## Screenshots

<img width="1018" height="928" alt="2025-08-11 22_57_37 - WezTerm" src="https://github.com/user-attachments/assets/1d789a52-2591-43ae-9f6a-8c297d18684a" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
