### PR TITLE
Support `pre_hook` option in prompt library when applicable for chat strategy.

### DIFF
--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -112,6 +112,9 @@ function Strategies:chat()
       })
     end
 
+    if type(opts.pre_hook) == "function" then
+      opts.pre_hook()
+    end
     log:info("[Strategy] Chat Initiated")
     return require("codecompanion.strategies.chat").new({
       adapter = self.selected.adapter,


### PR DESCRIPTION
## Description

Previously the `pre_hook` function in the prompt library is only called for inline strategy. This PR enables this hook for chat strategy too, so that users [can run code to prepare custom workflow](https://github.com/Davidyz/VectorCode/pull/264).

With this PR and [the vectorcode WIP feature that requires this](https://github.com/Davidyz/VectorCode/pull/264), we would be able also to have [this](https://github.com/olimorris/codecompanion.nvim/pull/1741#issuecomment-3015999094), but without the web search tool.

## Related Issue(s)

https://github.com/Davidyz/VectorCode/pull/264

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
