### PR TITLE
feat(chat): improve buffer variables/context

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -61,6 +61,27 @@ require("codecompanion").setup({
 })
 ```
 
+### Pinning and Watching
+
+To [pin or watch](/usage/chat-buffer/variables#with-parameters) buffers by default, you can add this configuration:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      variables = {
+        ["buffer"] = {
+          opts = {
+            default_params = 'pin', -- or 'watch'
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+
 ## Slash Commands
 
 [Slash Commands](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua#L114) (invoked with `/`) let you dynamically insert context into the chat buffer, such as file contents or date/time.

--- a/doc/usage/chat-buffer/variables.md
+++ b/doc/usage/chat-buffer/variables.md
@@ -1,25 +1,23 @@
 # Using Variables
 
-> [!IMPORTANT]
-> As of `v17.5.0`, variables must be wrapped in curly braces, such as `#{buffer}` or `#{lsp}`
-
 <p align="center">
   <img src="https://github.com/user-attachments/assets/642ef2df-f1c4-41c4-93e2-baa66d7f0801" />
 </p>
 
-Variables allow you to share data about the current state of Neovim with an LLM. Simply type `#` in the chat buffer and trigger code completion if you're not using blink.cmp or nvim-cmp (or coc.nvim). Alternatively, type the variables manually. After the response is sent to the LLM, you should see the variable output tagged as a context item in the chat buffer.
+Variables allow you to share Neovim context with an LLM. Typing `#` in the chat buffer will trigger a code completion menu. Alternatively, you can type variables manually. After the response is sent to the LLM, you will see the variable output tagged as a context item in the chat buffer.
 
-Custom variables can be shared by adding them to the `strategies.chat.variables` table in your configuration.
+Custom variables can be shared in the chat buffer by adding them to the `strategies.chat.variables` table in your configuration.
 
 ## #buffer
 
-> [!NOTE]
-> As of [v16.2.0](https://github.com/olimorris/codecompanion.nvim/releases/tag/v16.2.0), buffers are now watched by default
+The _#{buffer}_ variable shares the full contents from the last buffer that the user was in (as determined by `BufEnter`). To select multiple buffers, it's recommended to use the _/buffer_ slash command.
 
-The _#{buffer}_ variable shares the full contents from the buffer that the user was last in when they initiated `:CodeCompanionChat`. To select another buffer, use the _/buffer_ slash command. These buffers can be [pinned or watched](/usage/chat-buffer/index#context) to enable updated content to be automatically shared with the LLM:
+By default, buffers are [watched](/usage/chat-buffer/index#context) to enable updated content to be automatically shared with the LLM. They can also be pinned:
 
-- `#{buffer}{pin}` - To pin the current buffer
-- `#{buffer}{watch}` - To watch the current buffer
+- `#{buffer}{watch}` - Sends the changes in the underlying buffer to the LLM
+- `#{buffer}{pin}` - Sends the entire buffer (regardless of changes) to the LLM
+
+You can also share specific buffers using the completion menus with something like `#{buffer:http/init.lua}`.
 
 To pin or watch buffers by default, you can add this configuration:
 

--- a/doc/usage/chat-buffer/variables.md
+++ b/doc/usage/chat-buffer/variables.md
@@ -4,7 +4,7 @@
   <img src="https://github.com/user-attachments/assets/642ef2df-f1c4-41c4-93e2-baa66d7f0801" />
 </p>
 
-Variables allow you to share Neovim context with an LLM. Typing `#` in the chat buffer will trigger a code completion menu. Alternatively, you can type variables manually. After the response is sent to the LLM, you will see the variable output tagged as a context item in the chat buffer.
+Variables allow you to dynamically insert Neovim context into your chat messages using the `#{variable_name}` syntax. They're processed when you send your message to the LLM, automatically including relevant content like buffer contents, LSP diagnostics, or your current viewport. Type `#` in the chat buffer to see available variables through code completion, or type them manually.
 
 Custom variables can be shared in the chat buffer by adding them to the `strategies.chat.variables` table in your configuration.
 

--- a/doc/usage/chat-buffer/variables.md
+++ b/doc/usage/chat-buffer/variables.md
@@ -8,34 +8,45 @@ Variables allow you to share Neovim context with an LLM. Typing `#` in the chat 
 
 Custom variables can be shared in the chat buffer by adding them to the `strategies.chat.variables` table in your configuration.
 
+## Basic Usage
+
+Variables use the `#{variable_name}` syntax to dynamically insert content into your chat. For example `#{buffer}`. Variables are processed when you send your message to the LLM.
+
 ## #buffer
 
-The _#{buffer}_ variable shares the full contents from the last buffer that the user was in (as determined by `BufEnter`). To select multiple buffers, it's recommended to use the _/buffer_ slash command.
+> [!IMPORTANT]
+> By default, CodeCompanion automatically applies `{watch}` to all buffers
 
-By default, buffers are [watched](/usage/chat-buffer/index#context) to enable updated content to be automatically shared with the LLM. They can also be pinned:
+The `#{buffer}` variable shares buffer contents with the LLM. It has two special parameters which control how content is shared with the LLM:
 
-- `#{buffer}{watch}` - Sends the changes in the underlying buffer to the LLM
-- `#{buffer}{pin}` - Sends the entire buffer (regardless of changes) to the LLM
+**`{pin}`** - Sends the entire buffer content to the LLM whenever the buffer changes. Use this when you want the LLM to always have the complete, up-to-date file context.
 
-You can also share specific buffers using the completion menus with something like `#{buffer:http/init.lua}`.
+**`{watch}`** - Sends only the changed portions of the buffer to the LLM. Use this for large files where you only want to share incremental changes to reduce token usage.
 
-To pin or watch buffers by default, you can add this configuration:
 
-```lua
-require("codecompanion").setup({
-  strategies = {
-    chat = {
-      variables = {
-        ["buffer"] = {
-          opts = {
-            default_params = 'pin', -- or 'watch'
-          },
-        },
-      },
-    },
-  },
-})
+### Basic Usage
+
+- `#{buffer}` - Shares the current buffer (last one you were in)
+
+### Target Specific Buffers
+
+- `#{buffer:init.lua}` - Shares a specific file by name
+- `#{buffer:src/main.rs}` - Shares a file by relative path
+- `#{buffer:utils}` - Shares a file containing "utils" in the path
+
+### With Parameters
+
+- `#{buffer}{pin}` - Pins the buffer (sends entire buffer on changes)
+- `#{buffer}{watch}` - Watches for changes (sends only changes)
+- `#{buffer:config.lua}{pin}` - Combines targeting with parameters
+
+### Multiple Buffers
+
 ```
+Compare #{buffer:old_file.js} with #{buffer:new_file.js} and explain the differences.
+```
+
+> **Note:** For selecting multiple buffers with more control, use the `/buffer` slash command.
 
 ## #lsp
 

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -17,6 +17,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionChatAdapter` - Fired after the adapter has been set in the chat
 - `CodeCompanionChatModel` - Fired after the model has been set in the chat
 - `CodeCompanionChatPin` - Fired after a pinned context item has been updated in the messages table
+- `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -201,6 +201,19 @@ local defaults = {
             contains_code = true,
             default_params = "watch", -- watch|pin
             has_params = true,
+            excluded = {
+              buftypes = {
+                "nofile",
+                "quickfix",
+                "prompt",
+                "popup",
+              },
+              fts = {
+                "codecompanion",
+                "help",
+                "terminal",
+              },
+            },
           },
         },
         ["lsp"] = {

--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -83,7 +83,10 @@ function Debug:render()
   local adapter = vim.deepcopy(self.chat.adapter)
   self.adapter = adapter
 
-  local bufname = buf_utils.name_from_bufnr(self.chat.buffer_context.bufnr)
+  local bufname
+  if _G.codecompanion_last_buffer and api.nvim_buf_is_valid(_G.codecompanion_last_buffer) then
+    bufname = buf_utils.name_from_bufnr(_G.codecompanion_last_buffer)
+  end
 
   -- Get the current settings from the chat buffer rather than making new ones
   local current_settings = self.settings or {}
@@ -98,7 +101,9 @@ function Debug:render()
 
   table.insert(lines, '-- Adapter: "' .. adapter.formatted_name .. '"')
   table.insert(lines, "-- Buffer Number: " .. self.chat.bufnr)
-  table.insert(lines, '-- Current Context: "' .. bufname .. '" (' .. self.chat.buffer_context.bufnr .. ")")
+  if bufname then
+    table.insert(lines, '-- Following Buffer: "' .. bufname .. '" (' .. _G.codecompanion_last_buffer .. ")")
+  end
 
   -- Add settings
   if not config.display.chat.show_settings then

--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -84,8 +84,8 @@ function Debug:render()
   self.adapter = adapter
 
   local bufname
-  if _G.codecompanion_last_buffer and api.nvim_buf_is_valid(_G.codecompanion_last_buffer) then
-    bufname = buf_utils.name_from_bufnr(_G.codecompanion_last_buffer)
+  if _G.codecompanion_current_context and api.nvim_buf_is_valid(_G.codecompanion_current_context) then
+    bufname = buf_utils.name_from_bufnr(_G.codecompanion_current_context)
   end
 
   -- Get the current settings from the chat buffer rather than making new ones
@@ -102,7 +102,7 @@ function Debug:render()
   table.insert(lines, '-- Adapter: "' .. adapter.formatted_name .. '"')
   table.insert(lines, "-- Buffer Number: " .. self.chat.bufnr)
   if bufname then
-    table.insert(lines, '-- Following Buffer: "' .. bufname .. '" (' .. _G.codecompanion_last_buffer .. ")")
+    table.insert(lines, '-- Following Buffer: "' .. bufname .. '" (' .. _G.codecompanion_current_context .. ")")
   end
 
   -- Add settings

--- a/lua/codecompanion/strategies/chat/variables/buffer.lua
+++ b/lua/codecompanion/strategies/chat/variables/buffer.lua
@@ -62,7 +62,7 @@ function Variable:output(selected, opts)
   selected = selected or {}
   opts = opts or {}
 
-  local bufnr = selected.bufnr or _G.codecompanion_last_buffer
+  local bufnr = selected.bufnr or _G.codecompanion_current_context
   local params = selected.params or self.params
 
   if self.target then

--- a/lua/codecompanion/strategies/chat/variables/buffer.lua
+++ b/lua/codecompanion/strategies/chat/variables/buffer.lua
@@ -16,9 +16,42 @@ function Variable.new(args)
     Chat = args.Chat,
     config = args.config,
     params = args.params,
+    target = args.target,
   }, { __index = Variable })
 
   return self
+end
+
+---Find buffer by display option (filename, relative path, etc.) - Static version
+---@param target string
+---@return number|nil
+function Variable._find_buffer(target)
+  local open_buffers = buf_utils.get_open()
+
+  for _, buf_info in ipairs(open_buffers) do
+    -- Check exact filename match
+    if buf_info.name == target then
+      return buf_info.bufnr
+    end
+    -- Check relative path match
+    if buf_info.relative_path == target then
+      return buf_info.bufnr
+    end
+    -- Check short path match
+    if buf_info.short_path == target then
+      return buf_info.bufnr
+    end
+  end
+
+  -- Try to find by filepath even if not loaded
+  return buf_utils.get_bufnr_from_filepath(target)
+end
+
+---Find buffer by display option (filename, relative path, etc.) - Instance method
+---@param target string
+---@return number|nil
+function Variable:find_buffer(target)
+  return Variable._find_buffer(target)
 end
 
 ---Add the contents of the current buffer to the chat
@@ -29,8 +62,18 @@ function Variable:output(selected, opts)
   selected = selected or {}
   opts = opts or {}
 
-  local bufnr = selected.bufnr or self.Chat.buffer_context.bufnr
+  local bufnr = selected.bufnr or _G.codecompanion_last_buffer
   local params = selected.params or self.params
+
+  if self.target then
+    local found = self:find_buffer(self.target)
+    if found then
+      bufnr = found
+      log:debug("Found buffer %d for display option: %s", bufnr, self.target)
+    else
+      return log:warn("Could not find buffer for display option: %s", self.target)
+    end
+  end
 
   if params and not vim.tbl_contains(reserved_params, params) then
     return log:warn("Invalid parameter for buffer variable: %s", params)
@@ -71,14 +114,46 @@ function Variable:output(selected, opts)
 end
 
 ---Replace the variable in the message
+---@param prefix string
 ---@param message string
 ---@param bufnr number
 ---@return string
 function Variable.replace(prefix, message, bufnr)
+  local result = message
+
+  -- Handle #{buffer:filename}{param} - display option with parameters
+  local display_option_with_params_pattern = prefix .. "{buffer:([^}]*)}{[^}]*}"
+  result = result:gsub(display_option_with_params_pattern, function(target)
+    local found = Variable._find_buffer(target)
+    if found then
+      local bufname = buf_utils.name_from_bufnr(found)
+      return "file `" .. bufname .. "` (with buffer number: " .. found .. ")"
+    else
+      -- Fallback to original behavior if buffer not found
+      local bufname = buf_utils.name_from_bufnr(bufnr)
+      return "file `" .. bufname .. "` (with buffer number: " .. bufnr .. ")"
+    end
+  end)
+
+  -- Handle #{buffer:filename} - Just display option
+  local display_option_pattern = prefix .. "{buffer:([^}]*)}"
+  result = result:gsub(display_option_pattern, function(target)
+    local found = Variable._find_buffer(target)
+    if found then
+      local bufname = buf_utils.name_from_bufnr(found)
+      return "file `" .. bufname .. "` (with buffer number: " .. found .. ")"
+    else
+      -- Fallback to original behavior if buffer not found
+      local bufname = buf_utils.name_from_bufnr(bufnr)
+      return "file `" .. bufname .. "` (with buffer number: " .. bufnr .. ")"
+    end
+  end)
+
+  -- Finally handle #{buffer}
   local bufname = buf_utils.name_from_bufnr(bufnr)
   local replacement = "file `" .. bufname .. "` (with buffer number: " .. bufnr .. ")"
 
-  local result = message:gsub(prefix .. "{buffer}{[^}]*}", replacement)
+  result = result:gsub(prefix .. "{buffer}{[^}]*}", replacement)
   result = result:gsub(prefix .. "{buffer}", replacement)
 
   return result

--- a/lua/codecompanion/strategies/chat/variables/init.lua
+++ b/lua/codecompanion/strategies/chat/variables/init.lua
@@ -9,9 +9,18 @@ local CONSTANTS = {
 ---Check a message for any parameters that have been given to the variable
 ---@param message table
 ---@param var string
+---@param target? string If provided, look for params after this specific target
 ---@return string|nil
-local function find_params(message, var)
-  local pattern = CONSTANTS.PREFIX .. "{" .. var .. "}{([^}]*)}"
+local function find_params(message, var, target)
+  local pattern
+  if target then
+    -- #{var:target}{params}
+    pattern = CONSTANTS.PREFIX .. "{" .. var .. ":" .. vim.pesc(target) .. "}{([^}]*)}"
+  else
+    -- #{var}{params}
+    pattern = CONSTANTS.PREFIX .. "{" .. var .. "}{([^}]*)}"
+  end
+
   local params = message.content:match(pattern)
   if params then
     log:trace("Params found for variable: %s", params)
@@ -165,7 +174,7 @@ function Variables:parse(chat, message)
 
       -- Check for regular params
       if var_config.opts and var_config.opts.has_params then
-        params = find_params(message, var)
+        params = find_params(message, var, target)
       end
 
       resolve(chat, var_config, params, target)

--- a/lua/codecompanion/strategies/chat/variables/init.lua
+++ b/lua/codecompanion/strategies/chat/variables/init.lua
@@ -23,8 +23,9 @@ end
 ---@param chat CodeCompanion.Chat
 ---@param var_config table
 ---@param params? string
+---@param target? string
 ---@return table
-local function resolve(chat, var_config, params)
+local function resolve(chat, var_config, params, target)
   if type(var_config.callback) == "string" then
     local splits = vim.split(var_config.callback, ".", { plain = true })
     local path = table.concat(splits, ".", 1, #splits - 1)
@@ -36,6 +37,7 @@ local function resolve(chat, var_config, params)
       Chat = chat,
       config = var_config,
       params = params or (var_config.opts and var_config.opts.default_params),
+      target = target,
     }
 
     -- User is using a custom callback
@@ -53,6 +55,7 @@ local function resolve(chat, var_config, params)
       Chat = chat,
       config = var_config,
       params = params,
+      target = target,
     })
     :output()
 end
@@ -71,12 +74,25 @@ end
 ---Creates a regex pattern to match a variable in a message
 ---@param var string The variable name to create a pattern for
 ---@param include_params? boolean Whether to include parameters in the pattern
+---@param include_display_option? boolean Whether to include display options in the pattern
 ---@return string The compiled regex pattern
-function Variables:_pattern(var, include_params)
-  return CONSTANTS.PREFIX .. "{" .. var .. "}" .. (include_params and "{[^}]*}" or "")
+function Variables:_pattern(var, include_params, include_display_option)
+  local base_pattern = CONSTANTS.PREFIX .. "{" .. var
+
+  if include_display_option then
+    base_pattern = base_pattern .. ":[^}]*"
+  end
+
+  base_pattern = base_pattern .. "}"
+
+  if include_params then
+    base_pattern = base_pattern .. "{[^}]*}"
+  end
+
+  return base_pattern
 end
 
----Check a message for a variable
+---Check a message for a variable and return all instances
 ---@param message table
 ---@return table|nil
 function Variables:find(message)
@@ -85,9 +101,36 @@ function Variables:find(message)
   end
 
   local found = {}
+  local content = message.content
+
   for var, _ in pairs(self.vars) do
-    if regex.find(message.content, self:_pattern(var)) then
-      table.insert(found, var)
+    local display_pattern = CONSTANTS.PREFIX .. "{" .. var .. ":([^}]*)}"
+    for target in content:gmatch(display_pattern) do
+      table.insert(found, {
+        var = var,
+        target = target,
+      })
+    end
+
+    -- Check for regular syntax (#{var}) - but avoid duplicating display option matches
+    local regular_pattern = CONSTANTS.PREFIX .. "{" .. var .. "}"
+    local start_pos = 1
+    while true do
+      local match_start, match_end = content:find(regular_pattern, start_pos, true)
+      if not match_start then
+        break
+      end
+
+      -- Make sure this isn't part of a display option by checking if there's a colon before the brace
+      local char_before_brace = content:sub(match_end - 1, match_end - 1)
+      if char_before_brace ~= ":" then
+        table.insert(found, {
+          var = var,
+          target = nil,
+        })
+      end
+
+      start_pos = match_end + 1
     end
   end
 
@@ -103,11 +146,12 @@ end
 ---@param message table
 ---@return boolean
 function Variables:parse(chat, message)
-  local vars = self:find(message)
-  if vars then
-    for _, var in ipairs(vars) do
+  local instances = self:find(message)
+  if instances then
+    for _, instance in ipairs(instances) do
+      local var = instance.var
       local var_config = self.vars[var]
-      log:debug("Variable found: %s", var)
+      log:debug("Variable found: %s (target: %s)", var, instance.target or "none")
 
       var_config["name"] = var
 
@@ -116,12 +160,15 @@ function Variables:parse(chat, message)
         goto continue
       end
 
+      local target = instance.target
       local params = nil
+
+      -- Check for regular params
       if var_config.opts and var_config.opts.has_params then
         params = find_params(message, var)
       end
 
-      resolve(chat, var_config, params)
+      resolve(chat, var_config, params, target)
 
       ::continue::
     end
@@ -143,6 +190,11 @@ function Variables:replace(message, bufnr)
     if var:match("^buffer") then
       message = require("codecompanion.strategies.chat.variables.buffer").replace(CONSTANTS.PREFIX, message, bufnr)
     else
+      -- Remove display option syntax first
+      message = regex.replace(message, self:_pattern(var, true, true), "")
+      message = regex.replace(message, self:_pattern(var, false, true), "")
+
+      -- Then remove regular syntax
       message = regex.replace(message, self:_pattern(var, true), "")
       message = vim.trim(regex.replace(message, self:_pattern(var), ""))
     end

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -30,12 +30,14 @@
 ---@class CodeCompanion.Variable
 ---@field Chat CodeCompanion.Chat The chat buffer
 ---@field config table The config for the variable
----@field params string
+---@field target string The buffer that's being targeted by the variable
+---@field params string Any additional parameters for the variable
 
 ---@class CodeCompanion.VariableArgs
 ---@field Chat CodeCompanion.Chat The chat buffer
 ---@field config table The config for the variable
----@field params string
+---@field target string The buffer that's being targeted by the variable
+---@field params string Any additional parameters for the variable
 
 ---@class CodeCompanion.Watchers
 ---@field buffers table<number, CodeCompanion.WatcherState> Map of buffer numbers to their states

--- a/lua/codecompanion/utils/buffers.lua
+++ b/lua/codecompanion/utils/buffers.lua
@@ -50,13 +50,14 @@ function M.get_info(bufnr)
     number = bufnr,
     name = vim.fn.fnamemodify(bufname, ":t"),
     path = bufname,
+    short_path = vim.fn.fnamemodify(bufname, ":h:t") .. "/" .. vim.fn.fnamemodify(bufname, ":t"),
     relative_path = relative_path,
   }
 end
 
 ---Return metadata on all of the currently valid and loaded buffers
 ---@param ft? string The filetype to filter the buffers by
----@return table
+---@return {name: string, bufnr: number, filetype: string, path: string, relative_path: string}[]
 function M.get_open(ft)
   local buffers = {}
 

--- a/plugin/codecompanion.lua
+++ b/plugin/codecompanion.lua
@@ -8,6 +8,7 @@ if vim.fn.has("nvim-0.11") == 0 then
 end
 
 local config = require("codecompanion.config")
+local util = require("codecompanion.utils")
 local api = vim.api
 
 -- Set the highlight groups
@@ -33,10 +34,10 @@ api.nvim_create_autocmd("FileType", {
   pattern = "codecompanion",
   group = syntax_group,
   callback = vim.schedule_wrap(function()
-    vim.iter(config.strategies.chat.variables):each(function(name, var)
+    vim.iter(config.strategies.chat.variables):each(function(name)
       vim.cmd.syntax('match CodeCompanionChatVariable "#{' .. name .. '}"')
       vim.cmd.syntax('match CodeCompanionChatVariable "#{' .. name .. ':[^}]*}"')
-      vim.cmd.syntax('match CodeCompanionChatVariable "#{' .. name .. '}{[^}]*}"')
+      vim.cmd.syntax('match CodeCompanionChatVariable "#{' .. name .. ':[^}]*}{[^}]*}"')
     end)
     vim
       .iter(config.strategies.chat.tools)
@@ -81,7 +82,7 @@ api.nvim_create_autocmd("TermEnter", {
   end,
 })
 
-_G.codecompanion_last_buffer = nil
+_G.codecompanion_current_context = nil
 api.nvim_create_autocmd("BufEnter", {
   group = buf_group,
   desc = "Capture the last buffer the user was in",
@@ -96,7 +97,8 @@ api.nvim_create_autocmd("BufEnter", {
       not vim.tbl_contains(excluded_fts, vim.bo[bufnr].filetype)
       and not vim.tbl_contains(excluded_buftypes, vim.bo[bufnr].buftype)
     then
-      _G.codecompanion_last_buffer = bufnr
+      _G.codecompanion_current_context = bufnr
+      util.fire("ContextChanged", { bufnr = bufnr })
     end
   end,
 })

--- a/tests/strategies/chat/test_variables.lua
+++ b/tests/strategies/chat/test_variables.lua
@@ -113,6 +113,24 @@ T["Variables"][":parse"]["multiple buffer vars"] = function()
   h.eq(2, #buffer_messages)
 end
 
+T["Variables"][":parse"]["buffer vars with params"] = function()
+  vim.cmd("edit lua/codecompanion/init.lua")
+
+  table.insert(chat.messages, {
+    role = "user",
+    content = "Look at #{buffer:init.lua}{pin} Isn't it marvellous?",
+  })
+
+  vars:parse(chat, chat.messages[#chat.messages])
+
+  local buffer_messages = vim.tbl_filter(function(msg)
+    return msg.opts and msg.opts.tag == "variable"
+  end, chat.messages)
+
+  h.eq(1, #buffer_messages)
+  h.eq(true, chat.context_items[1].opts.pinned)
+end
+
 T["Variables"][":replace"]["should replace the variable in the message"] = function()
   local message = "#{foo} #{bar} replace this var"
   local result = vars:replace(message, 0)


### PR DESCRIPTION
## Description

This PR will improve how buffer variables work in the chat buffer, significantly:

- [x] Can pass in the name of the buffer to the _buffer_ variable e.g. `#{buffer:init.lua}`
- [x] Intelligent caching to change the values in the completion menu
- [x] The `#{buffer}` variable now follows the most recent buffer the user was in
- [x] Test coverage - some more to add
- [ ] Rename variables to be context?! - Thinking about this

This should work for all completion providers as I won't be touching a line of their code.

## Screenshots

<img width="3024" height="1886" alt="2025-08-13 00_09_31 - WezTerm@2x" src="https://github.com/user-attachments/assets/74ec1193-cda6-49de-9186-47dca11b4f72" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
