### PR TITLE
feat(chat): global metadata

### DIFF
--- a/doc/usage/ui.md
+++ b/doc/usage/ui.md
@@ -2,6 +2,15 @@
 
 CodeCompanion aims to keep any changes to the user's UI to a minimum. Aesthetics, especially in Neovim, are highly subjective. So whilst it won't set much by default, it does endeavour to allow users to hook into the plugin and customize the UI to their liking via [Events](events).
 
+CodeCompanion exposes a global dictionary, `_G.codecompanion_chat_ui` which users can leverage throughout their configuration. Using the chat buffer's buffer number as the key, the dictionary contains:
+
+- `adapter` - The chat buffer's current adapter
+- `context_items` - The number of context items current in the chat buffer
+- `cycles` - The number of cycles (User->LLM->User) in the chat buffer
+- `id` - The ID of the chat buffer
+- `tokens` - The running total of tokens in the chat buffer
+- `tools` - The number of tools in the chat buffer
+
 Below are some examples of how you can customize the UI related to CodeCompanion.
 
 ## Progress updates with Fidget.nvim by [@jessevdp](https://github.com/jessevdp)

--- a/doc/usage/ui.md
+++ b/doc/usage/ui.md
@@ -1,7 +1,7 @@
 # User Interface
 
 <p>
-  <video muted controls src="https://github.com/user-attachments/assets/a37180a0-0f1b-4ffb-8fae-44669e9d3df7"></video>
+  <video muted controls loop src="https://github.com/user-attachments/assets/a37180a0-0f1b-4ffb-8fae-44669e9d3df7"></video>
 </p>
 
 CodeCompanion aims to keep any changes to the user's UI to a minimum. Aesthetics, especially in Neovim, are highly subjective. So whilst it won't set much by default, it does endeavour to allow users to hook into the plugin and customize the UI to their liking via [Events](events).

--- a/doc/usage/ui.md
+++ b/doc/usage/ui.md
@@ -1,14 +1,18 @@
 # User Interface
 
+<p>
+  <video muted controls src="https://github.com/user-attachments/assets/a37180a0-0f1b-4ffb-8fae-44669e9d3df7"></video>
+</p>
+
 CodeCompanion aims to keep any changes to the user's UI to a minimum. Aesthetics, especially in Neovim, are highly subjective. So whilst it won't set much by default, it does endeavour to allow users to hook into the plugin and customize the UI to their liking via [Events](events).
 
-CodeCompanion exposes a global dictionary, `_G.codecompanion_chat_ui` which users can leverage throughout their configuration. Using the chat buffer's buffer number as the key, the dictionary contains:
+CodeCompanion exposes a global dictionary, `_G.codecompanion_chat_metadata` which users can leverage throughout their configuration. Using the chat buffer's buffer number as the key, the dictionary contains:
 
-- `adapter` - The chat buffer's current adapter
+- `adapter` - The `name` and `model` of the chat buffer's current adapter
 - `context_items` - The number of context items current in the chat buffer
-- `cycles` - The number of cycles (User->LLM->User) in the chat buffer
+- `cycles` - The number of cycles (User->LLM->User) that have taken place in the chat buffer
 - `id` - The ID of the chat buffer
-- `tokens` - The running total of tokens in the chat buffer
+- `tokens` - The running total of tokens for the chat buffer
 - `tools` - The number of tools in the chat buffer
 
 Below are some examples of how you can customize the UI related to CodeCompanion.
@@ -95,7 +99,9 @@ return M
 
 ## Heirline.nvim integration
 
-The plugin can also be integrated into heirline.nvim to show an icon when a request is being sent to an LLM:
+The plugin can also be integrated into [heirline.nvim](https://github.com/rebelot/heirline.nvim) to show an icon when a request is being sent to an LLM and also to show useful meta information about the chat buffer.
+
+In the video at the top of this page, you can see the fidget spinner alongside the heirline.nvim integration below:
 
 ```lua
 local CodeCompanion = {
@@ -122,4 +128,90 @@ local CodeCompanion = {
     hl = { fg = "yellow" },
   },
 }
+
+local IsCodeCompanion = function()
+  return package.loaded.codecompanion and vim.bo.filetype == "codecompanion"
+end
+
+local CodeCompanionCurrentContext = {
+  static = {
+    enabled = true,
+  },
+  condition = function(self)
+    return IsCodeCompanion() and _G.codecompanion_current_context ~= nil and self.enabled
+  end,
+  provider = function()
+    local bufname = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(_G.codecompanion_current_context), ":t")
+    return "[  " .. bufname .. " ] "
+  end,
+  hl = { fg = "gray", bg = "bg" },
+  update = {
+    "User",
+    pattern = { "CodeCompanionRequest*", "CodeCompanionContextChanged" },
+    callback = vim.schedule_wrap(function(self, args)
+      if args.match == "CodeCompanionRequestStarted" then
+        self.enabled = false
+      elseif args.match == "CodeCompanionRequestFinished" then
+        self.enabled = true
+      end
+      vim.cmd("redrawstatus")
+    end),
+  },
+}
+
+local CodeCompanionStats = {
+  condition = function(self)
+    return IsCodeCompanion()
+  end,
+  static = {
+    chat_values = {},
+  },
+  init = function(self)
+    local bufnr = vim.api.nvim_get_current_buf()
+    self.chat_values = _G.codecompanion_chat_metadata[bufnr]
+  end,
+  -- Tokens block
+  {
+    condition = function(self)
+      return self.chat_values.tokens > 0
+    end,
+    RightSlantStart,
+    {
+      provider = function(self)
+        return "   " .. self.chat_values.tokens .. " "
+      end,
+      hl = { fg = "gray", bg = "statusline_bg" },
+      update = {
+        "User",
+        pattern = { "CodeCompanionChatOpened", "CodeCompanionRequestFinished" },
+        callback = vim.schedule_wrap(function()
+          vim.cmd("redrawstatus")
+        end),
+      },
+    },
+    RightSlantEnd,
+  },
+  -- Cycles block
+  {
+    condition = function(self)
+      return self.chat_values.cycles > 0
+    end,
+    RightSlantStart,
+    {
+      provider = function(self)
+        return "  " .. self.chat_values.cycles .. " "
+      end,
+      hl = { fg = "gray", bg = "statusline_bg" },
+      update = {
+        "User",
+        pattern = { "CodeCompanionChatOpened", "CodeCompanionRequestFinished" },
+        callback = vim.schedule_wrap(function()
+          vim.cmd("redrawstatus")
+        end),
+      },
+    },
+    RightSlantEnd,
+  },
+}
+
 ```

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -550,6 +550,7 @@ M.change_adapter = {
           { bufnr = chat.bufnr, adapter = require("codecompanion.adapters").make_safe(chat.adapter) }
         )
         chat.ui.adapter = chat.adapter
+        chat:update_metadata()
         chat:apply_settings()
       end
 
@@ -604,6 +605,7 @@ M.change_adapter = {
         end
 
         chat:apply_model(selected)
+        chat:update_metadata()
         chat:apply_settings()
       end)
     end)


### PR DESCRIPTION
## Description

Add a global table that users can leverage throughout their config.

## Screenshots

https://github.com/user-attachments/assets/a37180a0-0f1b-4ffb-8fae-44669e9d3df7

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
