### PR TITLE
fix(chat): buffer var with no context

### DIFF
--- a/lua/codecompanion/strategies/chat/variables/buffer.lua
+++ b/lua/codecompanion/strategies/chat/variables/buffer.lua
@@ -62,7 +62,7 @@ function Variable:output(selected, opts)
   selected = selected or {}
   opts = opts or {}
 
-  local bufnr = selected.bufnr or _G.codecompanion_current_context
+  local bufnr = selected.bufnr or _G.codecompanion_current_context or self.Chat.buffer_context.bufnr
   local params = selected.params or self.params
 
   if self.target then


### PR DESCRIPTION
## Description

Fixes an issue in #1967 where `_G.codecompanion_current_context` hadn't been set and the buffer variable had nothing to fall back on.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
