### PR TITLE
refactor(chat): set global var and luals annotations

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -5,6 +5,7 @@
 ---@class CodeCompanion.Chat
 ---@field adapter CodeCompanion.Adapter The adapter to use for the chat
 ---@field builder CodeCompanion.Chat.UI.Builder The builder for the chat UI
+---@field create_buf fun(): integer The function that creates a new buffer for the chat
 ---@field aug number The ID for the autocmd group
 ---@field bufnr integer The buffer number of the chat
 ---@field buffer_context table The context of the buffer that the chat was initiated from
@@ -608,6 +609,11 @@ function Chat.new(args)
   })
 
   self:update_metadata()
+
+  -- Likely this hasn't been set by the time the user opens the chat buffer
+  if not _G.codecompanion_current_context then
+    _G.codecompanion_current_context = self.buffer_context.bufnr
+  end
 
   if args.messages then
     self.messages = args.messages


### PR DESCRIPTION
## Description

If CodeCompanion starts via a user creating a chat, then `_G.codecompanion_current_context` won't have been set. This accounts for this.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
