### PR TITLE
feat(inline): multiple variables and better completion

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 13
+*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 14
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -476,20 +476,18 @@ INLINE ASSISTANT              *codecompanion-getting-started-inline-assistant*
 The inline assistant enables an LLM to write code directly into a Neovim
 buffer.
 
-Run `:CodeCompanion <your prompt>` to call the inline assistant. The assistant
+Run `:CodeCompanion your prompt` to call the inline assistant. The assistant
 will evaluate the prompt and either write code or open a chat buffer. You can
 also make a visual selection and call the assistant. To send additional context
 alongside your prompt, you can leverage
 |codecompanion-usage-inline-assistant-variables| such as `:CodeCompanion
-#{buffer} <your prompt>`:
+#{buffer} <your prompt>`.
 
-- `buffer` - shares the contents of the current buffer
-- `chat` - shares the LLM’s messages from the last chat buffer
-
-For convenience, you can call prompts from the
-|codecompanion-configuration-prompt-library| via the cmd line, such as
-`:'<,'>CodeCompanion /explain`. The prompt library comes with the following
-defaults:
+For convenience, you can call prompts with their `short_name` from the prompt
+library
+<https://github.com/olimorris/codecompanion.nvim/blob/6a4341a4cfe8988a57ad9e8b7dc01ccd6f3e1628/lua/codecompanion/config.lua#L565>
+such as `:'<,'>CodeCompanion /explain`. The prompt library comes with the
+following defaults:
 
 - `/commit` - Generate a commit message
 - `/explain` - Explain how selected code in a buffer works
@@ -2871,20 +2869,23 @@ notion of variables:
 
 - `buffer` - shares the contents of the current buffer
 - `chat` - shares the LLM’s messages from the last chat buffer
+- `clipboard` - shares the data on your clipboard with the LLM
 
 Simply include them in your prompt. For example `:CodeCompanion #{buffer} add a
 new method to this file`. Multiple variables can be sent as part of the same
 prompt. You can even add your own custom variables as per the
 |codecompanion-configuration-inline-assistant-variables|.
 
+You can also have multiple variables a part of a prompt, for example:
+`:CodeCompanion #{buffer} #{clipboard} analyze this code`.
+
 
 ADAPTERS ~
 
 You can specify a different adapter to that in the configuration
 (`strategies.inline.adapter`) when sending an inline prompt. Simply include the
-adapter name as the first word in the prompt. For example `:<','>CodeCompanion
-deepseek can you refactor this?`. This approach can also be combined with
-variables.
+adapter name within `<>`. For example `:<','>CodeCompanion <deepseek> can you
+refactor this?`. This approach can also be combined with variables.
 
 
 CLASSIFICATION ~
@@ -2937,8 +2938,8 @@ buffer’s buffer number as the key, the dictionary contains:
 - `tokens` - The running total of tokens for the chat buffer
 - `tools` - The number of tools in the chat buffer
 
-You can also leverage `_G.codecompanion_current_context` to fetch the buffer
-number of the buffer which the `#{buffer}` variable points at.
+You can also leverage `_G.codecompanion_current_context` to fetch the number of
+the buffer which the `#{buffer}` variable points at.
 
 Below are some examples of how you can customize the UI related to
 CodeCompanion.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -109,12 +109,9 @@ _Tools_, accessed via `@`, allow the LLM to function as an agent and leverage ex
 
 The inline assistant enables an LLM to write code directly into a Neovim buffer.
 
-Run `:CodeCompanion <your prompt>` to call the inline assistant. The assistant will evaluate the prompt and either write code or open a chat buffer. You can also make a visual selection and call the assistant. To send additional context alongside your prompt, you can leverage [variables](/usage/inline-assistant#variables) such as `:CodeCompanion #{buffer} <your prompt>`:
+Run `:CodeCompanion your prompt` to call the inline assistant. The assistant will evaluate the prompt and either write code or open a chat buffer. You can also make a visual selection and call the assistant. To send additional context alongside your prompt, you can leverage [variables](/usage/inline-assistant#variables) such as `:CodeCompanion #{buffer} <your prompt>`.
 
-- `buffer` - shares the contents of the current buffer
-- `chat` - shares the LLM's messages from the last chat buffer
-
-For convenience, you can call prompts from the [prompt library](/configuration/prompt-library) via the cmd line, such as `:'<,'>CodeCompanion /explain`. The prompt library comes with the following defaults:
+For convenience, you can call prompts with their `short_name` from the [prompt library](https://github.com/olimorris/codecompanion.nvim/blob/6a4341a4cfe8988a57ad9e8b7dc01ccd6f3e1628/lua/codecompanion/config.lua#L565) such as `:'<,'>CodeCompanion /explain`. The prompt library comes with the following defaults:
 
 - `/commit` - Generate a commit message
 - `/explain` - Explain how selected code in a buffer works

--- a/doc/usage/inline-assistant.md
+++ b/doc/usage/inline-assistant.md
@@ -17,12 +17,15 @@ The inline assistant allows you to send context alongside your prompt via the no
 
 - `buffer` - shares the contents of the current buffer
 - `chat` - shares the LLM's messages from the last chat buffer
+- `clipboard` - shares the data on your clipboard with the LLM
 
 Simply include them in your prompt. For example `:CodeCompanion #{buffer} add a new method to this file`. Multiple variables can be sent as part of the same prompt. You can even add your own custom variables as per the [configuration](/configuration/inline-assistant#variables).
 
+You can also have multiple variables a part of a prompt, for example: `:CodeCompanion #{buffer} #{clipboard} analyze this code`.
+
 ## Adapters
 
-You can specify a different adapter to that in the configuration (`strategies.inline.adapter`) when sending an inline prompt. Simply include the adapter name as the first word in the prompt. For example `:<','>CodeCompanion deepseek can you refactor this?`. This approach can also be combined with variables.
+You can specify a different adapter to that in the configuration (`strategies.inline.adapter`) when sending an inline prompt. Simply include the adapter name within `<>`. For example `:<','>CodeCompanion <deepseek> can you refactor this?`. This approach can also be combined with variables.
 
 ## Classification
 

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -228,6 +228,32 @@ function Inline:set_adapter(adapter)
   end
 end
 
+---Parse special syntax from user prompt (adapters and maintain variables)
+---@param prompt string
+---@return string The cleaned prompt
+function Inline:parse_special_syntax(prompt)
+  -- 1. Handle adapter syntax: <adapter_name>
+  local adapter_pattern = "<([%w_]+)>"
+  local adapter_match = prompt:match(adapter_pattern)
+  if adapter_match and config.adapters[adapter_match] then
+    self:set_adapter(config.adapters[adapter_match])
+    prompt = prompt:gsub(adapter_pattern, "", 1) -- Remove only the first occurrence
+  end
+
+  -- 2. Handle legacy first-word adapter detection for backward compatibility
+  if not adapter_match then
+    local split = vim.split(prompt, " ")
+    local first_word = split[1]
+    if config.adapters[first_word] then
+      self:set_adapter(config.adapters[first_word])
+      table.remove(split, 1)
+      prompt = table.concat(split, " ")
+    end
+  end
+
+  return vim.trim(prompt)
+end
+
 ---Prompt the LLM
 ---@param user_prompt? string The prompt supplied by the user
 ---@return nil
@@ -269,16 +295,10 @@ function Inline:prompt(user_prompt)
   end
 
   if user_prompt then
-    -- 1. Check if the first word is an adapter
-    local split = vim.split(user_prompt, " ")
-    local adapter = config.adapters[split[1]]
-    if adapter then
-      self:set_adapter(adapter)
-      table.remove(split, 1)
-      user_prompt = table.concat(split, " ")
-    end
+    -- Parse adapters and variables from the entire prompt
+    user_prompt = self:parse_special_syntax(user_prompt)
 
-    -- 2. Check for any variables
+    -- Check for any variables
     local vars = variables.new({ inline = self, prompt = user_prompt })
     local found = vars:find():replace():output()
     if found then
@@ -288,7 +308,7 @@ function Inline:prompt(user_prompt)
       user_prompt = vars.prompt
     end
 
-    -- 3. Add the user's prompt
+    -- Add the user's prompt
     add_prompt("<prompt>" .. user_prompt .. "</prompt>")
     log:debug("[Inline] Modified user prompt: %s", user_prompt)
   end

--- a/lua/codecompanion/strategies/inline/variables/buffer.lua
+++ b/lua/codecompanion/strategies/inline/variables/buffer.lua
@@ -13,21 +13,18 @@ end
 ---Fetch and output a buffer's contents
 ---@return string|nil
 function Buffer:output()
-  local ok, content = pcall(buf_utils.get_content, self.context.bufnr)
+  local message = "To help you assist with my user prompt, I'm attaching the contents of a buffer"
+
+  local ok, content, _, _ = pcall(buf_utils.format_for_llm, {
+    bufnr = self.context.bufnr,
+    path = buf_utils.get_info(self.context.bufnr).path,
+  }, { message = message })
 
   if not ok then
     return
   end
 
-  return string.format(
-    [[To help you assist with my user prompt, I'm attaching the contents of a buffer:
-
-```%s
-%s
-```]],
-    self.context.filetype,
-    content
-  )
+  return content
 end
 
 return Buffer

--- a/lua/codecompanion/strategies/inline/variables/clipboard.lua
+++ b/lua/codecompanion/strategies/inline/variables/clipboard.lua
@@ -1,0 +1,27 @@
+---@class CodeCompanion.Inline.Variables.ClipBoard: CodeCompanion.Inline.Variables
+local ClipBoard = {}
+
+---@param args CodeCompanion.Inline.VariablesArgs
+function ClipBoard.new(args)
+  return setmetatable({
+    context = args.context,
+  }, { __index = ClipBoard })
+end
+
+---Fetch and output a buffer's contents
+---@return string|nil
+function ClipBoard:output()
+  local content = vim.fn.getreg("+")
+  if content == "" then
+    content = vim.fn.getreg("*")
+  end
+
+  return string.format(
+    [[Sharing the contents of my clipboard:
+
+<clipboard>%s</clipboard>]],
+    content
+  )
+end
+
+return ClipBoard

--- a/lua/codecompanion/strategies/inline/variables/init.lua
+++ b/lua/codecompanion/strategies/inline/variables/init.lua
@@ -37,7 +37,8 @@ end
 ---@param include_params? boolean Whether to include parameters in the pattern
 ---@return string The compiled regex pattern
 function Variables:_pattern(var, include_params)
-  return CONSTANTS.PREFIX .. "{" .. var .. "}" .. (include_params and "{[^}]*}" or "")
+  local escaped_var = vim.pesc(var)
+  return CONSTANTS.PREFIX .. "{" .. escaped_var .. "}" .. (include_params and "{[^}]*}" or "")
 end
 
 ---Check a prompt for a variable

--- a/tests/strategies/inline/test_inline.lua
+++ b/tests/strategies/inline/test_inline.lua
@@ -186,4 +186,37 @@ T["Inline"]["integration"] = function()
   h.eq("<prompt>can you print hello world?</prompt>", submitted_prompts[3].content)
 end
 
+T["Inline"]["can parse adapter syntax"] = function()
+  local submitted_prompts = {}
+  function inline:submit(prompts)
+    submitted_prompts = prompts
+  end
+
+  -- Mock the buffer variable to return predictable content
+  local original_buffer_variable = require("codecompanion.config").strategies.inline.variables.buffer
+  require("codecompanion.config").strategies.inline.variables.buffer = {
+    callback = function()
+      return "mocked buffer content"
+    end,
+    description = "Mock buffer for testing",
+  }
+
+  -- Default adapter
+  h.eq(inline.adapter.name, "test_adapter")
+
+  inline:prompt("<fake_adapter> #{buffer} print hello world")
+  h.eq("fake_adapter", inline.adapter.name)
+
+  -- Should be system + buffer content + user prompt
+  h.eq(3, #submitted_prompts)
+
+  h.eq("mocked buffer content", submitted_prompts[2].content)
+
+  -- Check We've cleaned up the prompt
+  h.eq("<prompt>print hello world</prompt>", submitted_prompts[#submitted_prompts].content)
+
+  -- Restore original buffer variable
+  require("codecompanion.config").strategies.inline.variables.buffer = original_buffer_variable
+end
+
 return T


### PR DESCRIPTION
## Description

This PR adds support for:
- A new `#{clipboard}` variable
- Multiple variables in one inline prompt e.g. `:CodeCompanion what does the code in #{buffer} #{clipboard} do?`
- Adapters can now be wrapped in `<>` tags (e.g. `<deepseek>`) so they can be included with variables, anywhere in the prompt
- Completion for everything, everywhere

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
