### PR TITLE
fix: ensure buffer is valid

### DIFF
--- a/plugin/codecompanion.lua
+++ b/plugin/codecompanion.lua
@@ -88,6 +88,10 @@ api.nvim_create_autocmd("BufEnter", {
   desc = "Capture the last buffer the user was in",
   callback = function(args)
     local bufnr = args.buf
+    if not api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+
     local buffer_config = config.strategies.chat.variables.buffer.opts
     local excluded = (buffer_config and buffer_config.excluded) or {}
     local excluded_fts = excluded.fts or {}


### PR DESCRIPTION
## Description

Put check in place to prevent the below issue from occurring when a buffer may not be valid

## Related Issue(s)

#1983

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
