### PR TITLE
fix: make tools more resilient

### DIFF
--- a/lua/codecompanion/adapters/tavily.lua
+++ b/lua/codecompanion/adapters/tavily.lua
@@ -32,6 +32,7 @@ return {
         ---@param data table The data from the LLM's tool call
         ---@return nil
         setup = function(self, opts, data)
+          opts = opts or {}
           self.handlers.set_body = function()
             local body = {
               query = data.query,

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -50,7 +50,7 @@ function Client.new(args)
 end
 
 ---@class CodeCompanion.Adapter.RequestActions
----@field callback fun(err: nil|string, chunk: nil|table) Callback function, executed when the request has finished or is called multiple times if the request is streaming
+---@field callback fun(err: nil|table, chunk: nil|table) Callback function, executed when the request has finished or is called multiple times if the request is streaming
 ---@field done? fun() Function to run when the request is complete
 
 ---Send a HTTP request
@@ -158,6 +158,7 @@ function Client:request(payload, actions, opts)
         opts.status = "success"
         if data.status >= 400 then
           opts.status = "error"
+          actions.callback({ message = string.format([[%d error: ]], data.status), stderr = data }, nil)
         end
 
         if not opts.silent then

--- a/lua/codecompanion/strategies/chat/tools/catalog/search_web.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/search_web.lua
@@ -117,7 +117,7 @@ return {
     error = function(self, tools, _, stderr, _)
       local chat = tools.chat
       local args = self.args
-      log:debug("[Web Search Tool] Error output: %s", stderr)
+      log:debug("[Search Web Tool] Error output: %s", stderr)
 
       local error_output = fmt([[Error searching for `%s`]], args.query)
 

--- a/lua/codecompanion/strategies/chat/tools/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/init.lua
@@ -121,88 +121,103 @@ end
 ---@param tools table The tools requested by the LLM
 ---@return nil
 function Tools:execute(chat, tools)
+  local id
   self.chat = chat
 
-  ---Resolve and run the tool
-  ---@param orchestrator CodeCompanion.Tools.Orchestrator The orchestrator instance
-  ---@param tool table The tool to run
-  local function enqueue_tool(orchestrator, tool)
-    local name = tool["function"].name
-    local tool_config = self.tools_config[name]
-    local function handle_missing_tool(tool_call, err_message)
-      tool_call.name = name
-      tool_call.function_call = tool_call
-      log:error(err_message)
-      local available_tools_msg = next(chat.tool_registry.in_use or {})
-          and "The available tools are: " .. table.concat(
-            vim.tbl_map(function(t)
-              return "`" .. t .. "`"
-            end, vim.tbl_keys(chat.tool_registry.in_use)),
-            ", "
-          )
-        or "No tools available"
-      self.chat:add_tool_output(tool_call, string.format("Tool `%s` not found. %s", name, available_tools_msg), "")
-      return util.fire("ToolsFinished", { bufnr = self.bufnr })
-    end
-    if not tool_config then
-      return handle_missing_tool(vim.deepcopy(tool), string.format("Couldn't find the tool `%s`", name))
-    end
-
-    local ok, resolved_tool = pcall(function()
-      return Tools.resolve(tool_config)
-    end)
-    if not ok or not resolved_tool then
-      return handle_missing_tool(vim.deepcopy(tool), string.format("Couldn't resolve the tool `%s`", name))
-    end
-
-    self.tool = vim.deepcopy(resolved_tool)
-
-    self.tool.name = name
-    self.tool.function_call = tool
-    if tool["function"].arguments then
-      local args = tool["function"].arguments
-      -- For some adapter's that aren't streaming, the args are strings rather than tables
-      if type(args) == "string" then
-        local decoded
-        xpcall(function()
-          decoded = vim.json.decode(args)
-        end, function(err)
-          log:error("Couldn't decode the tool arguments: %s", args)
-          self.chat:add_tool_output(
-            self.tool,
-            string.format('You made an error in calling the %s tool: "%s"', name, err),
-            ""
-          )
-          return util.fire("ToolsFinished", { bufnr = self.bufnr })
-        end)
-        args = decoded
+  -- Wrap the entire tool execution in error handling
+  local function safe_execute()
+    ---Resolve and run the tool
+    ---@param orchestrator CodeCompanion.Tools.Orchestrator The orchestrator instance
+    ---@param tool table The tool to run
+    local function enqueue_tool(orchestrator, tool)
+      if self.status == CONSTANTS.STATUS_ERROR then
+        return
       end
-      self.tool.args = args
+
+      local name = tool["function"].name
+      local tool_config = self.tools_config[name]
+      local function handle_missing_tool(tool_call, err_message)
+        tool_call.name = name
+        tool_call.function_call = tool_call
+        log:error(err_message)
+        local available_tools_msg = next(chat.tool_registry.in_use or {})
+            and "The available tools are: " .. table.concat(
+              vim.tbl_map(function(t)
+                return "`" .. t .. "`"
+              end, vim.tbl_keys(chat.tool_registry.in_use)),
+              ", "
+            )
+          or "No tools available"
+        self.chat:add_tool_output(tool_call, string.format("Tool `%s` not found. %s", name, available_tools_msg), "")
+        return util.fire("ToolsFinished", { bufnr = self.bufnr })
+      end
+      if not tool_config then
+        return handle_missing_tool(vim.deepcopy(tool), string.format("Couldn't find the tool `%s`", name))
+      end
+
+      local ok, resolved_tool = pcall(function()
+        return Tools.resolve(tool_config)
+      end)
+      if not ok or not resolved_tool then
+        return handle_missing_tool(vim.deepcopy(tool), string.format("Couldn't resolve the tool `%s`", name))
+      end
+
+      self.tool = vim.deepcopy(resolved_tool)
+
+      self.tool.name = name
+      self.tool.function_call = tool
+      if tool["function"].arguments then
+        local args = tool["function"].arguments
+        -- For some adapter's that aren't streaming, the args are strings rather than tables
+        if type(args) == "string" then
+          local decoded
+          xpcall(function()
+            decoded = vim.json.decode(args)
+          end, function(err)
+            log:error("Couldn't decode the tool arguments: %s", args)
+            self.chat:add_tool_output(
+              self.tool,
+              string.format('You made an error in calling the %s tool: "%s"', name, err),
+              ""
+            )
+            return util.fire("ToolsFinished", { bufnr = self.bufnr })
+          end)
+          args = decoded
+        end
+        self.tool.args = args
+      end
+      self.tool.opts = vim.tbl_extend("force", self.tool.opts or {}, tool_config.opts or {})
+
+      if self.tool.env then
+        local env = type(self.tool.env) == "function" and self.tool.env(vim.deepcopy(self.tool)) or {}
+        util.replace_placeholders(self.tool.cmds, env)
+      end
+      return orchestrator.queue:push(self.tool)
     end
-    self.tool.opts = vim.tbl_extend("force", self.tool.opts or {}, tool_config.opts or {})
 
-    if self.tool.env then
-      local env = type(self.tool.env) == "function" and self.tool.env(vim.deepcopy(self.tool)) or {}
-      util.replace_placeholders(self.tool.cmds, env)
+    id = math.random(10000000)
+    local orchestrator = Orchestrator.new(self, id)
+    for _, tool in ipairs(tools) do
+      enqueue_tool(orchestrator, tool)
     end
-    return orchestrator.queue:push(self.tool)
-  end
+    self:set_autocmds()
 
-  local id = math.random(10000000)
-  local orchestrator = Orchestrator.new(self, id)
-
-  for _, tool in ipairs(tools) do
-    enqueue_tool(orchestrator, tool)
-  end
-  self:set_autocmds()
-
-  util.fire("ToolsStarted", { id = id, bufnr = self.bufnr })
-  xpcall(function()
+    util.fire("ToolsStarted", { id = id, bufnr = self.bufnr })
     orchestrator:setup()
-  end, function(err)
-    log:error("Tool System execution error:\n%s", err)
-    util.fire("ToolsFinished", { id = id, bufnr = self.bufnr })
+  end
+
+  -- Execute all tools with error handling
+  local ok, err = xpcall(safe_execute, function(error_msg)
+    return debug.traceback(error_msg, 2)
   end)
+
+  if not ok then
+    log:error("chat::tools::init::execute - Execution error %s", err)
+    self.status = CONSTANTS.STATUS_ERROR
+    vim.schedule(function()
+      util.fire("ToolsFinished", { id = id, bufnr = self.bufnr })
+    end)
+  end
 end
 
 ---Creates a regex pattern to match a tool name in a message

--- a/lua/codecompanion/strategies/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/strategies/chat/tools/orchestrator.lua
@@ -106,18 +106,29 @@ end
 function Orchestrator:setup_handlers()
   self.handlers = {
     setup = function()
+      if not self.tool then
+        return
+      end
       _G.codecompanion_current_tool = self.tool.name
       if self.tool.handlers and self.tool.handlers.setup then
         return self.tool.handlers.setup(self.tool, self.tools)
       end
     end,
     prompt_condition = function()
+      if not self.tool then
+        return
+      end
+
       if self.tool.handlers and self.tool.handlers.prompt_condition then
         return self.tool.handlers.prompt_condition(self.tool, self.tools, self.tools.tools_config)
       end
       return true
     end,
     on_exit = function()
+      if not self.tool then
+        return
+      end
+
       if self.tool.handlers and self.tool.handlers.on_exit then
         return self.tool.handlers.on_exit(self.tool, self.tools)
       end
@@ -126,11 +137,19 @@ function Orchestrator:setup_handlers()
 
   self.output = {
     prompt = function()
+      if not self.tool then
+        return
+      end
+
       if self.tool.output and self.tool.output.prompt then
         return self.tool.output.prompt(self.tool, self.tools)
       end
     end,
     rejected = function(cmd)
+      if not self.tool then
+        return
+      end
+
       if self.tool.output and self.tool.output.rejected then
         self.tool.output.rejected(self.tool, self.tools, cmd)
       else
@@ -139,6 +158,10 @@ function Orchestrator:setup_handlers()
       end
     end,
     error = function(cmd)
+      if not self.tool then
+        return
+      end
+
       if self.tool.output and self.tool.output.error then
         self.tool.output.error(self.tool, self.tools, cmd, self.tools.stderr)
       else
@@ -146,6 +169,10 @@ function Orchestrator:setup_handlers()
       end
     end,
     cancelled = function(cmd)
+      if not self.tool then
+        return
+      end
+
       if self.tool.output and self.tool.output.cancelled then
         self.tool.output.cancelled(self.tool, self.tools, cmd)
       else
@@ -153,6 +180,10 @@ function Orchestrator:setup_handlers()
       end
     end,
     success = function(cmd)
+      if not self.tool then
+        return
+      end
+
       if self.tool.output and self.tool.output.success then
         self.tool.output.success(self.tool, self.tools, cmd, self.tools.stdout)
       else
@@ -269,7 +300,17 @@ function Orchestrator:error(action, error)
   log:debug("Orchestrator:error")
   self.tools.status = self.tools.constants.STATUS_ERROR
   table.insert(self.tools.stderr, error)
-  self.output.error(action)
+
+  local ok, err = pcall(function()
+    self.output.error(action)
+  end)
+  if not ok then
+    log:error("Error in %s error handler: %s", self.tool.name, err)
+    if self.tool and self.tool.function_call then
+      self.tools.chat:add_tool_output(self.tool, string.format("Internal error with `%s` tool", self.tool.name))
+    end
+  end
+
   self:setup()
 end
 
@@ -283,7 +324,16 @@ function Orchestrator:success(action, output)
   if output then
     table.insert(self.tools.stdout, output)
   end
-  self.output.success(action)
+  local ok, err = pcall(function()
+    self.output.success(action)
+  end)
+
+  if not ok then
+    log:error("Error in tool success handler: %s", err)
+    if self.tool and self.tool.function_call then
+      self.tools.chat:add_tool_output(self.tool, string.format("Internal error with `%s` tool", self.tool.name))
+    end
+  end
 end
 
 ---Close the execution of the tool

--- a/lua/codecompanion/strategies/chat/tools/runtime/runner.lua
+++ b/lua/codecompanion/strategies/chat/tools/runtime/runner.lua
@@ -35,6 +35,12 @@ end
 ---@param output any The output from the previous function
 ---@return nil
 function Runner:proceed_to_next(output)
+  local current_tool = self.orchestrator.tool
+  if not current_tool then
+    self.orchestrator:close()
+    return self.orchestrator:setup(output)
+  end
+
   if self.index < #self.orchestrator.tool.cmds then
     local next_func = self.orchestrator.tool.cmds[self.index + 1]
     local next_executor = Runner.new(self.orchestrator, next_func, self.index + 1)


### PR DESCRIPTION
## Description

Resiliency for tools has simply not been good enough. Whilst I'd tried to make sure that errors would not wreck a user's chat buffer, there would often be errors such as:

```
Error: {"error":{"message":"An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. The following tool_call_ids did not have response messages: call_n9lKWN2ARtjGrix0H11BzSiL","code":"invalid_request_body"}}
```

The tool spec had been designed so that messages would be written back to the chat buffer on success or an error of the tool execution, via handlers. However, these handlers were not wrapped in a `pcall` and this was causing issues such as the one above.

Tools will fail. An LLM will call them incorrectly. The tool will fail to handle certain conditions. This is all expected. However, it's vital that we allow a chat to carry on without errors.  This PR adds much more resiliency throughout the tools implementation.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
