### PR TITLE
feat(adapter): support for OpenAI gpt-5 models

### DIFF
--- a/lua/codecompanion/adapters/openai.lua
+++ b/lua/codecompanion/adapters/openai.lua
@@ -328,6 +328,9 @@ return {
       ---@type string|fun(): string
       default = "gpt-4.1",
       choices = {
+        ["gpt-5"] = { opts = { has_vision = true, can_reason = true } },
+        ["gpt-5-mini"] = { opts = { has_vision = true, can_reason = true } },
+        ["gpt-5-nano"] = { opts = { has_vision = true, can_reason = true } },
         ["o4-mini-2025-04-16"] = { opts = { has_vision = true, can_reason = true } },
         ["o3-mini-2025-01-31"] = { opts = { can_reason = true } },
         ["o3-2025-04-16"] = { opts = { has_vision = true, can_reason = true } },
@@ -365,6 +368,7 @@ return {
         "high",
         "medium",
         "low",
+        "minimal",
       },
     },
     temperature = {


### PR DESCRIPTION
## Description
The gpt-5 models reason by default, making it relevant to adjust `reasoning_effort` since you may not want reasoning for quick simple tasks.

Also, the gpt-5 models introduced a new level for reasoning called `minimal`: https://platform.openai.com/docs/api-reference/responses/object#responses/object-reasoning

Being able to set reasoning effort is especially relevant for the gpt-5 models, since they use medium reasoning effort by default, resulting in considerably slower responses than the gpt-4 models: https://community.openai.com/t/gpt-5-is-very-slow-compared-to-4-1-responses-api/1337859

## Checklist
- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
