### PR TITLE
fix(ui): snacks being completely ignored

### DIFF
--- a/lua/codecompanion/providers/init.lua
+++ b/lua/codecompanion/providers/init.lua
@@ -11,14 +11,7 @@ local configs = {
   telescope = { module = "telescope", name = "telescope" },
   mini_pick = { module = "mini.pick", name = "mini_pick" },
   fzf_lua = { module = "fzf-lua", name = "fzf_lua" },
-  snacks = {
-    module = "snacks",
-    name = "snacks",
-    condition = function(snacks)
-      -- Snacks can be installed but the Picker is disabled
-      return snacks and snacks.config.picker.enabled
-    end,
-  },
+  snacks = { module = "snacks", name = "snacks" },
 
   -- Diffs
   inline = {


### PR DESCRIPTION
## Description

Snacks was failing to be used as the default provider due to the condition applied.

Note: I should probably set a default provider option at some point in the config.

## Related Issue(s)

#2009

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
