### PR TITLE
fix(tools): list code usages tool

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
@@ -179,7 +179,9 @@ local function get_file_extension(context_bufnr)
   end
 
   local filename = Utils.safe_get_buffer_name(context_bufnr)
-  return filename:match("%.([^%.]+)$") or "*"
+  local name_only = filename:match("([^/\\]+)$") or filename
+
+  return (name_only:match("%.([^%.]+)$")) or "*"
 end
 
 return {
@@ -241,9 +243,12 @@ return {
               return
             end
 
-            -- Restore original state of view
-            api.nvim_set_current_buf(context_bufnr)
-            api.nvim_set_current_win(chat_winnr)
+            if Utils.is_valid_buffer(context_bufnr) then
+              pcall(api.nvim_set_current_buf, context_bufnr)
+            end
+            if chat_winnr and api.nvim_win_is_valid(chat_winnr) then
+              pcall(api.nvim_set_current_win, chat_winnr)
+            end
 
             -- Store state for output handler
             ListCodeUsagesTool.symbol_data = state.symbol_data

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
@@ -203,8 +203,8 @@ return {
       end
 
       -- Save current state of view
-      local context_winnr = self.chat.context.winnr
-      local context_bufnr = self.chat.context.bufnr
+      local context_winnr = self.chat.buffer_context.winnr
+      local context_bufnr = self.chat.buffer_context.bufnr
       local chat_winnr = api.nvim_get_current_win()
 
       -- Get file extension from context buffer if available

--- a/tests/strategies/chat/tools/catalog/list_code_usages/test_list_code_usages.lua
+++ b/tests/strategies/chat/tools/catalog/list_code_usages/test_list_code_usages.lua
@@ -1,616 +1,516 @@
+-- tests/strategies/chat/tools/catalog/list_code_usages/test_integration_grep.lua
 local h = require("tests.helpers")
 
 local new_set = MiniTest.new_set
-
 local child = MiniTest.new_child_neovim()
+
 local T = new_set({
   hooks = {
     pre_case = function()
       h.child_start(child)
       child.lua([[
-        -- Load the list_code_usages tool
+        -- Load modules under test
         ListCodeUsagesTool = require("codecompanion.strategies.chat.tools.catalog.list_code_usages")
-        Utils = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.utils")
+        ResultProcessor = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.result_processor")
         SymbolFinder = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.symbol_finder")
         LspHandler = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.lsp_handler")
-        ResultProcessor = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.result_processor")
 
-        -- Mock all the dependencies
-        _G.mock_state = {
-          symbol_finder_lsp_results = {},
-          symbol_finder_grep_results = nil,
-          lsp_handler_results = {},
-          result_processor_counts = {},
-          utils_calls = {},
-          vim_calls = {}
+        -- Test workspace setup
+        local tmp_root = vim.fs.normalize(vim.fn.fnamemodify(vim.fn.tempname(), ":h"))
+        _G.TEST_WS = vim.fs.joinpath(tmp_root, "cc_list_code_usages_ws")
+        vim.fn.mkdir(_G.TEST_WS, "p")
+        vim.cmd("cd " .. vim.fn.fnameescape(_G.TEST_WS))
+
+        -- Create minimal source files (Lua) to trigger grep + fallback extraction
+        local function writef(rel, lines)
+          local p = vim.fs.joinpath(_G.TEST_WS, rel)
+          vim.fn.mkdir(vim.fs.dirname(p), "p")
+          vim.fn.writefile(lines, p)
+          return p
+        end
+
+        _G.FILE_A = writef("src/a.lua", {
+          "local function foo(x)",
+          "  return x + 1",
+          "end",
+          "",
+          "local function bar()",
+          "  return foo(41)",
+          "end",
+        })
+
+        _G.FILE_B = writef("src/b.lua", {
+          "local function baz()",
+          "  local y = foo(10)",
+          "  return y",
+          "end",
+        })
+
+        -- Open a context window on FILE_A (buffer_context)
+        vim.cmd("edit " .. vim.fn.fnameescape(_G.FILE_A))
+        local ctx_win = vim.api.nvim_get_current_win()
+        local ctx_buf = vim.api.nvim_get_current_buf()
+
+        -- Create a second window to represent the chat window
+        vim.cmd("vsplit")
+        local chat_win = vim.api.nvim_get_current_win()
+        local chat_buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_win_set_buf(chat_win, chat_buf)
+
+        -- Minimal chat/tools harness
+        _G.captured_tool_output = nil
+        local chat = {
+          buffer_context = { winnr = ctx_win, bufnr = ctx_buf },
+          add_tool_output = function(self, tool, content)
+            _G.captured_tool_output = content
+            return content
+          end,
         }
+        _G.tools = { chat = chat }
 
-        -- Mock SymbolFinder
-        SymbolFinder.find_with_lsp_async = function(symbol_name, file_paths, callback)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "find_with_lsp_async",
-            symbol_name = symbol_name,
-            file_paths = file_paths
-          }
-          vim.schedule(function()
-            callback(_G.mock_state.symbol_finder_lsp_results)
-          end)
+        -- Helpers to build a qflist for foo occurrences
+        local function load_buf(path)
+          vim.cmd("edit " .. vim.fn.fnameescape(path))
+          return vim.api.nvim_get_current_buf()
+        end
+        local bufa = load_buf(_G.FILE_A)
+        local bufb = load_buf(_G.FILE_B)
+
+        -- Compute rough columns for 'foo' (fallback extractor does not require exact)
+        local function col_of(s, pat) return (s:find(pat, 1, true) or 1) end
+
+        local a_lines = vim.api.nvim_buf_get_lines(bufa, 0, -1, false)
+        local b_lines = vim.api.nvim_buf_get_lines(bufb, 0, -1, false)
+
+        local qf = {
+          -- definition in FILE_A line 1
+          { bufnr = bufa, lnum = 1, col = col_of(a_lines[1] or "", "foo") },
+          -- usage in FILE_A line 6
+          { bufnr = bufa, lnum = 6, col = col_of(a_lines[6] or "", "foo") },
+          -- usage in FILE_B line 2
+          { bufnr = bufb, lnum = 2, col = col_of(b_lines[2] or "", "foo") },
+        }
+        vim.fn.setqflist(qf)
+
+        -- Stub SymbolFinder to avoid shell grep and control inputs.
+        SymbolFinder.find_with_lsp_async = function(symbol, file_paths, cb)
+          cb({}) -- No LSP symbols in this integration
         end
 
-        SymbolFinder.find_with_grep_async = function(symbol_name, file_extension, file_paths, callback)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "find_with_grep_async",
-            symbol_name = symbol_name,
-            file_extension = file_extension,
-            file_paths = file_paths
-          }
-          vim.schedule(function()
-            callback(_G.mock_state.symbol_finder_grep_results)
-          end)
+        SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+          -- Provide "first match" plus full quickfix; tool will also later read getqflist()
+          local first = qf[1]
+          cb({
+            file = vim.fn.bufname(first.bufnr),
+            line = first.lnum,
+            col = first.col,
+            bufnr = first.bufnr,
+            qflist = qf,
+          })
         end
 
-        -- Mock LspHandler
-        LspHandler.execute_request_async = function(bufnr, method, callback)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "execute_request_async",
-            bufnr = bufnr,
-            method = method
-          }
-          vim.schedule(function()
-            callback(_G.mock_state.lsp_handler_results[method] or {})
-          end)
+        -- Stub LSP requests to no-op so only grep path is exercised.
+        LspHandler.execute_request_async = function(bufnr, method, cb)
+          cb({})
         end
-
-        -- Mock ResultProcessor
-        ResultProcessor.process_lsp_results = function(lsp_results, operation, symbol_data)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "process_lsp_results",
-            operation = operation
-          }
-          return _G.mock_state.result_processor_counts[operation] or 0
-        end
-
-        ResultProcessor.process_quickfix_references = function(qflist, symbol_data)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "process_quickfix_references"
-          }
-          return _G.mock_state.result_processor_counts["quickfix"] or 0
-        end
-
-        -- Mock Utils functions
-        Utils.async_edit_file = function(filepath, callback)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "async_edit_file",
-            filepath = filepath
-          }
-          vim.schedule(function()
-            callback(true) -- Always succeed unless overridden
-          end)
-        end
-
-        Utils.async_set_cursor = function(line, col, callback)
-          _G.mock_state.utils_calls[#_G.mock_state.utils_calls + 1] = {
-            func = "async_set_cursor",
-            line = line,
-            col = col
-          }
-          vim.schedule(function()
-            callback(true) -- Always succeed unless overridden
-          end)
-        end
-
-        Utils.is_valid_buffer = function(bufnr)
-          return bufnr and bufnr > 0
-        end
-
-        Utils.safe_get_buffer_name = function(bufnr)
-          return "/test/project/test.lua"
-        end
-
-        Utils.safe_get_filetype = function(bufnr)
-          return "lua"
-        end
-
-        -- Mock vim functions
-        _G.original_vim_cmd = vim.cmd
-        vim.cmd = function(cmd)
-          _G.mock_state.vim_calls[#_G.mock_state.vim_calls + 1] = {
-            func = "vim.cmd",
-            cmd = cmd
-          }
-          if cmd ~= "stopinsert" then
-            _G.original_vim_cmd(cmd)
-          end
-        end
-
-        _G.original_set_current_win = vim.api.nvim_set_current_win
-        vim.api.nvim_set_current_win = function(winnr)
-          _G.mock_state.vim_calls[#_G.mock_state.vim_calls + 1] = {
-            func = "nvim_set_current_win",
-            winnr = winnr
-          }
-        end
-
-        _G.original_set_current_buf = vim.api.nvim_set_current_buf
-        vim.api.nvim_set_current_buf = function(bufnr)
-          _G.mock_state.vim_calls[#_G.mock_state.vim_calls + 1] = {
-            func = "nvim_set_current_buf",
-            bufnr = bufnr
-          }
-        end
-
-        _G.original_get_current_win = vim.api.nvim_get_current_win
-        vim.api.nvim_get_current_win = function()
-          return 2 -- Mock chat window
-        end
-
-        _G.original_get_current_buf = vim.api.nvim_get_current_buf
-        vim.api.nvim_get_current_buf = function()
-          return 1 -- Mock current buffer
-        end
-
-        _G.original_getqflist = vim.fn.getqflist
-        vim.fn.getqflist = function()
-          return _G.mock_state.quickfix_list or {}
-        end
-
-        -- Helper to create mock tool context
-        function create_mock_tool_context(args)
-          return {
-            args = args or {},
-            chat = {
-              context = {
-                winnr = 1, -- Mock context window
-                bufnr = 1  -- Mock context buffer
-              },
-              add_tool_output = function(self, tool, content)
-                _G.mock_state.tool_output = content
-                return content
-              end
-            }
-          }
-        end
-
-        -- Helper to reset mock state
-        function reset_mock_state()
-          _G.mock_state = {
-            symbol_finder_lsp_results = {},
-            symbol_finder_grep_results = nil,
-            lsp_handler_results = {},
-            result_processor_counts = {},
-            utils_calls = {},
-            vim_calls = {},
-            quickfix_list = {},
-            tool_output = nil
-          }
-          -- Ensure symbol_data is properly initialized as a table
-          ListCodeUsagesTool.symbol_data = {}
-          ListCodeUsagesTool.filetype = ""
-        end
+      ]])
+    end,
+    post_case = function()
+      child.lua([[
+        if _G.TEST_WS then vim.fn.delete(_G.TEST_WS, "rf") end
+        _G.captured_tool_output = nil
+        _G.tools = nil
       ]])
     end,
     post_once = child.stop,
   },
 })
 
-T["main command function"] = new_set({
-  hooks = {
-    pre_case = function()
-      child.lua([[reset_mock_state()]])
-    end,
-  },
-})
-
-T["main command function"]["validates symbol name is required"] = function()
+T["validates symbol name is required"] = function()
   child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = "" })
-    local output_received = false
-    local output_result = nil
-
-    local output_handler = function(result)
-      output_received = true
-      output_result = result
-    end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    _G.test_result = {
-      output_received = output_received,
-      output_result = output_result
-    }
+    local tool_context = { args = { symbol_name = "" }, chat = _G.tools.chat }
+    local done, res = false, nil
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function(r)
+      res = r; done = true
+    end)
+    vim.wait(300, function() return done end, 10)
+    _G.test_result = res
   ]])
-
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.output_received)
-  h.eq("error", result.output_result.status)
-  h.expect_contains("Symbol name is required", result.output_result.data)
+  local res = child.lua_get("_G.test_result")
+  h.eq("error", res.status)
+  h.expect_contains("Symbol name is required", res.data)
 end
 
-T["main command function"]["validates symbol name is not nil"] = function()
+T["validates symbol name is not nil"] = function()
   child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = nil })
-    local output_received = false
-    local output_result = nil
-
-    local output_handler = function(result)
-      output_received = true
-      output_result = result
-    end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    _G.test_result = {
-      output_received = output_received,
-      output_result = output_result
-    }
+    local tool_context = { args = {}, chat = _G.tools.chat }
+    local done, res = false, nil
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function(r)
+      res = r; done = true
+    end)
+    vim.wait(300, function() return done end, 10)
+    _G.test_result = res
   ]])
-
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.output_received)
-  h.eq("error", result.output_result.status)
-  h.expect_contains("Symbol name is required", result.output_result.data)
+  local res = child.lua_get("_G.test_result")
+  h.eq("error", res.status)
+  h.expect_contains("Symbol name is required", res.data)
 end
 
-T["main command function"]["executes successfully with valid symbol"] = function()
+T["passes file paths to symbol finder"] = function()
   child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = "testFunction" })
-    local output_received = false
-    local output_result = nil
+    local seen = { lsp = nil, grep = nil }
+    local orig_lsp, orig_grep = SymbolFinder.find_with_lsp_async, SymbolFinder.find_with_grep_async
 
-    -- Set up mock results to ensure success
-    _G.mock_state.symbol_finder_lsp_results = {
-      {
-        file = "/test/file.lua",
-        range = { start = { line = 5, character = 0 } }
-      }
-    }
-    _G.mock_state.result_processor_counts = {
-      references = 1,
-      definition = 1,
-      quickfix = 1
-    }
-
-    local output_handler = function(result)
-      output_received = true
-      output_result = result
+    SymbolFinder.find_with_lsp_async = function(symbol, file_paths, cb)
+      seen.lsp = file_paths; cb({})
+    end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+      seen.grep = file_paths; cb(nil)
     end
 
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(500) -- Wait for async operations
-
-    _G.test_result = {
-      output_received = output_received,
-      output_result = output_result,
-      utils_calls = _G.mock_state.utils_calls,
-      vim_calls = _G.mock_state.vim_calls
+    local tool_context = {
+      args = { symbol_name = "foo", file_paths = { "src/a.lua", "src/b.lua" } },
+      chat = _G.tools.chat,
     }
+    local done = false
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function() done = true end)
+    vim.wait(400, function() return done end, 10)
+
+    SymbolFinder.find_with_lsp_async, SymbolFinder.find_with_grep_async = orig_lsp, orig_grep
+    _G.test_result = seen
   ]])
-
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.output_received)
-  h.eq("success", result.output_result.status)
-
-  -- Check that symbol finder was called
-  local lsp_call = nil
-  local grep_call = nil
-  for _, call in ipairs(result.utils_calls) do
-    if call.func == "find_with_lsp_async" then
-      lsp_call = call
-    elseif call.func == "find_with_grep_async" then
-      grep_call = call
-    end
-  end
-  h.not_eq(nil, lsp_call)
-  h.not_eq(nil, grep_call)
-  h.eq("testFunction", lsp_call.symbol_name)
-  h.eq("testFunction", grep_call.symbol_name)
+  local res = child.lua_get("_G.test_result")
+  h.not_eq(nil, res.lsp)
+  h.not_eq(nil, res.grep)
+  h.expect_tbl_contains("src/a.lua", res.lsp)
+  h.expect_tbl_contains("src/b.lua", res.lsp)
+  h.expect_tbl_contains("src/a.lua", res.grep)
+  h.expect_tbl_contains("src/b.lua", res.grep)
 end
 
-T["main command function"]["handles no results found"] = function()
+T["error handler formats error correctly"] = function()
   child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = "nonExistentFunction" })
-    local output_received = false
-    local output_result = nil
-
-    -- Set up mock results to return no results
-    _G.mock_state.symbol_finder_lsp_results = {}
-    _G.mock_state.symbol_finder_grep_results = nil
-    _G.mock_state.result_processor_counts = {} -- All counts are 0
-
-    local output_handler = function(result)
-      output_received = true
-      output_result = result
-    end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(500) -- Wait for async operations
-
-    _G.test_result = {
-      output_received = output_received,
-      output_result = output_result
-    }
-  ]])
-
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.output_received)
-  h.eq("error", result.output_result.status)
-  h.expect_contains("Symbol not found in workspace", result.output_result.data)
-end
-
-T["main command function"]["switches windows correctly"] = function()
-  child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = "testFunction" })
-    local output_received = false
-
-    -- Set up mock results to ensure success
-    _G.mock_state.result_processor_counts = { references = 1 }
-
-    local output_handler = function(result)
-      output_received = true
-    end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(500) -- Wait for async operations
-
-    _G.test_result = {
-      output_received = output_received,
-      vim_calls = _G.mock_state.vim_calls
-    }
-  ]])
-
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.output_received)
-
-  -- Check that stopinsert was called
-  local stopinsert_call = nil
-  local set_win_calls = {}
-  for _, call in ipairs(result.vim_calls) do
-    if call.func == "vim.cmd" and call.cmd == "stopinsert" then
-      stopinsert_call = call
-    elseif call.func == "nvim_set_current_win" then
-      set_win_calls[#set_win_calls + 1] = call
-    end
-  end
-
-  h.not_eq(nil, stopinsert_call)
-  h.expect_truthy(#set_win_calls >= 2) -- Should switch to context window and back to chat
-end
-
-T["main command function"]["passes file paths to symbol finder"] = function()
-  child.lua([[
-    local tool_context = create_mock_tool_context({
-      symbol_name = "testFunction",
-      file_paths = { "src/main.lua", "lib/utils.lua" }
-    })
-    local output_received = false
-
-    _G.mock_state.result_processor_counts = { references = 1 }
-
-    local output_handler = function(result)
-      output_received = true
-    end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(500) -- Wait for async operations
-
-    _G.test_result = {
-      output_received = output_received,
-      utils_calls = _G.mock_state.utils_calls
-    }
-  ]])
-
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.output_received)
-
-  -- Check that file paths were passed to symbol finders
-  local lsp_call = nil
-  local grep_call = nil
-  for _, call in ipairs(result.utils_calls) do
-    if call.func == "find_with_lsp_async" then
-      lsp_call = call
-    elseif call.func == "find_with_grep_async" then
-      grep_call = call
-    end
-  end
-
-  h.not_eq(nil, lsp_call)
-  h.not_eq(nil, grep_call)
-  h.eq(2, #lsp_call.file_paths)
-  h.eq(2, #grep_call.file_paths)
-  h.expect_tbl_contains("src/main.lua", lsp_call.file_paths)
-  h.expect_tbl_contains("lib/utils.lua", lsp_call.file_paths)
-end
-
-T["output handlers"] = new_set({
-  hooks = {
-    pre_case = function()
-      child.lua([[reset_mock_state()]])
-    end,
-  },
-})
-
-T["output handlers"]["error handler formats error correctly"] = function()
-  child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = "testFunction" })
-    local mock_tool_system = {
-      chat = tool_context.chat
-    }
-
+    _G.captured_tool_output = nil
+    local tool_context = { args = { symbol_name = "foo" }, chat = _G.tools.chat }
+    local mock_tools = { chat = _G.tools.chat }
     local stderr = { "Error: Symbol not found" }
-    local result = ListCodeUsagesTool.output.error(tool_context, mock_tool_system, nil, stderr, nil)
+
+    local out = ListCodeUsagesTool.output.error(tool_context, mock_tools, nil, stderr)
+    _G.test_result = { out = out, captured = _G.captured_tool_output }
+  ]])
+  local res = child.lua_get("_G.test_result")
+
+  h.not_eq(nil, res.out)
+  h.eq("Error: Symbol not found", res.captured)
+end
+
+T["get_file_extension extracts extension (lua)"] = function()
+  child.lua([[
+    local cap = {}
+    local orig_grep = SymbolFinder.find_with_grep_async
+    local orig_lsp = SymbolFinder.find_with_lsp_async
+    SymbolFinder.find_with_lsp_async = function(_, _, cb) cb({}) end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+      cap.file_ext = file_ext
+      cb(nil)
+    end
+
+    local tool_context = { args = { symbol_name = "foo" }, chat = _G.tools.chat }
+    local done = false
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function() done = true end)
+    vim.wait(400, function() return done end, 10)
+
+    SymbolFinder.find_with_grep_async = orig_grep
+    SymbolFinder.find_with_lsp_async = orig_lsp
+    _G.test_result = cap
+  ]])
+  local res = child.lua_get("_G.test_result")
+
+  h.eq("lua", res.file_ext)
+end
+
+T["get_file_extension handles files without extension"] = function()
+  child.lua([[
+    -- create a new buffer named 'Makefile' and use as context
+    local buf = vim.api.nvim_create_buf(false, true)
+    local path = vim.fs.joinpath(_G.TEST_WS, "Makefile")
+    vim.api.nvim_buf_set_name(buf, path)
+
+    local orig_ctx = _G.tools.chat.buffer_context.bufnr
+    _G.tools.chat.buffer_context.bufnr = buf
+
+    local cap = {}
+    local orig_grep = SymbolFinder.find_with_grep_async
+    local orig_lsp = SymbolFinder.find_with_lsp_async
+    SymbolFinder.find_with_lsp_async = function(_, _, cb) cb({}) end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+      cap.file_ext = file_ext
+      cb(nil)
+    end
+
+    local tool_context = { args = { symbol_name = "foo" }, chat = _G.tools.chat }
+    local done = false
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function() done = true end)
+    vim.wait(400, function() return done end, 10)
+
+    -- restore
+    _G.tools.chat.buffer_context.bufnr = orig_ctx
+    SymbolFinder.find_with_grep_async = orig_grep
+    SymbolFinder.find_with_lsp_async = orig_lsp
+    _G.test_result = cap
+  ]])
+  local res = child.lua_get("_G.test_result")
+
+  h.eq("*", res.file_ext)
+end
+
+T["get_file_extension handles invalid buffer"] = function()
+  child.lua([[
+    local orig_ctx = _G.tools.chat.buffer_context.bufnr
+    _G.tools.chat.buffer_context.bufnr = -1
+
+    local cap = {}
+    local orig_grep = SymbolFinder.find_with_grep_async
+    local orig_lsp = SymbolFinder.find_with_lsp_async
+    SymbolFinder.find_with_lsp_async = function(_, _, cb) cb({}) end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+      cap.file_ext = file_ext
+      cb(nil)
+    end
+
+    local tool_context = { args = { symbol_name = "foo" }, chat = _G.tools.chat }
+    local done = false
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function() done = true end)
+    vim.wait(400, function() return done end, 10)
+
+    -- restore
+    _G.tools.chat.buffer_context.bufnr = orig_ctx
+    SymbolFinder.find_with_grep_async = orig_grep
+    SymbolFinder.find_with_lsp_async = orig_lsp
+    _G.test_result = cap
+  ]])
+
+  local res = child.lua_get("_G.test_result")
+  h.eq("", res.file_ext)
+end
+
+T["Integration"] = new_set()
+
+T["Integration"]["grep-only integration discovers usages and formats output"] = function()
+  child.lua([[
+    local tool_context = {
+      args = { symbol_name = "foo" },
+      chat = _G.tools.chat,
+    }
+
+    local done = false
+    local result_status, result_data
+
+    -- Invoke the tool's main command
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function(res)
+      result_status = res.status
+      result_data = res.data
+      done = true
+    end)
+
+    vim.wait(1000, function() return done end, 20)
+
+    -- Now, format the collected results into chat output
+    local out = ListCodeUsagesTool.output.success(tool_context, _G.tools, nil, nil)
 
     _G.test_result = {
-      result = result,
-      tool_output = _G.mock_state.tool_output
+      status = result_status,
+      capture = _G.captured_tool_output or out,
     }
   ]])
 
-  local result = child.lua_get("_G.test_result")
-  h.not_eq(nil, result.result)
-  h.eq("Error: Symbol not found", result.tool_output)
+  local res = child.lua_get("_G.test_result")
+  h.eq("success", res.status)
+  h.expect_contains("Searched for symbol `foo`", res.capture)
+
+  -- Code fences and filenames
+  h.expect_contains("```", res.capture)
+  h.expect_contains("Filename: src/a.lua:", res.capture)
+  h.expect_contains("Filename: src/b.lua:", res.capture)
+
+  -- At least one block should include the function body or its indentation-based fallback
+  h.expect_contains("function", res.capture)
 end
 
-T["handlers"] = new_set({
-  hooks = {
-    pre_case = function()
-      child.lua([[reset_mock_state()]])
-    end,
-  },
-})
-
-T["handlers"]["on_exit handler cleans up state"] = function()
+T["Integration"]["no results returns user-facing error"] = function()
   child.lua([[
-    -- Test that the exit handler exists and can be called
-    -- The actual state cleanup is handled by the tool itself
-    local has_exit_handler = ListCodeUsagesTool.handlers and ListCodeUsagesTool.handlers.on_exit ~= nil
+    -- Make both LSP and grep return nothing
+    SymbolFinder.find_with_lsp_async = function(symbol, file_paths, cb) cb({}) end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb) cb(nil) end
+    vim.fn.setqflist({})
 
-    if has_exit_handler then
-      -- Call the exit handler - it should not error
-      local success = pcall(ListCodeUsagesTool.handlers.on_exit, nil, nil)
-      _G.test_result = {
-        has_exit_handler = true,
-        call_success = success
-      }
-    else
-      _G.test_result = {
-        has_exit_handler = false
-      }
-    end
-  ]])
+    local tool_context = {
+      args = { symbol_name = "does_not_exist" },
+      chat = _G.tools.chat,
+    }
 
-  local result = child.lua_get("_G.test_result")
-  h.eq(true, result.has_exit_handler)
-  h.eq(true, result.call_success)
-end
+    local done = false
+    local result_status, result_data
 
-T["helper functions"] = new_set({
-  hooks = {
-    pre_case = function()
-      child.lua([[reset_mock_state()]])
-    end,
-  },
-})
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function(res)
+      result_status = res.status
+      result_data = res.data
+      done = true
+    end)
 
-T["helper functions"]["get_file_extension extracts extension correctly"] = function()
-  child.lua([[
-    -- Mock buffer name function to return different file types
-    Utils.safe_get_buffer_name = function(bufnr)
-      if bufnr == 1 then return "/test/file.lua"
-      elseif bufnr == 2 then return "/test/file.py"
-      elseif bufnr == 3 then return "/test/file"
-      else return ""
-      end
-    end
-
-    -- Test the get_file_extension function by calling the main command
-    -- and checking what extension is passed to grep
-    local tool_context = create_mock_tool_context({ symbol_name = "test" })
-    tool_context.chat.context.bufnr = 1 -- Use buffer 1 (lua file)
-
-    _G.mock_state.result_processor_counts = { references = 1 }
-
-    local output_handler = function(result) end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(200) -- Wait for async operations
-
-    -- Find the grep call to see what extension was passed
-    local grep_call = nil
-    for _, call in ipairs(_G.mock_state.utils_calls) do
-      if call.func == "find_with_grep_async" then
-        grep_call = call
-        break
-      end
-    end
+    vim.wait(800, function() return done end, 20)
 
     _G.test_result = {
-      grep_call = grep_call
+      status = result_status,
+      data = result_data,
     }
   ]])
 
-  local result = child.lua_get("_G.test_result")
-  h.not_eq(nil, result.grep_call)
-  h.eq("lua", result.grep_call.file_extension)
+  local res = child.lua_get("_G.test_result")
+  h.eq("error", res.status)
+  h.expect_contains("Symbol not found in workspace", res.data)
 end
 
-T["helper functions"]["get_file_extension handles files without extension"] = function()
+T["Integration"]["lsp documentation is formatted without code fences"] = function()
   child.lua([[
-    Utils.safe_get_buffer_name = function(bufnr)
-      return "/test/Makefile" -- No extension
+    -- Make LSP return a single symbol and hover documentation
+    SymbolFinder.find_with_lsp_async = function(symbol, file_paths, cb)
+      cb({
+        {
+          file = _G.FILE_A,
+          range = { start = { line = 0, character = 0 } }, -- top of file A
+        },
+      })
+    end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+      cb(nil) -- disable grep for this test
     end
 
-    local tool_context = create_mock_tool_context({ symbol_name = "test" })
-    _G.mock_state.result_processor_counts = { references = 1 }
-
-    local output_handler = function(result) end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(200) -- Wait for async operations
-
-    -- Find the grep call to see what extension was passed
-    local grep_call = nil
-    for _, call in ipairs(_G.mock_state.utils_calls) do
-      if call.func == "find_with_grep_async" then
-        grep_call = call
-        break
+    local Methods = vim.lsp.protocol.Methods
+    LspHandler.execute_request_async = function(bufnr, method, cb)
+      if method == Methods.textDocument_hover then
+        cb({ client1 = { contents = "Doc for foo" } })
+      else
+        cb({})
       end
     end
 
-    _G.test_result = {
-      grep_call = grep_call
+    local tool_context = {
+      args = { symbol_name = "foo" },
+      chat = _G.tools.chat,
     }
+
+    local done, status = false, nil
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function(res)
+      status = res.status
+      done = true
+    end)
+    vim.wait(1000, function() return done end, 20)
+
+    local out = ListCodeUsagesTool.output.success(tool_context, _G.tools, nil, nil)
+    _G.test_result = { status = status, out = out or _G.captured_tool_output }
   ]])
 
-  local result = child.lua_get("_G.test_result")
-  h.not_eq(nil, result.grep_call)
-  h.eq("*", result.grep_call.file_extension) -- Should default to "*"
+  local res = child.lua_get("_G.test_result")
+  h.eq("success", res.status)
+  h.expect_contains("\ndocumentation:\n", res.out)
+  h.expect_contains("---\nDoc for foo\n", res.out)
+
+  -- Ensure it's not fenced like code
+  h.expect_truthy(not res.out:find("```Doc for foo", 1, true))
 end
 
-T["helper functions"]["get_file_extension handles invalid buffer"] = function()
+T["Integration"]["lsp and grep duplicates are merged"] = function()
   child.lua([[
-    local tool_context = create_mock_tool_context({ symbol_name = "test" })
-    tool_context.chat.context.bufnr = -1 -- Invalid buffer
+    -- Prepare a single qflist item for the usage in FILE_A line 6
+    local bufa = vim.fn.bufnr(_G.FILE_A, true)
+    local a_lines = vim.api.nvim_buf_get_lines(bufa, 0, -1, false)
+    local function col_of(s, pat) return (s:find(pat, 1, true) or 1) end
+    local col = col_of(a_lines[6] or "", "foo")
+    vim.fn.setqflist({ { bufnr = bufa, lnum = 6, col = col } })
 
-    _G.mock_state.result_processor_counts = { references = 1 }
+    -- Symbol at the same location via LSP references
+    SymbolFinder.find_with_lsp_async = function(symbol, file_paths, cb)
+      cb({
+        {
+          file = _G.FILE_A,
+          range = { start = { line = 5, character = math.max(col - 1, 0) } }, -- 0-indexed
+        },
+      })
+    end
+    SymbolFinder.find_with_grep_async = function(symbol, file_ext, file_paths, cb)
+      local qf = vim.fn.getqflist()
+      local first = qf[1]
+      cb({
+        file = vim.fn.bufname(first.bufnr),
+        line = first.lnum,
+        col = first.col,
+        bufnr = first.bufnr,
+        qflist = qf,
+      })
+    end
 
-    local output_handler = function(result) end
-
-    -- Execute the main command
-    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, output_handler)
-
-    vim.wait(200) -- Wait for async operations
-
-    -- Find the grep call to see what extension was passed
-    local grep_call = nil
-    for _, call in ipairs(_G.mock_state.utils_calls) do
-      if call.func == "find_with_grep_async" then
-        grep_call = call
-        break
+    local Methods = vim.lsp.protocol.Methods
+    LspHandler.execute_request_async = function(bufnr, method, cb)
+      if method == Methods.textDocument_references then
+        cb({
+          client1 = {
+            { uri = vim.uri_from_fname(_G.FILE_A), range = { start = { line = 5, character = math.max(col - 1, 0) } } },
+          },
+        })
+      else
+        cb({})
       end
     end
 
-    _G.test_result = {
-      grep_call = grep_call
+    local tool_context = {
+      args = { symbol_name = "foo" },
+      chat = _G.tools.chat,
     }
+
+    local done, status, out = false, nil, nil
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function(res)
+      status = res.status
+      done = true
+    end)
+    vim.wait(1000, function() return done end, 20)
+    out = ListCodeUsagesTool.output.success(tool_context, _G.tools, nil, nil)
+
+    -- Count occurrences of the a.lua filename header (should be exactly one)
+    local _, count = (out or _G.captured_tool_output):gsub("Filename: src/a.lua:", "")
+    _G.test_result = { status = status, count = count }
   ]])
 
-  local result = child.lua_get("_G.test_result")
-  h.not_eq(nil, result.grep_call)
-  h.eq("", result.grep_call.file_extension) -- Should be empty for invalid buffer
+  local res = child.lua_get("_G.test_result")
+  h.eq("success", res.status)
+  h.eq(1, res.count)
+end
+
+T["Integration"]["returns to chat window"] = function()
+  child.lua([[
+    -- Identify the chat window (the one not equal to context)
+    local ctx = _G.tools.chat.buffer_context.winnr
+    local chat_win
+    for _, w in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      if w ~= ctx then chat_win = w end
+    end
+
+    SymbolFinder.find_with_lsp_async = function(_, _, cb) cb({}) end
+    SymbolFinder.find_with_grep_async = function(_, _, _, cb)
+      cb(nil) -- Force no results to take the error path
+    end
+    vim.fn.setqflist({})
+
+    local tool_context = { args = { symbol_name = "noop" }, chat = _G.tools.chat }
+    local done = false
+    ListCodeUsagesTool.cmds[1](tool_context, tool_context.args, nil, function() done = true end)
+    vim.wait(600, function() return done end, 20)
+
+    _G.test_result = { current_win = vim.api.nvim_get_current_win(), expected = chat_win }
+  ]])
+
+  local res = child.lua_get("_G.test_result")
+  h.eq(res.expected, res.current_win)
 end
 
 return T


### PR DESCRIPTION
## Description

The list code usage tool was impacted by #1891. The tests underpinning this tool were too heavily mocked resulting in them not being able to catch the error.

## Related Issue(s)

#2018

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
