### PR TITLE
perf(chat): set undolevels to 10

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -465,6 +465,7 @@ local defaults = {
         completion_provider = providers.completion, -- blink|cmp|coc|default
         register = "+", -- The register to use for yanking code
         yank_jump_delay_ms = 400, -- Delay in milliseconds before jumping back from the yanked code
+        undo_levels = 10, -- Number of undo levels to add to chat buffers
 
         ---@type string|fun(path: string)
         goto_file_action = ui_utils.tabnew_reuse,

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -536,6 +536,7 @@ function Chat.new(args)
       local bufnr = api.nvim_create_buf(false, true)
       api.nvim_buf_set_name(bufnr, string.format("[CodeCompanion] %d", id))
       vim.bo[bufnr].filetype = "codecompanion"
+      vim.bo[bufnr].undolevels = config.strategies.chat.opts.undolevels or 10
 
       -- Set up omnifunc for automatic completion when no other completion provider is active
       local completion_provider = config.strategies.chat.opts.completion_provider


### PR DESCRIPTION
## Description

In the off chance that this may improve performance in the chat buffer, setting it as a default.

## Related Issue(s)

#552

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
