### PR TITLE
fix: prevent duplicate # and @ in CoC completions

### DIFF
--- a/lua/codecompanion/providers/completion/coc/init.lua
+++ b/lua/codecompanion/providers/completion/coc/init.lua
@@ -14,9 +14,9 @@ local function transform_complete_items(opt, complete_items)
   for _, item in ipairs(complete_items) do
     -- Populate standard Vim completion-items fields (see :h complete-items).
     if opt.triggerCharacter == "#" then
-      item.word = string.format("#{%s}", item.label:sub(2))
+      item.word = string.format("{%s}", item.label:sub(2))
     elseif opt.triggerCharacter == "@" then
-      item.word = string.format("@{%s}", item.label:sub(2))
+      item.word = string.format("{%s}", item.label:sub(2))
     else
       item.word = item.label:sub(2)
     end


### PR DESCRIPTION
## Description

Following the (not-so-recent) update to completion strings, # and @ were duplicated in CoC. This PR resolves it.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [X] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [X] I've updated the README and/or relevant docs pages
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
