### PR TITLE
fix: openai_compatible adapter error

### DIFF
--- a/lua/codecompanion/adapters/http/openai_compatible.lua
+++ b/lua/codecompanion/adapters/http/openai_compatible.lua
@@ -40,7 +40,7 @@ local function get_models(self, opts)
     return {}
   end
 
-  adapter:get_env_vars()
+  utils.get_env_vars(adapter)
   local url = adapter.env_replaced.url
   local models_endpoint = adapter.env_replaced.models_endpoint
 


### PR DESCRIPTION

## Description

After the recent refactor to the http adapters, the openai_compatible one was using a no longer existing adapter get_env_vars() function.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README and/or relevant docs pages
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
