### PR TITLE
fix(diff): display the correct `sign_text` in floating diffs

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/http/copilot/helpers.lua
@@ -231,6 +231,7 @@ function M.show_copilot_stats(get_and_authorize_token_fn, oauth_token)
       height = math.min(#lines + 2, 20),
     },
     ignore_keymaps = false,
+    style = "minimal",
   }
   local _, winnr = ui.create_float(lines, float_opts)
 

--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -242,6 +242,7 @@ function Debug:render()
     filetype = "lua",
     title = "Debug Chat",
     window = window_config,
+    style = "minimal",
     opts = window_config.opts or {
       wrap = true,
     },

--- a/lua/codecompanion/strategies/chat/helpers/super_diff.lua
+++ b/lua/codecompanion/strategies/chat/helpers/super_diff.lua
@@ -566,6 +566,7 @@ function M.show_super_diff(chat, opts)
     filetype = "markdown",
     title = title,
     window = window_config,
+    style = "minimal",
     ignore_keymaps = true,
   })
 

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -17,6 +17,7 @@ M.options = {
       title = "Options",
       lock = true,
       window = config.display.chat.window,
+      style = "minimal",
     }
 
     if next(_cached_options) ~= nil then

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -33,7 +33,7 @@ M.create_float = function(lines, opts)
     border = (vim.fn.exists("+winborder") == 0 or vim.o.winborder == "") and "single" or nil,
     width = width,
     height = height,
-    style = "minimal",
+    style = opts.style,
     row = row,
     col = col,
     title = opts.title or "Options",

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -33,7 +33,7 @@ M.create_float = function(lines, opts)
     border = (vim.fn.exists("+winborder") == 0 or vim.o.winborder == "") and "single" or nil,
     width = width,
     height = height,
-    style = opts.style,
+    style = opts.style or "minimal",
     row = row,
     col = col,
     title = opts.title or "Options",


### PR DESCRIPTION
## Description

This is a small fix to display the correct `sign_text` in floating diffs. The `open_window` function with option `style = "minimal"` prevents signs from showing up properly, so it’s better to leave the `style = "minimal"` option to the module rather than enforcing it inside the general `create_float` function.

## Related Issue(s)

Sign texts don’t appear near deleted lines (virtual text) in inline diffs.

Thank you

## Screenshots

Current behavior: no `sign_text` indicator appears next to the virtual lines highlighted in red.
<img width="674" height="385" alt="Screenshot 2025-08-27 at 5 46 37 PM" src="https://github.com/user-attachments/assets/792bc484-8197-4561-8c91-4d013aedde13" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
