### PR TITLE
replace integer with number

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -14,12 +14,12 @@ local utils = require("codecompanion.utils.adapters")
 ---@field codesearch boolean
 ---@field copilotignore_enabled boolean
 ---@field endpoints {api: string, ["origin-tracker"]: string, proxy: string, telemetry: string}
----@field expires_at integer
+---@field expires_at number
 ---@field individual boolean
 ---@field nes_enabled boolean
 ---@field prompt_8k boolean
 ---@field public_suggestions string
----@field refresh_in integer
+---@field refresh_in number
 ---@field sku string
 ---@field snippy_load_test_enabled boolean
 ---@field telemetry string

--- a/lua/codecompanion/helpers/actions.lua
+++ b/lua/codecompanion/helpers/actions.lua
@@ -2,8 +2,8 @@ local api = vim.api
 
 local M = {}
 
----@param start_line integer
----@param end_line integer
+---@param start_line number
+---@param end_line number
 ---@param opts table|nil
 function M.get_code(start_line, end_line, opts)
   local lines = {}
@@ -21,9 +21,9 @@ function M.get_code(start_line, end_line, opts)
 end
 
 ---Taken from the excellent plugin: https://github.com/piersolenski/wtf.nvim
----@param start_line integer
----@param end_line integer
----@param bufnr integer|nil
+---@param start_line number
+---@param end_line number
+---@param bufnr number|nil
 ---@return table
 function M.get_diagnostics(start_line, end_line, bufnr)
   if end_line == nil then

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -231,7 +231,7 @@ CodeCompanion.toggle = function()
 end
 
 ---Make a previously hidden chat buffer, visible again
----@param bufnr integer
+---@param bufnr number
 ---@return nil
 CodeCompanion.restore = function(bufnr)
   if not bufnr or not api.nvim_buf_is_valid(bufnr) then
@@ -250,7 +250,7 @@ CodeCompanion.restore = function(bufnr)
 end
 
 ---Return a chat buffer
----@param bufnr? integer
+---@param bufnr? number
 ---@return CodeCompanion.Chat|table
 CodeCompanion.buf_get_chat = function(bufnr)
   return require("codecompanion.strategies.chat").buf_get_chat(bufnr)

--- a/lua/codecompanion/providers/diff/utils.lua
+++ b/lua/codecompanion/providers/diff/utils.lua
@@ -6,10 +6,10 @@ local api = vim.api
 local M = {}
 
 ---@class CodeCompanion.Diff.Utils.DiffHunk
----@field old_start integer
----@field old_count integer
----@field new_start integer
----@field new_count integer
+---@field old_start number
+---@field old_count number
+---@field new_start number
+---@field new_count number
 ---@field old_lines string[]
 ---@field new_lines string[]
 ---@field context_before string[]
@@ -18,7 +18,7 @@ local M = {}
 ---Calculate diff hunks between two content arrays
 ---@param old_lines string[] Original content
 ---@param new_lines string[] New content
----@param context_lines? integer Number of context lines (default: 3)
+---@param context_lines? number Number of context lines (default: 3)
 ---@return CodeCompanion.Diff.Utils.DiffHunk[] hunks
 function M.calculate_hunks(old_lines, new_lines, context_lines)
   context_lines = context_lines or 3
@@ -81,12 +81,12 @@ function M.calculate_hunks(old_lines, new_lines, context_lines)
 end
 
 ---Apply visual highlights to hunks in a buffer with sign column indicators
----@param bufnr integer Buffer to apply highlights to
+---@param bufnr number Buffer to apply highlights to
 ---@param hunks CodeCompanion.Diff.Utils.DiffHunk[] Hunks to highlight
----@param ns_id integer Namespace for extmarks
----@param line_offset? integer Line offset (default: 0)
+---@param ns_id number Namespace for extmarks
+---@param line_offset? number Line offset (default: 0)
 ---@param opts? table Options: {show_removed: boolean, full_width_removed: boolean, status: string}
----@return integer[] extmark_ids
+---@return number[] extmark_ids
 function M.apply_hunk_highlights(bufnr, hunks, ns_id, line_offset, opts)
   line_offset = line_offset or 0
   opts = opts or { show_removed = true, full_width_removed = true, status = "pending" }

--- a/lua/codecompanion/strategies/chat/context.lua
+++ b/lua/codecompanion/strategies/chat/context.lua
@@ -74,7 +74,7 @@ end
 ---Add context to the chat buffer
 ---@param chat CodeCompanion.Chat
 ---@param context CodeCompanion.Chat.ContextItem
----@param row integer
+---@param row number
 local function add(chat, context, row)
   if not context.opts.visible then
     return

--- a/lua/codecompanion/strategies/chat/helpers/super_diff.lua
+++ b/lua/codecompanion/strategies/chat/helpers/super_diff.lua
@@ -483,9 +483,9 @@ local function generate_markdown_super_diff(tracked_files)
 end
 
 ---Apply highlights to show edit operation status and changes
----@param bufnr integer
+---@param bufnr number
 ---@param diff_info table[]
----@param ns_id integer
+---@param ns_id number
 local function apply_super_diff_highlights(bufnr, diff_info, ns_id)
   local all_extmark_ids = {}
   for i, section in ipairs(diff_info) do
@@ -592,9 +592,9 @@ function M.show_super_diff(chat, opts)
 end
 
 ---Setup keymaps for the super diff buffer
----@param bufnr integer Buffer number for the super diff
+---@param bufnr number Buffer number for the super diff
 ---@param chat CodeCompanion.Chat Chat instance with tracked edits
----@param ns_id integer Namespace ID for highlights
+---@param ns_id number Namespace ID for highlights
 function M.setup_keymaps(bufnr, chat, file_actions, ns_id)
   local function cleanup()
     if api.nvim_buf_is_valid(bufnr) then
@@ -691,14 +691,14 @@ function M.setup_keymaps(bufnr, chat, file_actions, ns_id)
 end
 
 ---Setup sticky header that follows cursor position and shows current file
----@param bufnr integer Buffer number for the super diff
----@param winnr integer Window number for the super diff
+---@param bufnr number Buffer number for the super diff
+---@param winnr number Window number for the super diff
 ---@param lines string[] All lines in the buffer
 function M.setup_sticky_header(bufnr, winnr, lines)
   local sticky_win = nil
   local sticky_buf = nil
   ---Find the current file header based on cursor position
-  ---@param cursor_line integer 1-based cursor line number
+  ---@param cursor_line number 1-based cursor line number
   ---@return string|nil filename, string|nil relative_dir
   local function find_current_file_header(cursor_line)
     -- Look backwards from cursor to find the nearest ## header

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -6,9 +6,9 @@
 ---@field acp_connection? CodeCompanion.ACP.Connection The ACP session ID and connection
 ---@field adapter CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter The adapter to use for the chat
 ---@field builder CodeCompanion.Chat.UI.Builder The builder for the chat UI
----@field create_buf fun(): integer The function that creates a new buffer for the chat
+---@field create_buf fun(): number The function that creates a new buffer for the chat
 ---@field aug number The ID for the autocmd group
----@field bufnr integer The buffer number of the chat
+---@field bufnr number The buffer number of the chat
 ---@field buffer_context table The context of the buffer that the chat was initiated from
 ---@field current_request table|nil The current request being executed
 ---@field current_tool table The current tool being executed
@@ -16,8 +16,8 @@
 ---@field edit_tracker? CodeCompanion.Chat.EditTracker Edit tracking information for the chat
 ---@field header_line number The line number of the user header that any Tree-sitter parsing should start from
 ---@field from_prompt_library? boolean Whether the chat was initiated from the prompt library
----@field header_ns integer The namespace for the virtual text that appears in the header
----@field id integer The unique identifier for the chat
+---@field header_ns number The namespace for the virtual text that appears in the header
+---@field id number The unique identifier for the chat
 ---@field messages? table The messages in the chat buffer
 ---@field opts CodeCompanion.ChatArgs Store all arguments in this table
 ---@field parser vim.treesitter.LanguageTree The Markdown Tree-sitter parser for the chat buffer
@@ -237,7 +237,7 @@ end
 local _cached_settings = {}
 
 ---Parse the chat buffer for settings
----@param bufnr integer
+---@param bufnr number
 ---@param parser vim.treesitter.LanguageTree
 ---@param adapter? CodeCompanion.HTTPAdapter
 ---@return table
@@ -1505,7 +1505,7 @@ function Chat:update_metadata()
 end
 
 ---Returns the chat object(s) based on the buffer number
----@param bufnr? integer
+---@param bufnr? number
 ---@return CodeCompanion.Chat|table
 function Chat.buf_get_chat(bufnr)
   if not bufnr then

--- a/lua/codecompanion/strategies/chat/slash_commands/help.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/help.lua
@@ -17,7 +17,7 @@ local CONSTANTS = {
 ---Find the tag row
 ---@param tag string The tag to find
 ---@param content string The content of the file
----@return integer The row of the tag
+---@return number The row of the tag
 local function get_tag_row(tag, content)
   local ft = "vimdoc"
   local parser = vim.treesitter.get_string_parser(content, "vimdoc")

--- a/lua/codecompanion/strategies/chat/tools/catalog/helpers/patch.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/helpers/patch.lua
@@ -4,7 +4,7 @@ local log = require("codecompanion.utils.log")
 ---@field prompt string The prompt text explaining the patch format to the LLM
 ---@field parse_edits fun(raw: string): CodeCompanion.Patch.Edit[], boolean, nil|string Parse raw LLM output into changes and whether markers were found
 ---@field apply fun(lines: string[], edit: CodeCompanion.Patch.Edit): string[]|nil,string|nil Apply an edit to file lines, returns nil if can't be confidently applied
----@field start_line fun(lines: string[], edit: CodeCompanion.Patch.Edit): integer|nil Get the line number (1-based) where edit would be applied
+---@field start_line fun(lines: string[], edit: CodeCompanion.Patch.Edit): number|nil Get the line number (1-based) where edit would be applied
 ---@field format fun(edit: CodeCompanion.Patch.Edit): string Format an edit object as a readable string for display/logging
 local Patch = {}
 
@@ -175,9 +175,9 @@ end
 
 ---Score how many lines from needle match haystack lines
 ---@param haystack string[] All file lines
----@param pos integer Starting index to check (1-based)
+---@param pos number Starting index to check (1-based)
 ---@param needle string[] Lines to match
----@return integer Score: 10 per perfect line, or 9 per trimmed match
+---@return number Score: 10 per perfect line, or 9 per trimmed match
 local function get_score(haystack, pos, needle)
   local score = 0
   for i, needle_line in ipairs(needle) do
@@ -193,9 +193,9 @@ end
 
 ---Compute the match score for focus lines above a position.
 ---@param lines string[] Lines of source file
----@param before_pos integer Scan up to this line (exclusive; 1-based)
+---@param before_pos number Scan up to this line (exclusive; 1-based)
 ---@param focus string[] Focus lines/context
----@return integer Score: 20 per matching focus line before position
+---@return number Score: 20 per matching focus line before position
 local function get_focus_score(lines, before_pos, focus)
   local start = 1
   local score = 0
@@ -214,7 +214,7 @@ end
 ---Get the overall score for placing an edit on a given line
 ---@param lines string[] File lines
 ---@param edit CodeCompanion.Patch.Edit To match
----@param i integer Line position
+---@param i number Line position
 ---@return number Score from 0.0 to 1.0
 local function get_match_score(lines, edit, i)
   local max_score = (#edit.focus * 2 + #edit.pre + #edit.old + #edit.post) * 10
@@ -228,7 +228,7 @@ end
 ---Determine best insertion spot for an edit and its match score
 ---@param lines string[] File lines
 ---@param edit CodeCompanion.Patch.Edit Patch block
----@return integer, number location (1-based), Score (0-1)
+---@return number, number location (1-based), Score (0-1)
 local function get_best_location(lines, edit)
   -- try applying patch in flexible spaces mode
   -- there is no standardised way to of spaces in diffs
@@ -256,7 +256,7 @@ end
 ---Get the start line location where an edit would be applied without actually applying it
 ---@param lines string[] File lines
 ---@param edit CodeCompanion.Patch.Edit Edit description
----@return integer|nil location The line number (1-based) where the edit would be applied
+---@return number|nil location The line number (1-based) where the edit would be applied
 function Patch.start_line(lines, edit)
   local location, score = get_best_location(lines, edit)
   if score < 0.5 then

--- a/lua/codecompanion/strategies/chat/tools/catalog/next_edit_suggestion.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/next_edit_suggestion.lua
@@ -4,9 +4,9 @@ local api = vim.api
 
 ---@class CodeCompanion.Tool.NextEditSuggestion.Args
 ---@field filepath string
----@field line integer
+---@field line number
 
----@alias jump_action fun(path: string):integer?
+---@alias jump_action fun(path: string):number?
 
 ---@class CodeCompanion.Tool.NextEditSuggestion: CodeCompanion.Tools.Tool
 return {

--- a/lua/codecompanion/strategies/chat/tools/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/init.lua
@@ -10,7 +10,7 @@
 ---@field stdout table The stdout of the tool
 ---@field stderr table The stderr of the tool
 ---@field tool CodeCompanion.Tools.Tool The current tool that's being run
----@field tools_ns integer The namespace for the virtual text that appears in the header
+---@field tools_ns number The namespace for the virtual text that appears in the header
 
 local EditTracker = require("codecompanion.strategies.chat.edit_tracker")
 local Orchestrator = require("codecompanion.strategies.chat.tools.orchestrator")

--- a/lua/codecompanion/strategies/chat/tools/tool_filter.lua
+++ b/lua/codecompanion/strategies/chat/tools/tool_filter.lua
@@ -19,7 +19,7 @@ local function clear_cache()
 end
 
 ---Check if the cache is valid (time + config unchanged)
----@param tools_config_hash integer The hash of the tools config
+---@param tools_config_hash number The hash of the tools config
 ---@return boolean
 local function is_cache_valid(tools_config_hash)
   local time_valid = vim.loop.now() - _cache_timestamp < CACHE_TTL

--- a/lua/codecompanion/strategies/chat/ui/icons.lua
+++ b/lua/codecompanion/strategies/chat/ui/icons.lua
@@ -9,8 +9,8 @@ local CONSTANTS = {
 }
 
 ---Apply colored icon overlay at column 0
----@param bufnr integer
----@param line integer 0-based line number
+---@param bufnr number
+---@param line number 0-based line number
 ---@param status string The tool status (in_progress, completed, failed)
 function Icons.apply_tool_icon(bufnr, line, status)
   local icon_configs = {
@@ -45,7 +45,7 @@ function Icons.apply_tool_icon(bufnr, line, status)
 end
 
 ---Clear all tool icons from buffer
----@param bufnr integer
+---@param bufnr number
 function Icons.clear_tool_icons(bufnr)
   api.nvim_buf_clear_namespace(bufnr, CONSTANTS.NS_TOOL_ICONS, 0, -1)
 end

--- a/lua/codecompanion/strategies/chat/ui/init.lua
+++ b/lua/codecompanion/strategies/chat/ui/init.lua
@@ -435,7 +435,7 @@ function UI:clear_virtual_text(extmark_id)
 end
 
 ---Get the last line, column and line count in the chat buffer
----@return integer, integer, integer
+---@return number, integer, integer
 function UI:last()
   local line_count = api.nvim_buf_line_count(self.chat_bufnr)
 
@@ -456,7 +456,7 @@ end
 
 ---Display the tokens in the chat buffer
 ---@param parser table
----@param start_row integer
+---@param start_row number
 ---@return nil
 function UI:display_tokens(parser, start_row)
   if config.display.chat.show_token_count and self.tokens then

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -3,7 +3,7 @@ The Inline Assistant - This is where code is applied directly to a Neovim buffer
 --]]
 
 ---@class CodeCompanion.Inline
----@field id integer The ID of the inline prompt
+---@field id number The ID of the inline prompt
 ---@field adapter CodeCompanion.HTTPAdapter The adapter to use for the inline prompt
 ---@field aug number The ID for the autocmd group
 ---@field buffer_context table The context of the buffer the inline prompt was initiated from

--- a/lua/codecompanion/strategies/inline/keymaps.lua
+++ b/lua/codecompanion/strategies/inline/keymaps.lua
@@ -6,7 +6,7 @@ local M = {}
 
 ---Clear a keymap from a specific buffer
 ---@param keymaps table
----@param bufnr? integer
+---@param bufnr? number
 local function clear_map(keymaps, bufnr)
   bufnr = bufnr or 0
 

--- a/lua/codecompanion/utils/context.lua
+++ b/lua/codecompanion/utils/context.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local ESC_FEEDKEY = api.nvim_replace_termcodes("<ESC>", true, false, true)
 
----@param bufnr nil|integer
+---@param bufnr nil|number
 ---@return string
 M.get_filetype = function(bufnr)
   bufnr = bufnr or 0
@@ -29,7 +29,7 @@ local function is_normal_mode(mode)
   return mode == "n" or mode == "no" or mode == "nov" or mode == "noV" or mode == "no"
 end
 
----@param bufnr nil|integer
+---@param bufnr nil|number
 ---@return table,number,number,number,number
 function M.get_visual_selection(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
@@ -93,7 +93,7 @@ function M.get_visual_selection(bufnr)
 end
 
 ---Get the context of the current buffer.
----@param bufnr? integer
+---@param bufnr? number
 ---@param args? table
 ---@return table
 function M.get(bufnr, args)

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -129,7 +129,7 @@ function M.safe_filetype(filetype)
 end
 
 ---Set an option in Neovim
----@param bufnr integer
+---@param bufnr number
 ---@param opt string
 ---@param value any
 function M.set_option(bufnr, opt, value)

--- a/lua/codecompanion/utils/log.lua
+++ b/lua/codecompanion/utils/log.lua
@@ -1,8 +1,8 @@
 ---@class CodeCompanion.LogHandler
 ---@field type? string
----@field level? integer
----@field formatter? fun(level: integer, msg: string, ...: any)
----@field handle? fun(level: integer, text: string)
+---@field level? number
+---@field formatter? fun(level: number, msg: string, ...: any)
+---@field handle? fun(level: number, text: string)
 local LogHandler = {}
 
 local levels_reverse = {}
@@ -176,7 +176,7 @@ local Logger = {}
 
 ---@class CodeCompanion.LoggerArgs
 ---@field handlers CodeCompanion.LogHandler[]
----@field level nil|integer
+---@field level nil|number
 
 ---@param opts CodeCompanion.LoggerArgs
 function Logger.new(opts)
@@ -197,7 +197,7 @@ function Logger.new(opts)
   return log
 end
 
----@param level integer
+---@param level number
 function Logger:set_level(level)
   for _, handler in ipairs(self.handlers) do
     handler.level = level
@@ -209,7 +209,7 @@ function Logger:get_handlers()
   return self.handlers
 end
 
----@param level integer
+---@param level number
 ---@param msg string
 ---@param ... any[]
 function Logger:log(level, msg, ...)

--- a/lua/codecompanion/utils/treesitter.lua
+++ b/lua/codecompanion/utils/treesitter.lua
@@ -3,7 +3,7 @@ local api = vim.api
 local M = {}
 
 ---@param direction string
----@param count integer
+---@param count number
 ---@return nil
 function M.goto_heading(direction, count)
   local bufnr = api.nvim_get_current_buf()
@@ -97,11 +97,11 @@ end
 -- They also treat a EOF/EOL char as a char ending in the first
 -- col of the next row.
 ---comment
----@param range integer[]
----@param buf integer|nil
----@return integer, integer, integer, integer
+---@param range number[]
+---@param buf number|nil
+---@return number, integer, integer, integer
 function M.get_vim_range(range, buf)
-  ---@type integer, integer, integer, integer
+  ---@type number, integer, integer, integer
   local srow, scol, erow, ecol = unpack(range)
   srow = srow + 1
   scol = scol + 1

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -171,8 +171,8 @@ M.buf_is_active = function(bufnr)
   return api.nvim_get_current_buf() == bufnr
 end
 
----@param bufnr nil|integer
----@return integer[]
+---@param bufnr nil|number
+---@return number[]
 M.buf_list_wins = function(bufnr)
   local wins = {}
 
@@ -199,7 +199,7 @@ M.scroll_to_end = function(winnr)
   api.nvim_win_set_cursor(winnr, { lnum, api.nvim_strwidth(last_line) })
 end
 
----@param bufnr nil|integer
+---@param bufnr nil|number
 ---@return nil
 M.buf_scroll_to_end = function(bufnr)
   for _, winnr in ipairs(M.buf_list_wins(bufnr or 0)) do
@@ -247,8 +247,8 @@ function M.scroll_and_highlight(bufnr, line_num, num_lines)
   end, 2000) -- 2 seconds
 end
 
----@param bufnr nil|integer
----@return nil|integer
+---@param bufnr nil|number
+---@return nil|number
 M.buf_get_win = function(bufnr)
   for _, winnr in ipairs(api.nvim_list_wins()) do
     if api.nvim_win_get_buf(winnr) == bufnr then
@@ -258,7 +258,7 @@ M.buf_get_win = function(bufnr)
 end
 
 ---Source: https://github.com/stevearc/oil.nvim/blob/dd432e76d01eda08b8658415588d011009478469/lua/oil/layout.lua#L22C8-L22C8
----@return integer
+---@return number
 M.get_editor_height = function()
   local editor_height = vim.o.lines - vim.o.cmdheight
   -- Subtract 1 if tabline is visible
@@ -381,7 +381,7 @@ end
 --- Otherwise, open it in a new tab.
 --- Returns the window ID after the jump.
 ---@param path string?
----@return integer
+---@return number
 function M.tabnew_reuse(path)
   local uri
   if path then


### PR DESCRIPTION
## Description

Ensure consistency across the code base by using `number` instead of `integer`. Some `integer` references remain for adapter schemas however.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
