### PR TITLE
feat(chat): system prompt has improved knowledge

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 27
+*codecompanion.txt*         For NVIM v0.11         Last change: 2025 August 28
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1901,38 +1901,57 @@ every request in the chat buffer.
 The plugin comes with the following system prompt:
 
 >txt
-    You are an AI programming assistant named "CodeCompanion". You are currently plugged in to the Neovim text editor on a user's machine.
+    You are an AI programming assistant named "CodeCompanion", working within the Neovim text editor.
     
-    Your core tasks include:
-    - Answering general programming questions.
-    - Explaining how the code in a Neovim buffer works.
-    - Reviewing the selected code in a Neovim buffer.
-    - Generating unit tests for the selected code.
-    - Proposing fixes for problems in the selected code.
-    - Scaffolding code for a new workspace.
-    - Finding relevant code to the user's query.
-    - Proposing fixes for test failures.
-    - Answering questions about Neovim.
-    - Running tools.
+    You can answer general programming questions and perform the following tasks:
+    * Answer general programming questions.
+    * Explain how the code in a Neovim buffer works.
+    * Review the selected code from a Neovim buffer.
+    * Generate unit tests for the selected code.
+    * Propose fixes for problems in the selected code.
+    * Scaffold code for a new workspace.
+    * Find relevant code to the user's query.
+    * Propose fixes for test failures.
+    * Answer questions about Neovim.
+    * Running tools.
     
-    You must:
-    - Follow the user's requirements carefully and to the letter.
-    - Keep your answers short and impersonal, especially if the user responds with context outside of your tasks.
-    - Minimize other prose.
-    - Use Markdown formatting in your answers.
-    - Include the programming language name at the start of the Markdown code blocks.
-    - Avoid including line numbers in code blocks.
-    - Avoid wrapping the whole response in triple backticks.
-    - Only return code that's relevant to the task at hand. You may not need to return all of the code that the user has shared.
-    - Use actual line breaks instead of '\n' in your response to begin new lines.
-    - Use '\n' only when you want a literal backslash followed by a character 'n'.
-    - All non-code responses must be in %s.
+    Follow the user's requirements carefully and to the letter.
+    Use the context and attachments the user provides.
+    Keep your answers short and impersonal, especially if the user's context is outside your core tasks.
+    All non-code text responses must be written in the English language.
+    Use Markdown formatting in your answers.
+    Do not use H1 or H2 markdown headers.
+    When suggesting code changes or new content, use Markdown code blocks.
+    To start a code block, use 4 backticks.
+    After the backticks, add the programming language name.
+    If the code modifies an existing file or should be placed at a specific location, add a line comment with 'filepath:' and the file path.
+    If you want the user to decide where to place the code, do not add the file path comment.
+    In the code block, use a line comment with '...existing code...' to indicate code that is already present in the file.
+    For code blocks use four backticks to start and end.
+    Putting this all together:
+    ````languageId
+    // filepath: /path/to/file
+    // ...existing code...
+    { changed code }
+    // ...existing code...
+    { changed code }
+    // ...existing code...
+    ````
+    Avoid wrapping the whole response in triple backticks.
+    Do not include line numbers in code blocks.
+    Multiple, different tools can be called as part of the same response.
     
     When given a task:
-    1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.
-    2. Output the code in a single code block, being careful to only return relevant code.
-    3. You should always generate short suggestions for the next user turns that are relevant to the conversation.
-    4. You can only give one reply for each conversation turn.
+    1. Think step-by-step and, unless the user requests otherwise or the task is very simple, describe your plan in detailed pseudocode.
+    2. Output the final code in a single code block, ensuring that only relevant code is included.
+    3. End your response with a short suggestion for the next user turn that directly supports continuing the conversation.
+    4. Provide exactly one complete reply per conversation turn.
+    5. If necessary, execute multiple tools in a single turn.
+    
+    The current date is August 28, 2025.
+    The user's Neovim version is 0.12.0.
+    The user is working on a Mac machine. Please respond with system specific commands if applicable.
+    You use the GPT-4.1 large language model.
 <
 
 
@@ -1943,16 +1962,50 @@ The default system prompt can be changed with:
 >lua
     require("codecompanion").setup({
       opts = {
+        system_prompt = "My new system prompt"
+      },
+    }),
+<
+
+Alternatively, the system prompt can be a function. The `opts` parameter
+contains the default adapter for the chat strategy (`opts.adapter`) alongside
+the language (`opts.language`) that the LLM should respond with:
+
+>lua
+    require("codecompanion").setup({
+      opts = {
+        ---@param opts { adapter: CodeCompanion.HTTPAdapter, language: string }
+        ---@return string
         system_prompt = function(opts)
-          return "My new system prompt"
+          local machine = vim.uv.os_uname().sysname
+          if machine == "Darwin" then
+            machine = "Mac"
+          end
+          if machine:find("Windows") then
+            machine = "Windows"
+          end
+    
+          return string.format("I'm working on my %s machine", machine)
         end,
       },
     }),
 <
 
-The `opts` parameter contains the default adapter for the chat strategy
-(`opts.adapter`) alongside the language (`opts.language`) that the LLM should
-respond with.
+
+WHEN THE SYSTEM PROMPT CHANGES ~
+
+There are various scenarios for when the system prompt may change in the chat
+buffer:
+
+- When a user changes adapter
+- When a user changes the model on an adapter
+- When a workspace is added
+
+CodeCompanion will always resolve a system prompt change asynchronously, as
+many adapters make a HTTP request to a server in order to obtain the available
+models. Refer to the config.lua
+<https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua>
+to see how the plugin accomplishes this.
 
 
 EXTENSIONS                            *codecompanion-configuration-extensions*

--- a/doc/configuration/system-prompt.md
+++ b/doc/configuration/system-prompt.md
@@ -4,40 +4,59 @@ The default system prompt has been carefully curated to deliver terse and profes
 
 The plugin comes with the following system prompt:
 
-```txt
-You are an AI programming assistant named "CodeCompanion". You are currently plugged in to the Neovim text editor on a user's machine.
+`````txt
+You are an AI programming assistant named "CodeCompanion", working within the Neovim text editor.
 
-Your core tasks include:
-- Answering general programming questions.
-- Explaining how the code in a Neovim buffer works.
-- Reviewing the selected code in a Neovim buffer.
-- Generating unit tests for the selected code.
-- Proposing fixes for problems in the selected code.
-- Scaffolding code for a new workspace.
-- Finding relevant code to the user's query.
-- Proposing fixes for test failures.
-- Answering questions about Neovim.
-- Running tools.
+You can answer general programming questions and perform the following tasks:
+* Answer general programming questions.
+* Explain how the code in a Neovim buffer works.
+* Review the selected code from a Neovim buffer.
+* Generate unit tests for the selected code.
+* Propose fixes for problems in the selected code.
+* Scaffold code for a new workspace.
+* Find relevant code to the user's query.
+* Propose fixes for test failures.
+* Answer questions about Neovim.
+* Running tools.
 
-You must:
-- Follow the user's requirements carefully and to the letter.
-- Keep your answers short and impersonal, especially if the user responds with context outside of your tasks.
-- Minimize other prose.
-- Use Markdown formatting in your answers.
-- Include the programming language name at the start of the Markdown code blocks.
-- Avoid including line numbers in code blocks.
-- Avoid wrapping the whole response in triple backticks.
-- Only return code that's relevant to the task at hand. You may not need to return all of the code that the user has shared.
-- Use actual line breaks instead of '\n' in your response to begin new lines.
-- Use '\n' only when you want a literal backslash followed by a character 'n'.
-- All non-code responses must be in %s.
+Follow the user's requirements carefully and to the letter.
+Use the context and attachments the user provides.
+Keep your answers short and impersonal, especially if the user's context is outside your core tasks.
+All non-code text responses must be written in the English language.
+Use Markdown formatting in your answers.
+Do not use H1 or H2 markdown headers.
+When suggesting code changes or new content, use Markdown code blocks.
+To start a code block, use 4 backticks.
+After the backticks, add the programming language name.
+If the code modifies an existing file or should be placed at a specific location, add a line comment with 'filepath:' and the file path.
+If you want the user to decide where to place the code, do not add the file path comment.
+In the code block, use a line comment with '...existing code...' to indicate code that is already present in the file.
+For code blocks use four backticks to start and end.
+Putting this all together:
+````languageId
+// filepath: /path/to/file
+// ...existing code...
+{ changed code }
+// ...existing code...
+{ changed code }
+// ...existing code...
+````
+Avoid wrapping the whole response in triple backticks.
+Do not include line numbers in code blocks.
+Multiple, different tools can be called as part of the same response.
 
 When given a task:
-1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.
-2. Output the code in a single code block, being careful to only return relevant code.
-3. You should always generate short suggestions for the next user turns that are relevant to the conversation.
-4. You can only give one reply for each conversation turn.
-```
+1. Think step-by-step and, unless the user requests otherwise or the task is very simple, describe your plan in detailed pseudocode.
+2. Output the final code in a single code block, ensuring that only relevant code is included.
+3. End your response with a short suggestion for the next user turn that directly supports continuing the conversation.
+4. Provide exactly one complete reply per conversation turn.
+5. If necessary, execute multiple tools in a single turn.
+
+The current date is August 28, 2025.
+The user's Neovim version is 0.12.0.
+The user is working on a Mac machine. Please respond with system specific commands if applicable.
+You use the GPT-4.1 large language model.
+`````
 
 ## Changing the System Prompt
 
@@ -46,10 +65,40 @@ The default system prompt can be changed with:
 ```lua
 require("codecompanion").setup({
   opts = {
+    system_prompt = "My new system prompt"
+  },
+}),
+```
+
+Alternatively, the system prompt can be a function. The `opts` parameter contains the default adapter for the chat strategy (`opts.adapter`) alongside the language (`opts.language`) that the LLM should respond with:
+
+```lua
+require("codecompanion").setup({
+  opts = {
+    ---@param opts { adapter: CodeCompanion.HTTPAdapter, language: string }
+    ---@return string
     system_prompt = function(opts)
-      return "My new system prompt"
+      local machine = vim.uv.os_uname().sysname
+      if machine == "Darwin" then
+        machine = "Mac"
+      end
+      if machine:find("Windows") then
+        machine = "Windows"
+      end
+
+      return string.format("I'm working on my %s machine", machine)
     end,
   },
 }),
 ```
-The `opts` parameter contains the default adapter for the chat strategy (`opts.adapter`) alongside the language (`opts.language`) that the LLM should respond with.
+
+
+## When the System Prompt Changes
+
+There are various scenarios for when the system prompt may change in the chat buffer:
+
+- When a user changes adapter
+- When a user changes the model on an adapter
+- When a workspace is added
+
+CodeCompanion will always resolve a system prompt change asynchronously, as many adapters make a HTTP request to a server in order to obtain the available models. Refer to the [config.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua) to see how the plugin accomplishes this.

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -533,14 +533,30 @@ return {
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
       default = "claude-sonnet-4-20250514",
       choices = {
-        ["claude-opus-4-20250514"] = { opts = { can_reason = true, has_vision = true } },
-        ["claude-sonnet-4-20250514"] = { opts = { can_reason = true, has_vision = true } },
+        ["claude-opus-4-20250514"] = {
+          nice_name = "Claude Opus 4",
+          opts = { can_reason = true, has_vision = true },
+        },
+        ["claude-sonnet-4-20250514"] = {
+          nice_name = "Claude Sonnet 4",
+          opts = { can_reason = true, has_vision = true },
+        },
         ["claude-3-7-sonnet-20250219"] = {
+          nice_name = "Claude 3.7 Sonnet",
           opts = { can_reason = true, has_vision = true, has_token_efficient_tools = true },
         },
-        ["claude-3-5-sonnet-20241022"] = { opts = { has_vision = true } },
-        ["claude-3-5-haiku-20241022"] = { opts = { has_vision = true } },
-        ["claude-3-opus-20240229"] = { opts = { has_vision = true } },
+        ["claude-3-5-sonnet-20241022"] = {
+          nice_name = "Claude Sonnet 3.5",
+          opts = { has_vision = true },
+        },
+        ["claude-3-5-haiku-20241022"] = {
+          nice_name = "Claude Haiku 3.5",
+          opts = { has_vision = true },
+        },
+        ["claude-3-opus-20240229"] = {
+          nice_name = "Claude Opus 3",
+          opts = { has_vision = true },
+        },
         "claude-2.1",
       },
     },

--- a/lua/codecompanion/adapters/http/copilot/helpers.lua
+++ b/lua/codecompanion/adapters/http/copilot/helpers.lua
@@ -95,7 +95,7 @@ function M.get_models(adapter, get_and_authorize_token_fn, authorize_token_fn)
         choice_opts.has_vision = true
       end
 
-      models[model.id] = { opts = choice_opts }
+      models[model.id] = { vendor = model.vendor, nice_name = model.name, opts = choice_opts }
     end
   end
 

--- a/lua/codecompanion/adapters/http/deepseek.lua
+++ b/lua/codecompanion/adapters/http/deepseek.lua
@@ -176,8 +176,8 @@ return {
       ---@type string|fun(): string
       default = "deepseek-reasoner",
       choices = {
-        ["deepseek-reasoner"] = { opts = { can_reason = true, can_use_tools = false } },
-        ["deepseek-chat"] = { opts = { can_use_tools = true } },
+        ["deepseek-reasoner"] = { nice_name = "DeepSeek", opts = { can_reason = true, can_use_tools = false } },
+        ["deepseek-chat"] = { nice_name = "DeepSeek", opts = { can_use_tools = true } },
       },
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -86,13 +86,16 @@ return {
       desc = "The model that will complete your prompt. See https://ai.google.dev/gemini-api/docs/models/gemini#model-variations for additional details and options.",
       default = "gemini-2.5-flash",
       choices = {
-        ["gemini-2.5-pro"] = { opts = { can_reason = true, has_vision = true } },
-        ["gemini-2.5-flash"] = { opts = { can_reason = true, has_vision = true } },
-        ["gemini-2.5-flash-preview-05-20"] = { opts = { can_reason = true, has_vision = true } },
-        ["gemini-2.0-flash"] = { opts = { has_vision = true } },
-        ["gemini-2.0-flash-lite"] = { opts = { has_vision = true } },
-        ["gemini-1.5-pro"] = { opts = { has_vision = true } },
-        ["gemini-1.5-flash"] = { opts = { has_vision = true } },
+        ["gemini-2.5-pro"] = { nice_name = "Gemini 2.5 Pro", opts = { can_reason = true, has_vision = true } },
+        ["gemini-2.5-flash"] = { nice_name = "Gemini 2.5 Flash", opts = { can_reason = true, has_vision = true } },
+        ["gemini-2.5-flash-preview-05-20"] = {
+          nice_name = "Gemini 2.5 Flash Preview",
+          opts = { can_reason = true, has_vision = true },
+        },
+        ["gemini-2.0-flash"] = { nice_name = "Gemini 2.0 Flash", opts = { has_vision = true } },
+        ["gemini-2.0-flash-lite"] = { nice_name = "Gemini 2.0 Flash Lite", opts = { has_vision = true } },
+        ["gemini-1.5-pro"] = { nice_name = "Gemini 1.5 Pro", opts = { has_vision = true } },
+        ["gemini-1.5-flash"] = { nice_name = "Gemini 1.5 Flash", opts = { has_vision = true } },
       },
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -17,7 +17,7 @@ local shared = require("codecompanion.adapters.shared")
 ---@field temp? table A table to store temporary values which are not passed to the request
 ---@field raw? table Any additional curl arguments to pass to the request
 ---@field opts? table Additional options for the adapter
----@field model? { name: string, opts: table } The model to use for the request
+---@field model? { name: string, nice_name?: string, vendor?: string, opts: table } The model to use for the request
 ---@field handlers table Functions which link the output from the request to CodeCompanion
 ---@field handlers.setup? fun(self: CodeCompanion.HTTPAdapter): boolean
 ---@field handlers.set_body? fun(self: CodeCompanion.HTTPAdapter, data: table): table|nil

--- a/lua/codecompanion/adapters/http/ollama.lua
+++ b/lua/codecompanion/adapters/http/ollama.lua
@@ -67,7 +67,7 @@ local function get_models(self, opts)
       proxy = config.adapters.http.opts.proxy,
       body = vim.json.encode({ model = model_obj.name }),
       callback = function(output)
-        models[model_obj.name] = { opts = {} }
+        models[model_obj.name] = { nice_name = model_obj.name, opts = {} }
         if output.status == 200 then
           local ok, model_info_json = pcall(vim.json.decode, output.body, { array = true, object = true })
           if ok then
@@ -89,6 +89,7 @@ local function get_models(self, opts)
   if opts and opts.last and latest_model then
     return latest_model.name
   end
+
   return models
 end
 

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -331,18 +331,50 @@ return {
         -- gpt-5 and gpt-5-mini (but not gpt-5-nano) require organizational
         -- verification with biometric data when streaming is enabled:
         -- https://news.ycombinator.com/item?id=44837367
-        ["gpt-5"] = { opts = { has_vision = true, can_reason = true, stream = false } },
-        ["gpt-5-mini"] = { opts = { has_vision = true, can_reason = true, stream = false } },
-        ["gpt-5-nano"] = { opts = { has_vision = true, can_reason = true, stream = true } },
-
-        ["o4-mini-2025-04-16"] = { opts = { has_vision = true, can_reason = true } },
-        ["o3-mini-2025-01-31"] = { opts = { can_reason = true } },
-        ["o3-2025-04-16"] = { opts = { has_vision = true, can_reason = true } },
-        ["o1-2024-12-17"] = { opts = { has_vision = true, can_reason = true } },
-        ["gpt-4.1"] = { opts = { has_vision = true } },
-        ["gpt-4o"] = { opts = { has_vision = true } },
-        ["gpt-4o-mini"] = { opts = { has_vision = true } },
-        ["gpt-4-turbo-preview"] = { opts = { has_vision = true } },
+        ["gpt-5"] = {
+          nice_name = "GPT 5",
+          opts = { has_vision = true, can_reason = true, stream = false },
+        },
+        ["gpt-5-mini"] = {
+          nice_name = "GPT 5 Mini",
+          opts = { has_vision = true, can_reason = true, stream = false },
+        },
+        ["gpt-5-nano"] = {
+          nice_name = "GPT 5 Nano",
+          opts = { has_vision = true, can_reason = true, stream = true },
+        },
+        ["o4-mini-2025-04-16"] = {
+          nice_name = "o4 Mini",
+          opts = { has_vision = true, can_reason = true },
+        },
+        ["o3-mini-2025-01-31"] = {
+          nice_name = "o3 Mini",
+          opts = { can_reason = true },
+        },
+        ["o3-2025-04-16"] = {
+          nice_name = "o3",
+          opts = { has_vision = true, can_reason = true },
+        },
+        ["o1-2024-12-17"] = {
+          nice_name = "o1",
+          opts = { has_vision = true, can_reason = true },
+        },
+        ["gpt-4.1"] = {
+          nice_name = "GPT 4.1",
+          opts = { has_vision = true },
+        },
+        ["gpt-4o"] = {
+          nice_name = "GPT-4o",
+          opts = { has_vision = true },
+        },
+        ["gpt-4o-mini"] = {
+          nice_name = "GPT-4o Mini",
+          opts = { has_vision = true },
+        },
+        ["gpt-4-turbo-preview"] = {
+          nice_name = "GPT-4 Turbo Preview",
+          opts = { has_vision = true },
+        },
         "gpt-4",
         "gpt-3.5-turbo",
       },

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -755,7 +755,7 @@ function Chat:apply_model(model)
 
   self.adapter.schema.model.default = model
   self.adapter = adapters.set_model(self.adapter)
-  self:update_metadata()
+  self:add_system_prompt()
 
   return self
 end
@@ -802,14 +802,15 @@ function Chat:add_system_prompt(prompt, opts)
     return self
   end
 
-  opts = opts or { visible = false, tag = "from_config" }
+  prompt = prompt or config.opts.system_prompt
+  opts = opts or { visible = false, tag = "system_prompt_from_config" }
 
-  -- Don't add the same system prompt twice
+  -- If the system prompt already exists, update it
   if has_tag(opts.tag, self.messages) then
-    return self
+    self:remove_tagged_message(opts.tag)
   end
 
-  -- Get the index of the last system prompt
+  -- Workout in the message stack the last system prompt is
   local index
   if not opts.index then
     for i = #self.messages, 1, -1 do
@@ -820,18 +821,16 @@ function Chat:add_system_prompt(prompt, opts)
     end
   end
 
-  prompt = prompt or config.opts.system_prompt
-  if prompt ~= "" then
-    if type(prompt) == "function" then
-      prompt = prompt({
-        adapter = self.adapter,
-        language = config.opts.language,
-      })
+  ---Add a system prompt to the messages table
+  ---@param p string
+  ---@return nil
+  local function insert_prompt(p)
+    if not p or p == "" then
+      return
     end
-
     local system_prompt = {
       role = config.constants.SYSTEM_ROLE,
-      content = prompt,
+      content = p,
     }
     system_prompt.id = make_id(system_prompt)
     system_prompt.cycle = self.cycle
@@ -839,6 +838,38 @@ function Chat:add_system_prompt(prompt, opts)
 
     table.insert(self.messages, index or 1, system_prompt)
   end
+
+  -- If prompt is a function, then resolve it asynchronously. This is because
+  -- some adapters, like Copilot, need to make a HTTP request to fetch the
+  -- models and other metadata that the system prompt func will need.
+  if type(prompt) == "function" or prompt == nil then
+    local a = require("codecompanion.utils.async")
+
+    local compute_prompt = a.wrap(function(cb)
+      vim.schedule(function()
+        local ok, out = pcall(prompt, {
+          adapter = self.adapter,
+          language = config.opts.language,
+        })
+        if not ok then
+          log:error("Error inserting the system prompt: %s", out)
+        end
+        cb(out)
+      end)
+    end)
+
+    a.sync(function()
+      local text = a.wait(compute_prompt())
+      a.wait(function(cb)
+        vim.schedule(cb)
+      end)
+      insert_prompt(text)
+    end)()
+
+    return self
+  end
+
+  insert_prompt(prompt)
   return self
 end
 
@@ -849,11 +880,11 @@ function Chat:toggle_system_prompt()
     vim.tbl_map(function(msg)
       return msg.opts.tag
     end, self.messages),
-    "from_config"
+    "system_prompt_from_config"
   )
 
   if has_system_prompt then
-    self:remove_tagged_message("from_config")
+    self:remove_tagged_message("system_prompt_from_config")
     util.notify("Removed system prompt")
   else
     self:add_system_prompt()

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -176,10 +176,8 @@ function SlashCommand:output(selected_group, opts)
     return g.name == selected_group
   end, self.workspace.groups)[1]
 
-  if group.opts then
-    if group.opts.remove_config_system_prompt then
-      self.Chat:remove_tagged_message("from_config")
-    end
+  if group.opts and group.opts.remove_config_system_prompt then
+    self.Chat:remove_tagged_message("system_prompt_from_config")
   end
 
   -- Add the system prompts

--- a/lua/codecompanion/utils/adapters.lua
+++ b/lua/codecompanion/utils/adapters.lua
@@ -338,4 +338,84 @@ function M.map_roles(roles, messages)
   return messages
 end
 
+---Get the currently selected model from the adapter
+---This is a little b*tch because of how the schema is strutured for adapters.
+---At some point I should refactor this to be less painful.
+---@param adapter CodeCompanion.HTTPAdapter
+---@param opts? table
+function M.get_model(adapter, opts)
+  if not adapter then
+    return nil
+  end
+  opts = opts or {}
+  local resolve_choices = opts.resolve_choices == true
+
+  local schema = adapter.schema or {}
+  local model_schema = schema.model
+  if not model_schema then
+    return adapter.model
+  end
+
+  -- Resolve current model name (cheap)
+  local name = model_schema.default
+  if type(name) == "function" then
+    name = name(adapter)
+  end
+  if not name and adapter.model and adapter.model.name then
+    name = adapter.model.name
+  end
+  if not name then
+    return nil
+  end
+
+  local out = { name = name, opts = nil }
+
+  -- If set_model already populated opts (and we're not forcing a blocking resolve), use it
+  if adapter.model and adapter.model.opts and not resolve_choices then
+    out.opts = adapter.model.opts
+    if adapter.model.nice_name then
+      out.nice_name = adapter.model.nice_name
+    end
+    if adapter.model.vendor then
+      out.vendor = adapter.model.vendor
+    end
+    return out
+  end
+
+  local function hoist_meta(entry)
+    if type(entry) ~= "table" then
+      return
+    end
+    out.opts = entry.opts or entry
+    -- If entry has a separate opts table, lift other keys (e.g., nice_name, vendor)
+    if entry.opts then
+      for k, v in pairs(entry) do
+        if k ~= "opts" and out[k] == nil then
+          out[k] = v
+        end
+      end
+    end
+  end
+
+  local choices = model_schema.choices
+
+  -- Static choices: O(1) lookup, no network
+  if type(choices) == "table" then
+    if not (vim.islist or vim.tbl_islist)(choices) then
+      hoist_meta(choices[name])
+    end
+    return out
+  end
+
+  -- Blocking resolve for dynamic choices (e.g., Copilot)
+  if resolve_choices and type(choices) == "function" then
+    local resolved = choices(adapter) -- may block (Copilot)
+    if type(resolved) == "table" and not (vim.islist or vim.tbl_islist)(resolved) then
+      hoist_meta(resolved[name])
+    end
+  end
+
+  return out
+end
+
 return M

--- a/lua/codecompanion/utils/async.lua
+++ b/lua/codecompanion/utils/async.lua
@@ -1,0 +1,90 @@
+-- Credit: ms-jpq/lua-async-await:
+-- https://github.com/ms-jpq/lua-async-await/blob/neo/lua/async.lua
+
+--#################### ############ ####################
+--#################### Async Region ####################
+--#################### ############ ####################
+
+local co = coroutine
+local unpack = table.unpack or unpack
+
+-- use with wrap
+local pong = function(func, callback)
+  assert(type(func) == "function", "type error :: expected func")
+  local thread = co.create(func)
+  local step = nil
+  step = function(...)
+    local pack = { co.resume(thread, ...) }
+    local status = pack[1]
+    local ret = pack[2]
+    assert(status, ret)
+    if co.status(thread) == "dead" then
+      if callback then
+        (function(_, ...)
+          callback(...)
+        end)(unpack(pack))
+      end
+    else
+      assert(type(ret) == "function", "type error :: expected func - coroutine yielded some value")
+      ret(step)
+    end
+  end
+  step()
+end
+
+-- use with pong, creates thunk factory
+local wrap = function(func)
+  assert(type(func) == "function", "type error :: expected func")
+  local factory = function(...)
+    local params = { ... }
+    local thunk = function(step)
+      table.insert(params, step)
+      return func(unpack(params))
+    end
+    return thunk
+  end
+  return factory
+end
+
+-- many thunks -> single thunk
+local join = function(thunks)
+  local len = #thunks
+  local done = 0
+  local acc = {}
+
+  local thunk = function(step)
+    if len == 0 then
+      return step()
+    end
+    for i, tk in ipairs(thunks) do
+      assert(type(tk) == "function", "thunk must be function")
+      local callback = function(...)
+        acc[i] = { ... }
+        done = done + 1
+        if done == len then
+          step(unpack(acc))
+        end
+      end
+      tk(callback)
+    end
+  end
+  return thunk
+end
+
+-- sugar over coroutine
+local await = function(defer)
+  assert(type(defer) == "function", "type error :: expected func")
+  return co.yield(defer)
+end
+
+local await_all = function(defer)
+  assert(type(defer) == "table", "type error :: expected table")
+  return co.yield(join(defer))
+end
+
+return {
+  sync = wrap(pong),
+  wait = await,
+  wait_all = await_all,
+  wrap = wrap,
+}

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,5 +1,3 @@
-local log = require("codecompanion.utils.log")
-
 local Helpers = {}
 
 Helpers = vim.tbl_extend("error", Helpers, require("tests.expectations"))

--- a/tests/strategies/chat/slash_commands/test_workspace.lua
+++ b/tests/strategies/chat/slash_commands/test_workspace.lua
@@ -115,18 +115,18 @@ T["Workspace"]["top-level prompts are not duplicated and are ordered correctly"]
   workspace_json = vim.json.decode(table.concat(vim.fn.readfile("tests/stubs/workspace_multiple.json"), ""))
 
   child.lua([[
-  _G.set_workspace("tests/stubs/workspace_multiple.json")
+    _G.set_workspace("tests/stubs/workspace_multiple.json")
   ]])
 
   child.lua([[
-  _G.wks:output("Test 1")
-  _G.wks:output("Test 2")
+    _G.wks:output("Test 1")
+    _G.wks:output("Test 2")
   ]])
 
   local messages = child.lua_get([[_G.chat.messages]])
 
-  h.eq(workspace_json.system_prompt, messages[1].content)
-  h.eq(workspace_json.groups[1].system_prompt, messages[2].content)
+  h.eq(workspace_json.groups[1].system_prompt, messages[1].content)
+  h.eq(workspace_json.system_prompt, messages[2].content)
   h.eq(workspace_json.groups[2].system_prompt, messages[3].content)
   h.expect_starts_with(workspace_json.data["test1-file"].description, messages[4].content)
 end

--- a/tests/stubs/messages.lua
+++ b/tests/stubs/messages.lua
@@ -4,7 +4,7 @@ local messages = {
     cycle = 1,
     id = 126646444,
     opts = {
-      tag = "from_config",
+      tag = "system_prompt_from_config",
       visible = false,
     },
     role = "system",

--- a/tests/stubs/workspace_multiple.json
+++ b/tests/stubs/workspace_multiple.json
@@ -2,7 +2,7 @@
   "name": "Workspace Example - When combining multiple workspace files",
   "version": "1.0.0",
   "workspace_spec": "1.0",
-  "system_prompt": "Workspace Multiple Example Prompt",
+  "system_prompt": "System Prompt for Workspace Multiple Example Prompt",
   "groups": [
     {
       "name": "Test 1",


### PR DESCRIPTION
## Description


The new system prompt contains information about the user's machine, the LLM they're working with and the current date. It has also been updated to instruct an LLM to use four backticks instead of three to prevent any issues with markdown code. Preventing the use of H1 and H2 is now a key line item.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
