### PR TITLE
feat(slash_cmd): workspaces can now take user prompts

### DIFF
--- a/codecompanion-workspace.json
+++ b/codecompanion-workspace.json
@@ -1,22 +1,16 @@
 {
   "name": "CodeCompanion.nvim",
   "version": "1.0.0",
-  "system_prompt": "CodeCompanion.nvim is an AI-powered productivity tool that seamlessly integrates large language models (LLMs) into the Neovim editing experience. The plugin is built around three core strategies: **Chat** (conversational interface), **Inline** (direct code generation), and **Tools** (tool execution).\n\n**Architecture Philosophy:**\n- **Adapter Pattern**: Unified interface for multiple LLM providers (OpenAI, Anthropic, Google Gemini, etc.)\n- **Strategy Pattern**: Different interaction modes (chat, inline, tools) with shared infrastructure\n- **Builder Pattern**: Complex UI operations broken into composable, testable components\n- **Event-Driven**: Extensible through subscribers, watchers, and workflows\n\n**Key Components:**\n- **Chat Buffer**: Markdown-formatted conversational interface with Tree-sitter parsing\n- **Adapters**: LLM-specific handlers for requests, responses, and capabilities\n- **Tools**: Function calling system for LLM-driven automation\n- **Variables & Context**: Context injection system for enhanced prompts\n- **Workflows**: Automated prompt chaining and response processing\n\n**Testing & Quality:**\nExtensively tested using Mini.Test with both unit tests and visual regression testing through screenshots. The codebase emphasizes maintainability through clear separation of concerns, comprehensive error handling, and modular design patterns that make extending functionality straightforward.",
+  "description": "CodeCompanion.nvim is an AI-powered productivity tool that seamlessly integrates large language models (LLMs) into the Neovim editing experience. The plugin is built around three core strategies: **Chat** (conversational interface), **Inline** (direct code generation), and **Tools** (tool execution).\n\n**Architecture Philosophy:**\n- **Adapter Pattern**: Unified interface for multiple LLM providers (OpenAI, Anthropic, Google Gemini, etc.)\n- **Strategy Pattern**: Different interaction modes (chat, inline, tools) with shared infrastructure\n- **Builder Pattern**: Complex UI operations broken into composable, testable components\n- **Event-Driven**: Extensible through subscribers, watchers, and workflows\n\n**Key Components:**\n- **Chat Buffer**: Markdown-formatted conversational interface with Tree-sitter parsing\n- **Adapters**: LLM-specific handlers for requests, responses, and capabilities\n- **Tools**: Function calling system for LLM-driven automation\n- **Variables & Context**: Context injection system for enhanced prompts\n- **Workflows**: Automated prompt chaining and response processing\n\n**Testing & Quality:**\nExtensively tested using Mini.Test with both unit tests and visual regression testing through screenshots. The codebase emphasizes maintainability through clear separation of concerns, comprehensive error handling, and modular design patterns that make extending functionality straightforward.",
   "groups": [
     {
       "name": "Chat Buffer",
-      "system_prompt": "I've grouped a number of files together into a group I'm calling \"${group_name}\". The chat buffer is a Neovim buffer which allows a user to interact with an LLM. The buffer is formatted as Markdown with a user's content residing under a H2 header. The user types their message, saves the buffer and the plugin then uses Tree-sitter to parse the buffer, extracting the contents and sending to an adapter which connects to the user's chosen LLM. The response back from the LLM is streamed into the buffer under another H2 header. The user is then free to respond back to the LLM.\n\nBelow are the relevant files which we will be discussing:\n\n${group_files}",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
+      "description": "I've grouped a number of files together into a group I'm calling \"${group_name}\". The chat buffer is a Neovim buffer which allows a user to interact with an LLM. The buffer is formatted as Markdown with a user's content residing under a H2 header. The user types their message, saves the buffer and the plugin then uses Tree-sitter to parse the buffer, extracting the contents and sending to an adapter which connects to the user's chosen LLM. The response back from the LLM is streamed into the buffer under another H2 header. The user is then free to respond back to the LLM.\n\nBelow are the relevant files which we will be discussing:\n\n${group_files}",
       "data": ["chat-buffer-init", "chat-messages"]
     },
     {
       "name": "Chat UI",
-      "system_prompt": "The Chat UI group contains the files responsible for rendering and formatting content in the chat buffer. This includes the message builder pattern that coordinates how different types of content (tool output, reasoning, standard messages) are formatted and displayed to the user.\n\nKey components:\n1. **Builder Pattern**: The main orchestrator that handles the flow of adding headers, formatting content, and writing to the buffer with centralized state management\n2. **Formatters**: Specialized classes that handle different message types (tools, reasoning, standard content)\n3. **UI Management**: Methods for handling buffer operations, folding, and visual presentation\n4. **State Management**: Rich formatting state objects that track role changes, content transitions, and section boundaries\n5. **Section Detection**: Logic for identifying when new sections are needed (e.g., LLM message → tool output transitions)\n\nThe files to analyze are:\n${group_files}",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
+      "description": "The Chat UI group contains the files responsible for rendering and formatting content in the chat buffer. This includes the message builder pattern that coordinates how different types of content (tool output, reasoning, standard messages) are formatted and displayed to the user.\n\nKey components:\n1. **Builder Pattern**: The main orchestrator that handles the flow of adding headers, formatting content, and writing to the buffer with centralized state management\n2. **Formatters**: Specialized classes that handle different message types (tools, reasoning, standard content)\n3. **UI Management**: Methods for handling buffer operations, folding, and visual presentation\n4. **State Management**: Rich formatting state objects that track role changes, content transitions, and section boundaries\n5. **Section Detection**: Logic for identifying when new sections are needed (e.g., LLM message → tool output transitions)\n\nThe files to analyze are:\n${group_files}",
       "data": [
         "chat-ui-builder",
         "chat-ui-formatters-base",
@@ -31,9 +25,6 @@
     {
       "name": "Workflows",
       "system_prompt": "Within the plugin, workflows are a way for users to be able to automatically send or chain multiple prompts, sequentially, to an LLM. They do this by \"subscribing\" to a chat buffer.\n\nFocus on:\n 1. How workflows integrate with the chat buffer\n2. How they can be refactored\n3. How they can work better with the chat buffer itself.\n\nThe files to analyze are:\n${group_files}",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
       "data": [
         "strategies-init",
         "chat-subscribers",
@@ -44,17 +35,11 @@
     {
       "name": "Tests",
       "system_prompt": "The plugin uses a testing framework called Mini.Test. The tests are written in Lua and are located in the `tests` directory. The tests are run using the `make test` command. The tests are written in a BDD style and are used to ensure the plugin is functioning as expected.",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
       "data": ["test-helpers", "minitest-docs", "test-screenshot-example"]
     },
     {
       "name": "Adapters",
       "system_prompt": "In the CodeCompanion plugin, adapters are used to connect to LLMs or Agents. HTTP adapters contain various options for the LLM's endpoint alongside a defined schema for properties such as the model, temperature, top k, top p etc. HTTP adapters also contain various handler functions which define how messages which are sent to the LLM should be formatted alongside how output from the LLM should be received and displayed in the chat buffer. The adapters are defined in the `adapters` directory.",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
       "data": [
         "adapters-init",
         "adapters-shared",
@@ -66,9 +51,6 @@
     {
       "name": "Inline",
       "system_prompt": "In the CodeCompanion plugin, the inline strategy allows user's to prompt LLMs to write code directly into a Neovim buffer. To make the experience as smooth as possible, the user can just send a prompt like 'refactor this class' and the LLM will generate code to answer the question, alongside providing a determination on where to place the code. This is called the placement.",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
       "data": [
         "inline-init",
         "http-client",
@@ -80,9 +62,6 @@
     {
       "name": "Tools",
       "system_prompt": "In the CodeCompanion plugin, tools can be leveraged by an LLM to execute lua functions or shell commands on the users machine. CodeCompanion uses an LLM's native function calling to receive a response in JSON, parse the response and call the corresponding tool. This feature has been implemented via the tools/init.lua file, which passes all of the tools and adds them to a queue. Then those tools are run consecutively by the orchestrator.lua file.",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
       "data": [
         "tool-system-init",
         "orchestrator",
@@ -96,9 +75,6 @@
     {
       "name": "ACP Integration",
       "system_prompt": "This group covers the ACP (Agent Communication Protocol) integration in CodeCompanion.nvim. ACP enables session-based, schema-driven communication with LLM agents, supporting authentication, streaming responses, tool calls, and permission handling. Key components:\n\n- **ACPAdapter**: Encapsulates ACP-specific logic for agent communication.\n- **ACPConnection**: Manages agent process, session lifecycle, authentication, and streaming.\n- **PromptBuilder**: Fluent API for sending prompts and handling streamed responses, tool calls, and errors.\n- **Chat Buffer**: Parses user messages, submits prompts via ACP, and streams agent responses into the buffer.\n\nRelevant files:\n- `lua/codecompanion/acp.lua` (ACPConnection, PromptBuilder)\n- `lua/codecompanion/adapters/acp/init.lua` (ACPAdapter)\n- `lua/codecompanion/strategies/chat/init.lua` (Chat Buffer logic)\n- [ACP JSON Schema](.codecompanion/acp_json_schema.json) (for schema awareness)\n\nRefer to the ACP documentation for message flow, schema types, and extensibility.",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
       "data": [
         "acp-implementation-notes",
         "acp-schema",

--- a/doc/extending/workspace.md
+++ b/doc/extending/workspace.md
@@ -14,14 +14,11 @@ The exact JSON schema for a workspace file can be seen [here](https://github.com
 {
   "name": "CodeCompanion.nvim",
   "version": "1.0.0",
-  "system_prompt": "CodeCompanion.nvim is an AI-powered productivity tool integrated into Neovim, designed to enhance the development workflow by seamlessly interacting with various large language models (LLMs). It offers features like inline code transformations, code creation, refactoring, and supports multiple LLMs such as OpenAI, Anthropic, and Google Gemini, among others. With tools for variable management, agents, and custom workflows, CodeCompanion.nvim streamlines coding tasks and facilitates intelligent code assistance directly within the Neovim editor.",
+  "description": "CodeCompanion.nvim is an AI-powered productivity tool integrated into Neovim, designed to enhance the development workflow by seamlessly interacting with various large language models (LLMs). It offers features like inline code transformations, code creation, refactoring, and supports multiple LLMs such as OpenAI, Anthropic, and Google Gemini, among others. With tools for variable management, agents, and custom workflows, CodeCompanion.nvim streamlines coding tasks and facilitates intelligent code assistance directly within the Neovim editor.",
   "groups": [
     {
       "name": "Chat Buffer",
-      "system_prompt": "I've grouped a number of files together into a group I'm calling \"${group_name}\". The chat buffer is a Neovim buffer which allows a user to interact with an LLM. The buffer is formatted as Markdown with a user's content residing under a H2 header. The user types their message, saves the buffer and the plugin then uses Tree-sitter to parse the buffer, extracting the contents and sending to an adapter which connects to the user's chosen LLM. The response back from the LLM is streamed into the buffer under another H2 header. The user is then free to respond back to the LLM.\n\nBelow are the relevant files which we will be discussing:\n\n${group_files}",
-      "opts": {
-        "remove_config_system_prompt": true
-      },
+      "description": "I've grouped a number of files together into a group I'm calling \"${group_name}\". The chat buffer is a Neovim buffer which allows a user to interact with an LLM. The buffer is formatted as Markdown with a user's content residing under a H2 header. The user types their message, saves the buffer and the plugin then uses Tree-sitter to parse the buffer, extracting the contents and sending to an adapter which connects to the user's chosen LLM. The response back from the LLM is streamed into the buffer under another H2 header. The user is then free to respond back to the LLM.\n\nBelow are the relevant files which we will be discussing:\n\n${group_files}",
       "data": ["chat-buffer-init", "chat-context", "chat-watchers"]
     },
   ],
@@ -45,11 +42,14 @@ The exact JSON schema for a workspace file can be seen [here](https://github.com
 }
 ```
 
-- The `system_prompt` value contains the prompt that will be sent to the LLM as a system prompt
+- The `description` value contains the prompt that will be sent to the LLM as a user.
 - The `groups` array contains the grouping of data that will be shared with the LLM.
-- The `data` object contains the files that will be shared as part of the group
+- The `data` object contains the files that will be shared as part of the group.
 
-When a user leverages the workspace slash command in the chat buffer, the high-level system prompt is added as a message, followed by the system prompt from the group. After that, the individual items in the data array on the group are added along with their descriptions as a regular user prompt.
+> [!TIP]
+> Use `description` to add a user prompt to the chat buffer or `system_prompt` to add it as a system prompt.
+
+When a user leverages the workspace slash command in the chat buffer, the high-level _description_ or _system prompt_ is added as a message, followed by the _description_ or _system prompt_ from the group. After that, the individual items in the data array on the group are added along with their descriptions as a regular user prompt.
 
 ## Groups
 

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -180,10 +180,16 @@ function SlashCommand:output(selected_group, opts)
     self.Chat:remove_tagged_message("system_prompt_from_config")
   end
 
-  -- Add the system prompts
+  -- Add the high-level prompts first
   if self.workspace.system_prompt then
     self.Chat:add_system_prompt(
       replace_vars(self.workspace, group, self.workspace.system_prompt),
+      { visible = false, tag = self.workspace.name .. " // Workspace" }
+    )
+  end
+  if self.workspace.description then
+    self.Chat:add_message(
+      { role = config.constants.USER_ROLE, content = replace_vars(self.workspace, group, self.workspace.description) },
       { visible = false, tag = self.workspace.name .. " // Workspace" }
     )
   end

--- a/lua/codecompanion/workspace-schema.json
+++ b/lua/codecompanion/workspace-schema.json
@@ -3,7 +3,14 @@
   "title": "CodeCompanion.nvim workspace configuration file",
   "description": "Schema for a CodeCompanion.nvim workspace configuration file. A workspace is a collection of groups which relate to functionality in a codebase",
   "type": "object",
-  "required": ["name", "version", "system_prompt", "groups", "data"],
+  "required": [
+    "name",
+    "version",
+    "description",
+    "system_prompt",
+    "groups",
+    "data"
+  ],
   "properties": {
     "name": {
       "type": "string",
@@ -12,6 +19,10 @@
     "version": {
       "type": "string",
       "description": "Version of the workspace file. Allows teams to know if there have been any changes to the file"
+    },
+    "description": {
+      "type": "string",
+      "description": "The default user prompt that's sent to an LLM when a workspace group is selected"
     },
     "system_prompt": {
       "type": "string",
@@ -29,11 +40,15 @@
       "description": "A group is a collection of objects from the data object in this schema, which relate to features and functionality in the codebase",
       "items": {
         "type": "object",
-        "required": ["name", "system_prompt", "data"],
+        "required": ["name", "description", "system_prompt", "data"],
         "properties": {
           "name": {
             "type": "string",
             "description": "The name of the group"
+          },
+          "description": {
+            "type": "string",
+            "description": "The user prompt specific to the group that is shared with an LLM when the group is selected"
           },
           "system_prompt": {
             "type": "string",

--- a/tests/strategies/chat/slash_commands/test_workspace.lua
+++ b/tests/strategies/chat/slash_commands/test_workspace.lua
@@ -60,7 +60,7 @@ T["Workspace"]["system prompts are added in the correct order along with a group
   h.eq(workspace_json.system_prompt, messages[2].content)
   h.eq(workspace_json.groups[1].system_prompt, messages[3].content)
 
-  h.eq(workspace_json.groups[1].description, messages[4].content)
+  h.eq(workspace_json.groups[1].description, messages[5].content)
 end
 
 T["Workspace"]["can remove the default system prompt"] = function()
@@ -73,6 +73,17 @@ T["Workspace"]["can remove the default system prompt"] = function()
 
   h.eq(workspace_json.system_prompt, messages[1].content)
   h.eq(workspace_json.groups[2].system_prompt, messages[2].content)
+end
+
+T["Workspace"]["can add workspace descriptions"] = function()
+  child.lua([[
+  _G.set_workspace()
+  _G.wks:output("Test")
+  ]])
+
+  local messages = child.lua_get([[_G.chat.messages]])
+
+  h.eq(workspace_json.description, messages[4].content)
 end
 
 T["Workspace"]["files and symbols are added to the chat"] = function()
@@ -89,11 +100,11 @@ T["Workspace"]["files and symbols are added to the chat"] = function()
 
   h.eq(
     'Test description for the file stub.go located at tests/stubs/stub.go\n\n```go\nimport (\n\t"math"\n)\n\ntype ExampleStruct struct {\n\tValue float64\n}\n\nfunc (e ExampleStruct) Compute() float64 {\n\treturn math.Sqrt(e.Value)\n}\n\n\n```',
-    messages[5].content
+    messages[6].content
   )
   h.expect_starts_with(
     "Test symbol description for the file stub.lua located at tests/stubs/stub.lua",
-    messages[6].content
+    messages[7].content
   )
 end
 
@@ -108,7 +119,7 @@ T["Workspace"]["can open a file as a buffer if it's already open"] = function()
 
   local messages = child.lua_get([[_G.chat.messages]])
 
-  h.expect_starts_with([[Test description for the file stub.go located at tests/stubs/stub.go]], messages[5].content)
+  h.expect_starts_with([[Test description for the file stub.go located at tests/stubs/stub.go]], messages[6].content)
 end
 
 T["Workspace"]["top-level prompts are not duplicated and are ordered correctly"] = function()

--- a/tests/stubs/workspace.json
+++ b/tests/stubs/workspace.json
@@ -2,6 +2,7 @@
   "name": "CodeCompanion.nvim",
   "version": "1.0.0",
   "workspace_spec": "1.0",
+  "description": "High-level description",
   "system_prompt": "Workspace system prompt",
   "groups": [
     {


### PR DESCRIPTION
## Description

Previously, only system prompts existed at the top of a workspace. This PR ensures that users can use `description` to add high-level information as a user prompt instead.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
