### PR TITLE
chore(slash_cmds): add error logging

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/helpers.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/helpers.lua
@@ -1,4 +1,5 @@
 local Path = require("plenary.path")
+local log = require("codecompanion.utils.log")
 
 local M = {}
 
@@ -43,6 +44,7 @@ function M.extract_file_symbols(filepath, target_kinds)
   end)
 
   if not ok then
+    log:error("[chat::slash_commands::helpers] Could not read the file at %s", filepath)
     return nil, nil
   end
 
@@ -51,7 +53,11 @@ function M.extract_file_symbols(filepath, target_kinds)
     return nil, content
   end
 
-  local parser = vim.treesitter.get_string_parser(content, ft)
+  local ok, parser = pcall(vim.treesitter.get_string_parser, content, ft)
+  if not ok then
+    log:error("[chat::slash_commands::helpers] Failed to get parser for %s", ft)
+    return nil, content
+  end
   local tree = parser:parse()[1]
 
   local symbols = {}


### PR DESCRIPTION
## Description

If the user doesn't have the parser installed, throw an error.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
