### PR TITLE
refactor(adapters): use blocking calls for debug and keymaps

### DIFF
--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -93,7 +93,7 @@ function Debug:render()
 
   if adapter.schema and adapter.schema.model then
     if type(adapter.schema.model.choices) == "function" then
-      models = adapter.schema.model.choices(adapter)
+      models = adapter.schema.model.choices(adapter, { async = false })
     else
       models = adapter.schema.model.choices
     end

--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -590,7 +590,7 @@ M.change_adapter = {
           models = { chat.adapter.schema.model.default }
         end
         if type(models) == "function" then
-          models = models(chat.adapter)
+          models = models(chat.adapter, { async = false })
         end
         if not models or vim.tbl_count(models) < 2 then
           return


### PR DESCRIPTION
## Description

For changing of adapters and the debug window, we shouldn't be making asynchronous calls.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
