### PR TITLE
refactor(adapters): fetch copilot models async at resolve

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -1,6 +1,5 @@
 local Curl = require("plenary.curl")
 
-local adapters = require("codecompanion.utils.adapters")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local token = require("codecompanion.adapters.http.copilot.token")
@@ -21,13 +20,21 @@ local M = {}
 local _cached_models
 local _cached_adapter
 local _cache_expires
-local _cache_file = vim.fn.tempname()
 local _fetch_in_progress = false
 
 ---Reset the cache
 ---@return nil
 function M.reset_cache()
   _cached_adapter = nil
+end
+
+---Refresh the cache expiry timestamp
+---@param seconds number|nil Number of seconds until the cache expires. Default: 1800
+---@return number
+local function set_cache_expiry(seconds)
+  seconds = seconds or 1800
+  _cache_expires = os.time() + seconds
+  return _cache_expires
 end
 
 ---Return cached models if the cache is still valid.
@@ -105,7 +112,7 @@ local function fetch_async(adapter)
         end
 
         _cached_models = models
-        _cache_expires = adapters.refresh_cache(_cache_file, config.adapters.http.opts.cache_models_for)
+        set_cache_expiry(config.adapters.http.opts.cache_models_for)
       end),
     })
   end)

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -4,7 +4,6 @@ local adapters = require("codecompanion.utils.adapters")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local token = require("codecompanion.adapters.http.copilot.token")
-local util = require("codecompanion.utils")
 
 local CONSTANTS = {
   TIMEOUT = 3000, -- 3 seconds
@@ -107,11 +106,6 @@ local function fetch_async(adapter)
 
         _cached_models = models
         _cache_expires = adapters.refresh_cache(_cache_file, config.adapters.http.opts.cache_models_for)
-
-        -- Notify internal listeners
-        pcall(function()
-          util.fire("ChatModelsResolved", { models = _cached_models })
-        end)
       end),
     })
   end)

--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -5,6 +5,7 @@ local stats = require("codecompanion.adapters.http.copilot.stats")
 local token = require("codecompanion.adapters.http.copilot.token")
 local utils = require("codecompanion.utils.adapters")
 
+local _fetching_models = false
 local version = vim.version()
 
 ---@class CodeCompanion.HTTPAdapter.Copilot: CodeCompanion.HTTPAdapter
@@ -42,6 +43,23 @@ return {
     return stats.show()
   end,
   handlers = {
+    ---Initiate fetching the models in the background as soon as the adapter is resolved
+    ---@param self CodeCompanion.HTTPAdapter
+    ---@return nil
+    resolve = function(self)
+      if _fetching_models then
+        return
+      end
+      _fetching_models = true
+
+      vim.schedule(function()
+        pcall(function()
+          get_models.choices(self, { async = true })
+        end)
+        _fetching_models = false
+      end)
+    end,
+
     ---Check for a token before starting the request
     ---@param self CodeCompanion.HTTPAdapter
     ---@return boolean

--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -162,10 +162,11 @@ return {
       ---@type fun(self: CodeCompanion.HTTPAdapter, opts?: table): table
       choices = function(self, opts)
         -- Ensure token is available before getting models
-        if not token.fetch().copilot_token then
+        local fetched = token.fetch()
+        if not fetched or not fetched.copilot_token then
           return { ["gpt-4.1"] = { opts = {} } }
         end
-        return get_models.choices(self, opts)
+        return get_models.choices(self, opts, fetched)
       end,
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -19,6 +19,7 @@ local shared = require("codecompanion.adapters.shared")
 ---@field opts? table Additional options for the adapter
 ---@field model? { name: string, nice_name?: string, vendor?: string, opts: table } The model to use for the request
 ---@field handlers table Functions which link the output from the request to CodeCompanion
+---@field handlers.resolve? fun(self: CodeCompanion.HTTPAdapter): nil When the adapter is resolved, call this method
 ---@field handlers.setup? fun(self: CodeCompanion.HTTPAdapter): boolean
 ---@field handlers.set_body? fun(self: CodeCompanion.HTTPAdapter, data: table): table|nil
 ---@field handlers.form_parameters fun(self: CodeCompanion.HTTPAdapter, params: table, messages: table): table
@@ -223,6 +224,10 @@ function Adapter.resolve(adapter, opts)
 
   if not adapter.type then
     adapter.type = "http"
+  end
+
+  if adapter.handlers and adapter.handlers.resolve then
+    adapter.handlers.resolve(adapter)
   end
 
   return Adapter.set_model(adapter)


### PR DESCRIPTION
## Description

When a user first initiates a chat buffer with the Copilot adapter, and tries to do an operation like change the model or open the debug window, there's an initial delay as both of those activities call the models endpoint in a blocking manner.

This PR ensures that when the Copilot adapter is resolved anywhere within the plugin, the models are fetched async and cached.

The chat buffer and Copilot should feel snappier.

Also removed redundant event.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
