### PR TITLE
fix(acp): fs/read_text_file returning empty string

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -514,14 +514,14 @@ function Connection:_handle_read_file_request(id, params)
     return self:_send_error(id, "invalid params", -32602)
   end
 
-  local fs_api = require("codecompanion.strategies.chat.acp.fs")
-  local ok, content_or_err = fs_api.read_text_file(path, { limit = params.limit, line = params.line })
+  local fs = require("codecompanion.strategies.chat.acp.fs")
+  local ok, content = fs.read_text_file(path, { line = params.line, limit = params.limit })
   if ok then
-    return self:_send_result(id, { content = content_or_err })
+    return self:_send_result(id, { content = content })
   end
 
   -- If the file does not exist we treat it as empty so the agent can create it
-  local errstr = tostring(content_or_err)
+  local errstr = tostring(content)
   if errstr:find("ENOENT", 1, true) then
     self:_send_result(id, { content = "" })
     return
@@ -550,8 +550,8 @@ function Connection:_handle_write_file_request(id, params)
     return self:_send_error(id, "invalid params", -32602)
   end
 
-  local fs_api = require("codecompanion.strategies.chat.acp.fs")
-  local ok, err = fs_api.write_text_file(path, content)
+  local fs = require("codecompanion.strategies.chat.acp.fs")
+  local ok, err = fs.write_text_file(path, content)
   if ok then
     -- Spec: WriteTextFileResponse is null
     self:_send_result(id, vim.NIL)

--- a/tests/stubs/fs_read_text_file.txt
+++ b/tests/stubs/fs_read_text_file.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
## Description

In #2054, when line and limit parameter options were introduced into _fs.lua_, I introduced a bug which failed to account for `vim.NIL`.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
