### PR TITLE
chore: add message types

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -879,7 +879,7 @@ function Chat:remove_tagged_message(tag)
 end
 
 ---Add a message to the message table
----@param data { role: string, content: string, reasoning?: table, tool_calls?: table }
+---@param data { role: string, content: string, reasoning?: CodeCompanion.Chat.Reasoning, tool_calls?: CodeCompanion.Chat.ToolCall[] }
 ---@param opts? table Options for the message
 ---@return CodeCompanion.Chat
 function Chat:add_message(data, opts)
@@ -888,16 +888,19 @@ function Chat:add_message(data, opts)
     opts.visible = true
   end
 
+  ---@type CodeCompanion.Chat.Message
   local message = {
+    id = 1,
+    _meta = {},
     role = data.role,
     content = data.content,
     reasoning = data.reasoning,
+    cycle = self.cycle,
     tool_calls = data.tool_calls,
   }
   message.id = make_id(message)
-  message.cycle = self.cycle
   message.opts = opts
-  message._meta = {}
+
   if opts.index then
     table.insert(self.messages, opts.index, message)
   else

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -18,7 +18,7 @@
 ---@field from_prompt_library? boolean Whether the chat was initiated from the prompt library
 ---@field header_ns number The namespace for the virtual text that appears in the header
 ---@field id number The unique identifier for the chat
----@field messages? table The messages in the chat buffer
+---@field messages? CodeCompanion.Chat.Messages The messages in the chat buffer
 ---@field opts CodeCompanion.ChatArgs Store all arguments in this table
 ---@field parser vim.treesitter.LanguageTree The Markdown Tree-sitter parser for the chat buffer
 ---@field context CodeCompanion.Chat.Context
@@ -44,7 +44,7 @@
 ---@field from_prompt_library? boolean Whether the chat was initiated from the prompt library
 ---@field ignore_system_prompt? boolean Do not send the default system prompt with the request
 ---@field last_role string The last role that was rendered in the chat buffer-
----@field messages? table The messages to display in the chat buffer
+---@field messages? CodeCompanion.Chat.Messages The messages to display in the chat buffer
 ---@field settings? table The settings that are used in the adapter of the chat buffer
 ---@field status? string The status of any running jobs in the chat buffe
 ---@field stop_context_insertion? boolean Stop any visual selection from being automatically inserted into the chat buffer
@@ -156,7 +156,7 @@ end
 
 ---Find a message in the table that has a specific tool call ID
 ---@param id string
----@param messages table
+---@param messages CodeCompanion.Chat.Messages
 ---@return table|nil
 local function find_tool_call(id, messages)
   for _, msg in ipairs(messages) do
@@ -169,7 +169,7 @@ end
 
 ---Determine if a tag exists in the messages table
 ---@param tag string
----@param messages table
+---@param messages CodeCompanion.Chat.Messages
 ---@return boolean
 local function has_tag(tag, messages)
   return vim.tbl_contains(

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -36,7 +36,7 @@
 ---@class CodeCompanion.Chat.Message
 ---@field id number Unique identifier for the message (generated via hash)
 ---@field role string Role of the author (e.g. "user", "llm", "system", "tool")
----@field content? string The raw Markdown/text content of the message (optional for tool-only entries)
+---@field content string The raw Markdown/text content of the message (optional for tool-only entries)
 ---@field cycle number The chat turn cycle when this message was added
 ---@field opts? table Optional metadata used by the UI and processing
 ---@field opts.visible? boolean Whether the message should be shown in the chat UI

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -31,6 +31,44 @@
 
 ---@meta CodeCompanion
 
+---@alias CodeCompanion.Chat.Messages CodeCompanion.Chat.Message[]
+
+---@class CodeCompanion.Chat.Message
+---@field id number Unique identifier for the message (generated via hash)
+---@field role string Role of the author (e.g. "user", "llm", "system", "tool")
+---@field content? string The raw Markdown/text content of the message (optional for tool-only entries)
+---@field cycle number The chat turn cycle when this message was added
+---@field opts? table Optional metadata used by the UI and processing
+---@field opts.visible? boolean Whether the message should be shown in the chat UI
+---@field opts.tag? string A tag to identify special messages (e.g. "system_prompt_from_config", "tool")
+---@field opts.context_id? string Link to a context item (used for pinned/context messages)
+---@field opts.pinned? boolean Whether the context message is pinned
+---@field opts.index? number If set, the message was inserted at this index
+---@field opts.watched? boolean Whether the context is being watched for changes
+---@field _meta table Internal metadata (e.g. { sent = true })
+---@field reasoning? CodeCompanion.Chat.Reasoning Optional reasoning object returned by some adapters
+---@field tool_calls? CodeCompanion.Chat.ToolCall[] Array of tool call descriptors attached to this message
+---@field tool_call_id? string Optional single tool call id that this message represents (links tool output -> call)
+---@field type? string Optional message type used by the UI (e.g. "llm_message", "tool_message", "reasoning_message")
+---@field _raw? any Any adapter-specific raw payload stored with the message
+---@field created_at? number Unix timestamp (optional, helpful for sorting/logging)
+---@field tokens? number Optional token count associated with this message
+
+---@class CodeCompanion.Chat.ToolFunctionCall
+---@field name string Name of the function/tool (e.g. "cmd_runner", "grep_search")
+---@field arguments string|table Raw JSON string or parsed table of arguments
+
+---@class CodeCompanion.Chat.ToolCall
+---@field id string Unique tool call identifier (e.g. "call_8Aoq8...")
+---@field type string Typically "function" (adapter/tool-specific)
+---@field _index? number Position index when returned by adapters
+---@field ["function"]? CodeCompanion.Chat.ToolFunctionCall Function descriptor (adapter key name is "function")
+---@field result? any Optional execution result or intermediate payload
+
+---@class CodeCompanion.Chat.Reasoning
+---@field content string The LLM's chain-of-thought / internal reasoning (often markdown)
+---@field meta? table Optional structured reasoning metadata
+
 ---@class CodeCompanion.SlashCommand
 ---@field Chat CodeCompanion.Chat The chat buffer
 ---@field config table The config of the slash command


### PR DESCRIPTION
## Description

Better type warnings with the LSP.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
