### PR TITLE
fix(chat): show settings error with acp adapter

### DIFF
--- a/lua/codecompanion/strategies/chat/ui/init.lua
+++ b/lua/codecompanion/strategies/chat/ui/init.lua
@@ -316,7 +316,7 @@ function UI:render(context, messages, opts)
     end
   end
 
-  if config.display.chat.show_settings then
+  if config.display.chat.show_settings and self.adapter.type == "http" then
     log:trace("Showing chat settings")
     lines = { "---" }
     local keys = schema.get_ordered_keys(self.adapter)


### PR DESCRIPTION
## Description

When a user enabled `show_settings` in the chat buffer and the adapter was of the type, `acp`, an error would be thrown.

This is because the UI looks to an adapter's schema as yaml and acp adapters do not have such a schema.

## Related Issue(s)

#2062

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
