### PR TITLE
Fix inline adapter parsing after ACP integration

### DIFF
--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -252,7 +252,7 @@ function Inline:parse_special_syntax(prompt)
       self:set_adapter(first_word)
       table.remove(split, 1)
       prompt = table.concat(split, " ")
-    else
+    end
   end
 
   return vim.trim(prompt)

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -253,8 +253,6 @@ function Inline:parse_special_syntax(prompt)
       table.remove(split, 1)
       prompt = table.concat(split, " ")
     else
-      vim.notify("Adapter not found: ".. adapter_match, vim.log.levels.ERROR)
-    end
   end
 
   return vim.trim(prompt)

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -237,14 +237,14 @@ function Inline:parse_special_syntax(prompt)
   local adapter_match = prompt:match(adapter_pattern)
   --TODO: change this as soon as `config.adapters` is removed in V18.0.0
   local config_adapters = vim.tbl_deep_extend("force", {}, config.adapters.acp, config.adapters.http, config.adapters)
-  if adapter_match then 
+  if adapter_match then
     if config_adapters[adapter_match] then
       self:set_adapter(adapter_match)
       prompt = prompt:gsub(adapter_pattern, "", 1) -- Remove only the first occurrence
     else
-      vim.notify("Adapter not found: ".. adapter_match, vim.log.levels.ERROR)
+      util.notify("Adapter not found: " .. adapter_match, vim.log.levels.ERROR)
     end
-  else 
+  else
     -- Handle legacy first-word adapter detection for backward compatibility
     local split = vim.split(prompt, " ")
     local first_word = split[1]


### PR DESCRIPTION
## Description

The change from adapters to adapters.http and adapters.acp broke the inline parsing for adapters when you do
```
:CodeCompanion <adapter> prompt
```

I used the same "hack" that is used inside adapters/init.lua to generate the full table of possible adapters. I also added a comment to change it as soon as v18 ships. 

I do not really have time right now to look at adding a test for this... I only checked manually with both default and custom adapters and it works.


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
