### PR TITLE
Can set adapter to workflows

### DIFF
--- a/doc/extending/workflows.md
+++ b/doc/extending/workflows.md
@@ -165,7 +165,10 @@ You can specify a specific adapter for a workflow prompt:
   strategy = "workflow",
   description = "My workflow",
   opts = {
-    adapter = "openai", -- Always use the OpenAI adapter for this workflow
+    adapter = {
+      name = "deepseek",
+      model = "deepseek-chat"
+    }
   },
   -- Prompts go here
 },

--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -189,6 +189,9 @@ function Strategies:workflow()
 
   local messages = prompts[1]
 
+  -- Set the workflow adapter if one is specified (Single adapter for entire workflow)
+  add_adapter(self, workflow.opts or {})
+
   -- We send the first batch of prompts to the chat buffer as messages
   local chat = require("codecompanion.strategies.chat").new({
     adapter = self.selected.adapter,


### PR DESCRIPTION
## Description

Can set adapters (models included) in a specific workflow.

## Screenshots

<img width="2046" height="819" alt="Xnapper-2025-09-02-22 03 51" src="https://github.com/user-attachments/assets/103a832f-2084-41f6-a52b-1e697dd16183" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
