### PR TITLE
chore(adapters): don't capture copilot token auth

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -134,7 +134,7 @@ local function get_copilot_token()
   end
 
   _token_fetch_in_progress = true
-  log:debug("Authorizing GitHub Copilot token")
+  log:trace("Authorizing GitHub Copilot token")
 
   local ok, request = pcall(function()
     return Curl.get("https://api.github.com/copilot_internal/v2/token", {


### PR DESCRIPTION
## Description

Lowering the log level on this.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
