### PR TITLE
fix: return endpoints from github token

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -199,6 +199,7 @@ function M.fetch()
   return {
     oauth_token = M._oauth_token,
     copilot_token = (M._copilot_token and M._copilot_token.token) or nil,
+    endpoints = (M._copilot_token and M._copilot_token.endpoints) or nil,
   }
 end
 


### PR DESCRIPTION
## Description

Use the passed endoints from the github token.

## Related Issue(s)

Fixes: #2073 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
