### PR TITLE
feat(adapters): allow hiding of acp adapters

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -955,10 +955,18 @@ can set the `show_defaults` option to `false`:
 >lua
     require("codecompanion").setup({
       adapters = {
-        opts = {
-          show_defaults = false,
+        acp = {
+          opts = {
+            show_defaults = false,
+          },
+          -- Define your custom adapters here
         },
-        -- Define your custom adapters here
+        http = {
+          opts = {
+            show_defaults = false,
+          },
+          -- Define your custom adapters here
+        },
       },
     })
 <

--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -265,10 +265,18 @@ By default, the plugin shows all available adapters, including the defaults. If 
 ```lua
 require("codecompanion").setup({
   adapters = {
-    opts = {
-      show_defaults = false,
+    acp = {
+      opts = {
+        show_defaults = false,
+      },
+      -- Define your custom adapters here
     },
-    -- Define your custom adapters here
+    http = {
+      opts = {
+        show_defaults = false,
+      },
+      -- Define your custom adapters here
+    },
   },
 })
 ```

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -37,6 +37,9 @@ local defaults = {
     acp = {
       claude_code = "claude_code",
       gemini_cli = "gemini_cli",
+      opts = {
+        show_defaults = true, -- Show default adapters
+      },
     },
   },
   constants = constants,

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -378,7 +378,17 @@ CodeCompanion.setup = function(opts)
   -- Setup the plugin's config
   config.setup(opts)
 
-  -- Handle adapter configuration
+  -- handle adapter configuration | acp
+  if opts and opts.adapters and opts.adapters.acp then
+    if config.adapters.acp.opts.show_defaults then
+      require("codecompanion.utils.adapters").extend(config.adapters.acp, opts.adapters.acp)
+    else
+      local copied = vim.deepcopy(opts.adapters.acp)
+      config.adapters.acp = copied
+    end
+  end
+
+  -- handle adapter configuration | http
   if opts and opts.adapters and opts.adapters.http then
     if config.adapters.http.opts.show_defaults then
       require("codecompanion.utils.adapters").extend(config.adapters.http, opts.adapters.http)


### PR DESCRIPTION
## Description

This PR allows the hiding of default ACP adapters. This was already possible for the default HTTP adapters.

## Related Issue(s)

See discussion: https://github.com/olimorris/codecompanion.nvim/discussions/2083


## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [X] I've updated the README and/or relevant docs pages
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
