### PR TITLE
fix(config): update date format to YYYY-MM-DD in config.lua

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -625,7 +625,7 @@ The current date is %s.
 The user's Neovim version is %s.
 The user is working on a %s machine. Please respond with system specific commands if applicable.]],
             args.language or "English",
-            os.date("%B %d, %Y"),
+            os.date("%Y-%m-%d"),
             vim.version().major .. "." .. vim.version().minor .. "." .. vim.version().patch,
             machine
           )


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

In default config, we user `os.date("%B %d, %Y")` to get time, but in chinese windows system, this function will return this:

<img width="496" height="78" alt="image" src="https://github.com/user-attachments/assets/7d7ec2ff-b660-43a9-835f-c0a534a512fd" />

This will be identified as illegal in some models, for example claude-opus-4

```
Error 400: {"type":"error","error":{"type":"invalid_request_error","message":"The request body is not valid JSON: str is not valid UTF-8: surrogates not allowed: line 1 c
olumn 1 (char 0)"},"request_id":"req_011CSqbEAABKkJ4VEeHjwfik"}
```

This is just a small change. We slightly adjusted the output style of the time and changed it to a digital output.

<img width="318" height="110" alt="image" src="https://github.com/user-attachments/assets/85dd777a-8455-46f7-adce-5a0f1b950d5f" />

I don't think this will destroy other content, it just improves the experience of some language users

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="3052" height="222" alt="image" src="https://github.com/user-attachments/assets/3198a69a-fab0-4646-8736-cee9c99050bf" />

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
