### PR TITLE
fix(tools): set strict=true for all chat tools

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/create_file.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/create_file.lua
@@ -162,6 +162,7 @@ return {
           "content",
         },
       },
+      strict = true,
     },
   },
   handlers = {

--- a/lua/codecompanion/strategies/chat/tools/catalog/fetch_webpage.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/fetch_webpage.lua
@@ -79,6 +79,7 @@ return {
         },
         required = { "url" },
       },
+      strict = true,
     },
   },
   output = {

--- a/lua/codecompanion/strategies/chat/tools/catalog/file_search.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/file_search.lua
@@ -104,6 +104,7 @@ return {
           "query",
         },
       },
+      strict = true,
     },
   },
   handlers = {

--- a/lua/codecompanion/strategies/chat/tools/catalog/get_changed_files.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/get_changed_files.lua
@@ -120,6 +120,7 @@ return {
           },
         },
       },
+      strict = true,
     },
   },
   handlers = {

--- a/lua/codecompanion/strategies/chat/tools/catalog/grep_search.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/grep_search.lua
@@ -189,6 +189,7 @@ return {
           "query",
         },
       },
+      strict = true,
     },
     type = "function",
   },

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
@@ -306,6 +306,7 @@ Request to list all usages (references, definitions, implementations etc) of a f
           "symbol_name",
         },
       },
+      strict = true,
     },
   },
   handlers = {

--- a/lua/codecompanion/strategies/chat/tools/catalog/read_file.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/read_file.lua
@@ -154,6 +154,7 @@ return {
           "end_line_number_base_zero",
         },
       },
+      strict = true,
     },
   },
   handlers = {

--- a/lua/codecompanion/strategies/chat/tools/catalog/search_web.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/search_web.lua
@@ -87,6 +87,7 @@ return {
         },
         required = { "query", "domains" },
       },
+      strict = true,
     },
   },
   output = {


### PR DESCRIPTION


## Description
Add strict=true to all function tool schemas to ensure consistent strictness across the chat tool catalog.

When I use a third-party model to call tools, I get an error: `All function tools should have the same strictness.` So I think all tools should set strict to true, tested this is correct

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Screenshots
<img width="1867" height="915" alt="图片" src="https://github.com/user-attachments/assets/4f3b17bd-e975-408a-bb28-f2d69a8f2dff" />

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied

