### PR TITLE
Cache Ollama models info

### DIFF
--- a/lua/codecompanion/adapters/http/ollama/init.lua
+++ b/lua/codecompanion/adapters/http/ollama/init.lua
@@ -15,6 +15,7 @@ return {
     stream = true,
     tools = true,
     vision = true,
+    cache_adapter = true, -- Cache the resolved adapter to prevent multiple resolutions
   },
   features = {
     text = true,


### PR DESCRIPTION
## Description

In the previous Ollama adapter refactor (#1829), the Ollama adapter sends excessive requests to the server because it doesn't cache any of the results. This blocks the UI whenever the schema is resolved.

This PR implements a basic caching mechanism that stores the model list and model capabilities (thinking and vision), so that we don't have to suffer from the delay when the schema is resolved. The first time the schema is resolved will still be blocking, but the subsequent calls to `get_models` or `check_thinking_capability` will use the cached results and will no longer block the UI.

## Related Issue(s)

#1829 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
