### PR TITLE
Move chat close events to fire before clearing the buffers.

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1163,6 +1163,10 @@ function Chat:close()
     last_chat = nil
   end
 
+  util.fire("ChatClosed", { bufnr = self.bufnr, id = self.id })
+  util.fire("ChatAdapter", { bufnr = self.bufnr, id = self.id, adapter = nil })
+  util.fire("ChatModel", { bufnr = self.bufnr, id = self.id, model = nil })
+
   table.remove(
     _G.codecompanion_buffers,
     vim.iter(_G.codecompanion_buffers):enumerate():find(function(_, v)
@@ -1187,9 +1191,6 @@ function Chat:close()
     self.acp_connection:disconnect()
   end
 
-  util.fire("ChatClosed", { bufnr = self.bufnr, id = self.id })
-  util.fire("ChatAdapter", { bufnr = self.bufnr, id = self.id, adapter = nil })
-  util.fire("ChatModel", { bufnr = self.bufnr, id = self.id, model = nil })
   self = nil
 end
 


### PR DESCRIPTION
## Description

This allows subscribers to the CodeCompanionChatClosed, Adapter, and Model functions to use the Neovim buffers. Otherwise, an invalid bufnr is passed to the event handler.

For my use case, I would like to be able to save a chat before it is cleared or closed. For cleared, we would either need to move when that event is fired or create a new event right before it is cleared.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
