### PR TITLE
refactor: clean up init.lua

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -12,24 +12,6 @@ local CodeCompanion = {
   extensions = _extensions.manager,
 }
 
----Keep the chat buffer open when switching tabs
----@return nil
-local function setup_sticky_chat_buffer()
-  api.nvim_create_autocmd("TabEnter", {
-    group = api.nvim_create_augroup("codecompanion.sticky_buffer", { clear = true }),
-    callback = function(args)
-      local chat = CodeCompanion.last_chat()
-      if chat and chat.ui:is_visible_non_curtab() then
-        chat.buffer_context = context_utils.get(args.buf)
-        vim.schedule(function()
-          CodeCompanion.close_last_chat()
-          chat.ui:open({ toggled = true })
-        end)
-      end
-    end,
-  })
-end
-
 ---Register an extension with setup and exports
 ---@param name string The name of the extension
 ---@param extension CodeCompanion.Extension The extension implementation
@@ -440,7 +422,19 @@ CodeCompanion.setup = function(opts)
 
   local window_config = config.display.chat.window
   if window_config.sticky and (window_config.layout ~= "buffer") then
-    setup_sticky_chat_buffer()
+    api.nvim_create_autocmd("TabEnter", {
+      group = api.nvim_create_augroup("codecompanion.sticky_buffer", { clear = true }),
+      callback = function(args)
+        local chat = CodeCompanion.last_chat()
+        if chat and chat.ui:is_visible_non_curtab() then
+          chat.buffer_context = context_utils.get(args.buf)
+          vim.schedule(function()
+            CodeCompanion.close_last_chat()
+            chat.ui:open({ toggled = true })
+          end)
+        end
+      end,
+    })
   end
 end
 


### PR DESCRIPTION
## Description

Clean up `init.lua`

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
