### PR TITLE
fix(prompt): tags renamed to be tag

### DIFF
--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -179,7 +179,7 @@ function Strategies:workflow()
             p.content = p.content(self.buffer_context)
           end
           if p.role == config.constants.SYSTEM_ROLE and not p.opts then
-            p.opts = { visible = false, tags = { "from_custom_prompt" } }
+            p.opts = { visible = false, tag = "from_custom_prompt" }
           end
           return p
         end)
@@ -281,7 +281,7 @@ function Strategies.evaluate_prompts(prompts, context)
     :map(function(prompt)
       local content = type(prompt.content) == "function" and prompt.content(context) or prompt.content
       if prompt.role == config.constants.SYSTEM_ROLE and not prompt.opts then
-        prompt.opts = { visible = false, tags = { "from_custom_prompt" } }
+        prompt.opts = { visible = false, tag = "from_custom_prompt" }
       end
       return {
         role = prompt.role or "",


### PR DESCRIPTION
## Description

Ensure `tag` is used uniformly across the plugin

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
