### PR TITLE
feat: adds block/goose as an ACP enabled adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Thank you to the following people:
 
 - :speech_balloon: [Copilot Chat](https://github.com/features/copilot) meets [Zed AI](https://zed.dev/blog/zed-ai), in Neovim
 - :electric_plug: Support for LLMs from Anthropic, Copilot, GitHub Models, DeepSeek, Gemini, Mistral AI, Novita, Ollama, OpenAI, Azure OpenAI, HuggingFace and xAI (or [bring your own](https://codecompanion.olimorris.dev/extending/adapters.html))
-- :robot: Support for [Agent Client Protocol](https://agentclientprotocol.com), enabling coding with agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) and [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- :robot: Support for [Agent Client Protocol](https://agentclientprotocol.com), enabling coding with agents like [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Gemini CLI](https://github.com/google-gemini/gemini-cli) and [Goose](https://github.com/block/goose)
 - :heart_hands: User contributed and supported [adapters](https://codecompanion.olimorris.dev/configuration/adapters#community-adapters)
 - :rocket: [Inline transformations](https://codecompanion.olimorris.dev/usage/inline-assistant.html), code creation and refactoring
 - :art: [Variables](https://codecompanion.olimorris.dev/usage/chat-buffer/variables.html), [Slash Commands](https://codecompanion.olimorris.dev/usage/chat-buffer/slash-commands.html), [Tools](https://codecompanion.olimorris.dev/usage/chat-buffer/tools.html) and [Workflows](https://codecompanion.olimorris.dev/usage/workflows.html) to improve LLM output

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1064,9 +1064,7 @@ To use Goose within CodeCompanion:
         acp = {
           goose = function()
             return require("codecompanion.adapters").extend("goose", {
-              -- Optional: Add MCP servers configuration if needed
               defaults = {
-                mcpServers = {},
                 timeout = 20000, -- 20 seconds
               },
             })

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*        For NVIM v0.11       Last change: 2025 September 04
+*codecompanion.txt*        For NVIM v0.11       Last change: 2025 September 13
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1046,6 +1046,40 @@ AN API KEY
       },
     })
 <
+
+
+SETUP: GOOSE VIA ACP ~
+
+Goose <https://github.com/block/goose> is an open-source developer agent that
+can be used with CodeCompanion via the Agent Client Protocol (ACP).
+
+To use Goose within CodeCompanion:
+
+1. Install <https://github.com/block/goose#installation> Goose
+2. Configure the adapter in your CodeCompanion config:
+
+>lua
+    require("codecompanion").setup({
+      adapters = {
+        acp = {
+          goose = function()
+            return require("codecompanion.adapters").extend("goose", {
+              -- Optional: Add MCP servers configuration if needed
+              defaults = {
+                mcpServers = {},
+                timeout = 20000, -- 20 seconds
+              },
+            })
+          end,
+        },
+      },
+    })
+<
+
+1. Select "goose" as your adapter when using CodeCompanion
+
+The Goose adapter supports vision capabilities and file system operations
+(read/write) through ACP.
 
 
 SETUP: USING OLLAMA REMOTELY ~

--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -348,6 +348,37 @@ require("codecompanion").setup({
 })
 ```
 
+## Setup: Goose via ACP
+
+[Goose](https://github.com/block/goose) is an open-source developer agent that can be used with CodeCompanion via the Agent Client Protocol (ACP).
+
+To use Goose within CodeCompanion:
+
+1. [Install](https://github.com/block/goose#installation) Goose
+2. Configure the adapter in your CodeCompanion config:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      goose = function()
+        return require("codecompanion.adapters").extend("goose", {
+          -- Optional: Add MCP servers configuration if needed
+          defaults = {
+            mcpServers = {},
+            timeout = 20000, -- 20 seconds
+          },
+        })
+      end,
+    },
+  },
+})
+```
+
+3. Select "goose" as your adapter when using CodeCompanion
+
+The Goose adapter supports vision capabilities and file system operations (read/write) through ACP.
+
 ## Setup: Using Ollama Remotely
 
 To use Ollama remotely, change the URL in the env table, set an API key and pass it via an "Authorization" header:

--- a/doc/configuration/adapters.md
+++ b/doc/configuration/adapters.md
@@ -363,9 +363,7 @@ require("codecompanion").setup({
     acp = {
       goose = function()
         return require("codecompanion.adapters").extend("goose", {
-          -- Optional: Add MCP servers configuration if needed
           defaults = {
-            mcpServers = {},
             timeout = 20000, -- 20 seconds
           },
         })

--- a/lua/codecompanion/adapters/acp/goose.lua
+++ b/lua/codecompanion/adapters/acp/goose.lua
@@ -1,0 +1,57 @@
+local helpers = require("codecompanion.adapters.acp.helpers")
+
+---@class CodeCompanion.ACPAdapter.Goose: CodeCompanion.ACPAdapter
+return {
+  name = "goose",
+  formatted_name = "Goose",
+  type = "acp",
+  roles = {
+    llm = "assistant",
+    user = "user",
+  },
+  opts = {
+    vision = true,
+  },
+  commands = {
+    default = {
+      "goose",
+      "acp",
+    },
+  },
+  defaults = {
+    mcpServers = {},
+    timeout = 20000, -- 20 seconds
+  },
+  env = {},
+  parameters = {
+    protocolVersion = 1,
+    clientCapabilities = {
+      fs = { readTextFile = true, writeTextFile = true },
+    },
+    clientInfo = {
+      name = "CodeCompanion.nvim",
+      version = "1.0.0",
+    },
+  },
+  handlers = {
+    ---@param self CodeCompanion.ACPAdapter
+    ---@return boolean
+    setup = function(self)
+      return true
+    end,
+
+    ---@param self CodeCompanion.ACPAdapter
+    ---@param messages table
+    ---@param capabilities table
+    ---@return table
+    form_messages = function(self, messages, capabilities)
+      return helpers.form_messages(self, messages, capabilities)
+    end,
+
+    ---Function to run when the request has completed. Useful to catch errors
+    ---@param self CodeCompanion.ACPAdapter
+    ---@param code number
+    ---@return nil
+    on_exit = function(self, code) end,
+  },
+}

--- a/lua/codecompanion/adapters/acp/goose.lua
+++ b/lua/codecompanion/adapters/acp/goose.lua
@@ -19,7 +19,6 @@ return {
     },
   },
   defaults = {
-    mcpServers = {},
     timeout = 20000, -- 20 seconds
   },
   env = {},

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -37,6 +37,7 @@ local defaults = {
     acp = {
       claude_code = "claude_code",
       gemini_cli = "gemini_cli",
+      goose = "goose",
       opts = {
         show_defaults = true, -- Show default adapters
       },

--- a/tests/adapters/acp/test_goose.lua
+++ b/tests/adapters/acp/test_goose.lua
@@ -1,0 +1,110 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        h = require("tests.helpers")
+        h.setup_plugin()
+        package.loaded["codecompanion.config"] = require("tests.config")
+      ]])
+    end,
+    post_case = child.stop,
+  },
+})
+
+T["Goose ACP Adapter"] = new_set()
+
+T["Goose ACP Adapter"]["can resolve goose adapter"] = function()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").resolve("goose")
+    return {
+      name = adapter.name,
+      formatted_name = adapter.formatted_name,
+      type = adapter.type,
+      resolved = require("codecompanion.adapters").resolved(adapter)
+    }
+  ]])
+
+  h.eq({
+    name = "goose",
+    formatted_name = "Goose",
+    type = "acp",
+    resolved = true,
+  }, result)
+end
+
+T["Goose ACP Adapter"]["has correct default configuration"] = function()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").resolve("goose")
+    return {
+      roles = adapter.roles,
+      opts = adapter.opts,
+      commands = adapter.commands,
+      defaults = adapter.defaults,
+    }
+  ]])
+
+  h.eq({
+    roles = { llm = "assistant", user = "user" },
+    opts = { vision = true },
+    commands = { default = { "goose", "acp" }, selected = { "goose", "acp" } },
+    defaults = { mcpServers = {}, timeout = 20000 },
+  }, result)
+end
+
+T["Goose ACP Adapter"]["has correct parameters"] = function()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").resolve("goose")
+    return adapter.parameters
+  ]])
+
+  h.eq({
+    protocolVersion = 1,
+    clientCapabilities = {
+      fs = { readTextFile = true, writeTextFile = true },
+    },
+    clientInfo = {
+      name = "CodeCompanion.nvim",
+      version = "1.0.0",
+    },
+  }, result)
+end
+
+T["Goose ACP Adapter"]["handlers setup returns true"] = function()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").resolve("goose")
+    return adapter.handlers.setup(adapter)
+  ]])
+
+  h.eq(true, result)
+end
+
+T["Goose ACP Adapter"]["form_messages handler works correctly"] = function()
+  local result = child.lua([[
+    local adapter = require("codecompanion.adapters").resolve("goose")
+    local messages = {
+      { role = "user", content = "Hello", _meta = { sent = false } },
+      { role = "assistant", content = "Hi there!", _meta = { sent = true } }
+    }
+    local capabilities = { promptCapabilities = {} }
+    local formed = adapter.handlers.form_messages(adapter, messages, capabilities)
+
+    -- Basic check that messages are returned (only unsent user messages should be returned)
+    return {
+      count = #formed,
+      first_type = formed[1] and formed[1].type or "text"
+    }
+  ]])
+
+  h.eq({
+    count = 1,
+    first_type = "text",
+  }, result)
+end
+
+return T

--- a/tests/adapters/acp/test_goose.lua
+++ b/tests/adapters/acp/test_goose.lua
@@ -53,7 +53,7 @@ T["Goose ACP Adapter"]["has correct default configuration"] = function()
     roles = { llm = "assistant", user = "user" },
     opts = { vision = true },
     commands = { default = { "goose", "acp" }, selected = { "goose", "acp" } },
-    defaults = { mcpServers = {}, timeout = 20000 },
+    defaults = { timeout = 20000 },
   }, result)
 end
 

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -65,6 +65,9 @@ return {
         command = { "node", "test-agent.js" },
         roles = { user = "user", assistant = "assistant" },
       },
+      goose = function()
+        return require("codecompanion.adapters.acp.goose")
+      end,
     },
   },
   strategies = {


### PR DESCRIPTION
## Description
Recently, [Goose](https://github.com/block/goose), a CLI agent tool akin to Claude Code/Gemini from Block/Square added a native [ACP integration](https://github.com/block/goose/pull/4511). This PR adds the adapter for an initial integration + associated docs and tests.
## Related Issue(s)
- https://github.com/olimorris/codecompanion.nvim/discussions/2119

## Screenshots

<img width="2056" height="1329" alt="Screenshot 2025-09-13 at 8 14 51 AM" src="https://github.com/user-attachments/assets/e64a4f56-68ed-411d-8c03-ffd244e2ee04" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
