### PR TITLE
refactor(chat): add warning when memory file can't be found

### DIFF
--- a/lua/codecompanion/strategies/chat/memory/helpers.lua
+++ b/lua/codecompanion/strategies/chat/memory/helpers.lua
@@ -158,7 +158,7 @@ function M.add_files_or_buffers(included_files, chat)
     else
       -- Otherwise, check the wider filesystem
       if not file_utils.exists(path) then
-        return log:debug("[Memory] Could not find the file %s", path)
+        return log:warn("Could not find the memory file `%s`", path)
       end
     end
 


### PR DESCRIPTION
## Description

Alert the user that a memory file couldn't be added to the chat buffer.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
