### PR TITLE
fix(chat): clip claude code tool output

### DIFF
--- a/lua/codecompanion/strategies/chat/acp/formatters.lua
+++ b/lua/codecompanion/strategies/chat/acp/formatters.lua
@@ -122,19 +122,15 @@ end
 
 ---Create a one-line message for tool-call events
 ---@param tool_call table
+---@param adapter CodeCompanion.ACPAdapter
 ---@return string
-function M.tool_message(tool_call)
+function M.tool_message(tool_call, adapter)
   local status = tool_call.status or "pending"
   local title = M.short_title(tool_call)
   if status == "completed" then
     local summary
-    if tool_call.kind == "read" then
-      local output = "Completed"
-      -- Account for Claude Code echoing the whole contents of the fs/read_text_file back into the buffer
-      if tool_call.rawInput and tool_call.rawInput.abs_path then
-        output = tool_call.rawInput.abs_path
-      end
-      summary = string.format("Read: %s", output)
+    if adapter.name == "claude_code" then
+      summary = title
     else
       summary = M.summarize_tool_content(tool_call)
     end

--- a/lua/codecompanion/strategies/chat/acp/handler.lua
+++ b/lua/codecompanion/strategies/chat/acp/handler.lua
@@ -139,7 +139,7 @@ function ACPHandler:process_tool_call(tool_call)
     tool_call = merged or tool_call
   end
 
-  local ok, content = pcall(formatter.tool_message, tool_call)
+  local ok, content = pcall(formatter.tool_message, tool_call, self.chat.adapter)
   if not ok then
     content = "[Error formatting tool output]"
   end


### PR DESCRIPTION
## Description

Claude Code likes to output its tool requests into the chat buffer. For now. hide this to make sure we don't break the buffer.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
