### PR TITLE
fix(chat): force memory to be added via slash command

### DIFF
--- a/lua/codecompanion/strategies/chat/memory/init.lua
+++ b/lua/codecompanion/strategies/chat/memory/init.lua
@@ -152,15 +152,18 @@ end
 
 ---Make the memory message
 ---@param chat CodeCompanion.Chat
+---@param opts? { force: boolean } Additional options
 ---@return nil
-function Memory:make(chat)
+function Memory:make(chat, opts)
+  opts = vim.tbl_extend("force", { force = false }, opts or {})
+
   local condition = config
     and config.memory
     and config.memory.opts
     and config.memory.opts.chat
     and config.memory.opts.chat.condition
 
-  if condition ~= nil then
+  if condition ~= nil and opts.force == false then
     local ctype = type(condition)
 
     if ctype == "function" then

--- a/lua/codecompanion/strategies/chat/slash_commands/memory.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/memory.lua
@@ -37,11 +37,11 @@ function SlashCommand:output(selected)
   return memory
     .init({
       name = selected.name,
+      files = selected.files,
       opts = selected.opts,
       parser = selected.parser,
-      files = selected.files,
     })
-    :make(self.Chat)
+    :make(self.Chat, { force = true })
 end
 
 return SlashCommand


### PR DESCRIPTION
## Description

The Slash Command will now force memory to be loaded in any given chat buffer, despite a conditional in the config preventing it.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
