### PR TITLE
fix(chat): debug window with acp adapters

### DIFF
--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -123,8 +123,10 @@ function Debug:render()
     local keys = {}
 
     -- Collect all settings keys including those with nil defaults
-    for key, _ in pairs(self.settings) do
-      table.insert(keys, key)
+    if self.settings then
+      for key, _ in pairs(self.settings) do
+        table.insert(keys, key)
+      end
     end
 
     -- Add any schema keys that have an explicit nil default


### PR DESCRIPTION
## Description

When using ACP adapters, the debug window (`gd`) was failing to render.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
