### PR TITLE
refactor(chat): add change_adapter helper

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps.lua
+++ b/lua/codecompanion/strategies/chat/keymaps.lua
@@ -568,14 +568,7 @@ M.change_adapter = {
 
       if current_adapter ~= selected_adapter then
         chat.acp_connection = nil
-        chat.adapter = require("codecompanion.adapters").resolve(adapters[selected_adapter])
-        util.fire(
-          "ChatAdapter",
-          { bufnr = chat.bufnr, adapter = require("codecompanion.adapters").make_safe(chat.adapter) }
-        )
-        chat.ui.adapter = chat.adapter
-        chat:update_metadata()
-        chat:apply_settings()
+        chat:change_adapter(selected_adapter)
       end
 
       -- Update the system prompt
@@ -631,8 +624,6 @@ M.change_adapter = {
           end
 
           chat:apply_model(selected_model)
-          chat:update_metadata()
-          chat:apply_settings()
         end)
       end
 

--- a/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/workspace.lua
@@ -182,7 +182,7 @@ function SlashCommand:output(selected_group, opts)
 
   -- Add the high-level prompts first
   if self.workspace.system_prompt then
-    self.Chat:add_system_prompt(
+    self.Chat:set_system_prompt(
       replace_vars(self.workspace, group, self.workspace.system_prompt),
       { visible = false, tag = self.workspace.name .. " // Workspace" }
     )
@@ -195,7 +195,7 @@ function SlashCommand:output(selected_group, opts)
   end
 
   if group.system_prompt then
-    self.Chat:add_system_prompt(
+    self.Chat:set_system_prompt(
       replace_vars(self.workspace, group, group.system_prompt),
       { visible = false, tag = group.name .. " // Workspace Group" }
     )

--- a/lua/codecompanion/strategies/chat/tool_registry.lua
+++ b/lua/codecompanion/strategies/chat/tool_registry.lua
@@ -152,7 +152,7 @@ function ToolRegistry:add_tool_system_prompt()
     self.chat:remove_tagged_message("system_prompt_from_config")
   end
 
-  self.chat:add_system_prompt(prompt, { index = index, visible = false, tag = "tool_system_prompt" })
+  self.chat:set_system_prompt(prompt, { index = index, visible = false, tag = "tool_system_prompt" })
 end
 
 ---Determine if the chat buffer has any tools in use


### PR DESCRIPTION
## Description

Make it easier to change the adapter and model from elsewhere in the plugin.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
