### PR TITLE
refactor: subscribers and callbacks

### DIFF
--- a/lua/codecompanion/strategies/chat/memory/helpers.lua
+++ b/lua/codecompanion/strategies/chat/memory/helpers.lua
@@ -111,7 +111,8 @@ function M.add_callbacks(args, memory_name)
   for _, name in ipairs(memories) do
     local current = config.memory[name]
     if current then
-      args.callbacks = util.callbacks_add(args.callbacks, "on_creation", function(chat)
+      -- Ensure that we extend any existing callbacks
+      args.callbacks = util.callbacks_extend(args.callbacks, "on_creation", function(chat)
         require("codecompanion.strategies.chat.memory").add_to_chat({
           name = name,
           opts = current.opts,

--- a/lua/codecompanion/strategies/chat/subscribers.lua
+++ b/lua/codecompanion/strategies/chat/subscribers.lua
@@ -39,10 +39,16 @@ function Subscribers:unsubscribe(event)
   end
 end
 
+---Return the number of queued subscribers
+---@return number
+function Subscribers:size()
+  return #self.queue
+end
+
 ---Does the chat buffer have any subscribers?
 ---@return boolean
 function Subscribers:has_subscribers()
-  return #self.queue > 0
+  return self:size() > 0
 end
 
 ---Execute the subscriber's callback
@@ -60,7 +66,7 @@ function Subscribers:action(chat, event)
     end
     self:unsubscribe(event)
     -- Don't auto submit a reuse prompt if it's the last one
-    if vim.tbl_isempty(self.queue) then
+    if self:size() == 0 then
       self.stopped = true
     end
     return

--- a/lua/codecompanion/strategies/init.lua
+++ b/lua/codecompanion/strategies/init.lua
@@ -221,7 +221,8 @@ function Strategies:workflow()
     local order = 1
     vim.iter(prompts):each(function(prompt)
       for _, val in ipairs(prompt) do
-        local event_data = vim.tbl_deep_extend("keep", {}, val, { type = "once" })
+        local event_type = (type(val.repeat_until) == "function") and "repeat" or "once"
+        local event_data = vim.tbl_deep_extend("keep", {}, val, { type = event_type })
         local event = {
           callback = function()
             if type(val.content) == "function" then

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -168,7 +168,7 @@ end
 ---@param callbacks table|nil The existing callbacks
 ---@param event string The event to add the callback to
 ---@param fn function The callback function
-function M.callbacks_add(callbacks, event, fn)
+function M.callbacks_extend(callbacks, event, fn)
   callbacks = callbacks or {}
   local existing = callbacks[event]
   if not existing then

--- a/tests/strategies/chat/test_subscribers.lua
+++ b/tests/strategies/chat/test_subscribers.lua
@@ -27,7 +27,7 @@ T["Subscribers"]["Can subscribe to chat buffer"] = function()
     end,
   })
 
-  h.eq(#chat.subscribers.queue, 1)
+  h.eq(chat.subscribers:size(), 1)
   chat:add_buf_message({ role = "user", content = "Hello World" })
 
   local buffer = h.get_buf_lines(chat.bufnr)
@@ -39,13 +39,42 @@ T["Subscribers"]["Can subscribe to chat buffer"] = function()
   -- Confirm subscriber message has been added to the chat buffer
   h.eq(message, buffer[#buffer])
   -- and removed from the subscriber queue
-  h.eq(#chat.subscribers.queue, 0)
+  h.eq(chat.subscribers:size(), 0)
 
   h.send_to_llm(chat, "Hello again")
   buffer = h.get_buf_lines(chat.bufnr)
 
   -- and not re-added to the chat buffer
   h.eq("Hello again", buffer[#buffer - 4])
+end
+
+T["Subscribers"]["size() reflects queue size"] = function()
+  local ev1 = { data = { type = "once" }, callback = function() end }
+  local ev2 = { data = { type = "once" }, callback = function() end }
+
+  chat.subscribers:subscribe(ev1)
+  chat.subscribers:subscribe(ev2)
+
+  h.eq(chat.subscribers:size(), 2)
+
+  chat.subscribers:unsubscribe(ev1)
+  h.eq(chat.subscribers:size(), 1)
+
+  -- Processing should consume the remaining once event
+  h.send_to_llm(chat, "trigger processing")
+  h.eq(chat.subscribers:size(), 0)
+end
+
+T["Subscribers"]["on_stop marks subscribers as stopped"] = function()
+  local ev = { data = { type = "once", opts = { auto_submit = true } }, callback = function() end }
+  chat.subscribers:subscribe(ev)
+
+  h.eq(chat.subscribers:size(), 1)
+  h.is_false(chat.subscribers.stopped)
+
+  -- Lifecycle stop event (wired to subscribers:stop() via on_stop)
+  chat:dispatch("on_stop")
+  h.is_true(chat.subscribers.stopped)
 end
 
 return T


### PR DESCRIPTION
## Description

Miscellaneous changes to subscribers and add more callbacks throughout _chat/init.lua_.

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
