### PR TITLE
feat(fzf_lua): add custom ActionPreviewer for improved action preview

### DIFF
--- a/lua/codecompanion/providers/actions/fzf_lua.lua
+++ b/lua/codecompanion/providers/actions/fzf_lua.lua
@@ -1,6 +1,71 @@
 local config = require("codecompanion.config")
 local fzf = require("fzf-lua")
 
+local ActionPreviewer = require("fzf-lua.previewer.builtin").base:extend()
+
+function ActionPreviewer:new(o, opts)
+  -- Correct super initializer: call with dot to pass instance as self
+  ActionPreviewer.super.new(self, o, opts)
+  self.name_to_item = o.name_to_item
+end
+
+function ActionPreviewer:gen_winopts()
+  local enforced_win_opts = {
+    wrap = true,
+    number = false,
+    relativenumber = false,
+    cursorcolumn = false,
+    spell = false,
+    list = false,
+    signcolumn = "no",
+    foldcolumn = "0",
+    colorcolumn = "",
+  }
+  return vim.tbl_extend("force", self.winopts, enforced_win_opts)
+end
+
+function ActionPreviewer:should_clear_preview(_)
+  return false
+end
+
+function ActionPreviewer:parse_entry(entry_str)
+  if not entry_str or entry_str == "" then
+    return {}
+  end
+  return self.name_to_item[entry_str] or {}
+end
+
+function ActionPreviewer:populate_preview_buf(entry_str)
+  if not self.win or not self.win:validate_preview() then
+    return
+  end
+
+  local item = self:parse_entry(entry_str)
+  if not item or vim.tbl_isempty(item) then
+    return
+  end
+
+  -- Update preview title to the action's name if available
+  if item.name and type(item.name) == "string" and #item.name > 0 then
+    self.win:update_preview_title(" " .. item.name .. " ")
+  end
+
+  if item.description == "[No messages]" and item.bufnr and vim.api.nvim_buf_is_valid(item.bufnr) then
+    -- Attach the provided buffer directly
+    -- Protect user buffer from being deleted when the previewer closes
+    self.listed_buffers[tostring(item.bufnr)] = true
+    self:set_preview_buf(item.bufnr)
+    self:update_render_markdown()
+  else
+    local tmpbuf = self:get_tmp_buffer()
+    local description = item.description and vim.split(item.description, "\n", { plain = true }) or { "No description" }
+    vim.api.nvim_buf_set_lines(tmpbuf, 0, -1, false, description)
+    self:set_preview_buf(tmpbuf)
+  end
+
+  self.win:update_preview_scrollbar()
+end
+
 ---@class CodeCompanion.Actions.Provider.FZF: CodeCompanion.SlashCommand.Provider
 ---@field context table
 ---@field resolve function
@@ -18,26 +83,32 @@ function FZF:picker(items, opts)
   opts = opts or {}
   opts.prompt = opts.prompt or config.display.action_palette.opts.title or "CodeCompanion actions"
 
-  local item_names = {}
-  local name_to_item = {}
+  local names = vim.tbl_map(function(item)
+    return item.name
+  end, items)
 
+  local name_to_item = {}
   for _, item in ipairs(items) do
-    table.insert(item_names, item.name)
     name_to_item[item.name] = item
   end
 
-  fzf.fzf_exec(item_names, {
+  fzf.fzf_exec(names, {
     prompt = opts.prompt,
-    preview = {
-      fn = function(it)
-        return name_to_item[it[1]].description
+    previewer = {
+      _ctor = function()
+        return ActionPreviewer
       end,
+      name_to_item = name_to_item,
     },
     actions = {
       ["default"] = function(selected)
-        if selected or vim.tbl_count(selected) ~= 0 then
-          for _, selection in ipairs(selected) do
-            return require("codecompanion.providers.actions.shared").select(self, name_to_item[selection])
+        if not selected or #selected == 0 then
+          return
+        end
+        for _, selection in ipairs(selected) do
+          local item = name_to_item[selection]
+          if item then
+            return require("codecompanion.providers.actions.shared").select(self, item)
           end
         end
       end,


### PR DESCRIPTION
## Description

- Introduce class to provide enhanced preview functionality for actions in the FZF picker.
- Replace simple preview function with a dedicated previewer supporting buffer attachment, markdown rendering, and improved window options.
- Refactor picker to use and streamline item name mapping.
- Improve selection handling and preview window configuration.

## Related Discussion

[Discussion 2150](https://github.com/olimorris/codecompanion.nvim/discussions/2150)

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
