### PR TITLE
feat(chat): better tool cancelling

### DIFF
--- a/doc/usage/chat-buffer/tools.md
+++ b/doc/usage/chat-buffer/tools.md
@@ -34,7 +34,7 @@ Use @{lorem_ipsum} to generate a random paragraph
 
 will yield:
 
-```
+```md
 Use the lorem_ipsum tool to generate a random paragraph
 ```
 
@@ -271,26 +271,22 @@ You can use it with:
 
 The plugin allows you to run tools on autopilot, with YOLO mode. This automatically approves any tool use instead of prompting the user, disables any diffs, submits errors and success messages and automatically saves any buffers that tools may have edited. In the chat buffer, the keymap `gty` will toggle YOLO mode on/off. Alternatively, set the global variable `vim.g.codecompanion_yolo_mode` to enable this or set it to `nil` to undo this.
 
-## Community Tools
-
-There is also a thriving ecosystem of user created tools:
-
-- [VectorCode](https://github.com/Davidyz/VectorCode/tree/main) - A code repository indexing tool to supercharge your LLM experience
-- [mcphub.nvim](https://github.com/ravitemer/mcphub.nvim) - A powerful Neovim plugin for managing MCP (Model Context Protocol) servers
-
-The section of the discussion forums which is dedicated to user created tools can be found [here](https://github.com/olimorris/codecompanion.nvim/discussions/categories/tools).
-
 ## Security and Approvals
 
 CodeCompanion takes security very seriously, especially in a world of agentic code development. To that end, every effort is made to ensure that LLMs are only given the information that they need to execute a tool successfully. CodeCompanion will endeavour to make sure that the full disk path to your current working directory (cwd) in Neovim is never shared. The impact of this is that the LLM can only work within the cwd when executing tools but will minimize actions that are hard to [recover from](https://www.businessinsider.com/replit-ceo-apologizes-ai-coding-tool-delete-company-database-2025-7).
 
-The plugin also puts approvals at the heart of its workflow. Some tools, such as the _@cmd_runner_, require the user to approve any actions before they can be executed. If the tool requires this a `vim.fn.confirm` dialog will prompt you for a response. You may also [enforce](/configuration/chat-buffer#approvals) an approval for _any_ tool.
+The plugin also puts approvals at the heart of its workflow. Some tools, such as the [@cmd_runner](#cmd-runner), require the user to approve any actions before they can be executed. If the tool requires this a `vim.fn.confirm` dialog will prompt you for a response. You may also [enforce](/configuration/chat-buffer#approvals) an approval for _any_ tool.
 
+When using CodeCompanion's in-built tools, there are three choices:
+
+1. **Approve** - The tool will be executed
+2. **Reject** - The tool will **NOT** be executed
+3. **Cancel** - All tools in the queue will **NOT** be executed
 
 ## Compatibility
 
 > [!NOTE]
-> Tools are not supported for ACP adapters.
+> Tools are not supported for ACP adapters as they have their own set.
 
 Below is the tool use status of various adapters and models in CodeCompanion:
 

--- a/tests/strategies/chat/tools/test_orchestrator.lua
+++ b/tests/strategies/chat/tools/test_orchestrator.lua
@@ -1,0 +1,144 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local T = new_set()
+
+local child = MiniTest.new_child_neovim()
+T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        h = require("tests.helpers")
+        _G.cancelled = {}
+      ]])
+    end,
+    post_case = function()
+      child.lua([[
+        _G.chat, _G.tools, _G.cancelled = nil, nil, nil
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+local function setup_with_tools_and_cancel_stub(n_tools)
+  child.lua(string.format(
+    [[
+    -- Build a minimal config with custom tools that require approval
+    local cfg = {
+      strategies = {
+        chat = {
+          tools = {
+            opts = {
+              auto_submit_success = false,
+              auto_submit_errors = false,
+            },
+          },
+        },
+      },
+    }
+
+    local function make_tool(n)
+      return {
+        name = n,
+        cmds = {
+          function(self, args, input, cb)
+            -- Should not run when 'Cancel' is selected, but return success if it does
+            cb({ status = "success", data = n .. "_ran" })
+          end,
+        },
+        schema = {
+          type = "function",
+          ["function"] = {
+            name = n,
+            description = "Test tool " .. n,
+            parameters = { type = "object", properties = {} },
+          },
+        },
+        opts = { requires_approval = true },
+        output = {
+          cancelled = function(self, tools, _)
+            _G.cancelled = _G.cancelled or {}
+            table.insert(_G.cancelled, self.name)
+            tools.chat:add_tool_output(self, "cancelled:" .. self.name)
+          end,
+        },
+      }
+    end
+
+    -- Register tools in test config
+    cfg.strategies.chat.tools.t1 = { callback = function() return make_tool("t1") end, enabled = true }
+    if %d >= 2 then
+      cfg.strategies.chat.tools.t2 = { callback = function() return make_tool("t2") end, enabled = true }
+    end
+    if %d >= 3 then
+      cfg.strategies.chat.tools.t3 = { callback = function() return make_tool("t3") end, enabled = true }
+    end
+
+    -- Create chat and tools
+    local chat, tools = h.setup_chat_buffer(cfg)
+    _G.chat, _G.tools = chat, tools
+
+    -- Stub confirm to always choose "3 Cancel"
+    local ui = require("codecompanion.utils.ui")
+    ui.confirm = function(_) return 3 end
+
+    -- Build tool calls
+    local calls = {
+      { ["function"] = { name = "t1", arguments = "{}" } },
+    }
+    if %d >= 2 then
+      table.insert(calls, { ["function"] = { name = "t2", arguments = "{}" } })
+    end
+    if %d >= 3 then
+      table.insert(calls, { ["function"] = { name = "t3", arguments = "{}" } })
+    end
+
+    -- Execute
+    _G.tools:execute(_G.chat, calls)
+    vim.wait(250)
+  ]],
+    n_tools,
+    n_tools,
+    n_tools,
+    n_tools
+  ))
+end
+
+T["cancels all queued tools when user selects cancel"] = function()
+  setup_with_tools_and_cancel_stub(3)
+
+  local cancelled = child.lua_get("_G.cancelled or {}")
+  h.eq(cancelled, { "t1", "t2", "t3" })
+
+  -- Ensure chat received cancellation outputs for each tool
+  local all = child.lua([[
+    local msgs = {}
+    for _, m in ipairs(_G.chat.messages or {}) do
+      if type(m.content) == "string" then table.insert(msgs, m.content) end
+    end
+    return table.concat(msgs, "\n")
+  ]])
+  h.expect_contains("cancelled:t1", all)
+  h.expect_contains("cancelled:t2", all)
+  h.expect_contains("cancelled:t3", all)
+end
+
+T["cancels current tool when it is the only one"] = function()
+  setup_with_tools_and_cancel_stub(1)
+
+  local cancelled = child.lua_get("_G.cancelled or {}")
+  h.eq(cancelled, { "t1" })
+
+  local all = child.lua([[
+    local msgs = {}
+    for _, m in ipairs(_G.chat.messages or {}) do
+      if type(m.content) == "string" then table.insert(msgs, m.content) end
+    end
+    return table.concat(msgs, "\n")
+  ]])
+  h.expect_contains("cancelled:t1", all)
+end
+
+return T


### PR DESCRIPTION
## Description

You can now cancel all tools in the queue.

## Related Issue(s)

#2149

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
