### PR TITLE
chore: add memory for testing and tools

### DIFF
--- a/.codecompanion/tests/test.md
+++ b/.codecompanion/tests/test.md
@@ -20,3 +20,8 @@ The plugin has some test helpers that allow for easier setting up of the plugin,
 @./tests/adapters/http/test_tools_in_chat_buffer.lua
 
 One of Mini.Tests unique selling points is its ability to allow for screenshot tests. That is, you can assert that Neovim looks as expected.
+
+## Tips
+
+Be mindful when using `child.lua` and `child.lua_get`. The former allows you to use `return` to output a value for use elsewhere in the test. The latter, applys `return` automatically and will fail if you include it.
+

--- a/.codecompanion/tools.md
+++ b/.codecompanion/tools.md
@@ -1,0 +1,40 @@
+# Tools
+
+In the CodeCompanion plugin, tools can be leveraged by an LLM to execute lua functions or shell commands on the users machine. CodeCompanion uses an LLM's native function calling to receive a response in JSON, parse the response and call the corresponding tool. This feature has been implemented via the tools/init.lua file, which passes all of the tools and adds them to a queue. Then those tools are run consecutively by the orchestrator.lua file.
+
+## Relevant Files
+
+### Tool System
+
+@./lua/codecompanion/strategies/chat/tools/init.lua
+
+This is the entry point for the tool system. If an LLM's response includes a function call (or tool call) then this file is triggered which in turns add tools to a queue before calling the orchestrator
+
+### Orchestrator
+
+@./lua/codecompanion/strategies/chat/tools/orchestrator.lua
+
+The orchestrator file runs the tools in the queue, according to first in, first out.
+
+### Queue
+
+@./lua/codecompanion/strategies/chat/tools/runtime/queue.lua
+@./tests/stubs/queue.txt
+
+The implementation of the tool queue, alongside an example queue.
+
+### Runtime Runner
+
+@./lua/codecompanion/strategies/chat/tools/runtime/runner.lua
+
+Runs a specific tool.
+
+## Example Tool
+
+@./lua/codecompanion/strategies/chat/tools/catalog/read_file.lua
+
+This is an example of a tool in CodeCompanion that reads a file in the current working directory. It's a great example of a function tool.
+
+@./tests/strategies/chat/tools/catalog/test_read_file.lua
+
+This is the corresponding test for the tool.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1206,6 +1206,12 @@ You must create or modify a workspace file through a series of prompts over mult
             ".codecompanion/tests/test.md",
           },
         },
+        ["tools"] = {
+          description = "Tools implementation in the plugin",
+          files = {
+            ".codecompanion/tools.md",
+          },
+        },
         ["ui"] = {
           description = "The chat UI implementation",
           files = {


### PR DESCRIPTION
## Description

Add memory for tests and tools

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
