### PR TITLE
fix(ui): try to append to existing winhighlight option values

### DIFF
--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -508,7 +508,9 @@ function M.set_winbar(winnr, text, hl)
   end
 
   local centered = "%=" .. (text or ""):gsub("%%", "%%%%") .. "%="
-  vim.wo[winnr].winhighlight = "WinBar:" .. hl .. ",WinBarNC:" .. hl
+  local existing_hl = vim.wo[winnr].winhighlight or ""
+  existing_hl = #existing_hl > 0 and existing_hl .. "," or existing_hl
+  vim.wo[winnr].winhighlight = existing_hl .. "WinBar:" .. hl .. ",WinBarNC:" .. hl
   vim.wo[winnr].winbar = centered
 end
 


### PR DESCRIPTION
## Description

Support custom values `winhighlight` in `config.display.chat.diff_window.opts.winhighlight`.

## Related Issue(s)

  - Fixes #2165


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
