### PR TITLE
docs: typo in adapters.md

### DIFF
--- a/doc/extending/adapters.md
+++ b/doc/extending/adapters.md
@@ -1,7 +1,7 @@
 # Creating Adapters
 
 > [!TIP]
-> Does your LLM state that it is "OpenAI Compatible"? If so, good news, you can extend from the `openai` adapter or use the `openai_compatible` one. Something we did with the [xAI](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/adapters/xai.lua) adapter
+> Does your LLM state that it is "OpenAI Compatible"? If so, good news, you can extend from the `openai` adapter or use the `openai_compatible` one. Something we did with the [xAI](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/adapters/http/xai.lua) adapter
 
 In CodeCompanion, adapters are interfaces that act as a bridge between the plugin's functionality and an LLM. All adapters must follow the interface, below.
 


### PR DESCRIPTION
Typo in link to xAI adapter