### PR TITLE
fix(acp): fix claude-code always outputting tool content

### DIFF
--- a/lua/codecompanion/adapters/acp/claude_code.lua
+++ b/lua/codecompanion/adapters/acp/claude_code.lua
@@ -11,6 +11,9 @@ return {
   },
   opts = {
     vision = true,
+    -- Claude Code has an annoying habit of outputting the entire contents of a
+    -- file in a tool call. This messes up the chat buffer formatting.
+    trim_tool_output = true,
   },
   commands = {
     default = {

--- a/lua/codecompanion/adapters/acp/init.lua
+++ b/lua/codecompanion/adapters/acp/init.lua
@@ -9,6 +9,7 @@ local shared = require("codecompanion.adapters.shared")
 ---@field roles table The mapping of roles in the config to the LLM's defined roles
 ---@field command table The command to execute
 ---@field commands { default: table, [string]: table } The list of possible commands for the adapter. Must include a 'default' key
+---@field opts? table Additional options for the adapter
 ---@field defaults? table Additional options for the adapter
 ---@field env? table Environment variables which can be referenced in the parameters
 ---@field env_replaced? table Replacement of environment variables with their actual values

--- a/lua/codecompanion/strategies/chat/acp/formatters.lua
+++ b/lua/codecompanion/strategies/chat/acp/formatters.lua
@@ -127,9 +127,11 @@ end
 function M.tool_message(tool_call, adapter)
   local status = tool_call.status or "pending"
   local title = M.short_title(tool_call)
+  local trim_tool_output = adapter.opts and adapter.opts.trim_tool_output
+
   if status == "completed" then
     local summary
-    if adapter.name == "claude_code" then
+    if trim_tool_output then
       summary = title
     else
       summary = M.summarize_tool_content(tool_call)
@@ -138,8 +140,13 @@ function M.tool_message(tool_call, adapter)
   elseif status == "in_progress" then
     return title .. " — running"
   elseif status == "failed" then
-    local summary = M.summarize_tool_content(tool_call)
-    return summary and (title .. " — failed: " .. summary) or (title .. " — failed")
+    local summary
+    if trim_tool_output then
+      summary = title
+    else
+      summary = M.summarize_tool_content(tool_call)
+    end
+    return summary or (title .. " — failed")
   else
     return title
   end


### PR DESCRIPTION
## Description

Ensure Claude Code does output markdown when returning an erroneous tool

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
