### PR TITLE
chore(ui): improve floating window title

### DIFF
--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -142,19 +142,12 @@ function M.build_float_title(opts)
   local title = opts.title or opts.title_prefix or "CodeCompanion"
 
   if opts.filepath then
-    local filename = vim.fs.basename(opts.filepath)
-    local function format_dirname(path)
-      local dirname = vim.fs.dirname(path)
-      if dirname and dirname ~= "." and dirname ~= "" then
-        return dirname .. "/"
-      end
-      return ""
-    end
     local ok, relative_path = pcall(function()
       return vim.fs.relpath(vim.uv.cwd(), vim.fs.normalize(opts.filepath))
     end)
     local path_to_use = (ok and relative_path and relative_path ~= "") and relative_path or opts.filepath
-    title = " " .. (opts.title_prefix or " Diff") .. ": [" .. filename .. "]:" .. format_dirname(path_to_use) .. " "
+
+    title = " " .. (opts.title_prefix or " Diff") .. ": " .. path_to_use .. " "
   end
 
   return title


### PR DESCRIPTION
## Description

Prior to this PR, a floating diff would have the title:

```
Diff: [filename.lua]:src/utils/
```

I found this to unintuitive. This PR moves it to be:

```
Diff: src/utils/filename.lua
```

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
