### PR TITLE
fix(adapters): allow user to prevent caching in Ollama adapter

### DIFF
--- a/lua/codecompanion/adapters/http/ollama.lua
+++ b/lua/codecompanion/adapters/http/ollama.lua
@@ -13,7 +13,7 @@ local _cached_adapter
 local function get_models(self, opts)
   -- Prevent the adapter from being resolved multiple times due to `get_models`
   -- having both `default` and `choices` functions
-  if not _cached_adapter then
+  if not _cached_adapter or self.opts.cache_adapter == false then
     local adapter = require("codecompanion.adapters").resolve(self)
     if not adapter then
       log:error("Could not resolve Ollama adapter in the `get_models` function")
@@ -124,6 +124,7 @@ return {
     stream = true,
     tools = true,
     vision = true,
+    cache_adapter = true, -- Cache the resolved adapter to prevent multiple resolutions
   },
   features = {
     text = true,


### PR DESCRIPTION
## Description

Allow users to disable caching of adapters in the Ollama model.

To test this out:

```lua
return require("codecompanion.adapters").extend("ollama", {
  opts = {
    cache_adapter = false,
  },
})
```

## Related Issue(s)

#2180

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
