### PR TITLE
refactor(ui): rename vars in diff implementation

### DIFF
--- a/lua/codecompanion/providers/diff/inline.lua
+++ b/lua/codecompanion/providers/diff/inline.lua
@@ -41,7 +41,7 @@ function InlineDiff.new(args)
   ---@cast self CodeCompanion.Diff.Inline
 
   local current_content = api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
-  if self:contents_equal(self.contents, current_content) then
+  if self:are_contents_equal(self.contents, current_content) then
     log:trace("[providers::diff::inline::new] No changes detected")
     util.fire("DiffAttached", { diff = "inline", bufnr = self.bufnr, id = self.id })
     return self
@@ -94,8 +94,8 @@ end
 ---@param content1 string[] First content array
 ---@param content2 string[] Second content array
 ---@return boolean equal True if contents are identical
-function InlineDiff:contents_equal(content1, content2)
-  return diff_utils.contents_equal(content1, content2)
+function InlineDiff:are_contents_equal(content1, content2)
+  return diff_utils.are_contents_equal(content1, content2)
 end
 
 ---Apply diff highlights to this instance
@@ -115,7 +115,7 @@ function InlineDiff:apply_diff_highlights(old_lines, new_lines)
   -- Add keymap hint above the first hunk if there are changes
   if #hunks > 0 then
     local first_hunk = hunks[1]
-    first_diff_line = math.max(1, first_hunk.new_start) -- Store for cursor positioning
+    first_diff_line = math.max(1, first_hunk.updated_start) -- Store for cursor positioning
     -- Only show keymap hints if config allows it, not in test mode, and not floating
     local show_keymap_hints = inline_config.opts.show_keymap_hints
     if show_keymap_hints == nil then
@@ -126,7 +126,7 @@ function InlineDiff:apply_diff_highlights(old_lines, new_lines)
     local is_testing = _G.MiniTest ~= nil
     -- Don't show hints for floating windows since they use winbar instead
     if show_keymap_hints and not is_testing and not self.is_floating then
-      local attach_line = math.max(0, first_hunk.new_start - 2)
+      local attach_line = math.max(0, first_hunk.updated_start - 2)
       if first_diff_line == 1 then
         attach_line = attach_line + 1
       end

--- a/lua/codecompanion/providers/diff/utils.lua
+++ b/lua/codecompanion/providers/diff/utils.lua
@@ -6,72 +6,79 @@ local api = vim.api
 local M = {}
 
 ---@class CodeCompanion.Diff.Utils.DiffHunk
----@field old_start number
----@field old_count number
----@field new_start number
----@field new_count number
----@field old_lines string[]
----@field new_lines string[]
+---@field original_start number
+---@field original_count number
+---@field updated_start number
+---@field updated_count number
+---@field removed_lines string[]
+---@field added_lines string[]
 ---@field context_before string[]
 ---@field context_after string[]
 
 ---Calculate diff hunks between two content arrays
----@param old_lines string[] Original content
----@param new_lines string[] New content
+---@param removed_lines string[]
+---@param added_lines string[]
 ---@param context_lines? number Number of context lines (default: 3)
 ---@return CodeCompanion.Diff.Utils.DiffHunk[] hunks
-function M.calculate_hunks(old_lines, new_lines, context_lines)
+function M.calculate_hunks(removed_lines, added_lines, context_lines)
   context_lines = context_lines or 3
-  local diff_fn = vim.text.diff or vim.diff
-  local old_text = table.concat(old_lines, "\n")
-  local new_text = table.concat(new_lines, "\n")
-  local ok, diff_result = pcall(diff_fn, old_text, new_text, {
+
+  local diff_engine = vim.text.diff or vim.diff
+  local original_text = table.concat(removed_lines, "\n")
+  local updated_text = table.concat(added_lines, "\n")
+  local ok, diff_result = pcall(diff_engine, original_text, updated_text, {
     result_type = "indices",
     algorithm = "histogram",
   })
+
   if not ok or not diff_result or #diff_result == 0 then
     return {}
   end
+
   local hunks = {}
   for _, hunk in ipairs(diff_result) do
-    local old_start, old_count, new_start, new_count = unpack(hunk)
+    local original_start, original_count, updated_start, updated_count = unpack(hunk)
+
     -- Extract changed lines
-    local hunk_old_lines = {}
-    for i = 0, old_count - 1 do
-      local line_idx = old_start + i
-      if old_lines[line_idx] then
-        table.insert(hunk_old_lines, old_lines[line_idx])
+    local orignal_hunk_lines = {}
+    for i = 0, original_count - 1 do
+      local original_line_index = original_start + i
+      if removed_lines[original_line_index] then
+        table.insert(orignal_hunk_lines, removed_lines[original_line_index])
       end
     end
-    local hunk_new_lines = {}
-    for i = 0, new_count - 1 do
-      local line_idx = new_start + i
-      if new_lines[line_idx] then
-        table.insert(hunk_new_lines, new_lines[line_idx])
+
+    local updated_hunk_lines = {}
+    for i = 0, updated_count - 1 do
+      local original_line_index = updated_start + i
+      if added_lines[original_line_index] then
+        table.insert(updated_hunk_lines, added_lines[original_line_index])
       end
     end
+
     -- Extract context
     local context_before = {}
-    local context_start = math.max(1, old_start - context_lines)
-    for i = context_start, old_start - 1 do
-      if old_lines[i] then
-        table.insert(context_before, old_lines[i])
+    local context_start = math.max(1, original_start - context_lines)
+    for i = context_start, original_start - 1 do
+      if removed_lines[i] then
+        table.insert(context_before, removed_lines[i])
       end
     end
+
     local context_after = {}
-    local context_end = math.min(#old_lines, old_start + old_count + context_lines - 1)
-    for i = old_start + old_count, context_end do
-      if old_lines[i] then
-        table.insert(context_after, old_lines[i])
+    local context_end = math.min(#removed_lines, original_start + original_count + context_lines - 1)
+    for i = original_start + original_count, context_end do
+      if removed_lines[i] then
+        table.insert(context_after, removed_lines[i])
       end
     end
     table.insert(hunks, {
-      old_start = old_start,
-      old_count = old_count,
-      new_start = new_start,
-      new_count = new_count,
-      old_lines = hunk_old_lines,
-      new_lines = hunk_new_lines,
+      original_start = original_start,
+      original_count = original_count,
+      updated_start = updated_start,
+      updated_count = updated_count,
+      removed_lines = orignal_hunk_lines,
+      added_lines = updated_hunk_lines,
       context_before = context_before,
       context_after = context_after,
     })
@@ -81,11 +88,11 @@ function M.calculate_hunks(old_lines, new_lines, context_lines)
 end
 
 ---Apply visual highlights to hunks in a buffer with sign column indicators
----@param bufnr number Buffer to apply highlights to
----@param hunks CodeCompanion.Diff.Utils.DiffHunk[] Hunks to highlight
----@param ns_id number Namespace for extmarks
----@param line_offset? number Line offset (default: 0)
----@param opts? table Options: {show_removed: boolean, full_width_removed: boolean, status: string}
+---@param bufnr number
+---@param hunks CodeCompanion.Diff.Utils.DiffHunk
+---@param ns_id number
+---@param line_offset? number
+---@param opts? {show_removed: boolean, full_width_removed: boolean, status: string}
 ---@return number[] extmark_ids
 function M.apply_hunk_highlights(bufnr, hunks, ns_id, line_offset, opts)
   line_offset = line_offset or 0
@@ -103,22 +110,26 @@ function M.apply_hunk_highlights(bufnr, hunks, ns_id, line_offset, opts)
       deletion = "DiagnosticError",
       modification = "DiagnosticWarn",
     }
+
   for _, hunk in ipairs(hunks) do
     -- Handle removed lines FIRST (virtual text above the change location)
-    if opts.show_removed and #hunk.old_lines > 0 then
-      local attach_line = math.max(0, hunk.new_start - 1 + line_offset)
+    if opts.show_removed and #hunk.removed_lines > 0 then
+      local attach_line = math.max(0, hunk.updated_start - 1 + line_offset)
       if attach_line >= api.nvim_buf_line_count(bufnr) then
         attach_line = api.nvim_buf_line_count(bufnr) - 1
       end
-      local is_modification = #hunk.new_lines > 0
-      local sign_hl = M.get_sign_highlight_for_change("removed", is_modification, highlight_groups)
+
+      local is_modified_hunk = #hunk.added_lines > 0
+      local sign_hl = M.get_sign_highlight_for_change("removed", is_modified_hunk, highlight_groups)
+
       -- Create virtual text for ALL removed lines in this hunk
       local virt_lines = {}
-      for _, old_line in ipairs(hunk.old_lines) do
+      for _, old_line in ipairs(hunk.removed_lines) do
         local display_line = old_line
         local padding = opts.full_width_removed and math.max(0, vim.o.columns - #display_line - 2) or 0
         table.insert(virt_lines, { { display_line .. string.rep(" ", padding), "DiffDelete" } })
       end
+
       -- Single extmark for all removed lines in this hunk
       local _, extmark_id = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, attach_line, 0, {
         virt_lines = virt_lines,
@@ -131,21 +142,21 @@ function M.apply_hunk_highlights(bufnr, hunks, ns_id, line_offset, opts)
       table.insert(extmark_ids, extmark_id)
       log:trace(
         "[providers::diff::utils::apply_hunk_highlights] Added %d removed lines as virtual text at line %d with %s sign",
-        #hunk.old_lines,
+        #hunk.removed_lines,
         attach_line,
         sign_hl
       )
     end
 
     -- Handle added/modified lines (highlight in green/red based on status)
-    for i, _ in ipairs(hunk.new_lines) do
-      local line_idx = hunk.new_start + i - 2 + line_offset -- Correct 0-based conversion
-      if line_idx >= 0 and line_idx < api.nvim_buf_line_count(bufnr) then
+    for i, _ in ipairs(hunk.added_lines) do
+      local target_row = hunk.updated_start + i - 2 + line_offset -- Correct 0-based conversion
+      if target_row >= 0 and target_row < api.nvim_buf_line_count(bufnr) then
         -- Determine change type and status
-        local is_modification = #hunk.old_lines > 0
-        local sign_hl = M.get_sign_highlight_for_change("added", is_modification, highlight_groups)
+        local is_modified_hunk = #hunk.removed_lines > 0
+        local sign_hl = M.get_sign_highlight_for_change("added", is_modified_hunk, highlight_groups)
         local line_hl = "DiffAdd"
-        local _, extmark_id = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, line_idx, 0, {
+        local _, extmark_id = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, target_row, 0, {
           line_hl_group = line_hl,
           priority = 100,
           sign_text = sign_text,
@@ -155,7 +166,7 @@ function M.apply_hunk_highlights(bufnr, hunks, ns_id, line_offset, opts)
         log:trace(
           "[providers::diff::utils::apply_hunk_highlights] Added %s highlight at line %d with %s sign",
           line_hl,
-          line_idx,
+          target_row,
           sign_hl
         )
       end
@@ -167,31 +178,32 @@ function M.apply_hunk_highlights(bufnr, hunks, ns_id, line_offset, opts)
 end
 
 ---Get appropriate sign highlight color for a change type
----@param change_type "added"|"removed" Type of change
----@param is_modification boolean Whether this is a modification or pure add/delete
----@param highlight_groups table Highlight group configuration
----@return string highlight_group
-function M.get_sign_highlight_for_change(change_type, is_modification, highlight_groups)
-  highlight_groups = highlight_groups
+---@param change_kind "added"|"removed"
+---@param is_modified boolean
+---@param hl_groups table
+---@return string
+function M.get_sign_highlight_for_change(change_kind, is_modified, hl_groups)
+  hl_groups = hl_groups
     or {
       addition = "DiagnosticOk",
       deletion = "DiagnosticError",
       modification = "DiagnosticWarn",
     }
-  if change_type == "removed" then
-    return is_modification and highlight_groups.modification or highlight_groups.deletion
-  elseif change_type == "added" then
-    return is_modification and highlight_groups.modification or highlight_groups.addition
+
+  if change_kind == "removed" then
+    return is_modified and hl_groups.modification or hl_groups.deletion
+  elseif change_kind == "added" then
+    return is_modified and hl_groups.modification or hl_groups.addition
   end
 
-  return highlight_groups.modification
+  return hl_groups.modification
 end
 
----Compare two content arrays for equality
----@param content1 string[] First content array
----@param content2 string[] Second content array
----@return boolean equal True if contents are identical
-function M.contents_equal(content1, content2)
+---Determine if two content arrays are equal
+---@param content1 string[]
+---@param content2 string[]
+---@return boolean
+function M.are_contents_equal(content1, content2)
   if #content1 ~= #content2 then
     return false
   end

--- a/lua/codecompanion/providers/diff/utils.lua
+++ b/lua/codecompanion/providers/diff/utils.lua
@@ -40,11 +40,11 @@ function M.calculate_hunks(removed_lines, added_lines, context_lines)
     local original_start, original_count, updated_start, updated_count = unpack(hunk)
 
     -- Extract changed lines
-    local orignal_hunk_lines = {}
+    local original_hunk_lines = {}
     for i = 0, original_count - 1 do
       local original_line_index = original_start + i
       if removed_lines[original_line_index] then
-        table.insert(orignal_hunk_lines, removed_lines[original_line_index])
+        table.insert(original_hunk_lines, removed_lines[original_line_index])
       end
     end
 
@@ -77,7 +77,7 @@ function M.calculate_hunks(removed_lines, added_lines, context_lines)
       original_count = original_count,
       updated_start = updated_start,
       updated_count = updated_count,
-      removed_lines = orignal_hunk_lines,
+      removed_lines = original_hunk_lines,
       added_lines = updated_hunk_lines,
       context_before = context_before,
       context_after = context_after,

--- a/lua/codecompanion/strategies/chat/edit_tracker.lua
+++ b/lua/codecompanion/strategies/chat/edit_tracker.lua
@@ -140,7 +140,7 @@ function EditTracker.register_edit_operation(chat, edit_info)
     if
       time_diff < time_window
       and existing_op.tool_name == edit_info.tool_name
-      and diff_utils.contents_equal(existing_op.original_content, edit_info.original_content)
+      and diff_utils.are_contents_equal(existing_op.original_content, edit_info.original_content)
     then
       log:debug("[Edit Tracker] Duplicate edit detected within %dms, skipping registration", time_diff / 1000000)
       log:debug("[Edit Tracker] Existing operation: %s, New tool: %s", existing_op.id, edit_info.tool_name)

--- a/lua/codecompanion/strategies/inline/keymaps.lua
+++ b/lua/codecompanion/strategies/inline/keymaps.lua
@@ -48,8 +48,8 @@ M.always_accept = {
       clear_map(config.strategies.inline.keymaps, inline.diff.bufnr)
     end
     vim.g.codecompanion_yolo_mode = true
-    utils.notify("Auto tool mode enabled - future edits will be automatically accepted")
-    log:trace("[Inline] Auto tool mode enabled")
+    utils.notify("YOLO mode enabled - future edits will be automatically accepted")
+    log:trace("[Inline] YOLO mode enabled")
   end,
 }
 

--- a/tests/providers/diff/test_inline.lua
+++ b/tests/providers/diff/test_inline.lua
@@ -88,18 +88,18 @@ T["InlineDiff"]["new - handles missing id parameter"] = function()
 end
 
 T["InlineDiff"]["calculate_hunks - delegates to DiffUtils"] = function()
-  local old_lines = { "line 1", "old line", "line 3" }
-  local new_lines = { "line 1", "new line", "line 3" }
-  local hunks = InlineDiff.calculate_hunks(old_lines, new_lines)
+  local removed_lines = { "line 1", "old line", "line 3" }
+  local added_lines = { "line 1", "new line", "line 3" }
+  local hunks = InlineDiff.calculate_hunks(removed_lines, added_lines)
 
   h.eq(type(hunks), "table")
 end
 
 T["InlineDiff"]["calculate_hunks - respects context parameter"] = function()
-  local old_lines = { "line 1", "line 2", "old line", "line 4", "line 5" }
-  local new_lines = { "line 1", "line 2", "new line", "line 4", "line 5" }
-  local hunks_default = InlineDiff.calculate_hunks(old_lines, new_lines)
-  local hunks_context_1 = InlineDiff.calculate_hunks(old_lines, new_lines, 1)
+  local removed_lines = { "line 1", "line 2", "old line", "line 4", "line 5" }
+  local added_lines = { "line 1", "line 2", "new line", "line 4", "line 5" }
+  local hunks_default = InlineDiff.calculate_hunks(removed_lines, added_lines)
+  local hunks_context_1 = InlineDiff.calculate_hunks(removed_lines, added_lines, 1)
 
   h.eq(type(hunks_default), "table")
   h.eq(type(hunks_context_1), "table")
@@ -112,12 +112,12 @@ T["InlineDiff"]["apply_hunk_highlights - delegates to DiffUtils"] = function()
 
   local hunks = {
     {
-      old_start = 2,
-      old_count = 1,
-      new_start = 2,
-      new_count = 1,
-      old_lines = { "old line" },
-      new_lines = { "new line" },
+      original_start = 2,
+      original_count = 1,
+      updated_start = 2,
+      updated_count = 1,
+      removed_lines = { "old line" },
+      added_lines = { "new line" },
       context_before = { "line 1" },
       context_after = { "line 3" },
     },
@@ -136,12 +136,12 @@ T["InlineDiff"]["apply_hunk_highlights - handles options"] = function()
 
   local hunks = {
     {
-      old_start = 1,
-      old_count = 0,
-      new_start = 1,
-      new_count = 1,
-      old_lines = {},
-      new_lines = { "line 1" },
+      original_start = 1,
+      original_count = 0,
+      updated_start = 1,
+      updated_count = 1,
+      removed_lines = {},
+      added_lines = { "line 1" },
       context_before = {},
       context_after = {},
     },
@@ -169,8 +169,8 @@ T["InlineDiff"]["contents_equal - delegates to DiffUtils"] = function()
   local content2 = { "line 1", "line 2" }
   local content3 = { "line 1", "different line 2" }
 
-  h.eq(diff:contents_equal(content1, content2), true)
-  h.eq(diff:contents_equal(content1, content3), false)
+  h.eq(diff:are_contents_equal(content1, content2), true)
+  h.eq(diff:are_contents_equal(content1, content3), false)
 end
 
 T["InlineDiff"]["apply_diff_highlights - applies highlights for changes"] = function()
@@ -184,10 +184,10 @@ T["InlineDiff"]["apply_diff_highlights - applies highlights for changes"] = func
     id = "test_highlights",
   })
 
-  local old_lines = { "line 1", "old line", "line 3" }
-  local new_lines = { "line 1", "new line", "line 3" }
+  local removed_lines = { "line 1", "old line", "line 3" }
+  local added_lines = { "line 1", "new line", "line 3" }
   local initial_extmarks = #diff.extmark_ids
-  diff:apply_diff_highlights(old_lines, new_lines)
+  diff:apply_diff_highlights(removed_lines, added_lines)
 
   h.expect_truthy(#diff.extmark_ids >= initial_extmarks)
   h.eq(vim.api.nvim_get_mode().mode, "n")

--- a/tests/providers/diff/test_utils.lua
+++ b/tests/providers/diff/test_utils.lua
@@ -16,79 +16,79 @@ T["DiffUtils"] = MiniTest.new_set({
 })
 
 T["DiffUtils"]["calculate_hunks - detects simple addition"] = function()
-  local old_lines = { "line 1", "line 2" }
-  local new_lines = { "line 1", "line 2", "line 3" }
+  local removed_lines = { "line 1", "line 2" }
+  local added_lines = { "line 1", "line 2", "line 3" }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
 
   h.eq(type(hunks), "table")
   h.expect_truthy(#hunks > 0)
 end
 
 T["DiffUtils"]["calculate_hunks - detects simple deletion"] = function()
-  local old_lines = { "line 1", "line 2", "line 3" }
-  local new_lines = { "line 1", "line 3" }
+  local removed_lines = { "line 1", "line 2", "line 3" }
+  local added_lines = { "line 1", "line 3" }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
 
   h.eq(type(hunks), "table")
   h.expect_truthy(#hunks > 0)
 end
 
 T["DiffUtils"]["calculate_hunks - detects modification"] = function()
-  local old_lines = { "line 1", "old line 2", "line 3" }
-  local new_lines = { "line 1", "new line 2", "line 3" }
+  local removed_lines = { "line 1", "old line 2", "line 3" }
+  local added_lines = { "line 1", "new line 2", "line 3" }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
 
   h.eq(type(hunks), "table")
   h.expect_truthy(#hunks > 0)
 end
 
 T["DiffUtils"]["calculate_hunks - returns empty for identical content"] = function()
-  local old_lines = { "line 1", "line 2", "line 3" }
-  local new_lines = { "line 1", "line 2", "line 3" }
+  local removed_lines = { "line 1", "line 2", "line 3" }
+  local added_lines = { "line 1", "line 2", "line 3" }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
 
   h.eq(type(hunks), "table")
   h.eq(#hunks, 0)
 end
 
 T["DiffUtils"]["calculate_hunks - handles empty content"] = function()
-  local old_lines = {}
-  local new_lines = { "new line" }
+  local removed_lines = {}
+  local added_lines = { "new line" }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
 
   h.eq(type(hunks), "table")
 end
 
 T["DiffUtils"]["calculate_hunks - respects context lines parameter"] = function()
-  local old_lines = { "line 1", "line 2", "line 3", "line 4", "line 5" }
-  local new_lines = { "line 1", "modified line 2", "line 3", "line 4", "line 5" }
+  local removed_lines = { "line 1", "line 2", "line 3", "line 4", "line 5" }
+  local added_lines = { "line 1", "modified line 2", "line 3", "line 4", "line 5" }
 
-  local hunks_default = diff_utils.calculate_hunks(old_lines, new_lines)
-  local hunks_context_1 = diff_utils.calculate_hunks(old_lines, new_lines, 1)
+  local hunks_default = diff_utils.calculate_hunks(removed_lines, added_lines)
+  local hunks_context_1 = diff_utils.calculate_hunks(removed_lines, added_lines, 1)
 
   h.eq(type(hunks_default), "table")
   h.eq(type(hunks_context_1), "table")
 end
 
 T["DiffUtils"]["calculate_hunks - returns valid hunk structure"] = function()
-  local old_lines = { "line 1", "old line", "line 3" }
-  local new_lines = { "line 1", "new line", "line 3" }
+  local removed_lines = { "line 1", "old line", "line 3" }
+  local added_lines = { "line 1", "new line", "line 3" }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
 
   if #hunks > 0 then
     local hunk = hunks[1]
-    h.eq(type(hunk.old_start), "number")
-    h.eq(type(hunk.old_count), "number")
-    h.eq(type(hunk.new_start), "number")
-    h.eq(type(hunk.new_count), "number")
-    h.eq(type(hunk.old_lines), "table")
-    h.eq(type(hunk.new_lines), "table")
+    h.eq(type(hunk.original_start), "number")
+    h.eq(type(hunk.original_count), "number")
+    h.eq(type(hunk.updated_start), "number")
+    h.eq(type(hunk.updated_count), "number")
+    h.eq(type(hunk.removed_lines), "table")
+    h.eq(type(hunk.added_lines), "table")
     h.eq(type(hunk.context_before), "table")
     h.eq(type(hunk.context_after), "table")
   end
@@ -100,12 +100,12 @@ T["DiffUtils"]["apply_hunk_highlights - returns extmark ids"] = function()
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "line 1", "new line", "line 3" })
   local hunks = {
     {
-      old_start = 2,
-      old_count = 1,
-      new_start = 2,
-      new_count = 1,
-      old_lines = { "old line" },
-      new_lines = { "new line" },
+      original_start = 2,
+      original_count = 1,
+      updated_start = 2,
+      updated_count = 1,
+      removed_lines = { "old line" },
+      added_lines = { "new line" },
       context_before = { "line 1" },
       context_after = { "line 3" },
     },
@@ -132,12 +132,12 @@ T["DiffUtils"]["apply_hunk_highlights - respects line offset"] = function()
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "header", "line 1", "new line", "line 3" })
   local hunks = {
     {
-      old_start = 2,
-      old_count = 1,
-      new_start = 2,
-      new_count = 1,
-      old_lines = { "old line" },
-      new_lines = { "new line" },
+      original_start = 2,
+      original_count = 1,
+      updated_start = 2,
+      updated_count = 1,
+      removed_lines = { "old line" },
+      added_lines = { "new line" },
       context_before = { "line 1" },
       context_after = { "line 3" },
     },
@@ -155,12 +155,12 @@ T["DiffUtils"]["apply_hunk_highlights - handles different status"] = function()
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "line 1", "new line", "line 3" })
   local hunks = {
     {
-      old_start = 2,
-      old_count = 1,
-      new_start = 2,
-      new_count = 1,
-      old_lines = { "old line" },
-      new_lines = { "new line" },
+      original_start = 2,
+      original_count = 1,
+      updated_start = 2,
+      updated_count = 1,
+      removed_lines = { "old line" },
+      added_lines = { "new line" },
       context_before = { "line 1" },
       context_after = { "line 3" },
     },
@@ -219,79 +219,79 @@ T["DiffUtils"]["get_sign_highlight_for_change - defaults to pending status"] = f
   h.eq(highlight_explicit, "DiagnosticOk")
 end
 
--- Test contents_equal function
-T["DiffUtils"]["contents_equal - returns true for identical content"] = function()
+-- Test are_contents_equal function
+T["DiffUtils"]["are_contents_equal - returns true for identical content"] = function()
   local content1 = { "line 1", "line 2", "line 3" }
   local content2 = { "line 1", "line 2", "line 3" }
-  local result = diff_utils.contents_equal(content1, content2)
+  local result = diff_utils.are_contents_equal(content1, content2)
 
   h.eq(result, true)
 end
 
-T["DiffUtils"]["contents_equal - returns false for different content"] = function()
+T["DiffUtils"]["are_contents_equal - returns false for different content"] = function()
   local content1 = { "line 1", "line 2", "line 3" }
   local content2 = { "line 1", "modified line 2", "line 3" }
-  local result = diff_utils.contents_equal(content1, content2)
+  local result = diff_utils.are_contents_equal(content1, content2)
 
   h.eq(result, false)
 end
 
-T["DiffUtils"]["contents_equal - returns false for different lengths"] = function()
+T["DiffUtils"]["are_contents_equal - returns false for different lengths"] = function()
   local content1 = { "line 1", "line 2" }
   local content2 = { "line 1", "line 2", "line 3" }
-  local result = diff_utils.contents_equal(content1, content2)
+  local result = diff_utils.are_contents_equal(content1, content2)
 
   h.eq(result, false)
 end
 
-T["DiffUtils"]["contents_equal - handles empty arrays"] = function()
+T["DiffUtils"]["are_contents_equal - handles empty arrays"] = function()
   local content1 = {}
   local content2 = {}
-  local result = diff_utils.contents_equal(content1, content2)
+  local result = diff_utils.are_contents_equal(content1, content2)
 
   h.eq(result, true)
 end
 
-T["DiffUtils"]["contents_equal - handles one empty array"] = function()
+T["DiffUtils"]["are_contents_equal - handles one empty array"] = function()
   local content1 = {}
   local content2 = { "line 1" }
-  local result = diff_utils.contents_equal(content1, content2)
+  local result = diff_utils.are_contents_equal(content1, content2)
 
   h.eq(result, false)
 end
 
 -- Integration tests
 T["DiffUtils"]["integration - full diff workflow"] = function()
-  local old_lines = {
+  local removed_lines = {
     "function hello()",
     "  print('old')",
     "end",
   }
-  local new_lines = {
+  local added_lines = {
     "function hello()",
     "  print('new')",
     "  print('extra line')",
     "end",
   }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
   h.expect_truthy(#hunks > 0)
 
   local bufnr = vim.api.nvim_get_current_buf()
   local ns_id = vim.api.nvim_create_namespace("test_integration")
-  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, new_lines)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, added_lines)
 
   local extmark_ids = diff_utils.apply_hunk_highlights(bufnr, hunks, ns_id)
   h.eq(type(extmark_ids), "table")
 
-  h.eq(diff_utils.contents_equal(old_lines, new_lines), false)
-  h.eq(diff_utils.contents_equal(old_lines, old_lines), true)
+  h.eq(diff_utils.are_contents_equal(removed_lines, added_lines), false)
+  h.eq(diff_utils.are_contents_equal(removed_lines, removed_lines), true)
 
   vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
 end
 
 T["DiffUtils"]["integration - complex multi-hunk diff"] = function()
-  local old_lines = {
+  local removed_lines = {
     "line 1",
     "line 2 old",
     "line 3",
@@ -299,7 +299,7 @@ T["DiffUtils"]["integration - complex multi-hunk diff"] = function()
     "line 5 old",
     "line 6",
   }
-  local new_lines = {
+  local added_lines = {
     "line 1",
     "line 2 new",
     "line 3",
@@ -309,7 +309,7 @@ T["DiffUtils"]["integration - complex multi-hunk diff"] = function()
     "line 6",
   }
 
-  local hunks = diff_utils.calculate_hunks(old_lines, new_lines)
+  local hunks = diff_utils.calculate_hunks(removed_lines, added_lines)
   h.expect_truthy(#hunks > 0)
 end
 
@@ -344,14 +344,14 @@ T["DiffUtils Screenshots"]["Shows hunk highlights with modifications"] = functio
     local diff_utils = require("codecompanion.providers.diff.utils")
 
     -- Set up buffer with original content
-    local old_lines = {
+    local removed_lines = {
       "local function calculate(a, b)",
       "  local result = a + b",
       "  return result",
       "end"
     }
 
-    local new_lines = {
+    local added_lines = {
       "local function calculate(a, b)",
       "  -- Added validation",
       "  if not a or not b then",
@@ -363,10 +363,10 @@ T["DiffUtils Screenshots"]["Shows hunk highlights with modifications"] = functio
     }
 
     -- Set buffer to new content (what the user sees)
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, new_lines)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, added_lines)
 
     -- Calculate hunks and apply highlights to show the diff
-    local hunks = diff_utils.calculate_hunks(old_lines, new_lines, 1)
+    local hunks = diff_utils.calculate_hunks(removed_lines, added_lines, 1)
     local ns_id = vim.api.nvim_create_namespace("screenshot_hunk_highlights")
 
     -- Apply the actual hunk highlights that the code uses
@@ -404,12 +404,12 @@ T["DiffUtils Screenshots"]["Shows hunk highlights in buffer"] = function()
     -- Simulate some hunks with highlights
     local hunks = {
       {
-        old_start = 2,
-        old_count = 2,
-        new_start = 2,
-        new_count = 3,
-        old_lines = { "    for item in items:", "        result = item.lower()" },
-        new_lines = { "    for item in items:", "        processed = item.upper()", "        results.append(processed)" },
+        original_start = 2,
+        original_count = 2,
+        updated_start = 2,
+        updated_count = 3,
+        removed_lines = { "    for item in items:", "        result = item.lower()" },
+        added_lines = { "    for item in items:", "        processed = item.upper()", "        results.append(processed)" },
         context_before = { "    results = []" },
         context_after = { "    return results" }
       }
@@ -444,12 +444,12 @@ T["DiffUtils Screenshots"]["Shows rejected changes highlighting"] = function()
     -- Simulate rejected changes
     local hunks = {
       {
-        old_start = 2,
-        old_count = 1,
-        new_start = 2,
-        new_count = 1,
-        old_lines = { "  apiUrl: 'https://api.example.com'," },
-        new_lines = { "  apiUrl: 'https://api.production.com'," },
+        original_start = 2,
+        original_count = 1,
+        updated_start = 2,
+        updated_count = 1,
+        removed_lines = { "  apiUrl: 'https://api.example.com'," },
+        added_lines = { "  apiUrl: 'https://api.production.com'," },
         context_before = { "const config = {" },
         context_after = { "  timeout: 5000," }
       }
@@ -470,7 +470,7 @@ T["DiffUtils Screenshots"]["Shows complex multi-hunk highlights"] = function()
 
     local diff_utils = require("codecompanion.providers.diff.utils")
 
-    local old_lines = {
+    local removed_lines = {
       "impl Calculator {",
       "    fn add(a: i32, b: i32) -> i32 {",
       "        a + b",
@@ -482,7 +482,7 @@ T["DiffUtils Screenshots"]["Shows complex multi-hunk highlights"] = function()
       "}"
     }
 
-    local new_lines = {
+    local added_lines = {
       "impl Calculator {",
       "    /// Adds two numbers together",
       "    fn add(a: i32, b: i32) -> i32 {",
@@ -506,10 +506,10 @@ T["DiffUtils Screenshots"]["Shows complex multi-hunk highlights"] = function()
     }
 
     -- Set buffer to new content (what the user sees)
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, new_lines)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, added_lines)
 
     -- Calculate hunks and apply highlights using the actual functions
-    local hunks = diff_utils.calculate_hunks(old_lines, new_lines, 2)
+    local hunks = diff_utils.calculate_hunks(removed_lines, added_lines, 2)
     local ns_id = vim.api.nvim_create_namespace("screenshot_multi_hunk")
 
     -- Apply the actual hunk highlights with complex multi-hunk changes


### PR DESCRIPTION
## Description

I was taking a look at our diff implementation the other day and thought I'd take the time to rename some of the variables so they're a little bit more explicit. 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
