### PR TITLE
fix(chat): Fix the run_command tool on Windows (#2179)

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/strategies/chat/tools/orchestrator.lua
@@ -15,80 +15,64 @@ local send_response_to_chat = function(exec, llm_message, user_message)
   exec.tools.chat:add_tool_output(exec.tool, llm_message, user_message)
 end
 
+---Execute a shell command with platform-specific handling
+---@param cmd table
+---@param callback function
+local function execute_shell_command(cmd, callback)
+  if vim.fn.has("win32") == 1 then
+    -- See PR #2186
+    local shell_cmd = table.concat(cmd, " ") .. "\r\nEXIT %ERRORLEVEL%\r\n"
+    vim.system({ "cmd.exe", "/Q", "/K" }, {
+      stdin = shell_cmd,
+      env = { PROMPT = "\r\n" },
+    }, callback)
+  else
+    vim.system(tool_utils.build_shell_command(cmd), {}, callback)
+  end
+end
+
 ---Converts a cmd-based tool to a function-based tool.
 ---@param tool CodeCompanion.Tools.Tool
 ---@return CodeCompanion.Tools.Tool
 local function cmd_to_func_tool(tool)
-  --NOTE: The `env` field should be processed in the tool beforehand
-
   tool.cmds = vim
     .iter(tool.cmds)
     :map(function(cmd)
       if type(cmd) == "function" then
-        -- function-based tool
         return cmd
-      else
-        local flag = cmd.flag
-        cmd = cmd.cmd or cmd
-        if type(cmd) == "string" then
-          cmd = vim.split(cmd, " ", { trimempty = true })
-        end
+      end
 
-        ---@param tools CodeCompanion.Tools
-        return function(tools, _, _, cb)
-          cb = vim.schedule_wrap(cb)
-          local system_on_exit_cb = function(process_result_obj)
-            -- Flags can be read higher up in the tool's execution
-            if flag then
-              tools.chat.tool_registry.flags = tools.chat.tool_registry.flags or {}
-              tools.chat.tool_registry.flags[flag] = (process_result_obj.code == 0)
-            end
-            local split_pattern = vim.fn.has("win32") == 1 and "\r?\n" or "\n"
-            if process_result_obj.code == 0 then
-              cb({
-                status = "success",
-                data = tool_utils.strip_ansi(vim.split(process_result_obj.stdout, split_pattern, { trimempty = true })),
-              })
-            else
-              local stderr = {}
-              if process_result_obj.stderr and process_result_obj.stderr ~= "" then
-                stderr =
-                  tool_utils.strip_ansi(vim.split(process_result_obj.stderr, split_pattern, { trimempty = true }))
-              end
+      local flag = cmd.flag
+      cmd = cmd.cmd or cmd
+      if type(cmd) == "string" then
+        cmd = vim.split(cmd, " ", { trimempty = true })
+      end
 
-              -- Some commands may return an error but populate stdout
-              local stdout = {}
-              if process_result_obj.stdout and process_result_obj.stdout ~= "" then
-                stdout =
-                  tool_utils.strip_ansi(vim.split(process_result_obj.stdout, split_pattern, { trimempty = true }))
-              end
-
-              local combined = {}
-              vim.list_extend(combined, stderr)
-              vim.list_extend(combined, stdout)
-
-              cb({
-                status = "error",
-                data = combined,
-              })
-            end
+      ---@param tools CodeCompanion.Tools
+      return function(tools, _, _, cb)
+        cb = vim.schedule_wrap(cb)
+        execute_shell_command(cmd, function(out)
+          if flag then
+            tools.chat.tool_registry.flags = tools.chat.tool_registry.flags or {}
+            tools.chat.tool_registry.flags[flag] = (out.code == 0)
           end
 
-          if vim.fn.has("win32") == 1 then
-            -- See PR #2186
-            local shell_line = table.concat(cmd, " ") .. "\r\n" .. "EXIT %ERRORLEVEL%" .. "\r\n"
-            local system_args = { "cmd.exe", "/Q", "/K" }
-            local system_opts = {
-              stdin = shell_line,
-              env = {
-                PROMPT = "\r\n",
-              },
-            }
-            vim.system(system_args, system_opts, system_on_exit_cb)
+          if out.code == 0 then
+            cb({
+              status = "success",
+              data = tool_utils.strip_ansi(vim.split(out.stdout, "\n", { trimempty = true })),
+            })
           else
-            vim.system(tool_utils.build_shell_command(cmd), {}, system_on_exit_cb)
+            local combined = {}
+            if out.stderr and out.stderr ~= "" then
+              vim.list_extend(combined, tool_utils.strip_ansi(vim.split(out.stderr, "\n", { trimempty = true })))
+            end
+            if out.stdout and out.stdout ~= "" then
+              vim.list_extend(combined, tool_utils.strip_ansi(vim.split(out.stdout, "\n", { trimempty = true })))
+            end
+            cb({ status = "error", data = combined })
           end
-        end
+        end)
       end
     end)
     :totable()

--- a/lua/codecompanion/strategies/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/strategies/chat/tools/orchestrator.lua
@@ -57,18 +57,20 @@ local function cmd_to_func_tool(tool)
             tools.chat.tool_registry.flags[flag] = (out.code == 0)
           end
 
+          local eol_pattern = vim.fn.has("win32") == 1 and "\r?\n" or "\n"
+
           if out.code == 0 then
             cb({
               status = "success",
-              data = tool_utils.strip_ansi(vim.split(out.stdout, "\n", { trimempty = true })),
+              data = tool_utils.strip_ansi(vim.split(out.stdout, eol_pattern, { trimempty = true })),
             })
           else
             local combined = {}
             if out.stderr and out.stderr ~= "" then
-              vim.list_extend(combined, tool_utils.strip_ansi(vim.split(out.stderr, "\n", { trimempty = true })))
+              vim.list_extend(combined, tool_utils.strip_ansi(vim.split(out.stderr, eol_pattern, { trimempty = true })))
             end
             if out.stdout and out.stdout ~= "" then
-              vim.list_extend(combined, tool_utils.strip_ansi(vim.split(out.stdout, "\n", { trimempty = true })))
+              vim.list_extend(combined, tool_utils.strip_ansi(vim.split(out.stdout, eol_pattern, { trimempty = true })))
             end
             cb({ status = "error", data = combined })
           end

--- a/tests/strategies/chat/tools/test_orchestrator.lua
+++ b/tests/strategies/chat/tools/test_orchestrator.lua
@@ -144,12 +144,12 @@ end
 T["cmd_runner handles Windows pipe command with empty string argument"] = function()
   -- Skip on non-Windows systems
   if vim.fn.has("win32") == 0 then
-    MiniTest.skip("Skipping Windows-specific test on non-Windows system")
+    MiniTest.skip("Skipping Windows specific test")
   end
 
   child.lua([[
     local h = require("tests.helpers")
-    
+
     -- Mock vim.system to execute real command but not call out_cb
     local command_results = {}
     local original_system = vim.system
@@ -160,7 +160,7 @@ T["cmd_runner handles Windows pipe command with empty string argument"] = functi
         -- Don't call the original callback - we'll handle the result in the test
       end)
     end
-    
+
     -- Use the actual cmd_runner tool
     local cfg = {
       strategies = {
@@ -171,28 +171,28 @@ T["cmd_runner handles Windows pipe command with empty string argument"] = functi
         }
       }
     }
-    
+
     local chat, tools = h.setup_chat_buffer(cfg)
     _G.chat, _G.tools, _G.command_results = chat, tools, command_results
-    
+
     -- Simulate LLM calling cmd_runner with pipe and find command that has empty string argument
     local calls = {
-      { 
-        ["function"] = { 
-          name = "cmd_runner", 
+      {
+        ["function"] = {
+          name = "cmd_runner",
           -- Use full path to find.exe, since I know developers
           -- who have added a POSIX find.exe earlier in their PATH
           -- Using find.exe to explicitly pass in an empty argument
           -- which needs to make it AS an empty argument and not
           -- overly escaped or overly quoted strings
-          arguments = '{"cmd": "echo hello there | %windir%\\\\System32\\\\find.exe /c /v \\"\\"", "flag": null}' 
-        } 
+          arguments = '{"cmd": "echo hello there | %windir%\\\\System32\\\\find.exe /c /v \\"\\"", "flag": null}'
+        }
       },
     }
-    
+
     _G.tools:execute(_G.chat, calls)
     vim.wait(1000) -- Give more time for the real command to execute
-    
+
     -- Restore original vim.system
     vim.system = original_system
   ]])

--- a/tests/strategies/chat/tools/test_orchestrator.lua
+++ b/tests/strategies/chat/tools/test_orchestrator.lua
@@ -141,4 +141,81 @@ T["cancels current tool when it is the only one"] = function()
   h.expect_contains("cancelled:t1", all)
 end
 
+T["cmd_runner handles Windows pipe command with empty string argument"] = function()
+  -- Skip on non-Windows systems
+  if vim.fn.has("win32") == 0 then
+    MiniTest.skip("Skipping Windows-specific test on non-Windows system")
+  end
+
+  child.lua([[
+    local h = require("tests.helpers")
+    
+    -- Mock vim.system to execute real command but not call out_cb
+    local command_results = {}
+    local original_system = vim.system
+    vim.system = function(args, opts, callback)
+      -- Execute the real command but capture the result instead of calling the callback
+      original_system(args, opts, function(result)
+        table.insert(command_results, result)
+        -- Don't call the original callback - we'll handle the result in the test
+      end)
+    end
+    
+    -- Use the actual cmd_runner tool
+    local cfg = {
+      strategies = {
+        chat = {
+          tools = {
+            cmd_runner = { enabled = true }
+          }
+        }
+      }
+    }
+    
+    local chat, tools = h.setup_chat_buffer(cfg)
+    _G.chat, _G.tools, _G.command_results = chat, tools, command_results
+    
+    -- Simulate LLM calling cmd_runner with pipe and find command that has empty string argument
+    local calls = {
+      { 
+        ["function"] = { 
+          name = "cmd_runner", 
+          -- Use full path to find.exe, since I know developers
+          -- who have added a POSIX find.exe earlier in their PATH
+          -- Using find.exe to explicitly pass in an empty argument
+          -- which needs to make it AS an empty argument and not
+          -- overly escaped or overly quoted strings
+          arguments = '{"cmd": "echo hello there | %windir%\\\\System32\\\\find.exe /c /v \\"\\"", "flag": null}' 
+        } 
+      },
+    }
+    
+    _G.tools:execute(_G.chat, calls)
+    vim.wait(1000) -- Give more time for the real command to execute
+    
+    -- Restore original vim.system
+    vim.system = original_system
+  ]])
+
+  -- Verify the actual command execution was successful and produced expected output
+  local command_results = child.lua_get("_G.command_results")
+  h.eq(#command_results, 1)
+
+  local result = command_results[1]
+  h.eq(result.code, 0) -- Command should succeed
+
+  -- Parse output lines and trim leading/trailing empty lines
+  local lines = vim.split(result.stdout, "\r?\n", { plain = false })
+  -- Remove leading empty lines
+  while #lines > 0 and (lines[1] == "" or lines[1] == "\r") do
+    table.remove(lines, 1)
+  end
+  -- Remove trailing empty lines
+  while #lines > 0 and (lines[#lines] == "" or lines[#lines] == "\r") do
+    table.remove(lines, #lines)
+  end
+
+  h.eq(lines, { "1" })
+end
+
 return T


### PR DESCRIPTION
## Description

<!-- If this is a feature request, please describe how it will benefit other CodeCompanion users -->
Parameter quoting rules on Windows are complicated, because Windows programs only receive one big string with all arguments which they or msvcrt split back into argv. libuv used by NeoVim tries to be helpful, but ends up sending literal quotes to cmd.exe (programs get `"C:\file.txt"` with quotes instead of `C:\file.txt`) or not literal enough to powershell (literal empty arguments `""` get lost along the way)

For those who don't doze on their wind: https://web.archive.org/web/20190109172835/https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/

Creating a temporary .bat file and executing it _almost_ works, but I have had the LLM propose running `for ... %i ...` commands which require doubling up the percentage sign. Even with prompting, it would still occasionally throw a `FOR` curveball.

What does work, is typing the command INTO cmd.exe, and letting cmd.exe figure things out. So we send table.concat(cmd, " ") on stdin, and run cmd.exe. But... we need a couple of things set up so as to not confuse the the LLM:
* pass /K to inhibit the Microsoft Logo and copyright; it will exit when stdin is exhausted
* pass /Q to inhibit showing the command we're executing, since that's not part of the output
* set %PROMPT% to a space, so that it doesn't see any c:\> prompt; %PROMPT% == "" means "use the default", hence one space
* tac a "\n" at the end of the command, since cmd doesn't treat EOF as an implicit CR, and it would just print out `More?` like a silly goose.

This seems to have resolved all the issues I was encountering.

I've added a windows-only test which invokes the `find` command (no relation to POSIX `find`), which is one of the more troublesome commands. 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #2179 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->
N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
