### PR TITLE
feat(acp): add session mode command and auto-connect chat buffers

### DIFF
--- a/lua/codecompanion/acp/methods.lua
+++ b/lua/codecompanion/acp/methods.lua
@@ -4,6 +4,7 @@ return {
   SESSION_CANCEL = "session/cancel",
   SESSION_LOAD = "session/load",
   SESSION_NEW = "session/new",
+  SESSION_SET_MODE = "session/set_mode",
   SESSION_PROMPT = "session/prompt",
   SESSION_REQUEST_PERMISSION = "session/request_permission",
   SESSION_UPDATE = "session/update",

--- a/lua/codecompanion/commands.lua
+++ b/lua/codecompanion/commands.lua
@@ -46,6 +46,7 @@ local chat_subcommands = vim.deepcopy(adapters)
 table.insert(chat_subcommands, "Toggle")
 table.insert(chat_subcommands, "Add")
 table.insert(chat_subcommands, "RefreshCache")
+table.insert(chat_subcommands, "SetSessionMode")
 
 ---@type CodeCompanion.Command[]
 return {

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -140,6 +140,8 @@ CodeCompanion.chat = function(args)
         return CodeCompanion.toggle(args)
       elseif prompt == "refreshcache" then
         return CodeCompanion.refresh_cache()
+      elseif prompt == "setsessionmode" then
+        return CodeCompanion.set_session_mode()
       else
         table.insert(messages, {
           role = config.constants.USER_ROLE,
@@ -254,6 +256,17 @@ CodeCompanion.restore = function(bufnr)
     return
   end
   chat.ui:open()
+end
+
+---Set Session Mode
+---@return nil
+CodeCompanion.set_session_mode = function()
+  local chat = CodeCompanion.last_chat()
+  if not chat then
+    return
+  end
+
+  chat.set_session_mode()
 end
 
 ---Return a chat buffer

--- a/lua/codecompanion/strategies/chat/acp/handler.lua
+++ b/lua/codecompanion/strategies/chat/acp/handler.lua
@@ -56,18 +56,7 @@ end
 ---Ensure ACP connection is established
 ---@return boolean success
 function ACPHandler:ensure_connection()
-  if not self.chat.acp_connection then
-    self.chat.acp_connection = get_client().new({
-      adapter = self.chat.adapter, --[[@type CodeCompanion.ACPAdapter]]
-    })
-
-    local connected = self.chat.acp_connection:connect_and_initialize()
-
-    if not connected then
-      return false
-    end
-  end
-  return true
+  return self.chat:ensure_acp_connection()
 end
 
 ---Create and configure the prompt request with all handlers

--- a/lua/codecompanion/strategies/chat/acp/set_session_mode.lua
+++ b/lua/codecompanion/strategies/chat/acp/set_session_mode.lua
@@ -1,0 +1,77 @@
+local util = require("codecompanion.utils")
+
+local M = {}
+
+local CONSTANTS = {
+  PROMPT_TITLE = "Set Session Mode",
+  PROMPT_KIND = "session mode",
+}
+
+---Build a human readable label for a mode entry
+---@param mode table
+---@param current_mode_id string|nil
+---@return string
+local function mode_label(mode, current_mode_id)
+  local name = mode and (mode.name or mode.displayName or mode.id)
+  if type(name) ~= "string" or name == "" then
+    name = tostring(mode and mode.id or "Unknown")
+  end
+
+  if current_mode_id and mode and mode.id == current_mode_id then
+    name = string.format("%s (current)", name)
+  end
+
+  return name
+end
+
+---Build prompt and mappings for vim.fn.confirm
+---@param modes table[]
+---@param current_mode_id string|nil
+---@return string, string[], table<number, string>, table<string, number>
+local function build_choices(modes, current_mode_id)
+  local prompt = string.format("%s: %s?", util.capitalize(CONSTANTS.PROMPT_KIND), CONSTANTS.PROMPT_TITLE)
+  local choices, index_to_mode, mode_to_index = {}, {}, {}
+
+  for index, mode in ipairs(modes or {}) do
+    local choice_label = mode_label(mode, current_mode_id)
+    table.insert(choices, string.format("&%d %s", index, choice_label))
+    if mode and mode.id then
+      index_to_mode[index] = mode.id
+      mode_to_index[mode.id] = index
+    end
+  end
+
+  return prompt, choices, index_to_mode, mode_to_index
+end
+
+---Display the available modes and return the selected mode id (if any)
+---@param chat CodeCompanion.Chat|nil
+---@param opts { available_modes: table[], current_mode_id?: string|nil }
+---@return string|nil
+function M.show(chat, opts)
+  opts = opts or {}
+  local _ = chat
+  local modes = opts.available_modes or {}
+  if vim.tbl_isempty(modes) then
+    return nil
+  end
+
+  local prompt, choices, index_to_mode, mode_to_index = build_choices(modes, opts.current_mode_id)
+  if #choices == 0 then
+    return nil
+  end
+
+  local default_choice = 1
+  if opts.current_mode_id and mode_to_index[opts.current_mode_id] then
+    default_choice = mode_to_index[opts.current_mode_id]
+  end
+
+  local picked = vim.fn.confirm(prompt, table.concat(choices, "\n"), default_choice, "Question")
+  if picked <= 0 then
+    return nil
+  end
+
+  return index_to_mode[picked]
+end
+
+return M

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1473,4 +1473,14 @@ function Chat.close_last_chat()
   end
 end
 
+---Set Session Mode
+---@return nil
+function Chat.set_session_mode()
+  if last_chat and not vim.tbl_isempty(last_chat) then
+    if last_chat.acp_connection:is_connected() then
+      last_chat.acp_connection:set_session_mode(last_chat)
+    end
+  end
+end
+
 return Chat


### PR DESCRIPTION
  ## Description

  - Add :CodeCompanionChat SetSessionMode so ACP chats can switch session modes.
  - Automatically connect ACP adapters when the chat opens (session/new) to retrieve available modes, showing a
  “Connecting to ACP...” status until the session is ready.

  ## Related Discussion(s)
  <!--
    If this PR fixes any issues, please link to the issue here.
    - Fixes #<issue_number>
  -->
  https://github.com/olimorris/codecompanion.nvim/discussions/2190

  ## Screenshots
  <!-- Add screenshots of the changes if applicable, to help visualize the change. -->
  
<img width="3016" height="1958" alt="CleanShot 2025-10-02 at 03 20 26@2x" src="https://github.com/user-attachments/assets/346c4772-4ac1-42f3-817c-3cffd1cb7020" />

<img width="3016" height="1958" alt="CleanShot 2025-10-02 at 03 20 45@2x" src="https://github.com/user-attachments/assets/8d530190-e5f4-4d28-982e-4ba34f72c20d" />


  ## Checklist

  - [ ] I've read the contributing (https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md)
  guidelines and have adhered to them in this PR
  - [ ] I've added test (https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature 
  - [ ] I've run make all to ensure docs are generated, tests pass and my formatting is applied
  - [x] (optional) I've updated CodeCompanion.has in the init.lua 
  - [ ] (optional) I've updated the README and/or relevant docs pages
