### PR TITLE
fix: use correct config item

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -361,7 +361,7 @@ function Chat.new(args)
       local bufnr = api.nvim_create_buf(false, true)
       api.nvim_buf_set_name(bufnr, fmt("[CodeCompanion] %d", id))
       api.nvim_set_option_value("filetype", "codecompanion", { buf = bufnr })
-      api.nvim_set_option_value("undolevels", config.strategies.chat.opts.undolevels or 10, { buf = bufnr })
+      api.nvim_set_option_value("undolevels", config.strategies.chat.opts.undo_levels or 10, { buf = bufnr })
 
       -- Safely attach treesitter
       vim.schedule(function()


### PR DESCRIPTION
## Description

Fixes `undolevels` key in the config

## Related Issue(s)

#2022

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
