### PR TITLE
refactor(adapters): don't display gpt-5-codex

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -101,6 +101,14 @@ local function fetch_async(adapter, provided_token)
 
         local models = {}
         for _, model in ipairs(json.data) do
+          if model.supported_endpoints then
+            for _, endpoint in ipairs(model.supported_endpoints) do
+              if endpoint == "/responses" then
+                log:debug("[Copilot] Skipping `%s` as it supports the /responses endpoint", model.id)
+                goto continue
+              end
+            end
+          end
           if model.model_picker_enabled and model.capabilities and model.capabilities.type == "chat" then
             local choice_opts = {}
 
@@ -116,6 +124,7 @@ local function fetch_async(adapter, provided_token)
 
             models[model.id] = { vendor = model.vendor, nice_name = model.name, opts = choice_opts }
           end
+          ::continue::
         end
 
         _cached_models = models


### PR DESCRIPTION
## Description

In Copilot, gpt-5-codex, requires the responses endpoint which is currently unsupported. This PR prevents the model from showing up in the model list.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
