### PR TITLE
refactor(adapters): models now have formatted_name instead of nice_name

### DIFF
--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -524,27 +524,27 @@ return {
       default = "claude-sonnet-4-20250514",
       choices = {
         ["claude-opus-4-20250514"] = {
-          nice_name = "Claude Opus 4",
+          formatted_name = "Claude Opus 4",
           opts = { can_reason = true, has_vision = true },
         },
         ["claude-sonnet-4-20250514"] = {
-          nice_name = "Claude Sonnet 4",
+          formatted_name = "Claude Sonnet 4",
           opts = { can_reason = true, has_vision = true },
         },
         ["claude-3-7-sonnet-20250219"] = {
-          nice_name = "Claude 3.7 Sonnet",
+          formatted_name = "Claude 3.7 Sonnet",
           opts = { can_reason = true, has_vision = true, has_token_efficient_tools = true },
         },
         ["claude-3-5-sonnet-20241022"] = {
-          nice_name = "Claude Sonnet 3.5",
+          formatted_name = "Claude Sonnet 3.5",
           opts = { has_vision = true },
         },
         ["claude-3-5-haiku-20241022"] = {
-          nice_name = "Claude Haiku 3.5",
+          formatted_name = "Claude Haiku 3.5",
           opts = { has_vision = true },
         },
         ["claude-3-opus-20240229"] = {
-          nice_name = "Claude Opus 3",
+          formatted_name = "Claude Opus 3",
           opts = { has_vision = true },
         },
         "claude-2.1",

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -12,7 +12,7 @@ local CONSTANTS = {
 local M = {}
 
 ---@class CopilotModels
----@field nice_name string
+---@field formatted_name string
 ---@field vendor string
 ---@field opts {can_stream: boolean, can_use_tools: boolean, has_vision: boolean}
 
@@ -122,7 +122,7 @@ local function fetch_async(adapter, provided_token)
               choice_opts.has_vision = true
             end
 
-            models[model.id] = { vendor = model.vendor, nice_name = model.name, opts = choice_opts }
+            models[model.id] = { vendor = model.vendor, formatted_name = model.name, opts = choice_opts }
           end
           ::continue::
         end

--- a/lua/codecompanion/adapters/http/deepseek.lua
+++ b/lua/codecompanion/adapters/http/deepseek.lua
@@ -176,8 +176,8 @@ return {
       ---@type string|fun(): string
       default = "deepseek-reasoner",
       choices = {
-        ["deepseek-reasoner"] = { nice_name = "DeepSeek", opts = { can_reason = true, can_use_tools = false } },
-        ["deepseek-chat"] = { nice_name = "DeepSeek", opts = { can_use_tools = true } },
+        ["deepseek-reasoner"] = { formatted_name = "DeepSeek", opts = { can_reason = true, can_use_tools = false } },
+        ["deepseek-chat"] = { formatted_name = "DeepSeek", opts = { can_use_tools = true } },
       },
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -86,16 +86,16 @@ return {
       desc = "The model that will complete your prompt. See https://ai.google.dev/gemini-api/docs/models/gemini#model-variations for additional details and options.",
       default = "gemini-2.5-flash",
       choices = {
-        ["gemini-2.5-pro"] = { nice_name = "Gemini 2.5 Pro", opts = { can_reason = true, has_vision = true } },
-        ["gemini-2.5-flash"] = { nice_name = "Gemini 2.5 Flash", opts = { can_reason = true, has_vision = true } },
+        ["gemini-2.5-pro"] = { formatted_name = "Gemini 2.5 Pro", opts = { can_reason = true, has_vision = true } },
+        ["gemini-2.5-flash"] = { formatted_name = "Gemini 2.5 Flash", opts = { can_reason = true, has_vision = true } },
         ["gemini-2.5-flash-preview-05-20"] = {
-          nice_name = "Gemini 2.5 Flash Preview",
+          formatted_name = "Gemini 2.5 Flash Preview",
           opts = { can_reason = true, has_vision = true },
         },
-        ["gemini-2.0-flash"] = { nice_name = "Gemini 2.0 Flash", opts = { has_vision = true } },
-        ["gemini-2.0-flash-lite"] = { nice_name = "Gemini 2.0 Flash Lite", opts = { has_vision = true } },
-        ["gemini-1.5-pro"] = { nice_name = "Gemini 1.5 Pro", opts = { has_vision = true } },
-        ["gemini-1.5-flash"] = { nice_name = "Gemini 1.5 Flash", opts = { has_vision = true } },
+        ["gemini-2.0-flash"] = { formatted_name = "Gemini 2.0 Flash", opts = { has_vision = true } },
+        ["gemini-2.0-flash-lite"] = { formatted_name = "Gemini 2.0 Flash Lite", opts = { has_vision = true } },
+        ["gemini-1.5-pro"] = { formatted_name = "Gemini 1.5 Pro", opts = { has_vision = true } },
+        ["gemini-1.5-flash"] = { formatted_name = "Gemini 1.5 Flash", opts = { has_vision = true } },
       },
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -17,7 +17,7 @@ local shared = require("codecompanion.adapters.shared")
 ---@field temp? table A table to store temporary values which are not passed to the request
 ---@field raw? table Any additional curl arguments to pass to the request
 ---@field opts? table Additional options for the adapter
----@field model? { name: string, nice_name?: string, vendor?: string, opts: table } The model to use for the request
+---@field model? { name: string, formatted_name?: string, vendor?: string, opts: table } The model to use for the request
 ---@field handlers table Functions which link the output from the request to CodeCompanion
 ---@field handlers.resolve? fun(self: CodeCompanion.HTTPAdapter): nil When the adapter is resolved, call this method
 ---@field handlers.setup? fun(self: CodeCompanion.HTTPAdapter): boolean

--- a/lua/codecompanion/adapters/http/ollama/get_models.lua
+++ b/lua/codecompanion/adapters/http/ollama/get_models.lua
@@ -13,11 +13,7 @@ local running = false
 
 M = {}
 
----Structure:
----```lua
----_cached_models[url][model_name] = { opts = { can_reason = true, has_vision = false }, nice_name = 'nice_name' }
----```
----@type table<string, table<string, { nice_name: string?, opts: {can_reason: boolean, has_vision: boolean} }>>
+---@type table<string, table<string, { formatted_name: string?, opts: {can_reason: boolean, has_vision: boolean} }>>
 local _cached_models = {}
 
 ---@alias OllamaGetModelsOpts {last?: boolean, async?: boolean}
@@ -87,7 +83,7 @@ local function fetch_async(adapter, opts)
             body = vim.json.encode({ model = model_obj.name }),
             timeout = CONSTANTS.TIMEOUT,
             callback = function(output)
-              _cached_models[url][model_obj.name] = { nice_name = model_obj.name, opts = {} }
+              _cached_models[url][model_obj.name] = { formatted_name = model_obj.name, opts = {} }
               if output.status == 200 then
                 local ok, model_info_json = pcall(vim.json.decode, output.body, { array = true, object = true })
                 if ok then

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -333,47 +333,47 @@ return {
         -- https://news.ycombinator.com/item?id=44837367
         -- (see also #2017)
         ["gpt-5"] = {
-          nice_name = "GPT 5",
+          formatted_name = "GPT 5",
           opts = { has_vision = true, can_reason = true, stream = false },
         },
         ["gpt-5-mini"] = {
-          nice_name = "GPT 5 Mini",
+          formatted_name = "GPT 5 Mini",
           opts = { has_vision = true, can_reason = true, stream = false },
         },
         ["gpt-5-nano"] = {
-          nice_name = "GPT 5 Nano",
+          formatted_name = "GPT 5 Nano",
           opts = { has_vision = true, can_reason = true },
         },
         ["o4-mini-2025-04-16"] = {
-          nice_name = "o4 Mini",
+          formatted_name = "o4 Mini",
           opts = { has_vision = true, can_reason = true },
         },
         ["o3-mini-2025-01-31"] = {
-          nice_name = "o3 Mini",
+          formatted_name = "o3 Mini",
           opts = { can_reason = true },
         },
         ["o3-2025-04-16"] = {
-          nice_name = "o3",
+          formatted_name = "o3",
           opts = { has_vision = true, can_reason = true },
         },
         ["o1-2024-12-17"] = {
-          nice_name = "o1",
+          formatted_name = "o1",
           opts = { has_vision = true, can_reason = true },
         },
         ["gpt-4.1"] = {
-          nice_name = "GPT 4.1",
+          formatted_name = "GPT 4.1",
           opts = { has_vision = true },
         },
         ["gpt-4o"] = {
-          nice_name = "GPT-4o",
+          formatted_name = "GPT-4o",
           opts = { has_vision = true },
         },
         ["gpt-4o-mini"] = {
-          nice_name = "GPT-4o Mini",
+          formatted_name = "GPT-4o Mini",
           opts = { has_vision = true },
         },
         ["gpt-4-turbo-preview"] = {
-          nice_name = "GPT-4 Turbo Preview",
+          formatted_name = "GPT-4 Turbo Preview",
           opts = { has_vision = true },
         },
         "gpt-4",

--- a/tests/adapters/http/copilot/test_models.lua
+++ b/tests/adapters/http/copilot/test_models.lua
@@ -92,12 +92,12 @@ T["copilot.models"]["choices() synchronous returns expected models"] = function(
   local expected = {
     model1 = {
       vendor = "copilot",
-      nice_name = "Model One",
+      formatted_name = "Model One",
       opts = { can_stream = true, can_use_tools = true, has_vision = true },
     },
     model2 = {
       vendor = "copilot",
-      nice_name = "Model Two",
+      formatted_name = "Model Two",
       opts = {},
     },
   }
@@ -171,12 +171,12 @@ T["copilot.models"]["choices() async populates cache and returns later"] = funct
   local expected = {
     model1 = {
       vendor = "copilot",
-      nice_name = "Model One",
+      formatted_name = "Model One",
       opts = { can_stream = true, can_use_tools = true, has_vision = true },
     },
     model2 = {
       vendor = "copilot",
-      nice_name = "Model Two",
+      formatted_name = "Model Two",
       opts = {},
     },
   }


### PR DESCRIPTION
## Description

Much cleaner. Wtf did I ever call them `nice_name`?!

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
