### PR TITLE
fix(super_diff): align variable names with updated diff hunk naming

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1394,6 +1394,7 @@ You must create or modify a workspace file through a series of prompts over mult
             dim = 25, -- Background dim level for floating diff (0-100, [100 full transparent], only applies when layout = "float")
             full_width_removed = true, -- Make removed lines span full width
             show_keymap_hints = true, -- Show "gda: accept | gdr: reject" hints above diff
+            show_dim = true, -- Enable dimming background for floating windows (applies to both diff and super_diff)
             show_removed = true, -- Show removed lines as virtual text
           },
         },

--- a/lua/codecompanion/strategies/chat/acp/request_permission.lua
+++ b/lua/codecompanion/strategies/chat/acp/request_permission.lua
@@ -331,6 +331,9 @@ local function show_diff(chat, request)
 
   local window_config = vim.tbl_deep_extend("force", config.display.chat.child_window, config.display.chat.diff_window)
 
+  local inline_config = config.display.diff.provider_opts.inline or {}
+  local show_dim = inline_config.opts and inline_config.opts.show_dim
+
   local bufnr, winnr = ui.create_float(new_lines, {
     window = { width = window_config.width, height = window_config.height },
     row = window_config.row or "center",
@@ -344,7 +347,7 @@ local function show_diff(chat, request)
     lock = true,
     ignore_keymaps = true,
     opts = window_config.opts,
-    show_dim = true,
+    show_dim = show_dim,
   })
 
   -- Build present kinds and normalize keymaps from config, then setup winbar

--- a/lua/codecompanion/strategies/chat/helpers/diff.lua
+++ b/lua/codecompanion/strategies/chat/helpers/diff.lua
@@ -139,6 +139,13 @@ end
 ---@param winnr number Window number to set up winbar for
 ---@return nil
 local function place_diff_winbar(winnr)
+  local inline_config = config.display.diff.provider_opts.inline or {}
+  local show_keymap_hints = inline_config.opts and inline_config.opts.show_keymap_hints
+
+  if not show_keymap_hints then
+    return
+  end
+
   local keymaps_config = config.strategies.inline.keymaps
   if not keymaps_config then
     return
@@ -166,6 +173,9 @@ end
 local function create_diff_floating_window(bufnr, filepath)
   local window_config = vim.tbl_deep_extend("force", config.display.chat.child_window, config.display.chat.diff_window)
 
+  local inline_config = config.display.diff.provider_opts.inline or {}
+  local show_dim = inline_config.opts and inline_config.opts.show_dim
+
   local filetype = api.nvim_get_option_value("filetype", { buf = bufnr })
   local content = {} -- Dummy content for create_float function
 
@@ -184,7 +194,7 @@ local function create_diff_floating_window(bufnr, filepath)
     lock = false, -- Allow edits for diff
     ignore_keymaps = true,
     opts = window_config.opts,
-    show_dim = true,
+    show_dim = show_dim,
   })
 
   if winnr then


### PR DESCRIPTION
## Description

After PR #2183, the super diff stopped working because of variable naming issues:

`E5108: Lua: ...lua/codecompanion/strategies/chat/helpers/super_diff.lua:232: bad argument #2 to 'fmt' (number expected, got nil)`

This PR fixes that error, adds dimming to super_diff, and exposes the internal `show_dim` configuration option for users.

## Related Issue(s)

PR #2183


Thank you

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
