### PR TITLE
fix(acp): ensure jobs can be cancelled

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -425,6 +425,9 @@ function Connection:handle_rpc_message(line)
   end
 
   if message.error then
+    if message.error.code == -32603 then
+      return log:debug("[acp::handle_rpc_message] Error: %s", message.error)
+    end
     log:error("[acp::handle_rpc_message] Error: %s", message.error)
   end
 end

--- a/lua/codecompanion/acp/prompt_builder.lua
+++ b/lua/codecompanion/acp/prompt_builder.lua
@@ -113,8 +113,9 @@ function PromptBuilder:send()
   self.connection:write_message(self.connection.methods.encode(req) .. "\n")
 
   self._streaming_started = false
+
   return {
-    shutdown = function()
+    cancel = function()
       self:cancel()
     end,
   }

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -474,6 +474,11 @@ function Client:request(payload, actions, opts)
     end
   end
 
+  -- Unify the API across the plugin
+  job.cancel = function()
+    job:shutdown()
+  end
+
   return job
 end
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -1243,18 +1243,16 @@ function Chat:stop()
 
     _G.codecompanion_cancel_tool = true
     pcall(function()
-      tool_job:shutdown()
+      tool_job.cancel()
     end)
   end
 
   if self.current_request then
-    print("Cancelling request...")
     local handle = self.current_request
     self.current_request = nil
 
     pcall(function()
       if handle and type(handle.cancel) == "function" then
-        print("Should be cancelled")
         handle.cancel()
       end
     end)

--- a/lua/codecompanion/strategies/inline/init.lua
+++ b/lua/codecompanion/strategies/inline/init.lua
@@ -391,7 +391,7 @@ end
 ---@return nil
 function Inline:stop()
   if self.current_request then
-    self.current_request:shutdown()
+    self.current_request.cancel()
     self.current_request = nil
     self.adapter.handlers.on_exit(self.adapter)
   end

--- a/tests/acp/test_prompt_builder.lua
+++ b/tests/acp/test_prompt_builder.lua
@@ -127,7 +127,7 @@ T["Prompt Builder"]["PromptBuilder"] = function()
       thought_call = handler_calls[1],
       message_call = handler_calls[2],
       complete_call = handler_calls[3],
-      has_shutdown = type(job.shutdown) == "function",
+      has_cancel = type(job.cancel) == "function",
       sent_request = vim.json.decode(vim.trim(sent_data)),
     }
   ]])
@@ -138,7 +138,7 @@ T["Prompt Builder"]["PromptBuilder"] = function()
   h.eq(result.message_call.type, "message")
   h.eq(result.message_call.content, "Hello!")
   h.eq(result.complete_call.type, "complete")
-  h.eq(result.has_shutdown, true)
+  h.eq(result.has_cancel, true)
   h.eq(result.sent_request.method, "session/prompt")
   h.eq(result.sent_request.params.sessionId, "test-session-123")
 end


### PR DESCRIPTION
## Description

Ensure's that ACP clients can be cancelled in the chat buffer.

## Related Issue(s)

#2223 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
