### PR TITLE
fix(chat): undolevels leaking outside of codecompanion

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -548,7 +548,6 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
         blank_prompt = "", -- The prompt to use when the user doesn't provide a prompt
         completion_provider = providers.completion, -- blink|cmp|coc|default
         register = "+", -- The register to use for yanking code
-        undo_levels = 10, -- Number of undo levels to add to chat buffers
         wait_timeout = 2e6, -- Time to wait for user response before timing out (milliseconds)
         yank_jump_delay_ms = 400, -- Delay before jumping back from the yanked code (milliseconds )
 

--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -361,7 +361,6 @@ function Chat.new(args)
       local bufnr = api.nvim_create_buf(false, true)
       api.nvim_buf_set_name(bufnr, fmt("[CodeCompanion] %d", id))
       api.nvim_set_option_value("filetype", "codecompanion", { buf = bufnr })
-      api.nvim_set_option_value("undolevels", config.strategies.chat.opts.undo_levels or 10, { buf = bufnr })
 
       -- Safely attach treesitter
       vim.schedule(function()


### PR DESCRIPTION
## Description

Setting the undolevels in a CodeCompanion buffer caused it to leak to other buffers. Unsure why this is the case so removing for now.

## Related Issue(s)

#2231

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
