### PR TITLE
fix(diff): fire detach when inline diff completes

### DIFF
--- a/lua/codecompanion/providers/diff/inline.lua
+++ b/lua/codecompanion/providers/diff/inline.lua
@@ -224,6 +224,18 @@ function InlineDiff:reject(opts)
   self:teardown()
 end
 
+---Close floating window if this diff is in a floating window
+---@return nil
+function InlineDiff:close_floating_window()
+  if self.is_floating and self.winnr and api.nvim_win_is_valid(self.winnr) then
+    log:debug("[providers::diff::inline::close_floating_window] Closing floating window %d", self.winnr)
+    pcall(api.nvim_win_close, self.winnr, true)
+    self.winnr = nil
+    local ui = require("codecompanion.utils.ui")
+    ui.close_background_window()
+  end
+end
+
 ---Cleans up the diff instance and fires detachment event
 ---@return nil
 function InlineDiff:teardown()
@@ -236,18 +248,6 @@ function InlineDiff:teardown()
   self:clear_highlights()
   self:close_floating_window()
   util.fire("DiffDetached", { diff = "inline", bufnr = self.bufnr, id = self.id })
-end
-
----Close floating window if this diff is in a floating window
----@return nil
-function InlineDiff:close_floating_window()
-  if self.is_floating and self.winnr and api.nvim_win_is_valid(self.winnr) then
-    log:debug("[providers::diff::inline::close_floating_window] Closing floating window %d", self.winnr)
-    pcall(api.nvim_win_close, self.winnr, true)
-    self.winnr = nil
-    local ui = require("codecompanion.utils.ui")
-    ui.close_background_window()
-  end
 end
 
 return InlineDiff


### PR DESCRIPTION
## Description

- Ensure inline diff sessions always emit CodeCompanionDiffDetached by delegating both accept() and reject() paths to the shared teardown() cleanup.
- Keeps event behaviour consistent with the split and mini diff providers so downstream consumers reliably detect when diff mode ends.

## Related Issue(s)

- https://github.com/lalitmee/codecompanion-spinners.nvim/issues/2

## Screenshots

- n/a

## Checklist

- [x] I've read the contributing (https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in
    this PR
- [ ] I've added test (https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run make all to ensure docs are generated, tests pass and my formatting is applied
- [ ] (optional) I've updated CodeCompanion.has in the init.lua (https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/
    init.lua#L239) file for my new feature
- [ ] (optional) I've updated the README and/or relevant docs pages
