### PR TITLE
feat(adapters): add verbosity param to openai responses

### DIFF
--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -88,11 +88,6 @@ return {
         params.include = { "reasoning.encrypted_content" }
       end
 
-      if type(params.verbosity) == "string" then
-        params.text = params.text or {}
-        params.text.verbosity = params.verbosity
-        params.verbosity = nil
-      end
       return params
     end,
 
@@ -649,11 +644,11 @@ return {
     },
     verbosity = {
       order = 8,
-      mapping = "parameters",
+      mapping = "parameters.text",
       type = "string",
       optional = true,
       default = "medium",
-      desc = "Controls verbosity of the model output. low, medium, or high.",
+      desc = "Determines how many output tokens are generated. Use high when you wish to have thorough explanations and low for concise answers or simple code generation.",
       choices = {
         "low",
         "medium",


### PR DESCRIPTION
## Description

Normalize `parameters.verbosity` into `text.verbosity` and add a schema enum with low/medium/high (default medium) for OpenAI Responses adapter.

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/discussions/1946

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
