### PR TITLE
fix(slash_cmds): fetching an image from a URL

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/image.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/image.lua
@@ -129,8 +129,8 @@ local choice = {
       local response
       local curl_ok, curl_payload = pcall(function()
         response = Curl.get(url, {
-          insecure = config.adapters.opts.allow_insecure,
-          proxy = config.adapters.opts.proxy,
+          insecure = config.adapters.http.opts.allow_insecure,
+          proxy = config.adapters.http.opts.proxy,
           output = loc,
         })
       end)


### PR DESCRIPTION
## Description

When ACP adapters were added to the plugin and we divided the config up into `http` and `acp`, I missed that downloading an image via a URL in the image slash command pointed to `adapter.opts` and not `adapter.http.opts`.

## Related Issue(s)

#2244 


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
