### PR TITLE
fix inline output for openai_responses

### DIFF
--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -449,16 +449,23 @@ return {
           return { status = "error", output = json }
         end
 
-        if json.output then
-          local content = json.output
-              and json.output[1]
-              and json.output[1].content
-              and json.output[1].content[1]
-              and json.output[1].content[1].text
-            or nil
-          return { status = "success", output = content }
-        end
+        local output
+        vim.iter(json.output):each(function(item)
+          if item.type == "message" then
+            if item.content then
+              for _, block in ipairs(item.content) do
+                if block.type == "output_text" then
+                  output = block.text
+                  break
+                end
+              end
+            end
+          end
+        end)
+        return { status = "success", output = output }
       end
+
+      return { status = "error", output = "No output from the model" }
     end,
 
     tools = {

--- a/tests/adapters/http/stubs/openai_responses_inline.txt
+++ b/tests/adapters/http/stubs/openai_responses_inline.txt
@@ -1,0 +1,38 @@
+{
+  "id": "resp_000acfefbab2c23d0168f126d570ec8195bab5847211c166e7",
+  "object": "response",
+  "created_at": 1760634581,
+  "status": "completed",
+  "model": "gpt-5-2025-08-07",
+  "output": [
+    {
+      "id": "rs_000acfefbab2c23d0168f126d62eb88195a3731f9e0d583eda",
+      "type": "reasoning",
+      "encrypted_content": "gAAAAABo8Sb",
+      "summary": [
+        {
+          "type": "summary_text",
+          "text": "Some summary text"
+        },
+        {
+          "type": "summary_text",
+          "text": "More summary"
+        }
+      ]
+    },
+    {
+      "id": "msg_000acfefbab2c23d0168f126e09d088195a730e4f3c4a91f9a",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "{\"code\": \"print('Hello World')\",\"language\": \"lua\",\"placement\": \"add\"}"
+        }
+      ],
+      "role": "assistant"
+    }
+  ]
+}

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -412,13 +412,16 @@ T["Responses"]["No Streaming"]["can process tools"] = function()
 end
 
 T["Responses"]["No Streaming"]["can output for the inline assistant"] = function()
-  local data = vim.fn.readfile("tests/adapters/http/stubs/openai_responses_no_streaming.txt")
+  local data = vim.fn.readfile("tests/adapters/http/stubs/openai_responses_inline.txt")
   data = table.concat(data, "\n")
 
   -- Match the format of the actual request
   local json = { body = data }
 
-  h.eq("Dynamic, expressive", adapter.handlers.inline_output(adapter, json).output)
+  h.eq(
+    '{"code": "print(\'Hello World\')","language": "lua","placement": "add"}',
+    adapter.handlers.inline_output(adapter, json).output
+  )
 end
 
 T["Responses"]["No Streaming"]["can process reasoning output"] = function()


### PR DESCRIPTION
## Description

OpenAI Responses adapter can generate inline output

## Related Issue(s)

#2252

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
