### PR TITLE
feat(keymaps): use `false` for disabling keymaps

### DIFF
--- a/doc/usage/chat-buffer/index.md
+++ b/doc/usage/chat-buffer/index.md
@@ -124,3 +124,17 @@ The keymaps available to the user in normal mode are:
 - `]]` to move to the next header
 - `{` to move to the previous chat
 - `}` to move to the next chat
+
+To disable a keymap, you can set it to `false` in your configuration:
+
+```lua
+require("codecompanion").setup({
+  strategies = {
+    chat = {
+      keymaps = {
+        clear = false,
+      }
+    }
+  }
+})
+```

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1446,6 +1446,17 @@ local M = {
   config = vim.deepcopy(defaults),
 }
 
+---@param keymaps table<string, table|boolean>
+local function remove_disabled_keymaps(keymaps)
+  local enabled = {}
+  for name, keymap in pairs(keymaps) do
+    if keymap ~= false then
+      enabled[name] = keymap
+    end
+  end
+  return enabled
+end
+
 ---@param args? table
 M.setup = function(args)
   args = args or {}
@@ -1459,6 +1470,9 @@ M.setup = function(args)
   end
 
   M.config = vim.tbl_deep_extend("force", vim.deepcopy(defaults), args)
+
+  M.config.strategies.chat.keymaps = remove_disabled_keymaps(M.config.strategies.chat.keymaps)
+  M.config.strategies.inline.keymaps = remove_disabled_keymaps(M.config.strategies.inline.keymaps)
 
   -- TODO: Add a deprecation warning at some point
   if M.config.opts and M.config.opts.system_prompt then

--- a/lua/codecompanion/utils/keymaps.lua
+++ b/lua/codecompanion/utils/keymaps.lua
@@ -65,6 +65,10 @@ end
 ---@return nil
 function Keymaps:set()
   for _, map in pairs(self.keymaps) do
+    if map == false then
+      goto continue
+    end
+
     local callback
     local rhs, action_opts = self:resolve(map.callback)
     if type(map.condition) == "function" and not map.condition() then


### PR DESCRIPTION
## Description

<!-- If this is a feature request, please describe how it will benefit other CodeCompanion users -->

Adding the possibility of disabling a keymap by setting the respective value to `false`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- https://github.com/olimorris/codecompanion.nvim/discussions/1806
- https://github.com/olimorris/codecompanion.nvim/discussions/1941

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
