### PR TITLE
fix(adapter): handle adapter returning vim.NIL instead of lua:nil

### DIFF
--- a/lua/codecompanion/strategies/chat/acp/request_permission.lua
+++ b/lua/codecompanion/strategies/chat/acp/request_permission.lua
@@ -304,10 +304,20 @@ local function get_diff(tool_call)
   local absolute_path = tool_call.locations and tool_call.locations[1] and tool_call.locations[1].path
   local path = absolute_path or vim.fs.joinpath(vim.fn.getcwd(), tool_call.content[1].path)
 
+  local old = tool_call.content[1].oldText
+  local new = tool_call.content[1].newText
+
+  if type(old) ~= "string" then
+    old = ""
+  end
+  if type(new) ~= "string" then
+    new = ""
+  end
+
   return {
     kind = tool_call.kind,
-    new = tool_call.content[1].newText,
-    old = tool_call.content[1].oldText,
+    old = old,
+    new = new,
     path = path,
     status = tool_call.status,
     title = tool_call.title,


### PR DESCRIPTION
## Description

This should fix #2261, since I have tracked this down to the new version of Claude code somehow returning `vim.NIL` instead of lua `nil`. And `vim.NIL` is not actually an empty type but a C userdata therefore not falling back to empty string.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
fix #2261 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
