### PR TITLE
fix(actions): add short_name to "Open chats..." default action

### DIFF
--- a/lua/codecompanion/actions/static.lua
+++ b/lua/codecompanion/actions/static.lua
@@ -55,6 +55,7 @@ return {
     opts = {
       index = 2,
       stop_context_insertion = true,
+      short_name = "__default_open_chats",
     },
     condition = function()
       return #codecompanion.buf_get_chat() > 0


### PR DESCRIPTION
## Description

As a user, I want to open the "Open chats..." action using a keymap. Adding `short_name` to the ops will allow to programmaticly open this window. 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
