### PR TITLE
Fix issue where missing ACP entry in config causes completion breakage

### DIFF
--- a/lua/codecompanion/providers/completion/default/omnifunc.lua
+++ b/lua/codecompanion/providers/completion/default/omnifunc.lua
@@ -26,7 +26,7 @@ function M.omnifunc(findstart, base)
     }
 
     if config.strategies.chat.slash_commands.opts.acp.enabled then
-      local trigger = config.strategies.chat.slash_commands.acp.opts.trigger or "\\"
+      local trigger = config.strategies.chat.slash_commands.opts.acp.trigger or "\\"
       local escaped = vim.pesc(trigger)
       table.insert(patterns, escaped .. "[%w_]*$") -- ACP commands
     end


### PR DESCRIPTION


## Description
Fixes an issue where, due to a typo in trigger logic, an error about acp related config being nil is encountered during completion

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
Fixes #2270 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
        Didn't add a new test, couldn't find a great existing place to add it. But the fix is straightforward enough
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
