### PR TITLE
fix(chat): debug window error with ACP adapters

### DIFF
--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -118,7 +118,7 @@ function Debug:render()
   end
 
   -- Add settings
-  if not config.display.chat.show_settings then
+  if not config.display.chat.show_settings and adapter.type ~= "acp" then
     table.insert(lines, "")
     local keys = {}
 


### PR DESCRIPTION
## Description

...surprised this hadn't surfaced earlier.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
