### PR TITLE
fix(acp): close all open connections on exit

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -142,11 +142,9 @@ function Connection:connect_and_initialize()
     api.nvim_create_autocmd("VimLeavePre", {
       group = vim.api.nvim_create_augroup("codecompanion.acp.disconnect", { clear = true }),
       callback = function()
-        if self._state.handle then
-          pcall(function()
-            return self:disconnect()
-          end)
-        end
+        pcall(function()
+          return self:disconnect()
+        end)
       end,
     })
   end


### PR DESCRIPTION
## Related Issue(s)

#2286

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
