### PR TITLE
Fix Race Condition During ACP Initialization w/ Command Updates

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -487,7 +487,7 @@ function Connection:handle_incoming_request_or_notification(notification)
       [self.METHODS.SESSION_UPDATE] = function(s, m)
         -- Handle available_commands_update at the connection level
         if m.params.update and m.params.update.sessionUpdate == "available_commands_update" then
-          s:handle_available_commands_update(m.params.update.availableCommands)
+          s:handle_available_commands_update(m.params.sessionId, m.params.update.availableCommands)
         elseif s._active_prompt then
           s._active_prompt:handle_session_update(m.params.update)
         end
@@ -606,11 +606,12 @@ function Connection:handle_fs_write_file_request(id, params)
 end
 
 ---Handle available_commands_update notification
+---@param session_id string
 ---@param commands ACP.availableCommands
 ---@return nil
-function Connection:handle_available_commands_update(commands)
-  if not self.session_id then
-    return log:debug("[acp::handle_available_commands_update] No session ID; ignoring commands update")
+function Connection:handle_available_commands_update(session_id, commands)
+  if not session_id then
+    return log:debug("[acp::handle_available_commands_update] No session ID in notification; ignoring commands update")
   end
 
   if type(commands) ~= "table" then
@@ -618,7 +619,7 @@ function Connection:handle_available_commands_update(commands)
   end
 
   local acp_commands = require("codecompanion.strategies.chat.acp.commands")
-  acp_commands.register_commands(self.session_id, commands)
+  acp_commands.register_commands(session_id, commands)
 end
 
 ---Handle process exit


### PR DESCRIPTION
## Description

When a new ACP session is created, the agent responds with both:
  1. A session response containing the session ID
  2. A session/update notification with available_commands_update

  These messages often arrive in the same I/O batch and are processed during the RPC wait loop (while waiting for the session creation response). The notification handler was checking self.session_id before it had been set, causing commands to be ignored with the log message:

```
[acp::handle_available_commands_update] No session ID; ignoring commands update
```

This resulted in slash command completions (as I added in #2260) being empty for the entire session. But only sometimes (since it's a race condition).

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
(This is kind of hard to test given how it arises; however, existing tests do pass)
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
