### PR TITLE
refactor: remove usages of `vim.lsp.protocol.Methods`

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/init.lua
@@ -12,13 +12,14 @@ local fmt = string.format
 local ListCodeUsagesTool = {}
 
 local CONSTANTS = {
+  --- @type table<string, vim.lsp.protocol.Method>
   LSP_METHODS = {
-    definition = vim.lsp.protocol.Methods.textDocument_definition,
-    references = vim.lsp.protocol.Methods.textDocument_references,
-    implementations = vim.lsp.protocol.Methods.textDocument_implementation,
-    declaration = vim.lsp.protocol.Methods.textDocument_declaration,
-    type_definition = vim.lsp.protocol.Methods.textDocument_typeDefinition,
-    documentation = vim.lsp.protocol.Methods.textDocument_hover,
+    definition = "textDocument/definition",
+    references = "textDocument/references",
+    implementations = "textDocument/implementation",
+    declaration = "textDocument/declaration",
+    type_definition = "textDocument/typeDefinition",
+    documentation = "textDocument/hover",
   },
 }
 

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/lsp_handler.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/lsp_handler.lua
@@ -5,9 +5,10 @@ local log = require("codecompanion.utils.log")
 local LspHandler = {}
 
 local CONSTANTS = {
+  --- @type table<string, vim.lsp.protocol.Method>
   LSP_METHODS = {
-    references = vim.lsp.protocol.Methods.textDocument_references,
-    documentation = vim.lsp.protocol.Methods.textDocument_hover,
+    references = "textDocument/references",
+    documentation = "textDocument/hover",
   },
 }
 

--- a/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/symbol_finder.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/list_code_usages/symbol_finder.lua
@@ -20,7 +20,7 @@ local CONSTANTS = {
 ---@param callback function Callback function called with array of found symbols
 function SymbolFinder.find_with_lsp_async(symbolName, paths, callback)
   local clients = vim.lsp.get_clients({
-    method = vim.lsp.protocol.Methods.workspace_symbol,
+    method = "workspace/symbol",
   })
 
   if #clients == 0 then
@@ -35,7 +35,7 @@ function SymbolFinder.find_with_lsp_async(symbolName, paths, callback)
   for _, client in ipairs(clients) do
     local params = { query = symbolName }
 
-    client:request(vim.lsp.protocol.Methods.workspace_symbol, params, function(err, result, _, _)
+    client:request("workspace/symbol", params, function(err, result, _, _)
       if result then
         for _, symbol in ipairs(result) do
           if symbol.name == symbolName then

--- a/tests/strategies/chat/tools/catalog/test_list_code_usages.lua
+++ b/tests/strategies/chat/tools/catalog/test_list_code_usages.lua
@@ -73,25 +73,24 @@ local T = new_set({
       -- Mock LspHandler: synthesize results for definition, references, documentation
       child.lua([[
         local LH = require("codecompanion.strategies.chat.tools.catalog.list_code_usages.lsp_handler")
-        local Methods = vim.lsp.protocol.Methods
 
         LH.execute_request_async = function(_, method, cb)
           local function uri(p) return vim.uri_from_fname(p) end
 
-          if method == Methods.textDocument_references then
+          if method == "textDocument/references" then
             cb({
               mock = {
                 { uri = uri(_G.USAGE_PATH), range = { start = { line = 2, character = 10 }, ["end"] = { line = 2, character = 17 } } },
                 { uri = uri(_G.USAGE_PATH), range = { start = { line = 3, character = 7  }, ["end"] = { line = 3, character = 14 } } },
               },
             })
-          elseif method == Methods.textDocument_definition then
+          elseif method == "textDocument/definition" then
             cb({
               mock = {
                 { uri = uri(_G.MODULE_PATH), range = { start = { line = 3, character = 0 }, ["end"] = { line = 5, character = 3 } } },
               },
             })
-          elseif method == Methods.textDocument_hover then
+          elseif method == "textDocument/hover" then
             cb({ mock = { contents = "My function docs" } })
           else
             cb({ mock = {} })


### PR DESCRIPTION
## Description

<!-- If this is a feature request, please describe how it will benefit other CodeCompanion users -->

This table was deprecated in https://github.com/neovim/neovim/pull/35998.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
