### PR TITLE
fix(prompt): use vim.system to get staged git diff for commit message in `Generate a Commit Message`

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1081,14 +1081,15 @@ This is the code, for context:
         {
           role = constants.USER_ROLE,
           content = function()
-            return fmt(
+            local diff = vim.system({ "git", "diff", "--no-ext-diff", "--staged" }, { text = true }):wait()
+            return string.format(
               [[You are an expert at following the Conventional Commit specification. Given the git diff listed below, please generate a commit message for me:
 
-```diff
+````diff
 %s
-```
+````
 ]],
-              vim.fn.system("git diff --no-ext-diff --staged")
+              diff.stdout
             )
           end,
           opts = {


### PR DESCRIPTION
- Replaced `vim.fn.system` with `vim.system(...):wait()` to retrieve the staged git diff.
- Ensured the diff output is passed as `diff.stdout` to the prompt.
- Updated code block formatting from triple to quadruple backticks for diff display.

## Description
https://github.com/olimorris/codecompanion.nvim/discussions/2263#discussion-9038736

Powershell on Windows seems to have trouble parsing commands passed as strings instead of tables, e.g. `vim.fn.system("git diff --no-ext-diff --staged")` vs `vim.fn.system({ "git", "diff", "--no-ext-diff", "--staged" }`

Updated the string to a table, which appears to fix the issue when using Powershell.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
