### PR TITLE
fix(tools): fetch webpage

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/fetch_webpage.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/fetch_webpage.lua
@@ -44,7 +44,7 @@ return {
         .new({
           adapter = adapter,
         })
-        :request(_, {
+        :request({ messages = {}, tools = nil }, {
           callback = function(err, data)
             if err then
               log:error("[Fetch Webpage Tool] Error fetching `%s`: %s", url, err)


### PR DESCRIPTION
## Description

Recent changes in the http adapter had not been propagated to the `fetch_webpage` tool

## Related Issue(s)

#2318

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
