### PR TITLE
refactor(tools): auto submit errors by default

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -189,7 +189,7 @@ local defaults = {
           description = "Find code symbol context",
         },
         opts = {
-          auto_submit_errors = false, -- Send any errors to the LLM automatically?
+          auto_submit_errors = true, -- Send any errors to the LLM automatically?
           auto_submit_success = true, -- Send any successful output to the LLM automatically?
           folds = {
             enabled = true, -- Fold tool output in the buffer?
@@ -339,6 +339,9 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
         ["image"] = {
           callback = "strategies.chat.slash_commands.image",
           description = "Insert an image",
+          enabled = function(adapter)
+            return adapter.opts and adapter.opts.vision == true
+          end,
           opts = {
             dirs = {}, -- Directories to search for images
             filetypes = { "png", "jpg", "jpeg", "gif", "webp" }, -- Filetypes to search for


### PR DESCRIPTION
## Description

Making the submission of tool errors automatic, by default.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
