### PR TITLE
fix(chat): conditionals for slash commands and tools

### DIFF
--- a/lua/codecompanion/adapters/acp/init.lua
+++ b/lua/codecompanion/adapters/acp/init.lua
@@ -128,6 +128,7 @@ function Adapter.make_safe(adapter)
     command = adapter.command,
     defaults = adapter.defaults,
     params = adapter.parameters,
+    opts = adapter.opts,
     handlers = adapter.handlers,
   }
 end

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -366,6 +366,7 @@ end
 function Adapter.make_safe(adapter)
   return {
     name = adapter.name,
+    type = adapter.type,
     model = adapter.model,
     available_tools = adapter.available_tools,
     formatted_name = adapter.formatted_name,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -339,7 +339,7 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
         ["image"] = {
           callback = "strategies.chat.slash_commands.catalog.image",
           description = "Insert an image",
-          ---@param opts { adapter: CodeCompanion.HTTPAdapter }
+          ---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
           ---@return boolean
           enabled = function(opts)
             if opts.adapter and opts.adapter.opts then
@@ -363,7 +363,7 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
         ["mode"] = {
           callback = "strategies.chat.slash_commands.catalog.mode",
           description = "Change the ACP session mode",
-          ---@param opts { adapter: CodeCompanion.Adapter }
+          ---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
           ---@return boolean
           enabled = function(opts)
             if opts.adapter and opts.adapter.type == "acp" then

--- a/lua/codecompanion/providers/completion/init.lua
+++ b/lua/codecompanion/providers/completion/init.lua
@@ -64,13 +64,27 @@ api.nvim_create_autocmd("User", {
   pattern = { "CodeCompanionChatAdapter", "CodeCompanionChatModel" },
   callback = function(args)
     local bufnr = args.data.bufnr
-    if args.data.adapter then
-      tool_filter.refresh_cache()
-      slash_command_filter.refresh_cache()
-      adapter_cache[bufnr] = args.data.adapter
-    else
-      adapter_cache[bufnr] = nil
+
+    -- Only update adapter cache if the event explicitly includes adapter data
+    local has_adapter_field = false
+    for k, _ in pairs(args.data) do
+      if k == "adapter" then
+        has_adapter_field = true
+        break
+      end
     end
+
+    if has_adapter_field then
+      if args.data.adapter then
+        tool_filter.refresh_cache()
+        slash_command_filter.refresh_cache()
+        adapter_cache[bufnr] = args.data.adapter
+      else
+        adapter_cache[bufnr] = nil
+      end
+    end
+
+    -- If adapter field is not present in the event then we don't update the cache
   end,
 })
 

--- a/lua/codecompanion/strategies/chat/slash_commands/filter.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/filter.lua
@@ -1,7 +1,7 @@
 local filter = require("codecompanion.strategies.chat.helpers.filter")
 
 ---@class CodeCompanion.SlashCommands.Filter
-local Filter = filter.create_filter("Slash Command", {
+local Filter = filter.create_filter({
   skip_keys = { "opts" },
 })
 

--- a/lua/codecompanion/strategies/chat/tools/filter.lua
+++ b/lua/codecompanion/strategies/chat/tools/filter.lua
@@ -2,7 +2,7 @@ local filter = require("codecompanion.strategies.chat.helpers.filter")
 local log = require("codecompanion.utils.log")
 
 ---@class CodeCompanion.Tools.Filter
-local Filter = filter.create_filter("Tool", {
+local Filter = filter.create_filter({
   skip_keys = { "opts", "groups" },
   post_filter = function(filtered_config, opts, enabled_items)
     -- Adapter specific tool

--- a/tests/providers/completion/test_adapter_cache.lua
+++ b/tests/providers/completion/test_adapter_cache.lua
@@ -1,0 +1,194 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["adapter cache"] = new_set()
+
+T["adapter cache"]["updates when ChatAdapter event fires"] = function()
+  child.lua([[
+    local completion = require("codecompanion.providers.completion")
+    local utils = require("codecompanion.utils")
+
+    -- Create a test config with a conditional slash command
+    local test_slash_commands = {
+      test_cmd = {
+        description = "Test command",
+        enabled = function(opts)
+          return opts.adapter and opts.adapter.name == "test_adapter"
+        end,
+      },
+      opts = {},
+    }
+
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+
+    -- Fire ChatAdapter event with test adapter
+    local adapter = { name = "test_adapter", type = "http" }
+    utils.fire("ChatAdapter", { bufnr = bufnr, adapter = adapter })
+
+    -- Get slash commands with our test config
+    local slash_command_filter = require("codecompanion.strategies.chat.slash_commands.filter")
+    local filtered = slash_command_filter.filter_enabled_slash_commands(test_slash_commands, { adapter = adapter })
+
+    _G.test_result = filtered.test_cmd ~= nil
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+
+  h.eq(child.lua_get("_G.test_result"), true)
+end
+
+T["adapter cache"]["preserves adapter when ChatModel event without adapter fires"] = function()
+  child.lua([[
+    local utils = require("codecompanion.utils")
+
+    local test_slash_commands = {
+      test_cmd = {
+        description = "Test command",
+        enabled = function(opts)
+          return opts.adapter and opts.adapter.type == "acp"
+        end,
+      },
+      opts = {},
+    }
+
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+
+    -- Set an ACP adapter
+    local adapter = { name = "claude_code", type = "acp" }
+    utils.fire("ChatAdapter", { bufnr = bufnr, adapter = adapter })
+
+    -- Fire ChatModel event without adapter field (simulating model selection)
+    utils.fire("ChatModel", { bufnr = bufnr, model = "some-model" })
+
+    -- Adapter should still be in cache, so filtering should still work
+    local slash_command_filter = require("codecompanion.strategies.chat.slash_commands.filter")
+    local filtered = slash_command_filter.filter_enabled_slash_commands(test_slash_commands, { adapter = adapter })
+
+    _G.test_result = filtered.test_cmd ~= nil
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+
+  h.eq(child.lua_get("_G.test_result"), true)
+end
+
+T["adapter cache"]["clears when adapter explicitly set to nil"] = function()
+  child.lua([[
+    local utils = require("codecompanion.utils")
+
+    local test_slash_commands = {
+      test_cmd = {
+        description = "Test command",
+        enabled = function(opts)
+          return opts.adapter and opts.adapter.name == "test_adapter"
+        end,
+      },
+      always_enabled_cmd = {
+        description = "Always enabled command",
+        -- No enabled function, so always enabled
+      },
+      opts = {},
+    }
+
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+
+    -- Set an adapter - test_cmd should be enabled
+    local adapter = { name = "test_adapter", type = "http" }
+    utils.fire("ChatAdapter", { bufnr = bufnr, adapter = adapter })
+
+    local slash_command_filter = require("codecompanion.strategies.chat.slash_commands.filter")
+    local filtered_before = slash_command_filter.filter_enabled_slash_commands(test_slash_commands, { adapter = adapter })
+
+    -- Explicitly clear it
+    utils.fire("ChatAdapter", { bufnr = bufnr, adapter = nil })
+
+    -- Refresh cache to pick up the cleared adapter
+    slash_command_filter.refresh_cache()
+
+    -- Filter with nil adapter - test_cmd should not be enabled, but always_enabled_cmd should be
+    local filtered_after = slash_command_filter.filter_enabled_slash_commands(test_slash_commands, { adapter = nil })
+
+    _G.test_cmd_before = filtered_before.test_cmd ~= nil
+    _G.test_cmd_after = filtered_after.test_cmd == nil
+    _G.always_enabled_before = filtered_before.always_enabled_cmd ~= nil
+    _G.always_enabled_after = filtered_after.always_enabled_cmd ~= nil
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+
+  -- Before clearing: test_cmd should be enabled
+  h.eq(child.lua_get("_G.test_cmd_before"), true)
+  -- After clearing: test_cmd should be disabled
+  h.eq(child.lua_get("_G.test_cmd_after"), true)
+  -- always_enabled_cmd should be enabled in both cases
+  h.eq(child.lua_get("_G.always_enabled_before"), true)
+  h.eq(child.lua_get("_G.always_enabled_after"), true)
+end
+
+T["adapter cache"]["updates when switching from HTTP to ACP adapter"] = function()
+  child.lua([[
+    local utils = require("codecompanion.utils")
+
+    -- Command that only works with ACP adapters
+    local test_slash_commands = {
+      acp_only_cmd = {
+        description = "ACP only command",
+        enabled = function(opts)
+          return opts.adapter and opts.adapter.type == "acp"
+        end,
+      },
+      opts = {},
+    }
+
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(bufnr)
+
+    -- Start with HTTP adapter
+    local http_adapter = { name = "copilot", type = "http" }
+    utils.fire("ChatAdapter", { bufnr = bufnr, adapter = http_adapter })
+
+    -- Command should not be available
+    local slash_command_filter = require("codecompanion.strategies.chat.slash_commands.filter")
+    local filtered_http = slash_command_filter.filter_enabled_slash_commands(
+      test_slash_commands,
+      { adapter = http_adapter }
+    )
+
+    -- Switch to ACP adapter
+    local acp_adapter = { name = "claude_code", type = "acp" }
+    utils.fire("ChatAdapter", { bufnr = bufnr, adapter = acp_adapter })
+
+    -- Fire a ChatModel event without adapter (simulating model selection)
+    utils.fire("ChatModel", { bufnr = bufnr, model = "default" })
+
+    -- Command should now be available because we're using ACP adapter
+    local filtered_acp = slash_command_filter.filter_enabled_slash_commands(
+      test_slash_commands,
+      { adapter = acp_adapter }
+    )
+
+    _G.http_result = filtered_http.acp_only_cmd == nil
+    _G.acp_result = filtered_acp.acp_only_cmd ~= nil
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+
+  h.eq(child.lua_get("_G.http_result"), true)
+  h.eq(child.lua_get("_G.acp_result"), true)
+end
+
+return T


### PR DESCRIPTION
## Description

#2330 wasn't properly implemented resulted in ACP slash commands not working alongside the conditionals for CodeCompanion's slash commands. This PR fixes that and adds test coverage.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
