### PR TITLE
chore(tools): rename tool

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/delete_file.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/delete_file.lua
@@ -1,4 +1,3 @@
-local files = require("codecompanion.utils.files")
 local helpers = require("codecompanion.strategies.chat.tools.catalog.helpers")
 local log = require("codecompanion.utils.log")
 
@@ -42,7 +41,7 @@ end
 
 ---@class CodeCompanion.Tool.DeleteFile: CodeCompanion.Tools.Tool
 return {
-  name = "create_file",
+  name = "delete_file",
   cmds = {
     ---Execute the file commands
     ---@param self CodeCompanion.Tool.DeleteFile
@@ -122,7 +121,7 @@ return {
     ---@param opts table
     ---@return nil
     rejected = function(self, tools, cmd, opts)
-      local message = "The user rejected the creation of the file"
+      local message = "The user rejected the deletion of the file"
       opts = vim.tbl_extend("force", { message = message }, opts or {})
       helpers.rejected(self, tools, cmd, opts)
     end,


### PR DESCRIPTION
## Description

Fix incorrect naming.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
