### PR TITLE
fix: protect against msg._meta being nil

### DIFF
--- a/lua/codecompanion/adapters/acp/helpers.lua
+++ b/lua/codecompanion/adapters/acp/helpers.lua
@@ -14,7 +14,7 @@ M.form_messages = function(self, messages, capabilities)
     .iter(messages)
     :filter(function(msg)
       -- Ensure we're only sending messages that the agent hasn't seen before
-      return msg.role == self.roles.user and not msg._meta.sent
+      return msg.role == self.roles.user and msg._meta and not msg._meta.sent
     end)
     :map(function(msg)
       if msg._meta and msg._meta.tag == "image" and msg.context and msg.context.mimetype then


### PR DESCRIPTION
## Description

If I use the `lsp` prompt via a keymap, I get an exception:

`attempt to index field '_meta' a nil value`

I'm not exactly sure how / why this happens, but this small fix works using the `claude_code` ACP adapter.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR