### PR TITLE
Attempt loading slash commands from a user module path

### DIFF
--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -15,7 +15,7 @@ local function resolve(callback)
   -- Try loading the tool from the user's config using a module path
   ok, slash_command = pcall(require, callback)
   if ok then
-    log:debug("Calling slash command: %s", callback)
+    log:debug("Calling slash command using a module path: %s", callback)
     return slash_command
   end
 
@@ -27,7 +27,7 @@ local function resolve(callback)
   end
 
   if slash_command then
-    log:debug("Calling slash command: %s", callback)
+    log:debug("Calling slash command from a file path: %s", callback)
     return slash_command()
   end
 end


### PR DESCRIPTION
## Description

Allow users to load their own slash commands with a relative module path.

## Related Issue(s)

Fixes: https://github.com/olimorris/codecompanion.nvim/issues/2369

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
