### PR TITLE
revert(completion): acp tool to have tool completion trigger

### DIFF
--- a/lua/codecompanion/providers/completion/init.lua
+++ b/lua/codecompanion/providers/completion/init.lua
@@ -187,12 +187,6 @@ end
 function M.acp_commands(bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
 
-  -- Only show ACP commands if this buffer is using an ACP adapter
-  local adapter_info = adapter_cache[bufnr]
-  if not adapter_info or adapter_info.type ~= "acp" then
-    return {}
-  end
-
   local acp_commands = require("codecompanion.strategies.chat.acp.commands")
   local commands = acp_commands.get_commands_for_buffer(bufnr)
   local acp_trigger = get_acp_trigger()


### PR DESCRIPTION
## Description

This reverts a tiny change during the update of conditionals for completion with this https://github.com/olimorris/codecompanion.nvim/pull/2336 PR.

While I completely understand the reasoning of ACP tools not having access to `lua` tools, through the https://ravitemer.github.io/mcphub.nvim/ plugin we can get access to some that are actually working.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

<img width="752" height="294" alt="image" src="https://github.com/user-attachments/assets/de58f6c2-7749-4e1f-a517-d69ba9d4f361" />
vs
no completion

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
