### PR TITLE
fix(acp): prevent auto-close of mini_diff provider

### DIFF
--- a/lua/codecompanion/strategies/chat/acp/request_permission.lua
+++ b/lua/codecompanion/strategies/chat/acp/request_permission.lua
@@ -388,7 +388,7 @@ local function show_diff(chat, request)
   local provider_config = config.display.diff.provider_opts[provider] or {}
   local layout = provider_config.layout
   local is_floating = provider == "inline" and layout == "float"
-  local keep_win_open = provider == "inline" and layout == "buffer" or provider == "split"
+  local keep_win_open = provider == "inline" and layout == "buffer" or provider == "split" or provider == "mini_diff"
 
   local diff = diff_module.new({
     bufnr = bufnr,


### PR DESCRIPTION
## Description

Accept/reject diff should not close main window.

## Related Issue(s)

None

## Screenshots

None

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
