### PR TITLE
feat(mistral): Override env when using codestral

### DIFF
--- a/lua/codecompanion/adapters/http/mistral.lua
+++ b/lua/codecompanion/adapters/http/mistral.lua
@@ -46,6 +46,13 @@ return {
           self.opts.tools = false
         end
       end
+      -- If using the codestral model, force using the codestral API key and endpoint
+      if model == "codestral-latest" then
+        self.env = {
+          url = "https://codestral.mistral.ai/",
+          api_key = "CODESTRAL_API_KEY",
+        }
+      end
 
       return true
     end,


### PR DESCRIPTION
When using codestral-latest, I wanna use the codestral API endpoint rather than the mistral one as it is free to use.