### PR TITLE
refactor: normalize all paths

### DIFF
--- a/lua/codecompanion/interactions/background/callbacks.lua
+++ b/lua/codecompanion/interactions/background/callbacks.lua
@@ -19,7 +19,7 @@ local function resolve(path)
   end
 
   -- Try loading the tool from the user's config using a file path
-  local action, err = loadfile(path)
+  local action, err = loadfile(vim.fs.normalize(path))
   if err then
     return
   end

--- a/lua/codecompanion/strategies/chat/slash_commands/init.lua
+++ b/lua/codecompanion/strategies/chat/slash_commands/init.lua
@@ -21,7 +21,7 @@ local function resolve(callback)
 
   -- Try loading the tool from the user's config using a file path
   local err
-  slash_command, err = loadfile(callback)
+  slash_command, err = loadfile(vim.fs.normalize(callback))
   if err then
     return log:error("Could not load the slash command: %s", callback)
   end

--- a/lua/codecompanion/strategies/chat/tools/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/init.lua
@@ -494,7 +494,7 @@ function Tools.resolve(tool)
 
   -- Try loading the tool from the user's config using a file path
   local err
-  module, err = loadfile(callback)
+  module, err = loadfile(vim.fs.normalize(callback))
   if err then
     return log:error("[Tools] Failed to load tool from %s: %s", callback, err)
   end

--- a/lua/codecompanion/strategies/inline/variables/init.lua
+++ b/lua/codecompanion/strategies/inline/variables/init.lua
@@ -98,7 +98,7 @@ function Variables:output()
 
     do
       local err
-      module, err = loadfile(callback)
+      module, err = loadfile(vim.fs.normalize(callback))
       if err then
         log:error("[Variables] %s could not be resolved", var)
         goto skip


### PR DESCRIPTION
## Description

If a user has custom tools or slash commands, they previously had to include the path in standard format. This PR uses `vim.fs.normalize` to make this cleaner for users.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
