### PR TITLE
feat: implement JSON argument validation for insert_edit_into_file

### DIFF
--- a/lua/codecompanion/strategies/chat/tools/catalog/insert_edit_into_file/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/insert_edit_into_file/init.lua
@@ -199,8 +199,7 @@ local function validate_json_arguments(args)
       error_path
     )
     return false,
-      fmt(
-        [[JSON argument validation failed: Invalid value type detected
+      fmt([[JSON argument validation failed: Invalid value type detected
 
 Your JSON arguments contain invalid values. Please ensure all values are valid JSON types:
 - Strings (text)
@@ -210,8 +209,7 @@ Your JSON arguments contain invalid values. Please ensure all values are valid J
 - Objects {}
 - null
 
-Do not include any code references, variables, or computed values - only literal JSON values.]]
-      )
+Do not include any code references, variables, or computed values - only literal JSON values.]])
   end
 
   -- Try to serialize to catch other JSON encoding issues (like circular references)

--- a/tests/strategies/chat/tools/catalog/insert_edit_into_file/test_json_validation.lua
+++ b/tests/strategies/chat/tools/catalog/insert_edit_into_file/test_json_validation.lua
@@ -395,7 +395,7 @@ T["JSON Validation"]["rejects oldText as array"] = function()
   local output = child.lua_get("chat.messages[#chat.messages].content")
   h.expect_contains("oldText", output)
   h.expect_contains("must be a string", output)
-  h.expect_contains("table", output)  -- Lua reports it as 'table'
+  h.expect_contains("table", output) -- Lua reports it as 'table'
 end
 
 T["JSON Validation"]["handles unescaped newline causing parse failure"] = function()


### PR DESCRIPTION
- Added functions to check for non-serializable types and validate JSON arguments.
- Enhanced error handling for invalid edits, ensuring required fields are present and correctly typed.
- Introduced comprehensive tests for various JSON validation scenarios, including edge cases and malformed JSON inputs.

## Description

<!-- If this is a feature request, please describe how it will benefit other CodeCompanion users -->

When I user claude sonnet 4.5 and opus 4.1, I meet this problem:

The llm ouputs incorrect tool call (contains unencoded characters)

## Screenshots

<img width="3050" height="548" alt="image" src="https://github.com/user-attachments/assets/a59ba385-fc07-4545-91f5-49952ffec141" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
