### PR TITLE
refactor(ui): diff resets winbar and doc updates

### DIFF
--- a/doc/.vitepress/config.mjs
+++ b/doc/.vitepress/config.mjs
@@ -1,5 +1,6 @@
 import { joinURL, withoutTrailingSlash } from "ufo";
 import { defineConfig } from "vitepress";
+import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 import { execSync } from "node:child_process";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
@@ -74,6 +75,11 @@ const headers = inProd ? [...baseHeaders, umamiScript] : baseHeaders;
 // https://vitepress.dev/reference/site-config
 export default withMermaid(
   defineConfig({
+    markdown: {
+      config(md) {
+        md.use(tabsMarkdownPlugin);
+      },
+    },
     mermaid: {
       securityLevel: "loose", // Allows more flexibility
       theme: "base", // Use base theme to allow CSS variables to take effect

--- a/doc/.vitepress/theme/index.js
+++ b/doc/.vitepress/theme/index.js
@@ -1,4 +1,10 @@
 import DefaultTheme from "vitepress/theme";
 import "./vaporwave.css";
+import { enhanceAppWithTabs } from "vitepress-plugin-tabs/client";
 
-export default DefaultTheme;
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    enhanceAppWithTabs(app);
+  },
+};

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*        For NVIM v0.11        Last change: 2025 November 23
+*codecompanion.txt*        For NVIM v0.11        Last change: 2025 November 24
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1866,69 +1866,9 @@ utilize the `insert_edit_into_file` tool, then the plugin can update files and
 buffers and a diff will be created so you can see the changes made by the LLM.
 The `inline` is the default diff.
 
-There are a number of diff settings available to you:
+Depending on which provider you choose, there are different configuration
+options available to you:
 
->lua
-    require("codecompanion").setup({
-      display = {
-        diff = {
-          enabled = true,
-          provider = providers.diff, -- mini_diff|split|inline
-    
-          provider_opts = {
-            -- Options for inline diff provider
-            inline = {
-              layout = "float", -- float|buffer - Where to display the diff
-    
-              diff_signs = {
-                signs = {
-                  text = "▌", -- Sign text for normal changes
-                  reject = "✗", -- Sign text for rejected changes in super_diff
-                  highlight_groups = {
-                    addition = "DiagnosticOk",
-                    deletion = "DiagnosticError",
-                    modification = "DiagnosticWarn",
-                  },
-                },
-                -- Super Diff options
-                icons = {
-                  accepted = " ",
-                  rejected = " ",
-                },
-                colors = {
-                  accepted = "DiagnosticOk",
-                  rejected = "DiagnosticError",
-                },
-              },
-    
-              opts = {
-                context_lines = 3, -- Number of context lines in hunks
-                dim = 25, -- Background dim level for floating diff (0-100, [100 full transparent], only applies when layout = "float")
-                full_width_removed = true, -- Make removed lines span full width
-                show_keymap_hints = true, -- Show "gda: accept | gdr: reject" hints above diff
-                show_removed = true, -- Show removed lines as virtual text
-              },
-            },
-    
-            -- Options for the split provider
-            split = {
-              close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...
-              layout = "vertical", -- vertical|horizontal split
-              opts = {
-                "internal",
-                "filler",
-                "closeoff",
-                "algorithm:histogram", -- https://adamj.eu/tech/2024/01/18/git-improve-diff-histogram/
-                "indent-heuristic", -- https://blog.k-nut.eu/better-git-diffs
-                "followwrap",
-                "linematch:120",
-              },
-            },
-          },
-        },
-      },
-    })
-<
 
 You can also customize the window that the diff appears in (taking precedence
 over `child_window`):

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -429,41 +429,32 @@ require("codecompanion").setup({
 
 CodeCompanion has built-in inline and split diffs available to you. If you utilize the `insert_edit_into_file` tool, then the plugin can update files and buffers and a diff will be created so you can see the changes made by the LLM. The `inline` is the default diff.
 
-There are a number of diff settings available to you:
+Depending on which provider you choose, there are different configuration options available to you:
+
+:::tabs
+
+== Select Provider
 
 ```lua
 require("codecompanion").setup({
   display = {
     diff = {
       enabled = true,
-      provider = providers.diff, -- mini_diff|split|inline
+      provider = providers.diff, -- inline|split|mini.diff
+    },
+  },
+})
+```
 
+== Inline Provider
+
+```lua
+require("codecompanion").setup({
+  display = {
+    diff = {
       provider_opts = {
-        -- Options for inline diff provider
         inline = {
           layout = "float", -- float|buffer - Where to display the diff
-
-          diff_signs = {
-            signs = {
-              text = "▌", -- Sign text for normal changes
-              reject = "✗", -- Sign text for rejected changes in super_diff
-              highlight_groups = {
-                addition = "DiagnosticOk",
-                deletion = "DiagnosticError",
-                modification = "DiagnosticWarn",
-              },
-            },
-            -- Super Diff options
-            icons = {
-              accepted = " ",
-              rejected = " ",
-            },
-            colors = {
-              accepted = "DiagnosticOk",
-              rejected = "DiagnosticError",
-            },
-          },
-
           opts = {
             context_lines = 3, -- Number of context lines in hunks
             dim = 25, -- Background dim level for floating diff (0-100, [100 full transparent], only applies when layout = "float")
@@ -472,8 +463,19 @@ require("codecompanion").setup({
             show_removed = true, -- Show removed lines as virtual text
           },
         },
+      },
+    },
+  },
+})
+```
 
-        -- Options for the split provider
+== Split Provider
+
+```lua
+require("codecompanion").setup({
+  display = {
+    diff = {
+      provider_opts = {
         split = {
           close_chat_at = 240, -- Close an open chat buffer if the total columns of your display are less than...
           layout = "vertical", -- vertical|horizontal split
@@ -492,6 +494,9 @@ require("codecompanion").setup({
   },
 })
 ```
+
+
+:::
 
 You can also customize the window that the diff appears in (taking precedence over `child_window`):
 

--- a/doc/package-lock.json
+++ b/doc/package-lock.json
@@ -9,7 +9,8 @@
         "mermaid": "^11.10.0",
         "ufo": "^1.6.1",
         "vitepress": "^1.5.0",
-        "vitepress-plugin-mermaid": "^2.0.17"
+        "vitepress-plugin-mermaid": "^2.0.17",
+        "vitepress-plugin-tabs": "^0.7.3"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -3916,6 +3917,17 @@
       "peerDependencies": {
         "mermaid": "10 || 11",
         "vitepress": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
+    "node_modules/vitepress-plugin-tabs": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-tabs/-/vitepress-plugin-tabs-0.7.3.tgz",
+      "integrity": "sha512-CkUz49UrTLcVOszuiHIA7ZBvfsg9RluRkFjRG1KvCg/NwuOTLZwcBRv7vBB3vMlDp0bWXIFOIwdI7bE93cV3Hw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vitepress": "^1.0.0",
+        "vue": "^3.5.0"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/doc/package.json
+++ b/doc/package.json
@@ -4,7 +4,8 @@
     "mermaid": "^11.10.0",
     "ufo": "^1.6.1",
     "vitepress": "^1.5.0",
-    "vitepress-plugin-mermaid": "^2.0.17"
+    "vitepress-plugin-mermaid": "^2.0.17",
+    "vitepress-plugin-tabs": "^0.7.3"
   },
   "scripts": {
     "dev": "vitepress dev",


### PR DESCRIPTION
## Description

Ensure that we restore a user's winbar rather than deleting it.

Also update docs regarding diffs.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
