### PR TITLE
fix(chat): preserve prompt library system prompts

### DIFF
--- a/lua/codecompanion/strategies/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/strategies/chat/keymaps/change_adapter.lua
@@ -246,7 +246,11 @@ function M.callback(chat)
       chat:change_adapter(selected_adapter)
     end
 
-    M.update_system_prompt(chat)
+    -- Only force a system prompt update if the user isn't ignoring it. This
+    -- occurs when a user has initiated a chat from the prompt library
+    if not chat.opts.ignore_system_prompt then
+      M.update_system_prompt(chat)
+    end
 
     if chat.adapter.type == "http" then
       M.select_model(chat)


### PR DESCRIPTION
## Description

When changing adapters, a system prompt from the prompt library was being overwritten.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
