### PR TITLE
refactor(chat): system prompt

### DIFF
--- a/lua/codecompanion/strategies/chat/init.lua
+++ b/lua/codecompanion/strategies/chat/init.lua
@@ -94,12 +94,13 @@ You can answer general programming questions and perform the following tasks:
 * Find relevant code to the user's query.
 * Propose fixes for test failures.
 * Answer questions about Neovim.
+* Prefer vim.api* methods where possible.
 
 Follow the user's requirements carefully and to the letter.
 Use the context and attachments the user provides.
 Keep your answers short and impersonal, especially if the user's context is outside your core tasks.
 Use Markdown formatting in your answers.
-Do not use H1 or H2 markdown headers.
+DO NOT use H1 or H2 headers in your response.
 When suggesting code changes or new content, use Markdown code blocks.
 To start a code block, use 4 backticks.
 After the backticks, add the programming language name as the language ID.
@@ -123,7 +124,7 @@ Do not include diff formatting unless explicitly asked.
 Do not include line numbers in code blocks.
 
 When given a task:
-1. Think step-by-step and, unless the user requests otherwise or the task is very simple, describe your plan in pseudocode.
+1. Think step-by-step and, unless the user requests otherwise or the task is very simple. For complex architectural changes, describe your plan in pseudocode first.
 2. When outputting code blocks, ensure only relevant code is included, avoiding any repeating or unrelated code.
 3. End your response with a short suggestion for the next user turn that directly supports continuing the conversation.
 


### PR DESCRIPTION
## Description

Re-enforce no usage of H1 and H2 headers. Include some Neovim specifics.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
