### PR TITLE
fix(diff): use scratch buffer for ACP diff view

### DIFF
--- a/lua/codecompanion/strategies/chat/acp/request_permission.lua
+++ b/lua/codecompanion/strategies/chat/acp/request_permission.lua
@@ -359,7 +359,6 @@ local function show_diff(chat, request)
   local bufnr = api.nvim_create_buf(false, true)
   local diff_id = math.random(10000000)
   api.nvim_buf_set_name(bufnr, d.path .. "_diff_" .. diff_id)
-  api.nvim_set_option_value("buftype", "nofile", { buf = bufnr })
   api.nvim_set_option_value("bufhidden", "wipe", { buf = bufnr })
   api.nvim_buf_set_lines(bufnr, 0, -1, false, new_lines)
 


### PR DESCRIPTION
## Description

Issue: For ACP, the buffer isn't  a scratch buffer when creating a diff. This PR fixes that and ensures the buffer is correctly set as scratch.

Thank you

## Related Issue(s)

#2442


## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
