### PR TITLE
rename user_confirmation to require_confirmation_after

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3501,9 +3501,9 @@ This tool can edit buffers and files for code changes from an LLM:
 use to determine how to edit files and buffers -
 `require_approval_before.buffer` (boolean) Require approval before editng a
 buffer? (Default: false) - `require_approval_before.file` (boolean) Require
-approval before editng a file? (Default: true) - `user_confirmation` (boolean)
-require confirmation from the user before moving on in the chat buffer?
-(Default: true)
+approval before editng a file? (Default: true) - `require_confirmation_after`
+(boolean) require confirmation after the execution and before moving on in the
+chat buffer? (Default: true)
 
 
 LIST_CODE_USAGES

--- a/doc/usage/chat-buffer/tools.md
+++ b/doc/usage/chat-buffer/tools.md
@@ -163,7 +163,7 @@ Can you apply the suggested changes to the buffer with @{insert_edit_into_file}?
 - `patching_algorithm` (string|table|function) The algorithm to use to determine how to edit files and buffers
 - `require_approval_before.buffer` (boolean) Require approval before editng a buffer? (Default: false)
 - `require_approval_before.file` (boolean) Require approval before editng a file? (Default: true)
-- `user_confirmation` (boolean) require confirmation from the user before moving on in the chat buffer? (Default: true)
+- `require_confirmation_after` (boolean) require confirmation after the execution and before moving on in the chat buffer? (Default: true)
 
 ### list_code_usages
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -138,7 +138,7 @@ local defaults = {
               buffer = false, -- For editing buffers in Neovim
               file = false, -- For editing files in the current working directory
             },
-            user_confirmation = true, -- Require confirmation from the user before accepting the edit?
+            require_confirmation_after = true, -- Require confirmation from the user before accepting the edit?
             file_size_limit_mb = 2, -- Maximum file size in MB
           },
         },

--- a/lua/codecompanion/strategies/chat/tools/catalog/insert_edit_into_file/init.lua
+++ b/lua/codecompanion/strategies/chat/tools/catalog/insert_edit_into_file/init.lua
@@ -742,7 +742,7 @@ local function edit_file(action, chat_bufnr, output_handler, opts)
     data = fmt("Edited `%s` file%s", action.filepath, extract_explanation(action)),
   }
 
-  if should_diff and opts.user_confirmation then
+  if should_diff and opts.require_confirmation_after then
     local accept = config.strategies.inline.keymaps.accept_change.modes.n
     local reject = config.strategies.inline.keymaps.reject_change.modes.n
 
@@ -905,7 +905,7 @@ local function edit_buffer(bufnr, chat_bufnr, action, output_handler, opts)
     data = fmt("Edited `%s` buffer%s", display_name, extract_explanation(action)),
   }
 
-  if should_diff and opts.user_confirmation then
+  if should_diff and opts.require_confirmation_after then
     local accept = config.strategies.inline.keymaps.accept_change.modes.n
     local reject = config.strategies.inline.keymaps.reject_change.modes.n
 

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -106,7 +106,7 @@ return {
               buffer = false,
               file = false,
             },
-            user_confirmation = false,
+            require_confirmation_after = false,
           },
         },
         ["create_file"] = {


### PR DESCRIPTION
## Description

`user_confirmation` is now `require_confirmation_after`

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
