### PR TITLE
chore: warn about breaking changes

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -359,7 +359,7 @@ end
 CodeCompanion.setup = function(opts)
   opts = opts or {}
 
-  if not opts.opts.ignore_warnings then
+  if not opts.ignore_warnings then
     vim.notify_once(
       [[[WARN] CodeCompanion.nvim will experience breaking changes soon. Pin to version v17.33.0 or earlier to avoid this.
 See: https://github.com/olimorris/codecompanion.nvim/pull/2439]],


### PR DESCRIPTION
## Description

Warn users about the upcoming breaking changes.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
