### PR TITLE
Rename `child_window` to `floating_window`

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1857,7 +1857,7 @@ The default sizing of this window can be configured:
     require("codecompanion").setup({
       display = {
         chat = {
-          child_window = {
+          floating_window = {
             width = vim.o.columns - 5,
             height = vim.o.lines - 2,
             row = "center",

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -458,7 +458,7 @@ require("codecompanion").setup({
 require("codecompanion").setup({
   display = {
     chat = {
-      child_window = {
+      floating_window = {
         ---@return number|fun(): number
         width = function()
           return vim.o.columns - 5
@@ -645,7 +645,7 @@ The default sizing of this window can be configured:
 require("codecompanion").setup({
   display = {
     chat = {
-      child_window = {
+      floating_window = {
         width = vim.o.columns - 5,
         height = vim.o.lines - 2,
         row = "center",

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1273,7 +1273,7 @@ This is the code, for context:
         },
       },
       -- Options for any windows that open within the chat buffer
-      child_window = {
+      floating_window = {
         ---@return number|fun(): number
         width = function()
           return vim.o.columns - 5
@@ -1291,7 +1291,7 @@ This is the code, for context:
           relativenumber = false,
         },
       },
-      -- Extend/override the child_window options for a diff
+      -- Extend/override the floating_window options for a diff
       diff_window = {
         ---@return number|fun(): number
         width = function()

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -353,7 +353,7 @@ CodeCompanion.setup = function(opts)
   -- Setup the plugin's config
   config.setup(opts)
 
-  -- handle adapter configuration | acp
+  -- Handle ACP adapter config
   if opts and opts.adapters and opts.adapters.acp then
     if config.adapters.acp.opts.show_defaults then
       require("codecompanion.utils.adapters").extend(config.adapters.acp, opts.adapters.acp)
@@ -363,7 +363,7 @@ CodeCompanion.setup = function(opts)
     end
   end
 
-  -- handle adapter configuration | http
+  -- Handle HTTP adapter config
   if opts and opts.adapters and opts.adapters.http then
     if config.adapters.http.opts.show_defaults then
       require("codecompanion.utils.adapters").extend(config.adapters.http, opts.adapters.http)

--- a/lua/codecompanion/strategies/chat/debug.lua
+++ b/lua/codecompanion/strategies/chat/debug.lua
@@ -256,7 +256,7 @@ function Debug:render()
     })
     :set()
 
-  local window_config = config.display.chat.child_window
+  local window_config = config.display.chat.floating_window
 
   ui_utils.create_float(lines, {
     bufnr = self.bufnr,

--- a/lua/codecompanion/strategies/chat/helpers/diff.lua
+++ b/lua/codecompanion/strategies/chat/helpers/diff.lua
@@ -166,7 +166,8 @@ end
 ---@param path string|nil Optional path for window title
 ---@return number? winnr Window number of the created floating window
 local function create_diff_floating_window(bufnr, path)
-  local window_config = vim.tbl_deep_extend("force", config.display.chat.child_window, config.display.chat.diff_window)
+  local window_config =
+    vim.tbl_deep_extend("force", config.display.chat.floating_window, config.display.chat.diff_window)
 
   local provider = config.display.diff.provider
   local provider_config = config.display.diff.provider_opts[provider] or {}

--- a/lua/codecompanion/strategies/chat/helpers/super_diff.lua
+++ b/lua/codecompanion/strategies/chat/helpers/super_diff.lua
@@ -542,7 +542,7 @@ function M.show_super_diff(chat, opts)
   local lines, file_sections, diff_info = generate_markdown_super_diff(tracked_files)
 
   local ui_utils = require("codecompanion.utils.ui")
-  local window_config = config.display.chat.child_window
+  local window_config = config.display.chat.floating_window
   local inline_config = config.display.diff.provider_opts.inline or {}
   local show_dim = inline_config.opts and inline_config.opts.show_dim
   local title = opts.title

--- a/tests/strategies/chat/acp/test_permission_request.lua
+++ b/tests/strategies/chat/acp/test_permission_request.lua
@@ -14,7 +14,7 @@ T = new_set({
         cfg.display = cfg.display or {}
         cfg.display.icons = cfg.display.icons or { warning = "!" }
         cfg.display.chat = cfg.display.chat or {}
-        cfg.display.chat.child_window = cfg.display.chat.child_window or {
+        cfg.display.chat.floating_window = cfg.display.chat.floating_window or {
           width = 60, height = 12, row = "center", col = "center", relative = "editor", opts = {},
         }
         -- Sensible default to avoid timeouts during tests

--- a/tests/strategies/chat/test_super_diff.lua
+++ b/tests/strategies/chat/test_super_diff.lua
@@ -13,7 +13,7 @@ local T = new_set({
         super_diff = require("codecompanion.strategies.chat.helpers.super_diff")
         edit_tracker = require("codecompanion.strategies.chat.edit_tracker")
 
-        -- Mock config to include child_window
+        -- Mock config to include floating_window
         local config = require("codecompanion.config")
         if not config.display then
           config.display = {}
@@ -21,7 +21,7 @@ local T = new_set({
         if not config.display.chat then
           config.display.chat = {}
         end
-        config.display.chat.child_window = {
+        config.display.chat.floating_window = {
           width = 80,
           height = 20,
           row = "center",


### PR DESCRIPTION
## Description

`child_window` is renamed to `floating_window`

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
