### PR TITLE
fix(ui): closing floating windows

### DIFF
--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -126,11 +126,13 @@ M.create_float = function(lines, opts)
   end
 
   local function close()
-    api.nvim_buf_delete(bufnr, { force = true })
+    pcall(function()
+      api.nvim_win_close(winnr, true)
+      api.nvim_buf_delete(bufnr, { force = true })
+    end)
   end
 
   vim.keymap.set("n", "q", close, { buffer = bufnr })
-  vim.keymap.set("n", "<ESC>", close, { buffer = bufnr })
 
   return bufnr, winnr
 end


### PR DESCRIPTION
## Description

Fix the annoying bug which causes an error when you try and close the debug window.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
