### PR TITLE
Adds envvar to disable breaking changes warning

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -359,10 +359,11 @@ end
 CodeCompanion.setup = function(opts)
   opts = opts or {}
 
-  if not opts.ignore_warnings then
+  if not opts.ignore_warnings and os.getenv("CODECOMPANION_SKIP_BREAKING_CHANGES_WARN") ~= "1" then
     vim.notify_once(
-      [[[WARN] CodeCompanion.nvim will experience breaking changes soon. Pin to version v17.33.0 or earlier to avoid this.
-See: https://github.com/olimorris/codecompanion.nvim/pull/2439]],
+      [[[WARN] CodeCompanion.nvim will experience breaking changes soon. Pin to version v17.33.0 or earlier to avoid this,
+      or set an environment variable CODECOMPANION_SKIP_BREAKING_CHANGES_WARN=1.
+      See: https://github.com/olimorris/codecompanion.nvim/pull/2439]],
       vim.log.levels.WARN,
       {
         title = "CodeCompanion",


### PR DESCRIPTION
## Description
Suggests an envvar to disable the breaking changes warning.

Reasoning:

* I do **not** want to tag to a version and miss the release once version 18 is out 
* I don't mind breaking changes, especially in this project where things are well documented (thank you 💜 )
* I open `nvim` dozens of times a day and having to hit _enter_ before starting to get shit done is _really_ annoying
* Ignore _all_ warnings is too bold
* Implementation is easy and clean, making it a piece of cake to delete it once new version is out

Alternatives is keeping a temporary file to limit the warning to once a day, or something that is not every simple `nvim` open.

## Related Issue(s)

#2439


## Screenshots

N/A

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
