### PR TITLE
fix(chat): Handle string model lists and add tests

### DIFF
--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -92,6 +92,10 @@ function M.get_models_list(adapter)
   local models_list = vim
     .iter(models)
     :map(function(key, value)
+      if type(key) == "string" and value == nil then
+        -- `models` is already a list
+        return key
+      end
       if type(value) == "table" and not value.id then
         value.id = key
       end

--- a/tests/interactions/chat/test_keymaps.lua
+++ b/tests/interactions/chat/test_keymaps.lua
@@ -65,6 +65,39 @@ T["Keymaps"]["change_adapter"]["get_models_list returns correct list with object
   h.expect_truthy(result.has_formatted_name)
 end
 
+T["Keymaps"]["change_adapter"]["get_models_list returns correct list with string models"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    config.adapters.http.opts.show_model_choices = true
+
+    local mock_adapter = {
+      schema = {
+        model = {
+          default = "gpt-4",
+          choices = {
+            "mistral-large-latest",
+            "pixtral-large-latest",
+            "gpt-4",
+            "gpt-3.5-turbo",
+          }
+        }
+      }
+    }
+
+    local list = change_adapter.get_models_list(mock_adapter)
+    if not list then return nil end
+
+    local names = {}
+    for _, model in ipairs(list) do
+      table.insert(names, model)
+    end
+    return { first_id = names[1], count = #names }
+  ]])
+
+  h.eq(result.first_id, "gpt-4")
+  h.eq(result.count, 4)
+end
+
 T["Keymaps"]["change_adapter"]["get_commands_list returns correct list"] = function()
   local list = child.lua([[
     h.setup_plugin()


### PR DESCRIPTION
## Description

Handle the special case where `models` is a list of strings in `get_models_list`.

1. [`vim.iter` treats tables and lists differently](https://github.com/neovim/neovim/blob/8c1327a62245c0b5ecc0c5f3795911b75144d5a0/runtime/lua/vim/iter.lua#L1092). When the parameter is a list, the signature of `map` would be `fun(item)` instead of `fun(key, value)`. 
2. When `model.choices` is a list of strings (happened when I was using `openai_compatible` adapter), the existing code essentially convert everything to `nil` because [`value` here](https://github.com/olimorris/codecompanion.nvim/blob/8ad65eef735b31bb47d76f59d878ee1bac4bdc85/lua/codecompanion/strategies/chat/keymaps/change_adapter.lua#L99) would be `nil`.
3. This caused the model list in the `vim.ui.select` picker to only contain the default model.

## Related Issue(s)

`git bisect` pointed me to #2427 

## Screenshot

I have a few (~10) LLMs on this endpoint, but without this PR, I can only see one.
<img width="1241" height="224" alt="image" src="https://github.com/user-attachments/assets/23adea70-645c-492c-90f0-22ed0ceda395" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
