### PR TITLE
feat(rules): default_rules can be a function

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -2151,6 +2151,14 @@ buffers. This is useful for ensuring that your preferred rules are always
 available.
 
 
+DEFAULT RULE GROUPS
+
+You can set default rule groups that are automatically applied to all chat
+buffers. This is useful for ensuring that your preferred rules are always
+available.
+
+
+
 PARSERS ~
 
 Parsers allow CodeCompanion to transform rules, affecting how they are shared

--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -123,22 +123,6 @@ require("codecompanion").setup({
 })
 ```
 
-== Setting Default Groups
-
-```lua
-require("codecompanion").setup({
-  rules = {
-    opts = {
-      chat = {
-        default_rules = "default",
-        -- Or, set multiple default groups
-        --default_rules = { "default", "another_new_group" },
-      },
-    },
-  },
-})
-```
-
 :::
 
 Nested groups allow you to apply the same conditional to multiple groups alongside keeping your config clean. In the example above, the main group is `CodeCompanion` and a sub-group, `acp`, sits within the files table. The `claude` parser sits across all of the groups.
@@ -146,6 +130,62 @@ Nested groups allow you to apply the same conditional to multiple groups alongsi
 When using the _Action Palette_ or the slash command, the plugin will extract these nested groups and display them.
 
 You can also set default groups that are automatically applied to all chat buffers. This is useful for ensuring that your preferred rules are always available.
+
+### Default Rule groups
+
+You can set default rule groups that are automatically applied to all chat buffers. This is useful for ensuring that your preferred rules are always available.
+
+::: tabs
+
+== Single Group
+
+```lua
+require("codecompanion").setup({
+  rules = {
+    opts = {
+      chat = {
+        default_rules = "default",
+      },
+    },
+  },
+})
+```
+
+== Multiple Groups
+
+```lua
+require("codecompanion").setup({
+  rules = {
+    opts = {
+      chat = {
+        default_rules = { "default", "another_new_group" },
+      },
+    },
+  },
+})
+```
+
+== Conditional Groups
+
+```lua
+require("codecompanion").setup({
+  rules = {
+    opts = {
+      chat = {
+        ---@return string|string[]
+        default_rules = function()
+          if vim.fn.getcwd():find("my_secret_project", 1, true) ~= nil then
+            return { "default", "secret_group" }
+          end
+          return "default"
+        end,
+      },
+    },
+  },
+})
+```
+
+:::
 
 ## Parsers
 

--- a/lua/codecompanion/strategies/chat/rules/helpers.lua
+++ b/lua/codecompanion/strategies/chat/rules/helpers.lua
@@ -98,12 +98,21 @@ function M.add_callbacks(args, rules_name)
     return args.callbacks
   end
 
-  local defaults = rules_name or rules.default_rules
+  local default_rules = rules_name or rules.default_rules
   local memories = {}
-  if type(defaults) == "string" then
-    memories = { defaults }
-  elseif type(defaults) == "table" then
-    memories = vim.deepcopy(defaults)
+  if type(default_rules) == "string" then
+    memories = { default_rules }
+  elseif type(default_rules) == "table" then
+    memories = vim.deepcopy(default_rules)
+  elseif type(default_rules) == "function" then
+    memories = default_rules()
+    assert(
+      type(memories) == "string" or type(memories) == "table",
+      "default_rules must return a string or table of strings"
+    )
+    if type(memories) == "string" then
+      memories = { memories }
+    end
   else
     return args.callbacks
   end


### PR DESCRIPTION
## Description

`default_rules` can now be a function allowing for users to create some complex customizations for when rules should be automatically loaded in the chat buffer.

## Related Issue(s)

#2424

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
