### PR TITLE
tests: ensure no http calls are made

### DIFF
--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -32,7 +32,22 @@ Helpers.setup_plugin = function(config)
       local get_models_ok, get_models = pcall(require, "codecompanion.adapters.http.copilot.get_models")
       if get_models_ok then
         get_models.choices = function(adapter, opts, provided_token)
-          return { "gpt-4.1" }
+          return { ["gpt-4.1"] = { opts = {} } }
+        end
+      end
+
+      -- Mock the token module to prevent HTTP calls
+      local token_ok, token = pcall(require, "codecompanion.adapters.http.copilot.token")
+      if token_ok then
+        token.init = function()
+          return true
+        end
+        token.fetch = function()
+          return {
+            oauth_token = "mock_oauth_token",
+            copilot_token = "mock_copilot_token",
+            endpoints = { api = "https://api.githubcopilot.com" },
+          }
         end
       end
     end


### PR DESCRIPTION
## Description

I've observed that some tests would make http calls. Turning the Wifi off pinpointed this. This PR fixes that.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
