### PR TITLE
refactor(background): use background adapter

### DIFF
--- a/lua/codecompanion/interactions/background/init.lua
+++ b/lua/codecompanion/interactions/background/init.lua
@@ -53,7 +53,7 @@ function Background.new(args)
   if args.adapter and adapters.resolved(args.adapter) then
     self.adapter = args.adapter --[[@as CodeCompanion.HTTPAdapter]]
   else
-    self.adapter = adapters.resolve(args.adapter or config.strategies.chat.adapter)
+    self.adapter = adapters.resolve(args.adapter or config.interactions.background.adapter)
   end
 
   -- Silence errors


### PR DESCRIPTION
## Description

Ensure that the background interaction uses the background adapter.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
