### PR TITLE
refactor!: remove old system prompt config option

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1053,14 +1053,10 @@ M.setup = function(args)
 
   M.config.strategies.chat.keymaps = remove_disabled_keymaps(M.config.strategies.chat.keymaps)
   M.config.strategies.inline.keymaps = remove_disabled_keymaps(M.config.strategies.inline.keymaps)
-
-  -- TODO: Add a deprecation warning at some point
-  if M.config.opts and M.config.opts.system_prompt then
-    M.config.strategies.chat.opts.system_prompt = M.config.opts.system_prompt
-    M.config.opts.system_prompt = nil
-  end
 end
 
+---Determine if code can be sent to the LLM
+---@return boolean
 M.can_send_code = function()
   if type(M.config.opts.send_code) == "boolean" then
     return M.config.opts.send_code


### PR DESCRIPTION
## Description

Previously, we allowed users to have `opts.system_prompt` in their config. Removing that so it's `strategies.chat.opts.system_prompt`.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
