### PR TITLE
fix: map strategies to interactions

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1047,8 +1047,10 @@ M.setup = function(args)
     )
   end
 
+  -- TODO: Remove in v19.0.0
   if args.strategies then
-    args.interactions = args.strategies
+    args.interactions = vim.tbl_deep_extend("force", vim.deepcopy(defaults.interactions), args.strategies)
+    args.strategies = nil
   end
 
   M.config = vim.tbl_deep_extend("force", vim.deepcopy(defaults), args)


### PR DESCRIPTION
## Description

Ensure that users don't have to modify their config when strategies change to interactions.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
