### PR TITLE
refactor(adapters): update anthropic and gemini defaults

### DIFF
--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -606,7 +606,7 @@ return {
       mapping = "parameters",
       type = "enum",
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
-      default = "claude-sonnet-4-20250514",
+      default = "claude-sonnet-4-5-20250929",
       choices = {
         ["claude-sonnet-4-5-20250929"] = {
           formatted_name = "Claude Sonnet 4.5",

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -119,7 +119,7 @@ return {
       mapping = "parameters",
       type = "enum",
       desc = "The model that will complete your prompt. See https://ai.google.dev/gemini-api/docs/models/gemini#model-variations for additional details and options.",
-      default = "gemini-2.5-flash",
+      default = "gemini-3-pro-preview",
       choices = {
         ["gemini-3-pro-preview"] = { formatted_name = "Gemini 3 Pro", opts = { can_reason = true, has_vision = true } },
         ["gemini-2.5-pro"] = { formatted_name = "Gemini 2.5 Pro", opts = { can_reason = true, has_vision = true } },


### PR DESCRIPTION
## Description

Set newer defaults on Anthropic and Gemini adapters.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
