### PR TITLE
Refactor/defaults become presets

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -31,7 +31,7 @@ local defaults = {
         allow_insecure = false, -- Allow insecure connections?
         cache_models_for = 1800, -- Cache adapter models for this long (seconds)
         proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
-        show_defaults = true, -- Show default adapters
+        show_presets = true, -- Show preset adapters
         show_model_choices = true, -- Show model choices when changing adapter
       },
     },
@@ -45,7 +45,7 @@ local defaults = {
       kimi_cli = "kimi_cli",
       opencode = "opencode",
       opts = {
-        show_defaults = true, -- Show default adapters
+        show_presets = true,
       },
     },
   },
@@ -752,7 +752,7 @@ The user is working on a %s machine. Please respond with system specific command
         { path = "CLAUDE.local.md", parser = "claude" },
         { path = "~/.claude/CLAUDE.md", parser = "claude" },
       },
-      is_default = true,
+      is_preset = true,
     },
     CodeCompanion = {
       description = "CodeCompanion rules",
@@ -806,7 +806,7 @@ The user is working on a %s machine. Please respond with system specific command
           },
         },
       },
-      is_default = true,
+      is_preset = true,
     },
     parsers = {
       claude = "claude", -- Parser for CLAUDE.md files
@@ -828,7 +828,7 @@ The user is working on a %s machine. Please respond with system specific command
         default_rules = "default", -- The rule groups to load
         default_params = "diff", -- all|diff
       },
-      show_defaults = true, -- Show the default rules files in the action palette?
+      show_presets = true, -- Show the preset rules files in the action palette?
     },
   },
   -- DISPLAY OPTIONS ----------------------------------------------------------

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -323,7 +323,7 @@ end
 ---@return nil
 local function handle_adapter_config(adapter_type, opts)
   if opts and opts.adapters and opts.adapters[adapter_type] then
-    if config.adapters[adapter_type].opts.show_defaults then
+    if config.adapters[adapter_type].opts.show_presets then
       require("codecompanion.utils.adapters").extend(config.adapters[adapter_type], opts.adapters[adapter_type])
     else
       config.adapters[adapter_type] = vim.deepcopy(opts.adapters[adapter_type])

--- a/lua/codecompanion/interactions/chat/rules/helpers.lua
+++ b/lua/codecompanion/interactions/chat/rules/helpers.lua
@@ -51,7 +51,7 @@ function M.list()
   local exclusions = { "opts", "parsers" }
 
   for name, cfg in pairs(config.rules or {}) do
-    if cfg.is_default and config.rules.opts.show_defaults == false then
+    if cfg.is_preset and config.rules.opts.show_presets == false then
       goto continue
     end
     if cfg.enabled == false then

--- a/tests/interactions/chat/rules/test_rules.lua
+++ b/tests/interactions/chat/rules/test_rules.lua
@@ -191,7 +191,7 @@ T["Rules:make()"]["integration: rules is added to a real chat messages stack"] =
       default = {
         description = "integration default",
         files = { %q },
-        is_default = true,
+        is_preset = true,
       },
       parsers = {},
       opts = {
@@ -200,7 +200,7 @@ T["Rules:make()"]["integration: rules is added to a real chat messages stack"] =
           default_rules = "default",
           condition = function() return true end,
         },
-        show_defaults = true,
+        show_presets = true,
       },
     })
 


### PR DESCRIPTION
## Description

Unwinding some dumb var naming from myself. Defaults are renamed to presets.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
