### PR TITLE
refactor: action palette opts

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*        For NVIM v0.11        Last change: 2025 December 08
+*codecompanion.txt*        For NVIM v0.11        Last change: 2025 December 09
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -578,8 +578,8 @@ You can change the appearance of the chat buffer by changing the
           prompt = "Prompt ", -- Prompt used for interactive LLM calls
           provider = "default", -- Can be "default", "telescope", "fzf_lua", "mini_pick" or "snacks". If not specified, the plugin will autodetect installed providers.
           opts = {
-            show_default_actions = true, -- Show the default actions in the action palette?
-            show_prompt_library_builtins = true, -- Show the default prompt library prompts in the action palette?
+            show_preset_actions = true, -- Show the preset actions in the action palette?
+            show_preset_prompts = true, -- Show the preset prompts in the action palette?
             title = "CodeCompanion actions", -- The title of the action palette
           },
         },
@@ -3046,7 +3046,7 @@ configuration options that CodeCompanion offers. It can be opened with
 Once opened, the user can see plugin defined actions such as `Chat` and `Open
 Chats`. The latter, enabling the user to move between any open chat buffers.
 These can be turned off in the config by setting
-`display.action_palette.opts.show_default_actions = false`.
+`display.action_palette.opts.show_preset_actions = false`.
 
 
 BUILT-IN PROMPTS ~
@@ -3066,7 +3066,7 @@ The plugin also contains two built-in workflows, `Code workflow` and `Edit test
 repeat workflow`. See the |codecompanion-usage-workflows| for more information.
 
 The built-in prompts can be turned off by setting
-`display.action_palette.show_prompt_library_builtins = false`.
+`display.action_palette.show_preset_prompts = false`.
 
 You can also refresh the markdown prompts in your prompt library with
 `:CodeCompanionActions refresh`

--- a/doc/configuration/action-palette.md
+++ b/doc/configuration/action-palette.md
@@ -26,8 +26,8 @@ require("codecompanion").setup({
       prompt = "Prompt ", -- Prompt used for interactive LLM calls
       provider = "default", -- Can be "default", "telescope", "fzf_lua", "mini_pick" or "snacks". If not specified, the plugin will autodetect installed providers.
       opts = {
-        show_default_actions = true, -- Show the default actions in the action palette?
-        show_prompt_library_builtins = true, -- Show the default prompt library prompts in the action palette?
+        show_preset_actions = true, -- Show the preset actions in the action palette?
+        show_preset_prompts = true, -- Show the preset prompts in the action palette?
         title = "CodeCompanion actions", -- The title of the action palette
       },
     },

--- a/doc/usage/action-palette.md
+++ b/doc/usage/action-palette.md
@@ -10,7 +10,7 @@ description: How to use the action palette in CodeCompanion
 
 The _Action Palette_ has been designed to be your entry point for the many configuration options that CodeCompanion offers. It can be opened with `:CodeCompanionActions`.
 
-Once opened, the user can see plugin defined actions such as `Chat` and `Open Chats`. The latter, enabling the user to move between any open chat buffers. These can be turned off in the config by setting `display.action_palette.opts.show_default_actions = false`.
+Once opened, the user can see plugin defined actions such as `Chat` and `Open Chats`. The latter, enabling the user to move between any open chat buffers. These can be turned off in the config by setting `display.action_palette.opts.show_preset_actions = false`.
 
 ## Built-in Prompts
 
@@ -27,6 +27,6 @@ The plugin also defines a number of prompts in the form of the prompt library:
 
 The plugin also contains two built-in workflows, `Code workflow` and `Edit test repeat workflow`. See the [workflows section](/usage/workflows) for more information.
 
-The built-in prompts can be turned off by setting `display.action_palette.show_prompt_library_builtins = false`.
+The built-in prompts can be turned off by setting `display.action_palette.show_preset_prompts = false`.
 
 You can also refresh the markdown prompts in your prompt library with `:CodeCompanionActions refresh`

--- a/lua/codecompanion/actions/init.lua
+++ b/lua/codecompanion/actions/init.lua
@@ -41,7 +41,7 @@ function Actions.set_items(context)
     local static_actions = require("codecompanion.actions.static")
 
     -- Add static actions
-    if config.display.action_palette.opts.show_default_actions then
+    if config.display.action_palette.opts.show_preset_actions then
       for _, action in ipairs(static_actions) do
         action.type = "static"
         table.insert(_cached_actions, action)
@@ -50,7 +50,7 @@ function Actions.set_items(context)
 
     -- Add builtin markdown prompts
     local markdown = require("codecompanion.actions.markdown")
-    if config.display.action_palette.opts.show_prompt_library_builtins then
+    if config.display.action_palette.opts.show_preset_prompts then
       local current_dir = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":h")
       local builtin_prompts = markdown.load_from_dir(vim.fs.joinpath(current_dir, "builtins"), context)
       for _, prompt in ipairs(builtin_prompts) do

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -839,8 +839,8 @@ The user is working on a %s machine. Please respond with system specific command
       prompt = "Prompt ", -- Prompt used for interactive LLM calls
       provider = providers.action_palette, -- telescope|mini_pick|snacks|default
       opts = {
-        show_default_actions = true, -- Show the default actions in the action palette?
-        show_prompt_library_builtins = true, -- Show the default prompt library in the action palette?
+        show_preset_actions = true, -- Show the preset actions in the action palette?
+        show_preset_prompts = true, -- Show the preset prompts in the action palette?
         title = "CodeCompanion actions", -- The title of the action palette
       },
     },


### PR DESCRIPTION
## Description

`display.action_palette.opts.show_default_actions` is now `show_preset_actions`
`display.action_palette.opts.show_prompt_library_builtins` is now`show_preset_prompts`

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
