### PR TITLE
perf(adapters): make copilot start faster

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -17,9 +17,10 @@ local function resolve_model_opts(adapter)
     model = model(adapter)
   end
   if type(choices) == "function" then
-    choices = choices(adapter, { async = false })
+    -- Avoid blocking during initialization
+    choices = choices(adapter, { async = true })
   end
-  return choices[model]
+  return choices and choices[model] or { opts = {} }
 end
 
 ---Return the handlers of a specific adapter, ensuring the correct endpoint is set
@@ -93,7 +94,7 @@ return {
   env = {
     ---@return string
     api_key = function()
-      return token.fetch().copilot_token
+      return token.fetch({ force = true }).copilot_token
     end,
   },
   headers = {
@@ -115,9 +116,14 @@ return {
       end
       _fetching_models = true
 
+      -- Defer token initialization - only fetch models in background without requiring tokens
       vim.schedule(function()
         pcall(function()
-          get_models.choices(self, { async = true })
+          -- Only fetch models if we already have a token cached, otherwise skip
+          local cached_token = token.fetch()
+          if cached_token and cached_token.copilot_token then
+            get_models.choices(self, { token = cached_token, async = true })
+          end
         end)
         _fetching_models = false
       end)
@@ -313,12 +319,15 @@ return {
       default = "gpt-4.1",
       ---@type fun(self: CodeCompanion.HTTPAdapter, opts?: table): table
       choices = function(self, opts)
-        -- Ensure token is available before getting models
-        local fetched = token.fetch()
+        opts = opts or {}
+        -- Force token initialization for synchronous requests (user-initiated model selection)
+        -- Don't force for async requests (background operations)
+        local force = opts.async == false
+        local fetched = token.fetch({ force = force })
         if not fetched or not fetched.copilot_token then
           return { ["gpt-4.1"] = { opts = {} } }
         end
-        return get_models.choices(self, opts, fetched)
+        return get_models.choices(self, { token = fetched, async = opts.async })
       end,
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -191,10 +191,16 @@ function M.init(adapter)
   return true
 end
 
----Return the Copilot tokens
----@return {oauth_token: CopilotOAuthToken, copilot_token: CopilotToken|nil}
-function M.fetch()
-  pcall(M.init)
+---Return the Copilot tokens without initializing them
+---@param opts? { force: boolean }
+---@return { oauth_token: CopilotOAuthToken, copilot_token: CopilotToken|nil }
+function M.fetch(opts)
+  opts = opts or {}
+
+  -- Only initialize tokens if explicitly requested or if we already have an oauth token cached
+  if opts.force or M._oauth_token then
+    pcall(M.init)
+  end
 
   return {
     oauth_token = M._oauth_token,

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -60,6 +60,7 @@ function M.get_models_list(adapter)
     models = { adapter.schema.model.default }
   end
   if type(models) == "function" then
+    -- When user explicitly wants to change models, force token creation
     models = models(adapter, { async = false })
   end
   if not models or vim.tbl_count(models) < 2 then

--- a/tests/adapters/http/copilot/test_copilot.lua
+++ b/tests/adapters/http/copilot/test_copilot.lua
@@ -421,4 +421,174 @@ T["Copilot adapter"]["No Streaming"]["can output for the inline assistant"] = fu
   )
 end
 
+local token_child = MiniTest.new_child_neovim()
+
+T["Token initialization"] = new_set({
+  hooks = {
+    pre_case = function()
+      token_child.restart({ "-u", "scripts/minimal_init.lua" })
+    end,
+    post_once = token_child.stop,
+  },
+})
+
+T["Token initialization"]["defers token fetching during adapter resolution"] = function()
+  token_child.lua([[
+      -- Ensure the token state is clean
+      local token = require("codecompanion.adapters.http.copilot.token")
+      token._oauth_token = nil
+      token._copilot_token = nil
+
+      -- Mock token.init to track if it's called
+      _G.init_called = false
+      local original_init = token.init
+      token.init = function(...)
+        _G.init_called = true
+        return original_init(...)
+      end
+
+      local test_adapter = require("codecompanion.adapters").resolve("copilot")
+
+      token.init = original_init
+    ]])
+
+  -- Token initialization should not have been called during resolution
+  h.eq(token_child.lua_get("_G.init_called"), false)
+  h.eq(token_child.lua_get("require('codecompanion.adapters.http.copilot.token')._oauth_token"), vim.NIL)
+  h.eq(token_child.lua_get("require('codecompanion.adapters.http.copilot.token')._copilot_token"), vim.NIL)
+end
+
+T["Token initialization"]["initializes tokens when api_key is accessed"] = function()
+  token_child.lua([[
+    local token = require("codecompanion.adapters.http.copilot.token")
+    token._oauth_token = nil
+    token._copilot_token = nil
+
+    local original_fetch = token.fetch
+    token.fetch = function(force_init)
+      if force_init or token._oauth_token then
+        token._oauth_token = "test_oauth_token"
+        token._copilot_token = { token = "test_copilot_token" }
+      end
+      return {
+        oauth_token = token._oauth_token,
+        copilot_token = token._copilot_token,
+      }
+    end
+
+    local test_adapter = require("codecompanion.adapters").resolve("copilot")
+    _G.api_key_result = test_adapter.env.api_key()
+    _G.oauth_token_result = token._oauth_token
+    _G.copilot_token_result = token._copilot_token
+    token.fetch = original_fetch
+  ]])
+
+  h.eq(token_child.lua_get("_G.api_key_result"), { token = "test_copilot_token" })
+  h.eq(token_child.lua_get("_G.oauth_token_result"), "test_oauth_token")
+  h.eq(token_child.lua_get("_G.copilot_token_result.token"), "test_copilot_token")
+end
+
+T["Token initialization"]["forces token init for synchronous model fetching"] = function()
+  token_child.lua([[
+      -- Reset token state
+      local token = require("codecompanion.adapters.http.copilot.token")
+      token._oauth_token = nil
+      token._copilot_token = nil
+
+      _G.init_called = false
+      local original_init = token.init
+      token.init = function()
+        _G.init_called = true
+        token._oauth_token = "test_oauth_token"
+        token._copilot_token = { token = "test_copilot_token", endpoints = { api = "https://api.githubcopilot.com" } }
+        return true
+      end
+
+      local get_models = require("codecompanion.adapters.http.copilot.get_models")
+
+      -- Mock vim.wait to return immediately
+      local original_wait = vim.wait
+      vim.wait = function() return true end
+
+      local mock_adapter = { headers = {} }
+
+      -- Synchronous model fetch should force token initialization
+      local models = get_models.choices(mock_adapter, { async = false })
+
+      -- Restore originals
+      token.init = original_init
+      vim.wait = original_wait
+    ]])
+
+  -- Token initialization should have been called for sync request
+  h.eq(token_child.lua_get("_G.init_called"), true)
+end
+
+T["test model selection dialog works with copilot adapter"] = function()
+  local child = MiniTest.new_child_neovim()
+  child.restart({ "-u", "scripts/minimal_init.lua" })
+
+  local results = child.lua([[
+    -- Mock config
+    local config = require("codecompanion.config")
+    config.adapters = {
+      http = {
+        opts = { show_model_choices = true }
+      }
+    }
+
+    -- Mock token module to return tokens when forced
+    package.loaded["codecompanion.adapters.http.copilot.token"] = {
+      fetch = function(force_init)
+        if force_init then
+          return {
+            oauth_token = "test_oauth",
+            copilot_token = "test_token",
+            endpoints = { api = "https://api.githubcopilot.com" }
+          }
+        end
+        return nil
+      end,
+    }
+
+    -- Mock get_models to return multiple models when tokens are available
+    package.loaded["codecompanion.adapters.http.copilot.get_models"] = {
+      choices = function(adapter, opts)
+        opts = opts or {}
+        if opts.token and opts.token.copilot_token then
+          return {
+            ["gpt-4.1"] = { formatted_name = "GPT-4.1" },
+            ["gpt-4o"] = { formatted_name = "GPT-4o" },
+            ["claude-3.5-sonnet"] = { formatted_name = "Claude 3.5 Sonnet" }
+          }
+        end
+        return { ["gpt-4.1"] = { opts = {} } }
+      end,
+    }
+
+    local copilot = require("codecompanion.adapters.http.copilot")
+    local change_adapter = require("codecompanion.interactions.chat.keymaps.change_adapter")
+
+    -- Test that get_models_list returns models for selection dialog
+    local models_list = change_adapter.get_models_list(copilot)
+
+    -- Return test results
+    return {
+      models_list_not_nil = models_list ~= nil,
+      models_list_type = type(models_list),
+      models_count = models_list and vim.tbl_count(models_list) or 0
+    }
+  ]])
+
+  child.stop()
+
+  h.eq(results.models_list_not_nil, true)
+  h.eq(results.models_list_type, "table")
+
+  -- Should have at least 2 models to show the selection dialog
+  if results.models_count < 2 then
+    error(string.format("Expected at least 2 models, but got %d", results.models_count))
+  end
+end
+
 return T


### PR DESCRIPTION
## Description

Ensure that when users load the chat buffer for the first time in a session and Copilot is their adapter, that it loads fast.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
