### PR TITLE
Fix(diff): correct timing of winbar placement in inline floating diff

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/diff.lua
+++ b/lua/codecompanion/interactions/chat/helpers/diff.lua
@@ -194,10 +194,6 @@ local function create_diff_floating_window(bufnr, path)
     show_dim = show_dim,
   })
 
-  if winnr then
-    place_diff_winbar(winnr)
-  end
-
   return winnr
 end
 
@@ -353,6 +349,10 @@ function M.create(bufnr_or_path, diff_id, opts)
   }
 
   local diff = diff_module.new(diff_args)
+
+  if diff and layout == "float" and winnr then
+    place_diff_winbar(winnr)
+  end
 
   if diff and opts.set_keymaps then
     vim.schedule(function()


### PR DESCRIPTION
## Description

This fixes the timing of when the winbar is captured, ensuring it happens **before** the winbar keymaps are applied.

## Related Issue(s)

Currently, if a file is not open and a diff appears in a floating window, opening that file afterward results in the CodeCompanion keymap winbar being shown.

## Screenshots


https://github.com/user-attachments/assets/8ae7a1a5-4613-48b3-b947-7d5bc8687cbd



## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
