### PR TITLE
fix(adapters): copilot stats forces oauth token fetching

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/stats.lua
+++ b/lua/codecompanion/adapters/http/copilot/stats.lua
@@ -25,7 +25,7 @@ end
 local function get_statistics()
   log:debug("Copilot Adapter: Fetching Copilot usage statistics")
 
-  local oauth_token = token.fetch().oauth_token
+  local oauth_token = token.fetch({ force = true }).oauth_token
 
   local ok, response = pcall(function()
     return Curl.get("https://api.github.com/copilot_internal/user", {


### PR DESCRIPTION
## Description

When getting stats from Copilot, if an OAuth token doesn't exist, fetch it, forcefully.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
