### PR TITLE
chore: document tree-sitter dependency

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*        For NVIM v0.11        Last change: 2025 December 14
+*codecompanion.txt*        For NVIM v0.11        Last change: 2025 December 15
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -143,14 +143,23 @@ REQUIREMENTS                         *codecompanion-installation-requirements*
 - The `curl` library
 - Neovim 0.11.0 or greater
 - `(Optional)` An API key for your chosen LLM
+- `(Optional)` nvim-treesitter <https://github.com/nvim-treesitter/nvim-treesitter> and a `yaml` parser for markdown prompt library items
 - `(Optional)` The file <https://man7.org/linux/man-pages/man1/file.1.html> command for detecting image mimetype
 - `(Optional)` The ripgrep <https://github.com/BurntSushi/ripgrep> library for the `grep_search` tool
+
+You can run `:checkhealth codecompanion` to verify that all requirements are
+met.
 
 
 INSTALLATION                         *codecompanion-installation-installation*
 
 The plugin can be installed with the plugin manager of your choice. It is
 recommended to pin the plugin to a specific release to avoid breaking changes.
+
+nvim-treesitter <https://github.com/nvim-treesitter/nvim-treesitter> is
+required if you plan to use markdown prompts in the
+|codecompanion-configuration-prompt-library|, ensuring you have the `yaml`
+parser installed.
 
 
 **Plenary.nvim note:**
@@ -226,7 +235,9 @@ troubleshoot, running it with `nvim --clean -u minimal.lua`.
   <https://github.com/zbirenbaum/copilot.lua> installed then expect CodeCompanion
   to work out of the box.
 This guide is intended to help you get up and running with CodeCompanion and
-begin your journey of coding with AI in Neovim.
+begin your journey of coding with AI in Neovim. It assumes that you have
+already installed the plugin. If you haven’t done so, please refer to the
+|codecompanion-installation| first.
 
 
 DOCUMENTATION                    *codecompanion-getting-started-documentation*
@@ -2119,19 +2130,7 @@ logic or reusable components:
     .prompts/
     ├── commit.md
     ├── commit.lua
-    ├── shared.lua
     └── utils.lua
-<
-
-**shared.lua:**
-
->lua
-    return {
-      code = function(args)
-        local actions = require("codecompanion.helpers.actions")
-        return actions.get_code(args.context.start_line, args.context.end_line)
-      end,
-    }
 <
 
 **commit.lua:**

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -7,7 +7,7 @@ description: Getting started with CodeCompanion
 > [!IMPORTANT]
 > The default adapter in CodeCompanion is [GitHub Copilot](https://docs.github.com/en/copilot/using-github-copilot/copilot-chat/asking-github-copilot-questions-in-your-ide). If you have [copilot.vim](https://github.com/github/copilot.vim) or [copilot.lua](https://github.com/zbirenbaum/copilot.lua) installed then expect CodeCompanion to work out of the box.
 
-This guide is intended to help you get up and running with CodeCompanion and begin your journey of coding with AI in Neovim.
+This guide is intended to help you get up and running with CodeCompanion and begin your journey of coding with AI in Neovim. It assumes that you have already installed the plugin. If you haven't done so, please refer to the [installation instructions](/installation) first.
 
 ## Using the Documentation
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -12,17 +12,23 @@ description: How to install CodeCompanion and it's dependencies
 - The `curl` library
 - Neovim 0.11.0 or greater
 - _(Optional)_ An API key for your chosen LLM
+- _(Optional)_ [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) and a `yaml` parser for markdown prompt library items
 - _(Optional)_ The [file](https://man7.org/linux/man-pages/man1/file.1.html) command for detecting image mimetype
 - _(Optional)_ The [ripgrep](https://github.com/BurntSushi/ripgrep) library for the `grep_search` tool
+
+You can run `:checkhealth codecompanion` to verify that all requirements are met.
 
 ## Installation
 
 The plugin can be installed with the plugin manager of your choice. It is recommended to pin the plugin to a specific release to avoid breaking changes.
 
+[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) is required if you plan to use markdown prompts in the [prompt library](/configuration/prompt-library), ensuring you have the `yaml` parser installed.
+
 ::: code-group
 
 ```lua [vim.pack]
 vim.pack.add("https://www.github.com/nvim-lua/plenary.nvim")
+vim.pack.add("https://github.com/nvim-treesitter/nvim-treesitter")
 vim.pack.add({
   src = "https://www.github.com/olimorris/codecompanion.nvim",
   version = vim.version.range("^18.0.0")
@@ -39,6 +45,7 @@ require("codecompanion").setup()
   opts = {},
   dependencies = {
     "nvim-lua/plenary.nvim",
+    "nvim-treesitter/nvim-treesitter",
   },
 },
 ```
@@ -52,7 +59,8 @@ use({
   end,
   requires = {
     "nvim-lua/plenary.nvim",
-  }
+    "nvim-treesitter/nvim-treesitter",
+  },
 }),
 ```
 

--- a/lua/codecompanion/health.lua
+++ b/lua/codecompanion/health.lua
@@ -17,7 +17,8 @@ M.deps = {
 
 M.parsers = {
   { name = "markdown" },
-  { name = "yaml" },
+  { name = "markdown_inline" },
+  { name = "yaml", optional = true },
 }
 
 M.libraries = {

--- a/minimal.lua
+++ b/minimal.lua
@@ -17,6 +17,11 @@ local plugins = {
     "olimorris/codecompanion.nvim",
     dependencies = {
       { "nvim-lua/plenary.nvim" },
+      {
+        "nvim-treesitter/nvim-treesitter",
+        lazy = false,
+        build = ":TSUpdate",
+      },
 
       -- Test with blink.cmp (delete if not required)
       {
@@ -57,6 +62,18 @@ local plugins = {
 -- This is so I can tell if they've really tested with their own minimal.lua file
 
 require("lazy.minit").repro({ spec = plugins })
+
+-- CONFIGURE PLUGINS HERE -----------------------------------------------------
+
+-- Setup Tree-sitter
+require("nvim-treesitter")
+  .install({
+    "lua",
+    "markdown",
+    "markdown_inline",
+    "yaml",
+  })
+  :wait(300000)
 
 -- Setup nvim-cmp
 -- local cmp_status, cmp = pcall(require, "cmp")


### PR DESCRIPTION
## Description

Account for nvim-treesitter and the yaml parser being required for prompt library markdown items.

## Related Issue(s)

#2524

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
