### PR TITLE
fix(gemini): merge system messages for gemini adapter

### DIFF
--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -58,9 +58,7 @@ return {
       return openai.handlers.form_tools(self, tools)
     end,
     form_messages = function(self, messages)
-      -- Gemini openai compatible api backend only reads last system_prompt.
-      -- So we merge all system prompts.
-      -- See https://github.com/olimorris/codecompanion.nvim/issues/2522
+      -- WARN: System prompts must be merged as per #2522
       messages = adapter_utils.merge_system_messages(messages)
 
       local result = openai.handlers.form_messages(self, messages)

--- a/tests/adapters/http/test_gemini.lua
+++ b/tests/adapters/http/test_gemini.lua
@@ -15,23 +15,23 @@ T["Gemini adapter"] = new_set({
 T["Gemini adapter"]["can form messages to be sent to the API"] = function()
   local messages = {
     {
-      content = "Follow the user's request",
-      role = "system",
-    },
-    {
-      content = "Respond in code",
+      content = "System Prompt 1",
       role = "system",
     },
     {
       content = "Explain Ruby in two words",
       role = "user",
     },
+    {
+      content = "System Prompt 2",
+      role = "system",
+    },
   }
 
   local output = {
     messages = {
       {
-        content = "Follow the user's request Respond in code",
+        content = "System Prompt 1 System Prompt 2",
         role = "system",
       },
       {


### PR DESCRIPTION
## Description

The Gemini OpenAI-compatible API backend only respects the last system prompt provided in the messages list. This change utilizes `merge_system_messages` to combine multiple system prompts into a single entry, ensuring the model receives the full context.

## Related Issue(s)

#2522 and #2012

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
