### PR TITLE
fix: pattern escape context

### DIFF
--- a/lua/codecompanion/utils/context.lua
+++ b/lua/codecompanion/utils/context.lua
@@ -119,7 +119,7 @@ function M.get(bufnr, args)
   return {
     bufnr = bufnr,
     buftype = api.nvim_get_option_value("buftype", { buf = bufnr }) or "",
-    code = vim.tbl_count(lines) > 0 and table.concat(lines, "\n"),
+    code = vim.tbl_count(lines) > 0 and vim.pesc(table.concat(lines, "\n")),
     cursor_pos = cursor_pos,
     end_col = end_col,
     end_line = end_line,


### PR DESCRIPTION
## Description

Ensure that any code that is received from the context object is pattern escaped.

## Related Issue(s)

#2525

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
