### PR TITLE
feat(cmds): can toggle with the adapter param

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -205,15 +205,23 @@ CodeCompanion.cmd = function(args)
 end
 
 ---Toggle the chat buffer
----@param opts? table
+---@param args? table
 ---@return nil
-CodeCompanion.toggle = function(opts)
-  local window_opts = opts and opts.window_opts
+CodeCompanion.toggle = function(args)
+  local window_opts = args and args.window_opts
 
   -- Get the most recent chat buffer, or create one
   local chat = CodeCompanion.last_chat()
   if not chat then
-    return CodeCompanion.chat(window_opts and { window_opts = window_opts })
+    local chat_opts = {}
+    if args and args.params then
+      chat_opts.params = args.params
+    end
+    if window_opts then
+      chat_opts.window_opts = window_opts
+    end
+
+    return CodeCompanion.chat(chat_opts)
   end
 
   -- If the chat is visible in a different tab, just hide it there
@@ -232,7 +240,7 @@ CodeCompanion.toggle = function(opts)
   CodeCompanion.close_last_chat()
 
   -- Reopen the chat in the current tab with the toggled flag
-  opts = { toggled = true }
+  local opts = { toggled = true }
   if window_opts then
     opts.window_opts = window_opts
   end


### PR DESCRIPTION
## Description

Allows for `:CodeCompanionChat Toggle adapter=anthropic`

## Related Issue(s)

#2527 #2528

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
