### PR TITLE
refactor(chat): changing models or acp commands

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/init.lua
+++ b/lua/codecompanion/interactions/chat/helpers/init.lua
@@ -115,7 +115,7 @@ function M.apply_settings_and_model(chat, settings)
   local old_model = chat.settings.model
   chat:apply_settings(settings)
   if old_model and old_model ~= settings.model then
-    chat:apply_model(settings.model)
+    chat:apply_model_or_command({ model = settings.model })
   end
 end
 

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -196,7 +196,7 @@ function M.select_model(chat)
       return
     end
     local model_id = get_model_id(selected_model)
-    chat:apply_model(model_id)
+    chat:apply_model_or_command({ model = model_id })
   end)
 end
 
@@ -214,9 +214,7 @@ function M.select_command(chat)
       return
     end
     local selected = chat.adapter.commands[selected_command]
-    chat.adapter.commands.selected = selected
-    utils.fire("ChatModel", { bufnr = chat.bufnr, model = selected })
-    chat:update_metadata()
+    chat:apply_model_or_command({ command = selected })
   end)
 end
 


### PR DESCRIPTION
## Description

This refactor will also fix the annoying issue of having to authorize an ACP adapter before you've selected the command.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
