### PR TITLE
refactor: more lazy loading to plugin/codecompanion.lua

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1053,6 +1053,21 @@ M.setup = function(args)
 
   M.config.interactions.chat.keymaps = remove_disabled_keymaps(M.config.interactions.chat.keymaps)
   M.config.interactions.inline.keymaps = remove_disabled_keymaps(M.config.interactions.inline.keymaps)
+
+  -- Set the diagnostic namespace for the chat buffer settings
+  M.config.INFO_NS = vim.api.nvim_create_namespace("CodeCompanion-info")
+  M.config.ERROR_NS = vim.api.nvim_create_namespace("CodeCompanion-error")
+
+  local diagnostic_config = {
+    underline = false,
+    virtual_text = {
+      spacing = 2,
+      severity = { min = vim.diagnostic.severity.INFO },
+    },
+    signs = false,
+  }
+  vim.diagnostic.config(diagnostic_config, M.config.INFO_NS)
+  vim.diagnostic.config(diagnostic_config, M.config.ERROR_NS)
 end
 
 ---Determine if code can be sent to the LLM


### PR DESCRIPTION
## Description

Don't eager load the config file in `plugin/codecompanion.lua`

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
