### PR TITLE
Fix Lazy.nvim syntax in installation.md

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -41,7 +41,7 @@ require("codecompanion").setup()
 ```lua [Lazy.nvim]
 {
   "olimorris/codecompanion.nvim",
-  version = "^18.0.0"
+  version = "^18.0.0",
   opts = {},
   dependencies = {
     "nvim-lua/plenary.nvim",


### PR DESCRIPTION
Fix the missing comma in the snippet for Lazy.nvim

## Description

Easy fix.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
