### PR TITLE
feat: add Gemini 3 Flash

### DIFF
--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -126,6 +126,10 @@ return {
       default = "gemini-3-pro-preview",
       choices = {
         ["gemini-3-pro-preview"] = { formatted_name = "Gemini 3 Pro", opts = { can_reason = true, has_vision = true } },
+        ["gemini-3-flash-preview"] = {
+          formatted_name = "Gemini 3 Flash",
+          opts = { can_reason = true, has_vision = true },
+        },
         ["gemini-2.5-pro"] = { formatted_name = "Gemini 2.5 Pro", opts = { can_reason = true, has_vision = true } },
         ["gemini-2.5-flash"] = { formatted_name = "Gemini 2.5 Flash", opts = { can_reason = true, has_vision = true } },
         ["gemini-2.5-flash-preview-05-20"] = {


### PR DESCRIPTION
## Description

Add [Gemini 3 Flash](https://blog.google/products/gemini/gemini-3-flash/) to the gemini adapter.

## Related Issue(s)

Possible followup: do we want to use the [Gemini API](https://ai.google.dev/api/models) for dynamically fetching and parsing available models (similar to copilot and ollama)?
```bash
curl "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY" \
-H "Content-Type: application/json"
```
This returns all kinds of models (including image generations, embedding, etc.), but we can filter them by checking for `"generateContent"` in the `"supportedGenerationMethods"` field.

The response also seems to contain a `thinking` key for each model, so we can actually generate accurate capabilities from the fetched data. The only caveat is that this API also returns some gemma-3 models, which may or may not be too verbose.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
