### PR TITLE
fix(debug): improve handling nested tables for the debug window

### DIFF
--- a/lua/codecompanion/interactions/chat/debug.lua
+++ b/lua/codecompanion/interactions/chat/debug.lua
@@ -170,6 +170,11 @@ function Debug:render()
         local val = self.settings[key]
         local is_nil = adapter.schema[key] and adapter.schema[key].default == nil
 
+        local formatted_key = key
+        if key:find("%.") then
+          formatted_key = '["' .. key .. '"]'
+        end
+
         if key == "model" then
           local other_models = " -- "
 
@@ -186,33 +191,36 @@ function Debug:render()
             val = val(self.adapter)
           end
           if vim.tbl_count(models) > 1 then
-            table.insert(lines, "  " .. key .. ' = "' .. val .. '", ' .. other_models)
+            table.insert(lines, "  " .. formatted_key .. ' = "' .. val .. '", ' .. other_models)
           else
-            table.insert(lines, "  " .. key .. ' = "' .. val .. '",')
+            table.insert(lines, "  " .. formatted_key .. ' = "' .. val .. '",')
           end
         elseif is_nil and current_settings[key] == nil then
-          table.insert(lines, "  " .. key .. " = nil,")
-        elseif type(val) == "number" or type(val) == "boolean" then
-          table.insert(lines, "  " .. key .. " = " .. tostring(val) .. ",")
-        elseif type(val) == "string" then
-          if key:find("%.") then
-            key = '["' .. key .. '"]'
-          end
-          table.insert(lines, "  " .. key .. ' = "' .. val .. '",')
-        elseif type(val) == "function" then
-          local expanded_val = val(self.adapter)
-          if type(expanded_val) == "number" or type(expanded_val) == "boolean" then
-            table.insert(lines, "  " .. key .. " = " .. tostring(val(self.adapter)) .. ",")
-          else
-            table.insert(lines, "  " .. key .. ' = "' .. tostring(val(self.adapter)) .. '",')
-          end
+          table.insert(lines, "  " .. formatted_key .. " = nil,")
         else
-          local inspected = vim.inspect(val)
-          for line in inspected:gmatch("[^\r\n]+") do
-            table.insert(lines, line)
+          if type(val) == "function" then
+            val = val(self.adapter)
+          end
+
+          if type(val) == "number" or type(val) == "boolean" then
+            table.insert(lines, "  " .. formatted_key .. " = " .. tostring(val) .. ",")
+          elseif type(val) == "string" then
+            table.insert(lines, "  " .. formatted_key .. ' = "' .. val .. '",')
+          else
+            local inspected = vim.inspect(val)
+            local lines_to_add = vim.split(inspected, "\n")
+            for i, line in ipairs(lines_to_add) do
+              if i == 1 then
+                table.insert(lines, "  " .. formatted_key .. " = " .. line)
+              else
+                table.insert(lines, "  " .. line)
+              end
+            end
+            lines[#lines] = lines[#lines] .. ","
           end
         end
       end
+
       table.insert(lines, "}")
     end
   end


### PR DESCRIPTION
## Description

I was running into an error when using the OpenRouter adapter. The issue comes from having a nested `provider` table, which is necessary for ignoring or blocking certain providers. However, this caused a problem because `nvim_buf_set_lines` was receiving a string that contained newline characters.

The new refactor ensures this is handled correctly. Other than that, it doesn’t introduce any additional behavior changes, but just standardize that every key is checked for dots regardless of whether the value is a string, number, or table.


## Related Issue(s)

pressing `gd` with openrouter will be cause this:
```lua
E5108: Lua: .../repos/codecompanion.nvim/lua/codecompanion/utils/ui.lua:101: 'replacement string' item contains newlines
stack traceback:
	[C]: in function 'nvim_buf_set_lines'
	.../repos/codecompanion.nvim/lua/codecompanion/utils/ui.lua:101: in function 'create_float'
	...anion.nvim/lua/codecompanion/interactions/chat/debug.lua:261: in function 'rhs'
	...s/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:94: in function <...s/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:91>
```

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
