### PR TITLE
fix: handle nil data in HTTP callbacks

### DIFF
--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -437,14 +437,15 @@ function Inline:submit(prompt)
         end
 
         if err then
-          return error(err)
+          local msg = type(err) == "table" and err.message or err
+          return error(msg)
         end
 
         if data then
           data = adapters.call_handler(adapter, "parse_inline", data, self.buffer_context)
-          if data.status == CONSTANTS.STATUS_SUCCESS then
+          if data and data.status == CONSTANTS.STATUS_SUCCESS then
             return self:done(data.output)
-          else
+          elseif data then
             return error(data.output)
           end
         end


### PR DESCRIPTION
## Description

When API requests fail (e.g., insufficient credits, invalid API key), the streaming callback receives error JSON but the final callback receives nil data. Accessing data.status without nil checks caused confusing "attempt to index local 'data'" errors.

Changes:
- Add nil checks before accessing data.status in http.lua
- Capture streaming error responses for use when data is nil
- Handle table-style errors in inline callback (extract err.message)
- Add nil check after parse_inline in inline/init.lua

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] ~~I've run `make all` to ensure docs are generated, tests pass and my formatting is applied~~
- [ ] _(optional)_ ~~I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature~~
- [ ] _(optional)_ ~~I've updated the README and/or relevant docs pages~~
