### PR TITLE
fix(openai_responses): add missing nano and mini models

### DIFF
--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -562,6 +562,14 @@ return {
           formatted_name = "GPT-5 Pro",
           opts = { has_function_calling = true, has_vision = true, can_reason = true, stream = false },
         },
+        ["gpt-5-mini"] = {
+          formatted_name = "GPT-5 Mini",
+          opts = { has_vision = true, can_reason = true },
+        },
+        ["gpt-5-nano"] = {
+          formatted_name = "GPT-5 Nano",
+          opts = { has_vision = true, can_reason = true },
+        },
         ["o4-mini-deep-research-2025-06-26"] = {
           formatted_name = "o4-mini-deep-research",
           opts = { has_function_calling = false, has_vision = true, can_reason = true },


### PR DESCRIPTION
## Description
Add missing models `gpt-5-mini` and `gpt-5-nano` to the `openai_reponses` adapter. They are already present at the `openai` (completion) adapter.

Note for the PR review bot: the list is not alphabetical, I inserted the models based on their publication chronology.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature → does not apply for just adding models
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature → too small a change for this to be relevant.
- [ ] _(optional)_ I've updated the README and/or relevant docs pages → too small a change for this to be relevant.
