### PR TITLE
fix(openai_responses): do not enable `reasoning.summary` by default

### DIFF
--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -616,17 +616,12 @@ return {
       optional = true,
       ---@type fun(self: CodeCompanion.HTTPAdapter): boolean
       enabled = function(self)
-        local model = self.schema.model.default
-        if type(model) == "function" then
-          model = model()
-        end
-        local choices = self.schema.model.choices
-        if type(choices) == "function" then
-          choices = choices(self)
-        end
-        if choices and choices[model] and choices[model].opts and choices[model].opts.can_reason then
-          return true
-        end
+        -- Reasoning summary requires a verified organization, something not
+        -- needed for API usage otherwise, and something many individual users
+        -- do not have done.
+        -- And since reasoning is only meant for debugging, we should not enable
+        -- it by default; users should enable it themselves in their config if
+        -- they want.
         return false
       end,
       default = "auto",


### PR DESCRIPTION
## Description

Reasoning summary requires organizational access, meaning it won't work for individual users. By default, you get this error message:

```
Error: {
  "error": {
    "message": "Your organization must be verified to generate reasoning summaries. Please go to: https://platform.openai.com/settings/organization/general and click on Verify Organization. If you just verified, it can take up to 15 minutes for access to propagate.",
    "type": "invalid_request_error",
    "param": "reasoning.summary",
    "code": "unsupported_value"
  }
}
```

The openai API does not require any form of extra verification otherwise, thus the verification is an opt-in thing most users will not have done. Since reasoning summary is meant for debugging (as stated in the description, which is taken from the openai docs), it should thus not be enabled by default, since it will ootb result in the error above for most people. Users should enable this feature themselves in their config if they want. 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature → not relevant for this
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
