### PR TITLE
fix(inline): leave visual mode upon triggering inline interaction

### DIFF
--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -420,7 +420,7 @@ function Inline:submit(prompt)
   log:info("[Inline] Request started")
 
   if self.buffer_context.is_visual then
-    vim.cmd.normal({ vim.fn.mode(), bang = true })
+    pcall(vim.cmd.normal, { vim.fn.mode(), bang = true })
   end
 
   -- Inline editing only works with streaming off - We should remember the current status


### PR DESCRIPTION
## Description
It is the idiomatic behavior of vim commands to leave visual mode upon triggering if you act upon the selection. Using the inline interaction, this is not the case, which this PR addresses.

## Related Issue(s)
  - Fixes #2538

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature --> not relevant for this kind of change
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
