### PR TITLE
refactor(chat): error handle yanking code block

### DIFF
--- a/lua/codecompanion/interactions/chat/keymaps/init.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/init.lua
@@ -342,8 +342,14 @@ local function yank_node(node)
   local cursor_position = vim.fn.getcurpos()
 
   -- Create marks for the node range
-  vim.api.nvim_buf_set_mark(0, "[", start_row + 1, start_col, {})
-  vim.api.nvim_buf_set_mark(0, "]", end_row + 1, end_col - 1, {})
+  local ok, _ = pcall(function()
+    vim.api.nvim_buf_set_mark(0, "[", start_row + 1, start_col, {})
+    vim.api.nvim_buf_set_mark(0, "]", end_row + 1, end_col - 1, {})
+  end)
+
+  if not ok then
+    return utils.notify("Failed to copy code block", vim.log.levels.WARN)
+  end
 
   -- Yank using marks
   vim.cmd(string.format('normal! `["%sy`]', config.interactions.chat.opts.register))


### PR DESCRIPTION
## Description

Copying a code block too early can result in a nasty error. Handle this.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
