### PR TITLE
fix: gemini default config

### DIFF
--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -201,7 +201,7 @@ return {
         "high",
         "medium",
         "low",
-        "minimal"
+        "minimal",
         "none",
       },
     },


### PR DESCRIPTION
## Description

Change the default reasoning_effort to `high` to match gemini-3-pro-preview's default thinking level, and add a `minimal` option for `gemini-3-flash-preview`.

## Related Issue(s)

Fixes https://github.com/olimorris/codecompanion.nvim/issues/2571

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] I've run `make all` to ensure docs are generated, tests pass and my formatting is applied
- [ ] _(optional)_ I've updated `CodeCompanion.has` in the [init.lua](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/init.lua#L239) file for my new feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
