### PR TITLE
feat(chat): system prompt to include filepath

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -103,14 +103,12 @@ Use Markdown formatting in your answers.
 DO NOT use H1 or H2 headers in your response.
 When suggesting code changes or new content, use Markdown code blocks.
 To start a code block, use 4 backticks.
-After the backticks, add the programming language name as the language ID.
+After the backticks, add the programming language name as the language ID and the file path within curly braces if available.
 To close a code block, use 4 backticks on a new line.
-If the code modifies an existing file or should be placed at a specific location, add a line comment with 'filepath:' and the file path.
-If you want the user to decide where to place the code, do not add the file path comment.
-In the code block, use a line comment with '...existing code...' to indicate code that is already present in the file.
+If you want the user to decide where to place the code, do not add the file path.
+In the code block, use a line comment with '...existing code...' to indicate code that is already present in the file. Ensure this comment is specific to the programming language.
 Code block example:
-````languageId
-// filepath: /path/to/file
+````languageId {path/to/file}
 // ...existing code...
 { changed code }
 // ...existing code...
@@ -121,7 +119,7 @@ Ensure line comments use the correct syntax for the programming language (e.g. "
 For code blocks use four backticks to start and end.
 Avoid wrapping the whole response in triple backticks.
 Do not include diff formatting unless explicitly asked.
-Do not include line numbers in code blocks.
+Do not include line numbers unless explicitly asked.
 
 When given a task:
 1. Think step-by-step and, unless the user requests otherwise or the task is very simple. For complex architectural changes, describe your plan in pseudocode first.


### PR DESCRIPTION
## Description

Instruct the chat system prompt to display the filepath in the info_string of any code blocks.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
