### PR TITLE
refactor(utils): re-order and remove func

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/diff.lua
+++ b/lua/codecompanion/interactions/chat/helpers/diff.lua
@@ -179,20 +179,17 @@ local function create_diff_floating_window(bufnr, path)
 
   local _, winnr = ui_utils.create_float(content, {
     bufnr = bufnr,
-    set_content = false, -- Don't overwrite existing buffer content
-    window = { width = window_config.width, height = window_config.height },
     row = window_config.row,
     col = window_config.col,
-    relative = window_config.relative,
     filetype = filetype,
-    title = ui_utils.build_float_title({
-      title_prefix = " Diff",
-      path = path,
-    }),
-    lock = false, -- Allow edits for diff
     ignore_keymaps = true,
+    lock = false, -- Allow edits for diff
     opts = window_config.opts,
+    overwrite_buffer = false,
+    relative = window_config.relative,
     show_dim = show_dim,
+    title = " Diff: " .. (path and vim.fs.relpath(vim.uv.cwd(), vim.fs.normalize(path)) or "[No Name]") .. " ",
+    window = { width = window_config.width, height = window_config.height },
   })
 
   return winnr

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -96,8 +96,7 @@ M.create_float = function(lines, opts)
     zindex = opts.show_dim and 99 or nil, -- When dimming, set above background win but below notifications
   })
 
-  -- Only set content if we created a new buffer OR if not explicitly disabled
-  if not opts.bufnr or opts.set_content ~= false then
+  if not opts.bufnr or opts.overwrite_buffer ~= false then
     api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   end
 
@@ -135,25 +134,6 @@ M.create_float = function(lines, opts)
   vim.keymap.set("n", "q", close, { buffer = bufnr })
 
   return bufnr, winnr
-end
-
----Build a floating window title with smart path handling
----@param opts { title?: string, title_prefix?: string, path?: string }
----@return string title The formatted title
-function M.build_float_title(opts)
-  opts = opts or {}
-  local title = opts.title or opts.title_prefix or "CodeCompanion"
-
-  if opts.path then
-    local ok, relative_path = pcall(function()
-      return vim.fs.relpath(vim.uv.cwd(), vim.fs.normalize(opts.path))
-    end)
-    local path_to_use = (ok and relative_path and relative_path ~= "") and relative_path or opts.path
-
-    title = " " .. (opts.title_prefix or " Diff") .. ": " .. path_to_use .. " "
-  end
-
-  return title
 end
 
 ---@param bufnr number

--- a/tests/interactions/chat/acp/test_permission_request.lua
+++ b/tests/interactions/chat/acp/test_permission_request.lua
@@ -119,13 +119,6 @@ local function with_mocks(opts)
         })
         return w
       end,
-      build_float_title = function(opts)
-        opts = opts or {}
-        if opts.path then
-          return (opts.title_prefix or "Test") .. ": " .. vim.fn.fnamemodify(opts.path, ":t")
-        end
-        return opts.title or opts.title_prefix or "Test"
-      end
     }
 
     -- Mock wait helper

--- a/tests/utils/test_ui.lua
+++ b/tests/utils/test_ui.lua
@@ -86,18 +86,18 @@ T["UI create_float Screenshots"]["Uses existing buffer without overwriting conte
     })
     vim.bo[existing_bufnr].filetype = "lua"
 
-    -- Use create_float with existing buffer and set_content = false
+    -- Use create_float with existing buffer and overwrite_buffer = false
     local dummy_lines = {"This should not appear", "These lines ignored"}
 
     local bufnr, winnr = ui.create_float(dummy_lines, {
       bufnr = existing_bufnr,
-      set_content = false,
-      window = { width = 45, height = 8 },
       row = "center",
       col = "center",
+      overwrite_buffer = false,
       relative = "editor",
-      title = "Existing Buffer Test",
       show_dim = true,
+      title = "Existing Buffer Test",
+      window = { width = 45, height = 8 },
     })
 
     -- Verify existing content was preserved
@@ -144,7 +144,7 @@ T["UI create_float Screenshots"]["Uses existing buffer with content overwrite (d
     -- Use create_float with existing buffer (debug.lua pattern)
     local bufnr, winnr = ui.create_float(new_debug_lines, {
       bufnr = existing_bufnr,
-      -- set_content is not specified, so defaults to true
+      -- overwrite_buffer is not specified, so defaults to true
       window = { width = 55, height = 16 },
       row = "center",
       col = "center",


### PR DESCRIPTION
## Description

Re-order items to be alphabetical. Remove redundant function that is used by only one file.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
