### PR TITLE
fix(chat): remove images from title prompt

### DIFF
--- a/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
+++ b/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
@@ -7,9 +7,25 @@ local M = {}
 ---Format the messages from a chat buffer
 ---@param messages CodeCompanion.Chat.Messages
 function M.format_messages(messages)
+  local exclude_tags = {
+    ["image"] = "[Image content omitted]",
+    ["rules"] = "",
+    ["system_prompt_from_config"] = "",
+  }
+
   local chat_messages = {}
-  for _, message in ipairs(messages or {}) do
-    table.insert(chat_messages, fmt("## %s\n%s", message.role, message.content))
+  for _, m in ipairs(messages or {}) do
+    local tag = m._meta and m._meta.tag
+    local replacement = exclude_tags[tag]
+
+    if replacement == "" then
+      goto continue
+    end
+
+    local content = replacement or m.content
+    table.insert(chat_messages, fmt("## %s\n%s", m.role, content))
+
+    ::continue::
   end
   return table.concat(chat_messages, "\n")
 end


### PR DESCRIPTION
## Description

Previously when titles were generated for chats that included images, warnings would appear saying that users had gone over the token limit. This could cause them to think that this was related to the chat rather than the generation of the title.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
