### PR TITLE
refactor: line number formatting for shared buffers

### DIFF
--- a/lua/codecompanion/helpers/actions.lua
+++ b/lua/codecompanion/helpers/actions.lua
@@ -10,7 +10,7 @@ function M.get_code(start_line, end_line, opts)
   for line_num = start_line, end_line do
     local line
     if opts and opts.show_line_numbers then
-      line = string.format("%d: %s", line_num, vim.fn.getline(line_num))
+      line = string.format("%d |%s", line_num, vim.fn.getline(line_num))
     else
       line = string.format("%s", vim.fn.getline(line_num))
     end

--- a/lua/codecompanion/utils/buffers.lua
+++ b/lua/codecompanion/utils/buffers.lua
@@ -121,7 +121,7 @@ function M.add_line_numbers(content)
 
   content = vim.split(content, "\n")
   for i, line in ipairs(content) do
-    table.insert(formatted, string.format("%d:  %s", i, line))
+    table.insert(formatted, string.format("%d |%s", i, line))
   end
 
   return table.concat(formatted, "\n")

--- a/tests/utils/test_buffers.lua
+++ b/tests/utils/test_buffers.lua
@@ -47,9 +47,9 @@ T["Utils->Buffers"]["add_line_numbers works"] = function()
     return _G.buf_utils.add_line_numbers(content)
   ]])
 
-  h.expect_match(result, "1:  hello")
-  h.expect_match(result, "2:  world")
-  h.expect_match(result, "3:  test")
+  h.expect_match(result, "1 |hello")
+  h.expect_match(result, "2 |world")
+  h.expect_match(result, "3 |test")
 end
 
 return T


### PR DESCRIPTION
## Description

Experiment with the formatting of line numbers when they're shared with an LLM.

## Related Issue(s)

#2544

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
