### PR TITLE
docs: fix broken claude documentation link

### DIFF
--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -254,7 +254,7 @@ require("codecompanion").setup({
 
 Parsers allow CodeCompanion to transform rules, affecting how they are shared in the chat buffer. This is particularly useful if you reference files in your rules. Currently, the plugin has two in-built parsers:
 
-- `claude` - which will import files into the chat buffer in the same way Claude Code [does](https://docs.anthropic.com/en/docs/claude-code/memory#claude-md-imports). Note, this requires rules to be `markdown` files
+- `claude` - which will import files into the chat buffer in the same way Claude Code [does](https://code.claude.com/docs/en/memory#claude-md-imports). Note, this requires rules to be `markdown` files
 - `CodeCompanion` - parses rules in the same ways as `claude` but allows for a system prompts to be extracted via a H2 "System Prompt" header
 - `none` - a blank parser which can be used to overwrite parsers that have been set on the default rules groups
 


### PR DESCRIPTION
## Description

Fixes a broken link on the Rules page

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
