### PR TITLE
Anthropic token count fixes

### DIFF
--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -415,6 +415,7 @@ return {
           if json.type == "message_start" then
             self.temp.input_tokens = (json.message.usage.input_tokens or 0)
               + (json.message.usage.cache_creation_input_tokens or 0)
+              + (json.message.usage.cache_read_input_tokens or 0)
 
             self.temp.output_tokens = json.message.usage.output_tokens or 0
           elseif json.type == "message_delta" then


### PR DESCRIPTION
## Description

The Anthropic token count had two issues:

- The token count was susceptible to a race condition if multiple Anthropic chat windows were communicating with an LLM at the same time
- The token count was not taking into account cached input tokens

The second issue I could understand if you don't want changed because if the primary concern is token cost, then the cached tokens should not be shown. However, this would be misleading anyway since what is shown is only the token count for the last request/response. My primary concern is the context window size, so I believe the accurate number needs to be shown in the chat window for all tokens currently in context.  

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
