### PR TITLE
fix(tools): gemini concatenated tools

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -88,10 +88,11 @@ end
 
 ---Resolve and prepare a tool for execution
 ---@param tool table The tool call from the LLM
----@return table|nil resolved_tool The resolved tool or nil if failed
----@return string|nil error_msg Error message if resolution failed
----@return boolean|nil is_json_error Whether this is a JSON parsing error that needs special handling
-function Tools:_resolve_and_prepare_tool(tool)
+---@param id number The execution ID for event firing
+---@return table|nil The resolved tool or nil if failed
+---@return string|nil Error message if resolution failed
+---@return boolean|nil Whether this is a JSON parsing error that needs special handling
+function Tools:_resolve_and_prepare_tool(tool, id)
   local name = tool["function"].name
   local tool_config = self.tools_config[name]
 
@@ -113,6 +114,8 @@ function Tools:_resolve_and_prepare_tool(tool)
     return nil, string.format("Couldn't resolve the tool `%s`", name), false
   end
 
+  -- NOTE: We deepcopy here to avoid mutating the original tool definition which
+  -- has disastrous side effects.
   local prepared_tool = vim.deepcopy(resolved_tool)
   prepared_tool.name = name
   prepared_tool.function_call = tool
@@ -125,20 +128,16 @@ function Tools:_resolve_and_prepare_tool(tool)
       if args == "" then
         args = "{}"
       end
-      local decoded
-      local json_ok = xpcall(function()
-        decoded = vim.json.decode(args)
-      end, function(err)
+      local ok, decoded = pcall(vim.json.decode, args)
+      if not ok then
         log:error("Couldn't decode the tool arguments: %s", args)
         self.chat:add_tool_output(
           prepared_tool,
-          string.format('You made an error in calling the %s tool: "%s"', name, err),
+          string.format('You made an error in calling the %s tool: "%s"', name, decoded),
           ""
         )
-        return utils.fire("ToolsFinished", { bufnr = self.bufnr })
-      end)
-
-      if not json_ok then
+        self.status = CONSTANTS.STATUS_ERROR
+        utils.fire("ToolsFinished", { id = id, bufnr = self.bufnr })
         return nil, "JSON parsing failed", true -- Special flag to indicate this was handled
       end
 
@@ -284,16 +283,16 @@ function Tools:execute(chat, tools)
   local id = math.random(10000000)
   self.chat = chat
 
-  -- Start edit tracking for all tools
   self:_start_edit_tracking(tools)
 
-  -- Wrap the entire tool execution in error handling
   local function safe_execute()
+    -- NOTE: Set autocmds early so that errors can be handled properly
+    self:set_autocmds()
+
     local orchestrator = Orchestrator.new(self, id)
 
-    -- Process each tool
     for _, tool in ipairs(tools) do
-      local resolved_tool, error_msg, is_json_error = self:_resolve_and_prepare_tool(tool)
+      local resolved_tool, error_msg, is_json_error = self:_resolve_and_prepare_tool(tool, id)
 
       if not resolved_tool then
         if is_json_error then
@@ -308,16 +307,11 @@ function Tools:execute(chat, tools)
       orchestrator.queue:push(resolved_tool)
     end
 
-    self:set_autocmds()
     utils.fire("ToolsStarted", { id = id, bufnr = self.bufnr })
     orchestrator:setup_next_tool()
   end
 
-  -- Execute all tools with error handling
-  local ok, err = xpcall(safe_execute, function(error_msg)
-    return debug.traceback(error_msg, 2)
-  end)
-
+  local ok, err = pcall(safe_execute)
   if not ok then
     log:error("chat::tools::init::execute - Execution error %s", err)
     self.status = CONSTANTS.STATUS_ERROR


### PR DESCRIPTION
## Description

If an LLM function calls with incorrect JSON, CodeCompanion would handle this but fail to return the chat buffer to a usable state. An autocmd wasn't created early enough in the tool's execution.

Also, Gemini would commonly make multiple tool calls by concatenating the arguments instead of issuing individual function calling requests. This is now accounted for at an adapter level.

## Related Issue(s)

#2620 

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted my code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
