### PR TITLE
refactor(adapters): warn users of using acp adapters

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -35,7 +35,10 @@ end
 ---@return nil
 CodeCompanion.inline = function(args)
   local context = get_context(api.nvim_get_current_buf(), args)
-  return require("codecompanion.interactions.inline").new({ buffer_context = context }):prompt(args.args)
+  local inline = require("codecompanion.interactions.inline").new({ buffer_context = context })
+  if inline then
+    inline:prompt(args.args)
+  end
 end
 
 ---Accept the next word of code completion
@@ -185,35 +188,37 @@ end
 CodeCompanion.cmd = function(args)
   local context = get_context(api.nvim_get_current_buf(), args)
 
-  return require("codecompanion.interactions.cmd")
-    .new({
-      buffer_context = context,
-      prompts = {
-        {
-          role = config.constants.SYSTEM_ROLE,
-          content = string.format(
-            [[Some additional context which **may** be useful:
+  local command = require("codecompanion.interactions.cmd").new({
+    buffer_context = context,
+    prompts = {
+      {
+        role = config.constants.SYSTEM_ROLE,
+        content = string.format(
+          [[Some additional context which **may** be useful:
 
 - The user is currently working in a %s file
 - It has %d lines
 - The user is currently on line %d
 - The file's full path is %s]],
-            context.filetype,
-            context.line_count,
-            context.cursor_pos[1],
-            context.filename
-          ),
-          opts = {
-            visible = false,
-          },
-        },
-        {
-          role = config.constants.USER_ROLE,
-          content = args.args,
+          context.filetype,
+          context.line_count,
+          context.cursor_pos[1],
+          context.filename
+        ),
+        opts = {
+          visible = false,
         },
       },
-    })
-    :start(args)
+      {
+        role = config.constants.USER_ROLE,
+        content = args.args,
+      },
+    },
+  })
+
+  if command then
+    command:start(args)
+  end
 end
 
 ---Toggle the chat buffer

--- a/lua/codecompanion/interactions/background/init.lua
+++ b/lua/codecompanion/interactions/background/init.lua
@@ -57,11 +57,11 @@ function Background.new(args)
   end
 
   -- Silence errors
-  if self.adapter.type ~= "http" then
-    return log:debug("[background::init] Only HTTP adapters are supported for background interactions")
-  end
   if not self.adapter then
-    return log:debug("[background::init] No adapter assigned for background interactions")
+    return log:debug("[Background] No adapter found")
+  end
+  if self.adapter.type ~= "http" then
+    return log:warn("Only HTTP adapters are supported for background interactions")
   end
 
   self.settings = schema.get_default(self.adapter, args.settings)

--- a/lua/codecompanion/interactions/cmd.lua
+++ b/lua/codecompanion/interactions/cmd.lua
@@ -22,7 +22,10 @@ function Cmd.new(args)
 
   self.adapter = adapters.resolve(config.interactions.cmd.adapter)
   if not self.adapter then
-    return log:error("No adapter found")
+    return log:error("[Command] No adapter found")
+  end
+  if self.adapter.type ~= "http" then
+    return log:warn("Only HTTP adapters are supported for command interactions")
   end
 
   -- Check if the user has manually overridden the adapter

--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -206,6 +206,9 @@ function Inline.new(args)
   if not self.adapter then
     return log:error("[Inline] No adapter found")
   end
+  if self.adapter.type ~= "http" then
+    return log:warn("Only HTTP adapters are supported for inline interactions")
+  end
 
   -- Check if the user has manually overridden the adapter
   if vim.g.codecompanion_adapter and self.adapter.name ~= vim.g.codecompanion_adapter then


### PR DESCRIPTION
## Description

Notify users if they're using an ACP adapter with any interaction other than `chat`.

## Related Issue(s)

#2654

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
