### PR TITLE
feat(acp): allow configuration of default mode

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*         For NVIM v0.11        Last change: 2026 January 21
+*codecompanion.txt*         For NVIM v0.11        Last change: 2026 January 23
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -714,6 +714,13 @@ Using a `function` is useful for working around the limitations
 Code SDK (which enables ACP support).
 
 
+CHANGING THE DEFAULT MODE ~
+
+You can set a default mode for ACP adapters to customize agent behavior. For
+example, to change the default mode for the Claude Code adapter:
+
+
+
 CHANGING ADAPTER SETTINGS ~
 
 To change any of the default settings for an ACP adapter, you can extend it in
@@ -980,9 +987,10 @@ The configuration for both types of adapters is exactly the same, however they
 sit within their own tables (`adapters.http.*` and `adapters.acp.*`) and have
 different options available. HTTP adapters use `models` to allow users to
 select the specific LLM they’d like to interact with. ACP adapters use
-`commands` to allow users to customize their interaction with agents (e.g.�
-enabling `yolo` mode). As there is a lot of shared functionality between the
-two adapters, it is recommend that you read this page alongside the ACP one.
+`commands` to allow users to customize their interaction with agents
+(e.g. enabling `yolo` mode). As there is a lot of shared functionality between
+the two adapters, it is recommend that you read this page alongside the ACP
+one.
 
 
 CHANGING THE DEFAULT ADAPTER ~
@@ -1036,7 +1044,7 @@ the adapter’s URL, headers, parameters and other fields at runtime.
   <https://github.com/olimorris/codecompanion.nvim/discussions/601>
 Supported `env` value types: - **Plain environment variable name (string)**: if
 the value is the name of an environment variable that has already been set
-(e.g.� `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
+(e.g. `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
 **Command (string prefixed with cmd:)**: any value that starts with `cmd:` will
 be executed via the shell. Example: `"cmd:op read
 op://personal/Gemini/credential --no-newline"`. - **Function**: you can provide
@@ -2690,7 +2698,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-tools-files| tool, combined with the
 |codecompanion-usage-chat-buffer-variables.html-buffer| variable or
@@ -4642,7 +4650,7 @@ These handlers manage tool/function calling:
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>
@@ -5331,8 +5339,8 @@ required.
                 role = "user",
                 opts = { auto_submit = true },
                 -- Scope this prompt to the cmd_runner tool
-                condition = function(chat)
-                  return chat.tools.tool and chat.tools.tool.name == "cmd_runner"
+                condition = function()
+                  return _G.codecompanion_current_tool == "cmd_runner"
                 end,
                 -- Repeat until the tests pass, as indicated by the testing flag
                 -- which the cmd_runner tool sets on the chat buffer
@@ -6438,7 +6446,7 @@ tool to function. In the case of Anthropic, we insert additional headers.
 <
 
 Some adapter tools can be a `hybrid` in terms of their implementation. That is,
-they’re an adapter tool that requires a client-side component (i.e.� a
+they’re an adapter tool that requires a client-side component (i.e. a
 built-in tool). This is the case for the
 |codecompanion-usage-chat-buffer-tools-memory| tool from Anthropic. To allow
 for this, ensure that the tool definition in `available_tools` has

--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -79,6 +79,63 @@ require("codecompanion").setup({
 
 Using a _function_ is useful for working around the [limitations](https://github.com/zed-industries/claude-code-acp/issues/225) in the Claude Code SDK (which enables ACP support).
 
+## Changing the Default Mode
+
+You can set a default mode for ACP adapters to customize agent behavior. For example, to change the default mode for the Claude Code adapter:
+
+::: code-group
+
+```lua [For Interactions]
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      adapter = {
+        name = "claude_code",
+        mode = "code-assist", -- or other supported mode
+      },
+    },
+  },
+}),
+```
+
+```lua [Adapters: Text]
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      claude_code = function()
+        return require("codecompanion.adapters").extend("claude_code", {
+          defaults = {
+            mode = "code-assist",
+          },
+        })
+      end,
+    }
+  },
+}),
+```
+
+```lua [Adapters: Function]
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      claude_code = function()
+        return require("codecompanion.adapters").extend("claude_code", {
+          defaults = {
+            ---@param self CodeCompanion.ACPAdapter
+            ---@return string
+            mode = function(self)
+              return "code-assist"
+            end,
+          },
+        })
+      end,
+    }
+  },
+}),
+```
+
+:::
+
 ## Changing Adapter Settings
 
 To change any of the default settings for an ACP adapter, you can extend it in your CodeCompanion setup. For example, to change the timeout and authentication method for the Gemini CLI adapter, you can do the following:


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Closes #2658.

Relevant ACP docs: https://agentclientprotocol.com/protocol/session-modes#session-modes

## AI Usage

codecompanion+opencode with gpt4.1+gpt-5-mini for implementation and documentation.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
