### PR TITLE
fix(adapters): copilot log error

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -146,7 +146,9 @@ local function get_copilot_token()
       insecure = config.adapters.http.opts.allow_insecure,
       proxy = config.adapters.http.opts.proxy,
       on_error = function(err)
-        log:error("Copilot Adapter: Token request error %s", err)
+        vim.schedule(function()
+          log:error("Copilot Adapter: Token request error %s", err)
+        end)
       end,
     })
   end)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Ensure that when outputting an error from the Copilot token `get` request, we wrap it in `vim.schedule`.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
