### PR TITLE
fix mini.diff option in comment for diff.provider

### DIFF
--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -40,7 +40,7 @@ require("codecompanion").setup({
   display = {
     diff = {
       enabled = true,
-      provider = providers.diff, -- inline|split|mini.diff
+      provider = providers.diff, -- inline|split|mini_diff
     },
   },
 })


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

`mini.diff` is the name but not a valid option. The option is `mini_diff` (with underscore).

## AI Usage

none

## Related Issue(s)

none

## Screenshots

<img width="871" height="156" alt="image" src="https://github.com/user-attachments/assets/280212d8-10e5-4ff6-9972-de593b8271fb" />
PS: this is nix code, not lua

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
