### PR TITLE
fix: Remove tool related globals to support concurrent tool usage.

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -5331,8 +5331,8 @@ required.
                 role = "user",
                 opts = { auto_submit = true },
                 -- Scope this prompt to the cmd_runner tool
-                condition = function()
-                  return _G.codecompanion_current_tool == "cmd_runner"
+                condition = function(chat)
+                  return chat.tools.tool and chat.tools.tool.name == "cmd_runner"
                 end,
                 -- Repeat until the tests pass, as indicated by the testing flag
                 -- which the cmd_runner tool sets on the chat buffer
@@ -5408,12 +5408,12 @@ Now let’s look at how we trigger the automated reflection prompts:
             role = "user",
             opts = { auto_submit = true },
             -- Scope this prompt to only run when the cmd_runner tool is active
-            condition = function()
-              return _G.codecompanion_current_tool == "cmd_runner"
+            condition = function(chat)
+              return chat.tools.tool and chat.tools.tool.name == "cmd_runner"
             end,
             -- Repeat until the tests pass, as indicated by the testing flag
             repeat_until = function(chat)
-              return chat.tools.flags.testing == true
+              return chat.tool_registry.flags.testing == true
             end,
             content = "The tests have failed. Can you edit the buffer and run the test suite again?",
           },

--- a/doc/extending/agentic-workflows.md
+++ b/doc/extending/agentic-workflows.md
@@ -134,12 +134,12 @@ Now let's look at how we trigger the automated reflection prompts:
         role = "user",
         opts = { auto_submit = true },
         -- Scope this prompt to only run when the cmd_runner tool is active
-        condition = function()
-          return _G.codecompanion_current_tool == "cmd_runner"
+        condition = function(chat)
+          return chat.tools.tool and chat.tools.tool.name == "cmd_runner"
         end,
         -- Repeat until the tests pass, as indicated by the testing flag
         repeat_until = function(chat)
-          return chat.tools.flags.testing == true
+          return chat.tool_registry.flags.testing == true
         end,
         content = "The tests have failed. Can you edit the buffer and run the test suite again?",
       },

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1449,7 +1449,6 @@ function Chat:stop()
     local tool_job = self.current_tool
     self.current_tool = nil
 
-    _G.codecompanion_cancel_tool = true
     pcall(function()
       tool_job.cancel()
     end)

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -114,8 +114,6 @@ function Orchestrator.new(tools, id)
     tools = tools,
   }, { __index = Orchestrator })
 
-  _G.codecompanion_cancel_tool = false
-
   return self
 end
 
@@ -127,7 +125,6 @@ function Orchestrator:_setup_handlers()
       if not self.tool then
         return
       end
-      _G.codecompanion_current_tool = self.tool.name
       if self.tool.handlers and self.tool.handlers.setup then
         return self.tool.handlers.setup(self.tool, self.tools)
       end
@@ -234,6 +231,7 @@ end
 ---@param self CodeCompanion.Tools.Orchestrator
 ---@return nil
 function Orchestrator:_finalize_tools()
+  self.tools.tool = nil
   return utils.fire("ToolsFinished", { id = self.id, bufnr = self.tools.bufnr })
 end
 

--- a/tests/interactions/chat/test_subscribers.lua
+++ b/tests/interactions/chat/test_subscribers.lua
@@ -20,7 +20,6 @@ T = new_set({
       child.lua([[
         h.teardown_chat_buffer()
         _G.chat = nil
-        _G.codecompanion_current_tool = nil
       ]])
     end,
     post_once = child.stop,


### PR DESCRIPTION


<!-- Please do not alter the structure of this PR template -->

## Description

The globals codecompanion_current_tool and codecompanion_cancel_tool are not needed (_G.codecompanion_cancel_tool is never used) and turn concurrent tool calls into a race condition. Instead, workflows can use the chat parameter they are already provided in the condition() function callback to check the current running tool.

I plan on making a follow up PR to fix the fact that tools are not cancellable right now, but one step at a time.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

I used Claude Sonnet initially, but ended up making the edits myself after it tried to overcomplicate things

## Related Issue(s)

## Screenshots

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [X] _(optional)_ I've updated the README and/or relevant docs pages
