### PR TITLE
Fix: Support tool cancellation

### DIFF
--- a/lua/codecompanion/interactions/chat/keymaps/init.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/init.lua
@@ -304,7 +304,7 @@ M.close = {
 
 M.stop = {
   callback = function(chat)
-    if chat.current_request then
+    if chat.current_request or chat.tool_orchestrator then
       chat:stop()
     end
   end,

--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -289,7 +289,7 @@ function Tools:execute(chat, tools)
     -- NOTE: Set autocmds early so that errors can be handled properly
     self:set_autocmds()
 
-    local orchestrator = Orchestrator.new(self, id)
+    chat.tool_orchestrator = Orchestrator.new(self, id)
 
     for _, tool in ipairs(tools) do
       local resolved_tool, error_msg, is_json_error = self:_resolve_and_prepare_tool(tool, id)
@@ -304,11 +304,11 @@ function Tools:execute(chat, tools)
       end
 
       self.tool = resolved_tool --[[@as CodeCompanion.Tools.Tool]]
-      orchestrator.queue:push(resolved_tool)
+      chat.tool_orchestrator.queue:push(resolved_tool)
     end
 
     utils.fire("ToolsStarted", { id = id, bufnr = self.bufnr })
-    orchestrator:setup_next_tool()
+    chat.tool_orchestrator:setup_next_tool()
   end
 
   local ok, err = pcall(safe_execute)

--- a/lua/codecompanion/interactions/chat/tools/runtime/runner.lua
+++ b/lua/codecompanion/interactions/chat/tools/runtime/runner.lua
@@ -82,7 +82,7 @@ function Runner:run_tool(cmd_func, action, args)
 
   ---@param msg {status:"success"|"error", data:any}
   local function output_handler(msg)
-    if tool_finished then
+    if tool_finished or self.orchestrator.cancelled then
       return
     end
     tool_finished = true

--- a/tests/interactions/chat/tools/runtime/test_queue_async.lua
+++ b/tests/interactions/chat/tools/runtime/test_queue_async.lua
@@ -56,7 +56,10 @@ T["Tools"]["queue"]["can queue multiple async functions"] = function()
       },
     }
     tools:execute(chat, tool_call)
-    vim.wait(2100)
+
+    while (chat.tool_orchestrator) do
+      vim.wait(100)
+    end
   ]])
 
   -- Test order
@@ -88,7 +91,9 @@ T["Tools"]["queue"]["can queue async function with sync function"] = function()
       },
     }
     tools:execute(chat, tool_call)
-    vim.wait(1100)
+    while (chat.tool_orchestrator) do
+      vim.wait(100)
+    end
   ]])
 
   -- Test order


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description
Currently, tools cannot be cancelled so accidental tool usage or long running tools cannot be stopped without closing the chat window and potentially losing the conversation. This PR allows the user to use the stop keymap in chat to cancel to the tool call and inform the AI agent.

This will kill the process for tools run through cmd_runner, but it does not actually cancel function calls. So tools invoked through something like MCPHub.nvim, or the builtin tools, will continue to execute in the background to completion. To actually cancel the function calls would require a bit more refactoring so I figured that it would be worth a discussion before any further implementation.

I tested this on Linux (Fedora) and Windows.

## AI Usage
Claude Sonnet 4.5 did an initial version, but I cleaned it up and essentially rewrote most of it.

## Related Issue(s)

## Screenshots

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
