### PR TITLE
fix(log): Prevent double reporting of errors.

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -385,10 +385,6 @@ CodeCompanion.setup = function(opts)
   log.set_root(log.new({
     handlers = {
       {
-        type = "echo",
-        level = vim.log.levels.ERROR,
-      },
-      {
         type = "notify",
         level = vim.log.levels.WARN,
       },


### PR DESCRIPTION
## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

When an error was logged, it triggered the log handlers for both ERROR and WARN. So anytime log:error() was called, the message was printing from both the echo and notify handlers.

The issue is that when we setup the handlers:

```lua
  -- Set the log root
  log.set_root(log.new({
    handlers = {
      {
        type = "echo",
        level = vim.log.levels.ERROR,
      },
      {
        type = "notify",
        level = vim.log.levels.WARN,
      },
      {
        type = "file",
        filename = "codecompanion.log",
        level = vim.log.levels[config.opts.log_level],
      },
    },
  }))
```

`vim.log.levels.WARN` < `vim.log.levels.ERROR`. So anytime the echo handler will run, the notify must also run. So the errors will always be reported twice since the log handler:

```lua
function LogHandler:log(level, msg, ...)
  if self.level <= level then
    local text = self.formatter(level, msg, ...)
    self.handle(level, text)
  end
end
```
always logs if the level is <= the configured handler level.

Another potential issue here is that the echo and notify handlers do not take into account the configured log level. So warning messages will still appear even if someone configures log level as `ERROR`. Not sure if that is intentional or not, since the configuration value on affects the "file" handler right now.
<!-- Please do not alter the structure of this PR template -->



## AI Usage
After a few rounds of prompting, Claude Sonnet 4.5 recommended the change (he got the cause of the double error printing wrong twice, but the third time he got it)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
