### PR TITLE
chore(copilot): use GH_HOST for Copilot endpoints and token lookup

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -34,8 +34,11 @@ end
 ---@return table
 local function handlers(adapter)
   local model_opts = resolve_model_opts(adapter)
+  local current_url = adapter.url or "https://api.githubcopilot.com/chat/completions"
+  local base_url = current_url:gsub("/chat/completions$", ""):gsub("/responses$", "")
+
   if model_opts.endpoint == "responses" then
-    adapter.url = "https://api.githubcopilot.com/responses"
+    adapter.url = base_url .. "/responses"
 
     local responses = require("codecompanion.adapters.http.openai_responses")
 
@@ -74,7 +77,7 @@ local function handlers(adapter)
     return responses.handlers
   end
 
-  adapter.url = "https://api.githubcopilot.com/chat/completions"
+  adapter.url = base_url .. "/chat/completions"
   return require("codecompanion.adapters.http.openai").handlers
 end
 

--- a/lua/codecompanion/adapters/http/copilot/stats.lua
+++ b/lua/codecompanion/adapters/http/copilot/stats.lua
@@ -27,8 +27,17 @@ local function get_statistics()
 
   local oauth_token = token.fetch({ force = true }).oauth_token
 
+  local host = vim.env.GH_HOST or "github.com"
+  local endpoint
+  if host == "github.com" then
+    endpoint = "https://api.github.com/copilot_internal/v2/token"
+  else
+    -- GitHub Enterprise usually puts the API under /api/v3
+    endpoint = string.format("https://%s/api/v3/copilot_internal/v2/token", host)
+  end
+
   local ok, response = pcall(function()
-    return Curl.get("https://api.github.com/copilot_internal/user", {
+    return Curl.get(endpoint, {
       sync = true,
       headers = {
         Authorization = "Bearer " .. oauth_token,


### PR DESCRIPTION
This PR is a continuation of #2090, but with a complete "fix" for the GH_HOST issue. There are several places where the variable needs to be read-referenced, and [as I said there](https://github.com/olimorris/codecompanion.nvim/pull/2090#issuecomment-3596631490) I don't think this fix is actually good, but it does work (I've been using my fork for a couple of months).