### PR TITLE
Fix(diff): properly clear auto commands for inline integration to prevent trigger the banner.

### DIFF
--- a/lua/codecompanion/diff/ui.lua
+++ b/lua/codecompanion/diff/ui.lua
@@ -9,6 +9,7 @@ local api = vim.api
 local M = {}
 
 ---@class CodeCompanion.DiffUI
+---@field aug_group? number The autocommand group ID for the banner
 ---@field banner? string The banner of keymaps to display above each hunk
 ---@field banner_ns? number The namespace ID for the banner extmark
 ---@field bufnr number The buffer number of the diff window
@@ -264,7 +265,10 @@ end
 ---Clear diff extmarks from buffer
 ---@return nil
 function DiffUI:clear()
-  -- Clear the banner namespace
+  if self.aug_group then
+    pcall(api.nvim_del_augroup_by_id, self.aug_group)
+  end
+
   if self.banner_ns then
     pcall(api.nvim_buf_clear_namespace, self.bufnr, self.banner_ns, 0, -1)
   end
@@ -445,6 +449,7 @@ end
 local function setup_banner(diff_ui, opts)
   local bufnr = diff_ui.bufnr
   local group = api.nvim_create_augroup("codecompanion.diff_window_" .. bufnr, { clear = true })
+  diff_ui.aug_group = group
 
   local function show_banner(args)
     args = args or {}


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

**Problem:** The banner virtual text is triggered when switching buffers after accepting/rejecting the change.

**Cause:** Autocommands used for `inline interaction` are not properly cleared, which causes the banner to reappear in the code buffer.

**Fix:** This PR ensures the relevant autocommands are correctly cleared, preventing the banner from being retriggered.


## AI Usage

weirdly enough, none. 

## Related Issue(s)

https://github.com/olimorris/codecompanion.nvim/pull/2692#issuecomment-3820879553

## Screenshots

the issue:

https://github.com/user-attachments/assets/fbe14e24-04da-4656-8b74-084687130d22

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
