### PR TITLE
feat(adapters): uses user-defined headers on get_model() call for openai_compatible adapters

### DIFF
--- a/lua/codecompanion/adapters/http/openai_compatible.lua
+++ b/lua/codecompanion/adapters/http/openai_compatible.lua
@@ -43,12 +43,7 @@ local function get_models(self, opts)
   adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
   local url = adapter.env_replaced.url .. adapter.env_replaced.models_endpoint
 
-  local headers = {
-    ["content-type"] = "application/json",
-  }
-  if adapter.env_replaced.api_key then
-    headers["Authorization"] = "Bearer " .. adapter.env_replaced.api_key
-  end
+  local headers = adapter_utils.set_env_vars(adapter, adapter.headers) or {}
 
   local ok, response, json
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

This allows the usage of custom headers on the `get_models()` call in the `openai_compatible` adapter. The current way is kinda hardcoded and some companies uses custom headers to control access on their AI Gateway.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

I used to review my changes and to check it there was a better way to implement this. I used Claude Haiku 4.5.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
