### PR TITLE
feat(chat): support hidden chat buffers on creation

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -172,6 +172,7 @@ CodeCompanion.chat = function(args)
     auto_submit = auto_submit,
     buffer_context = context,
     callbacks = args.callbacks,
+    hidden = args.hidden,
     messages = has_messages and messages or nil,
     window_opts = args and args.window_opts,
   })

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -274,4 +274,35 @@ T["Chat"]["ftplugin window options override plugin defaults"] = function()
   child_test.stop()
 end
 
+T["Chat"]["can create hidden chat without opening window"] = function()
+  local result = child.lua([[
+    local hidden_chat = codecompanion.chat({
+      hidden = true,
+      messages = {
+        { role = "user", content = "Test hidden chat" }
+      }
+    })
+
+    local line_count = vim.api.nvim_buf_line_count(hidden_chat.bufnr)
+    local cwd_ok, cwd_ctx = pcall(function() return hidden_chat:make_system_prompt_ctx() end)
+
+    return {
+      hidden = hidden_chat.hidden,
+      bufnr_valid = vim.api.nvim_buf_is_valid(hidden_chat.bufnr),
+      is_visible = hidden_chat.ui:is_visible(),
+      line_count = line_count,
+      buffer_has_content = line_count > 0,
+      cwd_works = cwd_ok,
+      cwd_value = cwd_ok and cwd_ctx.cwd or nil
+    }
+  ]])
+
+  h.eq(true, result.hidden)
+  h.eq(true, result.bufnr_valid)
+  h.eq(false, result.is_visible == true)
+  h.eq(true, result.line_count > 0)
+  h.eq(true, result.cwd_works)
+  h.eq(true, result.cwd_value ~= nil and result.cwd_value ~= "")
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR introduces a small feature enhancement to support opening chat buffers programmatically in a hidden (background) state.

Currently, achieving this requires a workaround: opening the chat visibly, then immediately hiding it and restoring the previously active chat (if any). This change removes the need for that hack by adding native support for hidden chat buffers.

> Note:
> This modification is minimal and does not affect any existing behavior. It only applies to programmatic use cases, such as when creating chats via `chat:new()` with the `hidden = true` option enabled.

Use cases:
Allows creating and managing chat buffers programmatically in the background without interrupting the user's current context. This enables automation, preloading, or preparation of chats that are only shown when needed. I'm building a feature that relies on this behavior.

Thank you

## AI Usage

None.


## Related Issue(s)

None, this is a feature request.


## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
