### PR TITLE
feat(tools): include tool arguments in events

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -232,7 +232,11 @@ end
 ---@return nil
 function Orchestrator:_finalize_tools()
   self.tools.tool = nil
-  return utils.fire("ToolsFinished", { id = self.id, bufnr = self.tools.bufnr })
+  return utils.fire("ToolsFinished", {
+    bufnr = self.tools.bufnr,
+    id = self.id,
+    status = self.tools.status,
+  })
 end
 
 ---Setup the tool to be executed
@@ -342,7 +346,12 @@ end
 ---@param args { cmd: function, input?: any }
 ---@return nil
 function Orchestrator:execute_tool(args)
-  utils.fire("ToolStarted", { id = self.id, tool = self.tool.name, bufnr = self.tools.bufnr })
+  utils.fire("ToolStarted", {
+    bufnr = self.tools.bufnr,
+    id = self.id,
+    tool = self.tool.name,
+    args = self.tool.args,
+  })
   return Runner.new({ index = 1, orchestrator = self, cmd = args.cmd }):setup(args.input)
 end
 
@@ -403,7 +412,12 @@ function Orchestrator:finalize_tool()
     pcall(function()
       self.handlers.on_exit()
     end)
-    utils.fire("ToolFinished", { id = self.id, name = self.tool.name, bufnr = self.tools.bufnr })
+    utils.fire("ToolFinished", {
+      bufnr = self.tools.bufnr,
+      id = self.id,
+      name = self.tool.name,
+      args = self.tool.args,
+    })
     self.tool = nil
   end
 end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR extends tool-related events to include the tool arguments in their payload. The change is additive and does not affect existing behavior.

### Benefits / Use cases

* Enables extensions such as **fs-monitor.nvim** to access relevant metadata (e.g. file paths) when tools operate on files.
* Improves observability of tool execution by exposing command arguments, enabling filtering, targeted notifications, and safety checks (for example, detecting potentially dangerous commands executed via `cmd_runner`).

**Example event output**:

```log
ToolStarted │ bufnr: 131 │ id: 5844143 │ cmd: find . -maxdepth 4 -name "*.rs" │ tool: cmd_runner
```

```log
ToolStarted │ bufnr: 131 │ id: 1017944 │ filepath: hive/src/config/loader.rs │ explanation: Refactoring configuration loading to improve error handling and reduce duplicate parsing logic │ tool: insert_edit_into_file
```

Thank you

## AI Usage

None

## Related Issue(s)

None.

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
