### PR TITLE
Add support for Kiro through ACP

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*        For NVIM v0.11        Last change: 2026 February 02
+*codecompanion.txt*        For NVIM v0.11        Last change: 2026 February 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -941,6 +941,14 @@ Install Kimi CLI
 their instructions. Then in the CLI, run `kimi` followed by `/login` to
 configure your API key. Then ensure that in your chat buffer you select the
 `kimi_cli` adapter.
+
+
+SETUP: KIRO CLI ~
+
+Install Kiro cli <https://kiro.dev/docs/cli/> as per their instructions. Then
+open it and login (if installation doesn’t already prompt you to login). the
+codecompanion adapter will execute `kiro-cli acp`, make sure to have it
+available on your PATH.
 
 
 SETUP: OPENCODE ~

--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -272,7 +272,7 @@ To use [Goose](https://block.github.io/goose/) in CodeCompanion, ensure you've f
 
 Install [Kimi CLI](https://github.com/MoonshotAI/kimi-cli?tab=readme-ov-file#installation) as per their instructions. Then in the CLI, run `kimi` followed by `/login` to configure your API key. Then ensure that in your chat buffer you select the `kimi_cli` adapter.
 
-## Setup: Kimi CLI
+## Setup: Kiro CLI
 
 Install [Kiro cli](https://kiro.dev/docs/cli/) as per their instructions. Then open it and login (if installation doesn't already prompt you to login). the codecompanion adapter will execute `kiro-cli acp`, make sure to have it available on your PATH.
 

--- a/lua/codecompanion/adapters/acp/codex.lua
+++ b/lua/codecompanion/adapters/acp/codex.lua
@@ -20,7 +20,7 @@ return {
   defaults = {
     auth_method = "openai-api-key", -- "openai-api-key"|"codex-api-key"|"chatgpt"
     mcpServers = {},
-    timeout = 20000,                -- 20 seconds
+    timeout = 20000, -- 20 seconds
   },
   env = {
     OPENAI_API_KEY = "OPENAI_API_KEY",

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -28,10 +28,10 @@ local defaults = {
       jina = "jina",
       tavily = "tavily",
       opts = {
-        allow_insecure = false,    -- Allow insecure connections?
-        cache_models_for = 1800,   -- Cache adapter models for this long (seconds)
-        proxy = nil,               -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
-        show_presets = true,       -- Show preset adapters
+        allow_insecure = false, -- Allow insecure connections?
+        cache_models_for = 1800, -- Cache adapter models for this long (seconds)
+        proxy = nil, -- [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
+        show_presets = true, -- Show preset adapters
         show_model_choices = true, -- Show model choices when changing adapter
       },
     },
@@ -141,12 +141,12 @@ local defaults = {
           callback = "interactions.chat.tools.builtin.insert_edit_into_file",
           description = "Robustly edit existing files with multiple automatic fallback interactions",
           opts = {
-            require_approval_before = {        -- Require approval before the tool is executed?
-              buffer = false,                  -- For editing buffers in Neovim
-              file = false,                    -- For editing files in the current working directory
+            require_approval_before = { -- Require approval before the tool is executed?
+              buffer = false, -- For editing buffers in Neovim
+              file = false, -- For editing files in the current working directory
             },
             require_confirmation_after = true, -- Require confirmation from the user before accepting the edit?
-            file_size_limit_mb = 2,            -- Maximum file size in MB
+            file_size_limit_mb = 2, -- Maximum file size in MB
           },
         },
         ["create_file"] = {
@@ -204,8 +204,7 @@ local defaults = {
         },
         ["memory"] = {
           callback = "interactions.chat.tools.builtin.memory",
-          description =
-          "The memory tool enables LLMs to store and retrieve information across conversations through a memory file directory",
+          description = "The memory tool enables LLMs to store and retrieve information across conversations through a memory file directory",
           opts = {
             require_approval_before = true,
           },
@@ -241,11 +240,11 @@ local defaults = {
           description = "Find code symbol context",
         },
         opts = {
-          auto_submit_errors = true,  -- Send any errors to the LLM automatically?
+          auto_submit_errors = true, -- Send any errors to the LLM automatically?
           auto_submit_success = true, -- Send any successful output to the LLM automatically?
           folds = {
-            enabled = true,           -- Fold tool output in the buffer?
-            failure_words = {         -- Words that indicate an error in the tool output. Used to apply failure highlighting
+            enabled = true, -- Fold tool output in the buffer?
+            failure_words = { -- Words that indicate an error in the tool output. Used to apply failure highlighting
               "cancelled",
               "error",
               "failed",
@@ -259,7 +258,7 @@ local defaults = {
           default_tools = {},
 
           system_prompt = {
-            enabled = true,                     -- Enable the tools system prompt?
+            enabled = true, -- Enable the tools system prompt?
             replace_main_system_prompt = false, -- Replace the main system prompt with the tools system prompt?
 
             ---The tool system prompt
@@ -350,7 +349,7 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
           description = "Insert open buffers",
           opts = {
             contains_code = true,
-            default_params = "diff",      -- all|diff
+            default_params = "diff", -- all|diff
             provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
         },
@@ -386,7 +385,7 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
           callback = "interactions.chat.slash_commands.builtin.fetch",
           description = "Insert URL contents",
           opts = {
-            adapter = "jina",             -- jina
+            adapter = "jina", -- jina
             cache_path = vim.fn.stdpath("data") .. "/codecompanion/urls",
             provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
@@ -412,7 +411,7 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
           description = "Insert content from help tags",
           opts = {
             contains_code = false,
-            max_lines = 128,           -- Maximum amount of lines to of the help file to send (NOTE: Each vimdoc line is typically 10 tokens)
+            max_lines = 128, -- Maximum amount of lines to of the help file to send (NOTE: Each vimdoc line is typically 10 tokens)
             provider = providers.help, -- telescope|fzf_lua|mini_pick|snacks
           },
         },
@@ -428,9 +427,9 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
             return false
           end,
           opts = {
-            dirs = {},                                           -- Directories to search for images
+            dirs = {}, -- Directories to search for images
             filetypes = { "png", "jpg", "jpeg", "gif", "webp" }, -- Filetypes to search for
-            provider = providers.images,                         -- telescope|snacks|default
+            provider = providers.images, -- telescope|snacks|default
           },
         },
         ["rules"] = {
@@ -660,13 +659,13 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
         },
       },
       opts = {
-        blank_prompt = "",                          -- The prompt to use when the user doesn't provide a prompt
+        blank_prompt = "", -- The prompt to use when the user doesn't provide a prompt
         completion_provider = providers.completion, -- blink|cmp|coc|default
-        debounce = 150,                             -- Time to debounce user input (milliseconds)
+        debounce = 150, -- Time to debounce user input (milliseconds)
 
-        register = "+",                             -- The register to use for yanking code
-        wait_timeout = 2e6,                         -- Time to wait for user response before timing out (milliseconds)
-        yank_jump_delay_ms = 400,                   -- Delay before jumping back from the yanked code (milliseconds )
+        register = "+", -- The register to use for yanking code
+        wait_timeout = 2e6, -- Time to wait for user response before timing out (milliseconds)
+        yank_jump_delay_ms = 400, -- Delay before jumping back from the yanked code (milliseconds )
 
         -- What to do when an ACP permission request times out? (allow_once|reject_once)
         acp_timeout_response = "reject_once",
@@ -682,18 +681,18 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
         ---@return string
         system_prompt = function(ctx)
           return ctx.default_system_prompt
-              .. fmt(
-                [[Additional context:
+            .. fmt(
+              [[Additional context:
 All non-code text responses must be written in the %s language.
 The current date is %s.
 The user's Neovim version is %s.
 The user is working on a %s machine. Please respond with system specific commands if applicable.
 ]],
-                ctx.language,
-                ctx.date,
-                ctx.nvim_version,
-                ctx.os
-              )
+              ctx.language,
+              ctx.date,
+              ctx.nvim_version,
+              ctx.os
+            )
         end,
       },
     },
@@ -757,8 +756,7 @@ The user is working on a %s machine. Please respond with system specific command
     cmd = {
       adapter = "copilot",
       opts = {
-        system_prompt =
-        [[You are currently plugged in to the Neovim text editor on a user's machine. Your core task is to generate an command-line inputs that the user can run within Neovim. Below are some rules to adhere to:
+        system_prompt = [[You are currently plugged in to the Neovim text editor on a user's machine. Your core task is to generate an command-line inputs that the user can run within Neovim. Below are some rules to adhere to:
 
 - Return plain text only
 - Do not wrap your response in a markdown block or backticks
@@ -789,8 +787,8 @@ The user is working on a %s machine. Please respond with system specific command
         ".github/copilot-instructions.md",
         "AGENT.md",
         "AGENTS.md",
-        { path = "CLAUDE.md",           parser = "claude" },
-        { path = "CLAUDE.local.md",     parser = "claude" },
+        { path = "CLAUDE.md", parser = "claude" },
+        { path = "CLAUDE.local.md", parser = "claude" },
         { path = "~/.claude/CLAUDE.md", parser = "claude" },
       },
       is_preset = true,
@@ -850,9 +848,9 @@ The user is working on a %s machine. Please respond with system specific command
       is_preset = true,
     },
     parsers = {
-      claude = "claude",               -- Parser for CLAUDE.md files
+      claude = "claude", -- Parser for CLAUDE.md files
       codecompanion = "codecompanion", -- Parser for CodeCompanion specific rules files
-      none = "none",                   -- No parsing, just raw text
+      none = "none", -- No parsing, just raw text
     },
     opts = {
       chat = {
@@ -875,13 +873,13 @@ The user is working on a %s machine. Please respond with system specific command
     action_palette = {
       width = 95,
       height = 10,
-      prompt = "Prompt ",                  -- Prompt used for interactive LLM calls
+      prompt = "Prompt ", -- Prompt used for interactive LLM calls
       provider = providers.action_palette, -- telescope|mini_pick|snacks|default
       opts = {
-        show_preset_actions = true,        -- Show the preset actions in the action palette?
-        show_preset_prompts = true,        -- Show the preset prompts in the action palette?
-        show_preset_rules = true,          -- Show the preset rules in the action palette?
-        title = "CodeCompanion actions",   -- The title of the action palette
+        show_preset_actions = true, -- Show the preset actions in the action palette?
+        show_preset_prompts = true, -- Show the preset prompts in the action palette?
+        show_preset_rules = true, -- Show the preset rules in the action palette?
+        title = "CodeCompanion actions", -- The title of the action palette
       },
     },
     chat = {
@@ -898,12 +896,12 @@ The user is working on a %s machine. Please respond with system specific command
 
       -- Window options for the chat buffer
       window = {
-        buflisted = false,   -- List the chat buffer in the buffer list?
-        sticky = false,      -- Chat buffer remains open when switching tabs
+        buflisted = false, -- List the chat buffer in the buffer list?
+        sticky = false, -- Chat buffer remains open when switching tabs
 
         layout = "vertical", -- float|vertical|horizontal|buffer
-        full_height = true,  -- for vertical layout
-        position = nil,      -- left|right|top|bottom (nil will default depending on vim.opt.splitright|vim.opt.splitbelow)
+        full_height = true, -- for vertical layout
+        position = nil, -- left|right|top|bottom (nil will default depending on vim.opt.splitright|vim.opt.splitbelow)
 
         width = 0.5, ---@return number|fun(): number
         height = 0.8, ---@return number|fun(): number
@@ -1005,12 +1003,12 @@ The user is working on a %s machine. Please respond with system specific command
           },
 
           opts = {
-            context_lines = 3,         -- Number of context lines in hunks
-            show_dim = true,           -- Enable dimming background for floating windows (applies to both diff and super_diff)
-            dim = 25,                  -- Background dim level for floating diff (0-100, [100 full transparent], only applies when layout = "float")
+            context_lines = 3, -- Number of context lines in hunks
+            show_dim = true, -- Enable dimming background for floating windows (applies to both diff and super_diff)
+            dim = 25, -- Background dim level for floating diff (0-100, [100 full transparent], only applies when layout = "float")
             full_width_removed = true, -- Make removed lines span full width
-            show_keymap_hints = true,  -- Show "gda: accept | gdr: reject" hints above diff
-            show_removed = true,       -- Show removed lines as virtual text
+            show_keymap_hints = true, -- Show "gda: accept | gdr: reject" hints above diff
+            show_removed = true, -- Show removed lines as virtual text
           },
         },
 
@@ -1023,7 +1021,7 @@ The user is working on a %s machine. Please respond with system specific command
             "filler",
             "closeoff",
             "algorithm:histogram", -- https://adamj.eu/tech/2024/01/18/git-improve-diff-histogram/
-            "indent-heuristic",    -- https://blog.k-nut.eu/better-git-diffs
+            "indent-heuristic", -- https://blog.k-nut.eu/better-git-diffs
             "followwrap",
             "linematch:120",
           },
@@ -1042,7 +1040,7 @@ The user is working on a %s machine. Please respond with system specific command
   extensions = {},
   -- GENERAL OPTIONS ----------------------------------------------------------
   opts = {
-    log_level = "ERROR",  -- TRACE|DEBUG|ERROR|INFO
+    log_level = "ERROR", -- TRACE|DEBUG|ERROR|INFO
     language = "English", -- The language used for LLM responses
 
     -- If this is false then any default prompt that is marked as containing code
@@ -1053,7 +1051,7 @@ The user is working on a %s machine. Please respond with system specific command
     send_code = true,
 
     job_start_delay = 1500, -- Delay in milliseconds between cmd tools
-    submit_delay = 2000,    -- Delay in milliseconds before auto-submitting the chat buffer
+    submit_delay = 2000, -- Delay in milliseconds before auto-submitting the chat buffer
   },
 }
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR adds the Kiro (formerly amazon Q) ACP adapter to code companion.

## AI Usage

I made the adapter and changes to readmes and the likes myself, and then used Kiro itself in code-companion to both test and refine the changes (I made 2 typos that it found).

## Related Issue(s)

No fixes on open issues, it does close one of the long standing discussions though: https://github.com/olimorris/codecompanion.nvim/discussions/2168

## Screenshots

<img width="1071" height="882" alt="Screenshot 2026-02-06 at 11 21 06" src="https://github.com/user-attachments/assets/5b370ea1-eb5b-4733-a03a-72ca39d1e01f" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
