### PR TITLE
fix(utils): escape percent signs

### DIFF
--- a/lua/codecompanion/utils/context.lua
+++ b/lua/codecompanion/utils/context.lua
@@ -119,7 +119,7 @@ function M.get(bufnr, args)
   return {
     bufnr = bufnr,
     buftype = api.nvim_get_option_value("buftype", { buf = bufnr }) or "",
-    code = vim.tbl_count(lines) > 0 and vim.pesc(table.concat(lines, "\n")),
+    code = vim.tbl_count(lines) > 0 and table.concat(lines, "\n"),
     cursor_pos = cursor_pos,
     end_col = end_col,
     end_line = end_line,

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -108,6 +108,16 @@ function M.extract_all_placeholders(prompts)
   return all_placeholders
 end
 
+---Escape percent signs in a string for use as a gsub replacement value.
+---In Lua's gsub, the replacement string treats %0-%9 as capture references
+---and %% as a literal percent. This function doubles all percent signs so
+---that the replacement is inserted verbatim.
+---@param str string
+---@return string
+local function escape_gsub_replacement(str)
+  return (str:gsub("%%", "%%%%"))
+end
+
 ---Replace any placeholders (e.g. ${placeholder}) in a string or table
 ---@param t table|string The content to process
 ---@param replacements table<string, string> Map of placeholder names to replacement values
@@ -115,7 +125,7 @@ end
 function M.replace_placeholders(t, replacements)
   if type(t) == "string" then
     for placeholder, replacement in pairs(replacements) do
-      t = t:gsub("%${" .. vim.pesc(placeholder) .. "}", replacement)
+      t = t:gsub("%${" .. vim.pesc(placeholder) .. "}", escape_gsub_replacement(replacement))
     end
     return t
   else
@@ -124,7 +134,7 @@ function M.replace_placeholders(t, replacements)
         M.replace_placeholders(value, replacements)
       elseif type(value) == "string" then
         for placeholder, replacement in pairs(replacements) do
-          value = value:gsub("%${" .. vim.pesc(placeholder) .. "}", replacement)
+          value = value:gsub("%${" .. vim.pesc(placeholder) .. "}", escape_gsub_replacement(replacement))
         end
         t[key] = value
       end

--- a/tests/utils/test_utils.lua
+++ b/tests/utils/test_utils.lua
@@ -200,6 +200,52 @@ T["Utils"]["replace_placeholders()"]["handles special characters in placeholder 
   h.eq(result, "Value: test")
 end
 
+T["Utils"]["replace_placeholders()"]["handles percent signs in replacement values"] = function()
+  local result = child.lua([[
+    return utils.replace_placeholders(
+      '(<a href="https://my.test.page/tester.php?login=${email}" title="Test Page">%20</a>)',
+      { email = "testuser%40testing.org" }
+    )
+  ]])
+  h.eq(result, '(<a href="https://my.test.page/tester.php?login=testuser%40testing.org" title="Test Page">%20</a>)')
+end
+
+T["Utils"]["replace_placeholders()"]["handles simple percent signs in replacement"] = function()
+  local result = child.lua([[
+    return utils.replace_placeholders(
+      "Encoded: ${value}",
+      { value = "%20" }
+    )
+  ]])
+  h.eq(result, "Encoded: %20")
+end
+
+T["Utils"]["replace_placeholders()"]["preserves special pattern characters in replacement values"] = function()
+  local result = child.lua([[
+    return utils.replace_placeholders(
+      "Code: ${context.code}",
+      { ["context.code"] = 'require("lazy.minit").repro({ spec = plugins })' }
+    )
+  ]])
+  h.eq(result, 'Code: require("lazy.minit").repro({ spec = plugins })')
+end
+
+T["Utils"]["replace_placeholders()"]["preserves parentheses and dots in table replacement"] = function()
+  child.lua([[
+    _G.test_table = {
+      { role = "user", content = "Review this: ${context.code}" },
+    }
+    utils.replace_placeholders(_G.test_table, {
+      ["context.code"] = "obj.method(arg1, arg2) + 100%",
+    })
+  ]])
+
+  local result = child.lua([[return _G.test_table]])
+  h.eq(result, {
+    { role = "user", content = "Review this: obj.method(arg1, arg2) + 100%" },
+  })
+end
+
 T["Utils"]["resolve_nested_value()"] = MiniTest.new_set()
 
 T["Utils"]["resolve_nested_value()"]["resolves top-level value"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Address the issues below relating to escaping percent signs.

## AI Usage

Claude Code to diagnose the issue and implement the fix. I added test coverage.

## Related Issue(s)

#2736 #2742

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
