### PR TITLE
fix(tools): grep_search cannot search patterns starting with `-`

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
@@ -65,6 +65,7 @@ local function grep_search(action, opts)
   table.insert(cmd, tostring(math.min(max_results, 50)))
 
   -- Add the query
+  table.insert(cmd, "-e") -- Use -e option to explicitly specify search pattern
   table.insert(cmd, query)
 
   -- Add the search path

--- a/tests/interactions/chat/tools/builtin/test_grep_search.lua
+++ b/tests/interactions/chat/tools/builtin/test_grep_search.lua
@@ -63,6 +63,12 @@ local T = new_set({
             path = 'src/utils/helpers.js',
             content = {
               '// Utility functions',
+              'const config = {',
+              '  -debug-mode: true,',
+              '  -debug-level: "verbose",',
+              '  -verbose: false,',
+              '};',
+              '',
               'export function formatDate(date) {',
               '  return date.toLocaleDateString();',
               '}',
@@ -73,7 +79,9 @@ local T = new_set({
               '    clearTimeout(timeoutId);',
               '    timeoutId = setTimeout(() => func.apply(this, args), delay);',
               '  };',
-              '}'
+              '}',
+              '',
+              'const settings = { -debug-mode: true };'
             }
           },
           {
@@ -147,6 +155,27 @@ T["can find basic text matches"] = function()
   h.expect_contains("src/components/Button.js:11", output) -- export default Button
   h.expect_contains("tests/button.test.js:2", output) -- import Button
   h.expect_contains("tests/button.test.js:5", output) -- render(<Button>
+end
+
+T["can search for patterns starting with hyphen"] = function()
+  child.lua([[
+    local tool = {
+      {
+        ["function"] = {
+          name = "grep_search",
+          arguments = [=[{"query": "-debug-\\w+", "is_regexp": true}]=]
+        },
+      },
+    }
+    tools:execute(chat, tool)
+    vim.wait(200)
+  ]])
+
+  local output = child.lua_get("chat.messages[#chat.messages].content")
+
+  h.expect_contains("src/utils/helpers.js:3", output) -- -debug-mode: true in config
+  h.expect_contains("src/utils/helpers.js:4", output) -- -debug-level: "verbose" in config
+  h.expect_contains("src/utils/helpers.js:20", output) -- -debug-mode in settings
 end
 
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->
`grep_search` cannot search patterns starting with `-`, which are incorrectly parsed as command line flags by `rg`. This PR adds a `-e` before the pattern to make `rg` always parse the next argument as the pattern.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->
I used CC with GLM 4.7 to pinpoint the precise location of the bug in the source tree, then generate a test case for it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->
Before:
<img width="840" height="789" alt="屏幕截图_20260211_151142" src="https://github.com/user-attachments/assets/8dd221b0-bca7-41c5-bc5c-c830b50a7986" />

After:
<img width="843" height="735" alt="屏幕截图_20260211_235759" src="https://github.com/user-attachments/assets/9657f416-0575-4f09-bba8-36ab4c99b82a" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
