### PR TITLE
feat(ui): show title in floating window

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -423,7 +423,7 @@ function Chat.new(args)
     messages = args.messages or {},
     opts = args,
     status = "",
-    title = args.title or nil,
+    title = args.title,
     create_buf = function()
       local bufnr = api.nvim_create_buf(config.display.chat.window.buflisted, true)
       api.nvim_buf_set_name(bufnr, fmt("[CodeCompanion] %d", bufnr))
@@ -527,6 +527,7 @@ function Chat.new(args)
     chat_bufnr = self.bufnr,
     roles = { user = user_role, llm = llm_role },
     settings = self.settings,
+    title = self.title,
     window_opts = args.window_opts,
   })
 
@@ -1693,6 +1694,7 @@ function Chat:set_title(title)
   assert(type(title) == "string", "title must be a string")
 
   self.title = title
+  self.ui.title = title
   chatmap[self.bufnr].description = title
   pcall(function()
     api.nvim_buf_set_name(self.bufnr, title)

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -54,6 +54,7 @@ end
 ---@field roles table The roles in the chat
 ---@field winnr number The window number of the chat
 ---@field settings table The settings for the chat
+---@field title string|nil The title of the chat window
 ---@field tokens number The current token count in the chat
 ---@field window_opts? table The window configuration options for the chat buffer
 
@@ -65,6 +66,7 @@ end
 ---@field roles table
 ---@field winnr number
 ---@field settings table
+---@field title string|nil
 ---@field tokens number
 ---@field window_opts? table
 
@@ -84,6 +86,7 @@ function UI.new(args)
     },
     roles = args.roles,
     settings = args.settings,
+    title = args.title,
     tokens = args.tokens,
     winnr = args.winnr,
     window_opts = args.window_opts,
@@ -232,6 +235,11 @@ function UI:open(opts)
   local width = window.width > 1 and window.width or math.floor(cols() * window.width)
 
   if window.layout == "float" then
+    local title = window.title or " CodeCompanion "
+    if self.title then
+      title = string.format(" %s ", self.title)
+    end
+
     local win_opts = {
       relative = window.relative,
       width = width,
@@ -239,7 +247,7 @@ function UI:open(opts)
       col = window.col or math.floor((cols() - width) / 2),
       row = window.row or math.floor((rows() - height) / 2),
       border = window.border,
-      title = window.title or "CodeCompanion",
+      title = title,
       title_pos = "center",
       zindex = 45,
     }


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

With the background interactions generating titles for users, this PR enables them to be displayed in the title of the chat buffer's floating window

## AI Usage

None.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
