### PR TITLE
feat(prompt_library): can enable/disable prompts

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -2481,17 +2481,18 @@ behaviour:
 - `adapter` - Specify a different adapter/model:
 
 
-- `alias` - Allows the prompt to be triggered via `:CodeCompanion /{alias}`
-- `auto_submit` - Automatically submit the prompt to the LLM
-- `ignore_system_prompt` - Don’t send the default system prompt with the request
-- `intro_message` - Custom intro message for the chat buffer UI
-- `is_slash_cmd` - Make the prompt available as a slash command in chat
-- `is_workflow` - Treat successive prompts as a workflow
-- `modes` - Only show in specific modes (`{ "v" }` for visual mode)
-- `placement` - For inline interaction: `new`, `replace`, `add`, `before`, `chat`
-- `pre_hook` - Function to run before the prompt is executed (Lua only)
-- `stop_context_insertion` - Prevent automatic context insertion
-- `user_prompt` - Get user input before actioning the response
+- `alias` `(string)` - Allows the prompt to be triggered via `:CodeCompanion /{alias}`
+- `auto_submit` `(boolean)` - Automatically submit the prompt to the LLM
+- `enabled` `(boolean)` - Enable/disable the prompt without removing it from the library
+- `ignore_system_prompt` `(boolean)` - Don’t send the default system prompt with the request
+- `intro_message` `(string)` - Custom intro message for the chat buffer UI
+- `is_slash_cmd` `(boolean)` - Make the prompt available as a slash command in chat
+- `is_workflow` `(boolean)` - Treat successive prompts as a workflow
+- `modes` `(array)` - Only show in specific modes (`{ "v" }` for visual mode)
+- `placement` `(string)` - For inline interaction: `new`, `replace`, `add`, `before`, `chat`
+- `pre_hook` `(function)` - Function to run before the prompt is executed (Lua only)
+- `stop_context_insertion` `(boolean)` - Prevent automatic context insertion
+- `user_prompt` `(string)` - Get user input before actioning the response
 
 
 WITH PLACEHOLDERS

--- a/doc/configuration/prompt-library.md
+++ b/doc/configuration/prompt-library.md
@@ -234,17 +234,18 @@ opts = {
 
 :::
 
-- `alias` - Allows the prompt to be triggered via `:CodeCompanion /{alias}`
-- `auto_submit` - Automatically submit the prompt to the LLM
-- `ignore_system_prompt` - Don't send the default system prompt with the request
-- `intro_message` - Custom intro message for the chat buffer UI
-- `is_slash_cmd` - Make the prompt available as a slash command in chat
-- `is_workflow` - Treat successive prompts as a workflow
-- `modes` - Only show in specific modes (`{ "v" }` for visual mode)
-- `placement` - For inline interaction: `new`, `replace`, `add`, `before`, `chat`
-- `pre_hook` - Function to run before the prompt is executed (Lua only)
-- `stop_context_insertion` - Prevent automatic context insertion
-- `user_prompt` - Get user input before actioning the response
+- `alias` _(string)_ - Allows the prompt to be triggered via `:CodeCompanion /{alias}`
+- `auto_submit` _(boolean)_ - Automatically submit the prompt to the LLM
+- `enabled` _(boolean)_ - Enable/disable the prompt without removing it from the library
+- `ignore_system_prompt` _(boolean)_ - Don't send the default system prompt with the request
+- `intro_message` _(string)_ - Custom intro message for the chat buffer UI
+- `is_slash_cmd` _(boolean)_ - Make the prompt available as a slash command in chat
+- `is_workflow` _(boolean)_ - Treat successive prompts as a workflow
+- `modes` _(array)_ - Only show in specific modes (`{ "v" }` for visual mode)
+- `placement` _(string)_ - For inline interaction: `new`, `replace`, `add`, `before`, `chat`
+- `pre_hook` _(function)_ - Function to run before the prompt is executed (Lua only)
+- `stop_context_insertion` _(boolean)_  - Prevent automatic context insertion
+- `user_prompt` _(string)_ - Get user input before actioning the response
 
 ### With Placeholders
 

--- a/lua/codecompanion/actions/builtins/upgrades/tools.md
+++ b/lua/codecompanion/actions/builtins/upgrades/tools.md
@@ -1,7 +1,7 @@
 ---
 name: Upgrade Tools
 interaction: chat
-description: Upgrade Tools from v19 to v20
+description: Upgrade Tools from v18 to v19
 opts:
   is_slash_cmd: false
   stop_context_insertion: true


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I have some test prompts that I don't want to always show in the action palette. Adding an `enabled` option.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
