### PR TITLE
refactor(tools): use `meta.id` instead of `opts.id`

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -861,7 +861,7 @@ end
 
 ---Set the system prompt in the chat buffer
 ---@param prompt? string
----@param opts? {opts: table, _meta: table, index?: number}
+---@param opts? {opts: table, _meta: table}
 ---@return CodeCompanion.Chat
 function Chat:set_system_prompt(prompt, opts)
   if self.opts and self.opts.ignore_system_prompt then
@@ -883,11 +883,10 @@ function Chat:set_system_prompt(prompt, opts)
   end
 
   -- Workout in the message stack the last system prompt is
-  local index
-  if not opts.index then
+  if not _meta.index then
     for i = #self.messages, 1, -1 do
       if self.messages[i].role == config.constants.SYSTEM_ROLE then
-        index = i + 1
+        _meta.index = i + 1
         break
       end
     end
@@ -906,10 +905,10 @@ function Chat:set_system_prompt(prompt, opts)
 
     _meta.cycle = self.cycle
     _meta.id = make_id(system_prompt)
-    _meta.index = #self.messages + 1
+    _meta.index = _meta.index or 1
     system_prompt._meta = _meta
 
-    table.insert(self.messages, index or opts.index or 1, system_prompt)
+    table.insert(self.messages, _meta.index, system_prompt)
   end
 
   return self
@@ -984,11 +983,11 @@ function Chat:add_message(data, opts)
 
   message.opts = opts
   message._meta.id = make_id(message)
-  message._meta.index = #self.messages + 1
 
-  if opts.index then
-    table.insert(self.messages, opts.index, message)
+  if message._meta.index then
+    table.insert(self.messages, message._meta.index, message)
   else
+    message._meta.index = #self.messages + 1
     table.insert(self.messages, message)
   end
 

--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -205,7 +205,7 @@ function ToolRegistry:add_tool_system_prompt()
     self.chat:remove_tagged_message("system_prompt_from_config")
   end
 
-  self.chat:set_system_prompt(prompt, { index = index, visible = false, _meta = { tag = "tool_system_prompt" } })
+  self.chat:set_system_prompt(prompt, { visible = false, _meta = { tag = "tool_system_prompt", index = index } })
 end
 
 ---Determine if the chat buffer has any tools in use

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -83,7 +83,6 @@
 ---@field tools.calls? CodeCompanion.Chat.ToolCall[] Array of tool calls
 ---@field tools.id? string Tool ID
 ---@field opts? table Optional metadata used by the UI and processing
----@field opts.index? number If set, the message was inserted at this index
 ---@field opts.sync_all? boolean When synced, whether the entire buffer is shared
 ---@field opts.sync_diff? boolean When synced, whether only buffer diffs are shared
 ---@field opts.visible? boolean Whether the message should be shown in the chat UI


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I noticed whilst testing tools that some messages in the chat buffer still had `opts.id` instead of `meta.id`. This PR refactors that.

## AI Usage

Auggie and Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
