### PR TITLE
feat: pass context to chat interaction when prompt is function

### DIFF
--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -87,7 +87,7 @@ function Interactions:chat()
   local prompts = self.selected.prompts
 
   if type(prompts[mode]) == "function" then
-    return prompts[mode]()
+    return prompts[mode](self.buffer_context)
   elseif type(prompts[mode]) == "table" then
     messages = self.evaluate_prompts(prompts[mode], self.buffer_context)
   else


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As title. Prompts in function are just useful to conditionally set configurations like adapter changes or call a tool (like attaching the current file)

```lua
prompts = function(context)
    local chat = codecompanion.chat({
        auto_submit = false,
        messages = { ... },
    })
    if chat then
        local file = require("codecompanion.interactions.chat.slash_commands.builtin.file").new({ Chat = chat, })
        file:output({ path = context.filename })
    end
    return chat
end
```
<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
