### PR TITLE
Fix/duplicate editor context

### DIFF
--- a/lua/codecompanion/interactions/chat/context.lua
+++ b/lua/codecompanion/interactions/chat/context.lua
@@ -152,6 +152,16 @@ function Context:add(context)
     if context.opts.visible == nil then
       context.opts.visible = config.display.chat.show_context
     end
+
+    -- Prevent duplicate context items with the same id
+    if context.id then
+      for _, existing in ipairs(self.Chat.context_items) do
+        if existing.id == context.id then
+          return self
+        end
+      end
+    end
+
     table.insert(self.Chat.context_items, context)
     if context.bufnr and context.opts.sync_diff then
       self.Chat.buffer_diffs:sync(context.bufnr)

--- a/tests/interactions/chat/test_context.lua
+++ b/tests/interactions/chat/test_context.lua
@@ -46,6 +46,23 @@ T["Context"]["Can be added to the UI of the chat buffer"] = function()
   h.eq("> - testing again", lines[5])
 end
 
+T["Context"]["Cannot be added twice with the same id"] = function()
+  child.lua([[
+    _G.chat.context:add({
+      source = "test",
+      name = "test",
+      id = "<buf>test.lua</buf>",
+    })
+    _G.chat.context:add({
+      source = "test",
+      name = "test",
+      id = "<buf>test.lua</buf>",
+    })
+  ]])
+
+  h.eq(1, child.lua_get([[#_G.chat.context_items]]), "Should only have 1 context item")
+end
+
 T["Context"]["Can be deleted"] = function()
   child.lua([[
     -- Add context_items
@@ -166,7 +183,7 @@ T["Context"]["Can share all of a buffer"] = function()
        },
      })
      _G.chat.context:add({
-       id = "<buf>sync_all example</buf>",
+       id = "<buf>sync_all example2</buf>",
        path = "test2",
        source = "test",
      })
@@ -184,7 +201,7 @@ T["Context"]["Can share all of a buffer"] = function()
          role = "user",
          content = "sync_all context",
          context = {
-           id = "<buf>sync_all example</buf>",
+           id = "<buf>sync_all example2</buf>",
          },
        },
      }
@@ -219,7 +236,7 @@ T["Context"]["Can share all of a buffer"] = function()
     string.format("> - %s<buf>sync_all example</buf>", child.lua_get([[config.display.chat.icons.buffer_sync_all]])),
     buffer[16]
   )
-  h.eq("> - <buf>sync_all example</buf>", buffer[17])
+  h.eq("> - <buf>sync_all example2</buf>", buffer[17])
 
   h.eq({
     {
@@ -233,7 +250,7 @@ T["Context"]["Can share all of a buffer"] = function()
       source = "tests.interactions.chat.slash_commands.basic",
     },
     {
-      id = "<buf>sync_all example</buf>",
+      id = "<buf>sync_all example2</buf>",
       opts = {
         sync_all = false,
         visible = true,


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Issue below quite rightly pointed out that it was possible to add the same editor context item twice. This PR fixes that.

## AI Usage

- Opus 4.6 to add the guard and I broke my rule and let it write the test as well!

## Related Issue(s)

#2770

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
