### PR TITLE
fix: prevent duplicate context items when add_group() or Context:add(…

### DIFF
--- a/lua/codecompanion/interactions/chat/context.lua
+++ b/lua/codecompanion/interactions/chat/context.lua
@@ -152,6 +152,17 @@ function Context:add(context)
     if context.opts.visible == nil then
       context.opts.visible = config.display.chat.show_context
     end
+
+    -- Refresh in place if a context item with the same id already exists
+    if context.id then
+      for i, existing in ipairs(self.Chat.context_items) do
+        if existing.id == context.id then
+          self.Chat.context_items[i] = context
+          return self
+        end
+      end
+    end
+
     table.insert(self.Chat.context_items, context)
     if context.bufnr and context.opts.sync_diff then
       self.Chat.buffer_diffs:sync(context.bufnr)

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1396,6 +1396,18 @@ function Chat:check_context()
       log:debug("Removing tool schema and usage flag for ID: %s", id) -- Optional logging
     end
   end
+
+  -- Preserve _group: keys for groups still in context
+  for _, ctx in ipairs(self.context_items) do
+    local group_name = ctx.id and ctx.id:match("<group>(.*)</group>")
+    if group_name then
+      local group_key = "_group:" .. group_name
+      if self.tool_registry.in_use[group_key] then
+        tools_in_use_to_keep[group_key] = true
+      end
+    end
+  end
+
   self.tool_registry.schemas = schemas_to_keep
   self.tool_registry.in_use = tools_in_use_to_keep
 end

--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -122,6 +122,13 @@ function ToolRegistry:add_group(group, tools_config)
     return
   end
 
+  -- Guard against duplicate group registration
+  local group_key = "_group:" .. group
+  if self.in_use[group_key] then
+    return
+  end
+  self.in_use[group_key] = true
+
   local opts = vim.tbl_deep_extend("force", { collapse_tools = true }, group_config.opts or {})
   local collapse_tools = opts.collapse_tools
 


### PR DESCRIPTION
…) is called multiple times

- Add in_use guard to ToolRegistry:add_group() using _group: prefixed keys to skip duplicate group registration (system prompt + context)
- Add id-based refresh-in-place to Context:add() so re-adding a context with the same id updates the existing entry instead of appending a duplicate
- Preserve _group: keys in Chat:check_context() when rebuilding in_use for groups that are still present in the chat buffer
- Add tests for deduplication, refresh-in-place, and group re-add after clear
- Fix existing test that relied on buggy duplicate-id behavior

<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

I am still not fimilar with the code everything was written by Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
