### PR TITLE
fix(chat): prevent tool groups being added twice.

### DIFF
--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -169,6 +169,10 @@ end
 function ToolRegistry:add_group(group, opts)
   opts = opts or {}
 
+  if self.groups[group] then
+    return nil
+  end
+
   local tools_config = opts.config or config.interactions.chat.tools
   local group_config = tools_config.groups[group]
   if not group_config or not group_config.tools then

--- a/tests/interactions/chat/tools/test_tool_registry.lua
+++ b/tests/interactions/chat/tools/test_tool_registry.lua
@@ -121,6 +121,22 @@ T["ToolRegistry"][":add_group"]["adds all tools in a group"] = function()
   h.expect_tbl_contains("cmd", registry)
 end
 
+T["ToolRegistry"][":add_group"]["does not add duplicate groups"] = function()
+  child.lua([[
+    _G.chat.tool_registry:add_group("tool_group")
+    _G.chat.tool_registry:add_group("tool_group")
+    _G.system_prompt_count = 0
+    for _, msg in ipairs(_G.chat.messages) do
+      if msg.context and msg.context.id == "<group>tool_group</group>" then
+        _G.system_prompt_count = _G.system_prompt_count + 1
+      end
+    end
+  ]])
+
+  h.eq(1, child.lua_get([[_G.system_prompt_count]]), "Group system prompt should only be added once")
+  h.eq(2, child.lua_get([[vim.tbl_count(_G.chat.tool_registry.in_use)]]), "Should still have 2 tools")
+end
+
 T["ToolRegistry"][":add_group"]["skips tools missing from config"] = function()
   child.lua([[
     _G.chat.tool_registry:add_group("senior_dev", {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Builds on #2771 to ensure that tool groups can't be added twice

## AI Usage

- Opis 4.6

## Related Issue(s)

#2771 and #2770

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
