### PR TITLE
feat(tools): fire an event when tool approval is requested

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -4631,6 +4631,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
+- `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
 - `CodeCompanionToolStarted` - Fired when a tool has started executing
 - `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -26,6 +26,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
+- `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
 - `CodeCompanionToolStarted` - Fired when a tool has started executing
 - `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -289,6 +289,12 @@ function Orchestrator:setup_next_tool(input)
 
     if require_approval_before then
       log:debug("[Orchestrator::setup_next_tool] Asking for approval")
+      utils.fire("ToolApprovalRequested", {
+        bufnr = self.tools.bufnr,
+        id = self.id,
+        name = self.tool.name,
+        args = self.tool.args,
+      })
 
       local prompt = self.output.prompt()
       if prompt == nil or prompt == "" then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fire an event when a tool is requesting approval to execute.

## AI Usage

None

## Related Issue(s)

#2781

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
