### PR TITLE
fix(docs): add missing details in the development required environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,8 @@ CodeCompanion.nvim is organized into several key directories:
 
 ### Prerequisites
 
-- Neovim 0.10.0+
+- Neovim 0.11.0+
+- [tree-sitter](https://github.com/tree-sitter/tree-sitter) for testing
 - [lua-language-server](https://github.com/LuaLS/lua-language-server) for LSP support and type annotations
 - [stylua](https://github.com/JohnnyMorganz/StyLua) for Lua formatting
 - [pandoc](https://pandoc.org) for doc generation


### PR DESCRIPTION
## Description

This change documents that tree-sitter CLI is needed to run the testing suite and updates the minimal Neovim required version to the minimum one in the CI matrix.

## AI Usage

None.

## Related Issue(s)

- https://github.com/olimorris/codecompanion.nvim/pull/2792
Suggested here.

## Screenshots

N/A

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [X] _(optional)_ I've updated the README and/or relevant docs pages
