### PR TITLE
fix(chat): editor context not displaying in the UI

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*        For NVIM v0.11        Last change: 2026 February 22
+*codecompanion.txt*        For NVIM v0.11        Last change: 2026 February 24
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -4212,16 +4212,16 @@ your chat, such as `#{buffer}`. Editor context is processed when you send your
 message to the LLM.
 
 
-  [!NOTE] With the exception of `#{buffer}`, editor context captures a
-  point-in-time snapshot when your message is sent. If the underlying data
-  changes (e.g.� new diagnostics, a different quickfix list), simply use the
+  [!IMPORTANT] With the exception of `#{buffer}` and `#{buffers}`, editor context
+  captures a point-in-time snapshot when your message is sent. If the underlying
+  data changes (e.g.� new diagnostics, a different quickfix list), simply use the
   context again in a new message to share the latest state.
 
 #BUFFER ~
 
 
-  [!IMPORTANT] By default, CodeCompanion automatically applies the `{diff}`
-  parameter to all buffers
+  [!NOTE] By default, CodeCompanion automatically applies the `{diff}` parameter
+  to all buffers
 The `#{buffer}` context shares buffer contents with the LLM. It has two special
 parameters which control how content is shared, or `synced`, with the LLM, on
 each turn:
@@ -4273,6 +4273,10 @@ with excluded buftypes (such as `nofile`, `quickfix`, `prompt`, `popup`) and
 filetypes (such as `codecompanion`, `help`, `terminal`) are automatically
 filtered out.
 
+>
+    #{buffers} can you explain what's going on in these files?
+<
+
 
 #DIAGNOSTICS ~
 
@@ -4283,12 +4287,20 @@ The `diagnostics` context shares any diagnostic information from LSP servers
 active in the current buffer. This can serve as useful context should you wish
 to troubleshoot any errors with an LLM.
 
+>
+    #{diagnostics} can you explain the LSP errors in this file and how to fix them?
+<
+
 
 #DIFF ~
 
 The `diff` context shares the current git diff with the LLM, including both
 staged and unstaged changes. This is useful for code review, generating commit
 messages, or asking for feedback on your recent changes.
+
+>
+    Sharing the latest git diff with you #{diff}
+<
 
 
 #MESSAGES ~
@@ -4297,20 +4309,34 @@ The `messages` context shares Neovim’s message history (`:messages`) with the
 LLM. This is useful when an error has been written to the message history and
 you want to share it with the LLM for troubleshooting.
 
+>
+    Can you explain the error I've just observed in Neovim? #{messages}
+<
+
 
 #QUICKFIX ~
 
 The `quickfix` context shares the contents of the quickfix list with the LLM.
-Files with diagnostics are formatted with smart grouping by TreeSitter symbols,
-while file-only entries show the full content. This is useful for sharing
-compiler errors, search results, or LSP diagnostics across multiple files.
+Files with diagnostics are formatted with smart grouping by Tree-sitter
+symbols, while file-only entries show the full content. This is useful for
+sharing compiler errors, search results, or LSP diagnostics across multiple
+files.
+
+>
+    The relevant output from my quickfix list has now been shared with you #{quickfix}
+<
 
 
 #SELECTION ~
 
 The `selection` context shares your current or most recent visual selection
 with the LLM. This is useful for asking about a specific piece of code without
-sharing the entire buffer.
+sharing the entire buffer. The selection is updated when you open or toggle a
+CodeCompanion chat buffer.
+
+>
+    Sharing the relevant code with you #{selection}
+<
 
 
 #TERMINAL ~
@@ -4320,11 +4346,19 @@ you entered. Subsequent uses capture only new output since the last time it was
 shared. This is useful for sharing test results, build output, or command-line
 errors.
 
+>
+    This was the output in my terminal #{terminal}
+<
+
 
 #VIEWPORT ~
 
 The `viewport` context shares with the LLM, exactly what you see on your screen
 at the point a response is sent (excluding the chat buffer of course).
+
+>
+    Sharing what I can see in Neovim #{viewport}
+<
 
 
 RULES                                              *codecompanion-usage-rules*

--- a/doc/usage/chat-buffer/editor-context.md
+++ b/doc/usage/chat-buffer/editor-context.md
@@ -16,12 +16,12 @@ Custom context can be shared in the chat buffer by adding them to the `interacti
 
 Editor context uses the `#{context}` syntax to dynamically insert content into your chat, such as `#{buffer}`. Editor context is processed when you send your message to the LLM.
 
-> [!NOTE]
-> With the exception of `#{buffer}`, editor context captures a point-in-time snapshot when your message is sent. If the underlying data changes (e.g. new diagnostics, a different quickfix list), simply use the context again in a new message to share the latest state.
+> [!IMPORTANT]
+> With the exception of `#{buffer}` and `#{buffers}`, editor context captures a point-in-time snapshot when your message is sent. If the underlying data changes (e.g. new diagnostics, a different quickfix list), simply use the context again in a new message to share the latest state.
 
 ## #buffer
 
-> [!IMPORTANT]
+> [!NOTE]
 > By default, CodeCompanion automatically applies the `{diff}` parameter to all buffers
 
 The `#{buffer}` context shares buffer contents with the LLM. It has two special parameters which control how content is shared, or _synced_, with the LLM, on each turn:
@@ -61,6 +61,10 @@ Compare #{buffer:old_file.js} with #{buffer:new_file.js} and explain the differe
 
 The _buffers_ context shares all currently open buffers with the LLM. Buffers with excluded buftypes (such as `nofile`, `quickfix`, `prompt`, `popup`) and filetypes (such as `codecompanion`, `help`, `terminal`) are automatically filtered out.
 
+```
+#{buffers} can you explain what's going on in these files?
+```
+
 ## #diagnostics
 
 > [!TIP]
@@ -68,26 +72,55 @@ The _buffers_ context shares all currently open buffers with the LLM. Buffers wi
 
 The _diagnostics_ context shares any diagnostic information from LSP servers active in the current buffer. This can serve as useful context should you wish to troubleshoot any errors with an LLM.
 
+```
+#{diagnostics} can you explain the LSP errors in this file and how to fix them?
+```
+
 ## #diff
 
 The _diff_ context shares the current git diff with the LLM, including both staged and unstaged changes. This is useful for code review, generating commit messages, or asking for feedback on your recent changes.
+
+```
+Sharing the latest git diff with you #{diff}
+```
 
 ## #messages
 
 The _messages_ context shares Neovim's message history (`:messages`) with the LLM. This is useful when an error has been written to the message history and you want to share it with the LLM for troubleshooting.
 
+```
+Can you explain the error I've just observed in Neovim? #{messages}
+```
+
 ## #quickfix
 
-The _quickfix_ context shares the contents of the quickfix list with the LLM. Files with diagnostics are formatted with smart grouping by TreeSitter symbols, while file-only entries show the full content. This is useful for sharing compiler errors, search results, or LSP diagnostics across multiple files.
+The _quickfix_ context shares the contents of the quickfix list with the LLM. Files with diagnostics are formatted with smart grouping by Tree-sitter symbols, while file-only entries show the full content. This is useful for sharing compiler errors, search results, or LSP diagnostics across multiple files.
+
+```
+The relevant output from my quickfix list has now been shared with you #{quickfix}
+```
 
 ## #selection
 
-The _selection_ context shares your current or most recent visual selection with the LLM. This is useful for asking about a specific piece of code without sharing the entire buffer.
+The _selection_ context shares your current or most recent visual selection with the LLM. This is useful for asking about a specific piece of code without sharing the entire buffer. The selection is updated when you open or toggle a CodeCompanion chat buffer.
+
+```
+Sharing the relevant code with you #{selection}
+```
 
 ## #terminal
 
 The _terminal_ context shares the latest output from the last terminal buffer you entered. Subsequent uses capture only new output since the last time it was shared. This is useful for sharing test results, build output, or command-line errors.
 
+```
+This was the output in my terminal #{terminal}
+```
+
 ## #viewport
 
 The _viewport_ context shares with the LLM, exactly what you see on your screen at the point a response is sent (excluding the chat buffer of course).
+
+```
+Sharing what I can see in Neovim #{viewport}
+```
+

--- a/lua/codecompanion/interactions/chat/editor_context/buffers.lua
+++ b/lua/codecompanion/interactions/chat/editor_context/buffers.lua
@@ -53,7 +53,7 @@ function EditorContext:apply()
 
   for _, buf_info in ipairs(buffers) do
     if not self:_is_excluded(buf_info.bufnr) then
-      local ok, content, _, _ = pcall(
+      local ok, content, id, _ = pcall(
         chat_helpers.format_buffer_for_llm,
         buf_info.bufnr,
         buf_info.path,
@@ -66,9 +66,16 @@ function EditorContext:apply()
           content = content,
         }, {
           _meta = { source = "editor_context", tag = "buffer" },
-          context = { path = buf_info.path },
+          context = { id = id, path = buf_info.path },
           visible = false,
         })
+
+        self.Chat.context:add({
+          bufnr = buf_info.bufnr,
+          id = id,
+          source = "codecompanion.interactions.chat.editor_context.buffers",
+        })
+
         count = count + 1
       end
     end

--- a/lua/codecompanion/interactions/chat/editor_context/diagnostics.lua
+++ b/lua/codecompanion/interactions/chat/editor_context/diagnostics.lua
@@ -44,6 +44,7 @@ function EditorContext:apply()
   }
 
   local bufnr = self:_resolve_bufnr()
+  local buf_info = buf_utils.get_info(bufnr)
 
   local diagnostics = vim.diagnostic.get(bufnr, {
     severity = { min = vim.diagnostic.severity.HINT },
@@ -67,8 +68,7 @@ function EditorContext:apply()
     table.insert(
       formatted,
       string.format(
-        [[
-Severity: %s
+        [[Severity: %s
 LSP Message: %s
 Code:
 ````%s
@@ -77,15 +77,17 @@ Code:
 ]],
         severity[diagnostic.severity],
         diagnostic.message,
-        self.Chat.buffer_context.filetype,
+        buf_info.filetype,
         table.concat(diagnostic.lines, "\n")
       )
     )
   end
 
+  local content = string.format("Diagnostics for `%s`:\n\n%s", buf_info.path, table.concat(formatted, "\n\n"))
+
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
-    content = table.concat(formatted, "\n\n"),
+    content = content,
   }, { _meta = { source = "editor_context", tag = "diagnostics" }, visible = false })
 end
 

--- a/lua/codecompanion/interactions/chat/editor_context/quickfix.lua
+++ b/lua/codecompanion/interactions/chat/editor_context/quickfix.lua
@@ -77,7 +77,7 @@ local function group_entries_by_file(entries)
   return files
 end
 
----Extract symbols from a file using TreeSitter
+---Extract symbols from a file using Tree-sitter
 ---@param path string Path to the file
 ---@return table[]|nil symbols Array of symbols with start_line, end_line, name, kind
 ---@return string|nil content File content if successful

--- a/lua/codecompanion/interactions/chat/editor_context/viewport.lua
+++ b/lua/codecompanion/interactions/chat/editor_context/viewport.lua
@@ -27,13 +27,12 @@ function EditorContext:apply()
   local count = 0
   for bufnr, ranges in pairs(buf_lines) do
     for _, range in ipairs(ranges) do
-      local content, id = chat_helpers.format_viewport_range_for_llm(bufnr, range)
+      local content = chat_helpers.format_viewport_range_for_llm(bufnr, range)
       self.Chat:add_message({
         role = config.constants.USER_ROLE,
         content = content,
       }, {
         _meta = { source = "editor_context", tag = "viewport" },
-        context = { id = id },
         visible = false,
       })
       count = count + 1

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -328,6 +328,13 @@ return {
             has_params = true,
           },
         },
+        ["buffers"] = {
+          path = "interactions.chat.editor_context.buffers",
+          description = "Share all open buffers with the LLM",
+          opts = {
+            contains_code = true,
+          },
+        },
         ["foo"] = {
           path = "tests.interactions.chat.editor_context.foo",
           description = "foo",


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I noticed that the `#{buffers}` editor context wasn't adding all of the buffers into the context element in the chat buffer. This PR also streamlines the other editor context elements, ensuring that filepaths are shared etc.

## AI Usage

- Opus 4.6 to read across all editor context and ensure they're uniform.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
