### PR TITLE
tests: improve acp test_handler

### DIFF
--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -6,11 +6,12 @@ local T = new_set()
 local child = MiniTest.new_child_neovim()
 T = new_set({
   hooks = {
-    pre_case = function()
+    pre_once = function()
       h.child_start(child)
+      child.lua([[h = require('tests.helpers')]])
+    end,
+    pre_case = function()
       child.lua([[
-        h = require('tests.helpers')
-
         -- Mock ACP connection for chat integration tests
         _G.mock_acp_connection = {
           connected = false,
@@ -87,6 +88,16 @@ T = new_set({
       child.lua([[
         _G.mock_acp_connection = nil
         _G.last_prompt_request = nil
+        _G.last_permission_request = nil
+        _G.codecompanion_chat_metadata = nil
+
+        -- Reset modules that tests may have overridden
+        package.loaded["codecompanion.acp"] = nil
+        package.loaded["codecompanion.interactions.chat.acp.request_permission"] = nil
+        package.loaded["codecompanion.interactions.chat.acp.handler"] = nil
+        package.loaded["codecompanion.interactions.chat.acp.commands"] = nil
+        package.loaded["codecompanion.interactions.chat"] = nil
+        package.loaded["codecompanion.config"] = nil
       ]])
     end,
     post_once = child.stop,


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR improves the time it takes to execute this test by c. 2 seconds.

## AI Usage

Opus 4.6 to refactor the test

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
