### PR TITLE
fix(actions): fix "Chat with rules" action calling undefined Rules.init()

### DIFF
--- a/lua/codecompanion/actions/static.lua
+++ b/lua/codecompanion/actions/static.lua
@@ -103,13 +103,13 @@ return {
                 callbacks = {
                   on_created = function(chat)
                     rules
-                      .init({
+                      .new({
                         name = item.name,
                         files = item.files,
                         opts = item.opts,
                         parser = item.parser,
                       })
-                      :make(chat)
+                      :make({ chat = chat })
                   end,
                 },
               })


### PR DESCRIPTION
## Summary

- The "Chat with rules" action in the Action Palette silently fails because `static.lua` calls `rules.init()` and `:make(chat)`, but these were renamed to `Rules.new()` and `:make({ chat = chat })` in `1b23363` without updating the call site in `actions/static.lua`.
- The error is swallowed by `pcall` in `Chat:dispatch()`, so no error is shown to the user — rules just silently don't load.

## Root cause

In commit `1b23363` (`feat(chat): rules path can be dirs and glob patterns #2509`), `rules/init.lua` was rewritten:
- `Rules.init()` → `Rules.new()`
- `Rules:make(chat)` → `Rules:make(args)` (expects `args.chat`)

But the call site in `lua/codecompanion/actions/static.lua` was not updated, so it still calls the old signatures.

The autoload path in `helpers.lua` is unaffected because it uses `add_to_chat_from_config`.

## Fix

```diff
-                    rules
-                      .init({
+                    rules
+                      .new({
                         name = item.name,
                         files = item.files,
                         opts = item.opts,
                         parser = item.parser,
                       })
-                      :make(chat)
+                      :make({ chat = chat })
```

## Test plan

- [ ] Open Neovim, run `:CodeCompanionActions`, select "Chat with rules ...", pick a rule group
- [ ] Press `gd` in the chat buffer — rule content should now appear in the messages
- [ ] Verify autoloaded rules still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)