### PR TITLE
fix(prompts): prevent duplicate prompts in action palette

### DIFF
--- a/lua/codecompanion/actions/prompt_library.lua
+++ b/lua/codecompanion/actions/prompt_library.lua
@@ -7,6 +7,7 @@ local _prompts = {}
 ---@param config table
 ---@return table
 function M.resolve(context, config)
+  _prompts = {}
   local sort_index = true
 
   for name, prompt in pairs(config.prompt_library) do


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Prevent duplicate prompts from appearing in the action palette.

## AI Usage

None

## Related Issue(s)

#2816

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
