### PR TITLE
fix(openai_compatible): make sure the system message is always first

### DIFF
--- a/lua/codecompanion/adapters/http/openai_compatible.lua
+++ b/lua/codecompanion/adapters/http/openai_compatible.lua
@@ -121,7 +121,35 @@ return {
       return openai.handlers.form_parameters(self, params, messages)
     end,
     form_messages = function(self, messages)
-      return openai.handlers.form_messages(self, messages)
+      local system_content = {}
+      local other_messages = {}
+
+      -- 1. Separate system messages from everything else
+      for _, msg in ipairs(messages) do
+        if msg.role == "system" then
+          table.insert(system_content, msg.content)
+        else
+          table.insert(other_messages, msg)
+        end
+      end
+
+      local final_messages = {}
+
+      -- 2. If there are system messages, merge them into ONE message at the top
+      if #system_content > 0 then
+        table.insert(final_messages, {
+          role = "system",
+          content = table.concat(system_content, "\n\n"),
+        })
+      end
+
+      -- 3. Append all the user/assistant messages
+      for _, msg in ipairs(other_messages) do
+        table.insert(final_messages, msg)
+      end
+
+      -- 4. Pass the cleaned messages to the standard OpenAI handler
+      return openai.handlers.form_messages(self, final_messages)
     end,
     form_tools = function(self, tools)
       return openai.handlers.form_tools(self, tools)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

this pr makes sure the system message is first,  some models like qwen3 used with llama.cpp enforces this

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

i used gemini3 pro

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

I opened a discussion about this, debugging this I realized reading the openai_compatible file that it is not supported, so if you decide to close this i've no concerns.

https://github.com/olimorris/codecompanion.nvim/discussions/2827

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
yep this errors out, but also in main
```
Formatting...
error: Config file not in correct format: TOML parse error at line 7, column 10
  |
7 | syntax = "Lua52"
  |          ^^^^^^^
unknown variant `Lua52`, expected `All` or `Lua51`

make: *** [Makefile:25: format] Error 2
  ~/c/codecompanion.nvim on   main ❯     
```
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
