### PR TITLE
fix(docs): using the correct adapters key

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -599,7 +599,7 @@ ADAPTERS ~
 <
 
 - The default adapters on the **Anthropic** and **Gemini** adapters have changed to `claude-sonnet-4-5-20250929` and `gemini-3-pro-preview`, respectively (#2494 <https://github.com/olimorris/codecompanion.nvim/pull/2494>)
-- If you wish to hide the adapters that come with CodeCompanion, `adapter.[acp|http].opts.show_defaults` has been renamed to `adapter.[acp|http].opts.show_presets` for both HTTP and ACP adapters (#2497 <https://github.com/olimorris/codecompanion.nvim/pull/2497>)
+- If you wish to hide the adapters that come with CodeCompanion, `adapters.[acp|http].opts.show_defaults` has been renamed to `adapters.[acp|http].opts.show_presets` for both HTTP and ACP adapters (#2497 <https://github.com/olimorris/codecompanion.nvim/pull/2497>)
 
 
 CHAT ~

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -67,7 +67,7 @@ return {
 ```
 
 - The default adapters on the **Anthropic** and **Gemini** adapters have changed to `claude-sonnet-4-5-20250929` and `gemini-3-pro-preview`, respectively ([#2494](https://github.com/olimorris/codecompanion.nvim/pull/2494))
-- If you wish to hide the adapters that come with CodeCompanion, `adapter.[acp|http].opts.show_defaults` has been renamed to `adapter.[acp|http].opts.show_presets` for both HTTP and ACP adapters ([#2497](https://github.com/olimorris/codecompanion.nvim/pull/2497))
+- If you wish to hide the adapters that come with CodeCompanion, `adapters.[acp|http].opts.show_defaults` has been renamed to `adapters.[acp|http].opts.show_presets` for both HTTP and ACP adapters ([#2497](https://github.com/olimorris/codecompanion.nvim/pull/2497))
 
 ### Chat
 


### PR DESCRIPTION
## Description

This PR corrects a documentation typo in both `doc/codecompanion.txt` and `doc/upgrading.md`.  
Specifically, it updates references from `adapter.[acp|http].opts.show_defaults` to `adapters.[acp|http].opts.show_defaults` and likewise for `show_presets`, ensuring consistency with the actual configuration structure.  
This change helps users avoid confusion when configuring or upgrading their CodeCompanion setup.

## AI Usage

I used CodeCompanion to review the documentation and confirm the correct configuration key names.  
No generative AI models were used for writing this PR.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
