### PR TITLE
feat(chat): provide ctx arg to tool system prompt

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 02
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 03
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -3170,7 +3170,7 @@ There are additional options available when working with tool system prompts:
                 replace_main_system_prompt = false, -- Replace the main system prompt with the tools system prompt?
     
                 ---The tool system prompt
-                ---@param args { tools: string[]} The tools available
+                ---@param args { ctx: CodeCompanion.SystemPrompt.Context, tools: string[]} The tools available
                 ---@return string
                 prompt = function(args)
                   return "My custom tools prompt"

--- a/doc/configuration/system-prompt.md
+++ b/doc/configuration/system-prompt.md
@@ -180,7 +180,7 @@ require("codecompanion").setup({
             replace_main_system_prompt = false, -- Replace the main system prompt with the tools system prompt?
 
             ---The tool system prompt
-            ---@param args { tools: string[]} The tools available
+            ---@param args { ctx: CodeCompanion.SystemPrompt.Context, tools: string[]} The tools available
             ---@return string
             prompt = function(args)
               return "My custom tools prompt"

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -313,7 +313,7 @@ The user is working on a %s machine. Please respond with system specific command
             replace_main_system_prompt = false, -- Replace the main system prompt with the tools system prompt?
 
             ---The tool system prompt
-            ---@param args { tools: string[]} The tools available
+            ---@param args { ctx: CodeCompanion.SystemPrompt.Context, tools: string[]} The tools available
             ---@return string
             prompt = function(args)
               return [[<instructions>

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -534,7 +534,10 @@ function Chat.new(args)
     bufnr = self.bufnr,
     messages = self.messages,
   })
-  self.tool_registry = require("codecompanion.interactions.chat.tool_registry").new({ chat = self })
+  self.tool_registry = require("codecompanion.interactions.chat.tool_registry").new({
+    chat = self,
+    ctx = self:make_system_prompt_context(),
+  })
 
   self.ui = require("codecompanion.interactions.chat.ui").new({
     adapter = self.adapter,

--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -4,6 +4,7 @@ Methods for handling interactions between the chat buffer and tools
 
 ---@class CodeCompanion.Chat.ToolRegistry
 ---@field chat CodeCompanion.Chat
+---@field ctx CodeCompanion.SystemPrompt.Context The context for the system prompt
 ---@field flags table Flags that external functions can update and subscribers can interact with
 ---@field groups table<string, string[]> Groups and their member tool names
 ---@field in_use table<string, boolean> Tools that are in use on the chat buffer
@@ -33,11 +34,13 @@ end
 
 ---@class CodeCompanion.Chat.ToolsArgs
 ---@field chat CodeCompanion.Chat
+---@field ctx CodeCompanion.SystemPrompt.Context
 
 ---@param args CodeCompanion.Chat.ToolsArgs
 function ToolRegistry.new(args)
   local self = setmetatable({
     chat = args.chat,
+    ctx = args.ctx,
     flags = {},
     groups = {},
     in_use = {},
@@ -236,7 +239,7 @@ function ToolRegistry:add_tool_system_prompt()
 
   local prompt = opts.prompt
   if type(prompt) == "function" then
-    prompt = prompt({ tools = vim.tbl_keys(self.in_use) })
+    prompt = prompt({ ctx = self.ctx, tools = vim.tbl_keys(self.in_use) })
   end
 
   local index = 2 -- Add after the main system prompt if not replacing

--- a/tests/interactions/chat/tools/test_tool_registry.lua
+++ b/tests/interactions/chat/tools/test_tool_registry.lua
@@ -371,4 +371,99 @@ T["ToolRegistry"][":add_group"]["ignore_tool_system_prompt is restored on remove
   h.eq(vim.NIL, child.lua_get([[_G.chat.tool_registry.flags.ignore_tool_system_prompt]]))
 end
 
+T["ToolRegistry"]["ctx"] = new_set()
+
+T["ToolRegistry"]["ctx"]["is stored on the registry"] = function()
+  local ctx = child.lua_get([[_G.chat.tool_registry.ctx]])
+
+  h.not_eq(vim.NIL, ctx)
+  h.not_eq(nil, ctx)
+end
+
+T["ToolRegistry"]["ctx"]["contains system prompt context fields"] = function()
+  local ctx = child.lua_get([[_G.chat.tool_registry.ctx]])
+
+  -- Static fields are directly accessible
+  h.not_eq(nil, ctx.nvim_version)
+  -- Dynamic fields (os, adapter) use metatables and are not serialized by child.lua_get
+  -- but nvim_version is a static field that should be present
+  local expected_version =
+    child.lua_get([[vim.version().major .. "." .. vim.version().minor .. "." .. vim.version().patch]])
+  h.eq(expected_version, ctx.nvim_version)
+end
+
+T["ToolRegistry"]["ctx"]["is passed to tool system prompt function"] = function()
+  child.lua([[
+    local config_module = require("codecompanion.config")
+    local test_config = vim.deepcopy(require("tests.config"))
+    test_config.interactions.chat.tools.opts.system_prompt = {
+      enabled = true,
+      replace_main_system_prompt = false,
+      prompt = function(args)
+        _G.captured_args = args
+        return "tool system prompt"
+      end,
+    }
+    config_module.setup(test_config)
+
+    _G.chat2, _ = require("tests.helpers").setup_chat_buffer(test_config)
+    _G.chat2.tool_registry:add_single_tool("func")
+  ]])
+
+  local captured = child.lua_get([[_G.captured_args]])
+  h.not_eq(vim.NIL, captured)
+  h.not_eq(nil, captured.ctx)
+  h.not_eq(nil, captured.tools)
+end
+
+T["ToolRegistry"]["ctx"]["ctx passed to tool system prompt has correct fields"] = function()
+  child.lua([[
+    local config_module = require("codecompanion.config")
+    local test_config = vim.deepcopy(require("tests.config"))
+    test_config.interactions.chat.tools.opts.system_prompt = {
+      enabled = true,
+      replace_main_system_prompt = false,
+      prompt = function(args)
+        _G.captured_ctx = args.ctx
+        return "tool system prompt"
+      end,
+    }
+    config_module.setup(test_config)
+
+    _G.chat3, _ = require("tests.helpers").setup_chat_buffer(test_config)
+    _G.chat3.tool_registry:add_single_tool("func")
+  ]])
+
+  local nvim_version =
+    child.lua_get([[vim.version().major .. "." .. vim.version().minor .. "." .. vim.version().patch]])
+  local captured_ctx = child.lua_get([[_G.captured_ctx]])
+  h.eq(nvim_version, captured_ctx.nvim_version)
+end
+
+T["ToolRegistry"]["ctx"]["tools list is passed alongside ctx"] = function()
+  child.lua([[
+    local config_module = require("codecompanion.config")
+    local test_config = vim.deepcopy(require("tests.config"))
+    test_config.interactions.chat.tools.opts.system_prompt = {
+      enabled = true,
+      replace_main_system_prompt = false,
+      prompt = function(args)
+        _G.captured_tools = args.tools
+        return "tool system prompt"
+      end,
+    }
+    config_module.setup(test_config)
+
+    _G.chat4, _ = require("tests.helpers").setup_chat_buffer(test_config)
+    _G.chat4.tool_registry:add_single_tool("func")
+    -- Add a second tool so that prompt is called again with func already in in_use
+    _G.chat4.tool_registry:add_single_tool("weather")
+  ]])
+
+  local captured_tools = child.lua_get([[_G.captured_tools]])
+  h.not_eq(vim.NIL, captured_tools)
+  -- After adding weather, prompt is called with func already in in_use
+  h.expect_tbl_contains("func", captured_tools)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR adds `ctx: CodeCompanion.SystemPrompt.Context` arg to tool system prompt callback.

Rationale: agent-like instructions may depend not just on list of active tools, but also on used model.
Example: Copilot uses extra agent-like instructions for GPT models, and this actually makes a difference!

NOTE: This param is already provided to `interactions.chat.tools.groups.*.system_prompt`, so adding it will improve overall consistency too.

## AI Usage

Claude Sonnet 4.6 added a test suite.

## Related Issue(s)

This change was discussed and approved in #2821.

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
