### PR TITLE
fix(chat): ensure added tool included in tool system prompt arg

### DIFF
--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -144,6 +144,7 @@ function ToolRegistry:add_single_tool(tool, opts)
         },
       },
     }, id)
+    self.in_use[tool] = true
   else
     local resolved_tool = self.chat.tools.resolve(tool_config)
     if not resolved_tool then
@@ -153,11 +154,11 @@ function ToolRegistry:add_single_tool(tool, opts)
     add_context(self.chat, id, opts)
     add_system_prompt(self.chat, resolved_tool, id)
     add_schema(self, resolved_tool, id)
+    self.in_use[tool] = true
     self:add_tool_system_prompt()
   end
 
   utils.fire("ChatToolAdded", { bufnr = self.chat.bufnr, id = self.chat.id, tool = tool })
-  self.in_use[tool] = true
 
   return self
 end

--- a/tests/interactions/chat/tools/test_tool_registry.lua
+++ b/tests/interactions/chat/tools/test_tool_registry.lua
@@ -172,6 +172,35 @@ T["ToolRegistry"][":add_group"]["adds group system prompt"] = function()
   h.eq(true, child.lua_get([[_G.has_system_prompt]]))
 end
 
+T["ToolRegistry"]["add_tool_system_prompt"] = new_set()
+
+T["ToolRegistry"]["add_tool_system_prompt"]["receives the added tool in its argument"] = function()
+  child.lua([[
+    _G.chat2, _G.tools2 = h.setup_chat_buffer({
+      interactions = {
+        chat = {
+          tools = {
+            opts = {
+              system_prompt = {
+                enabled = true,
+                replace_main_system_prompt = false,
+                prompt = function(args)
+                  _G.prompt_tools_arg = vim.deepcopy(args.tools)
+                  return "tool system prompt"
+                end,
+              },
+            },
+          },
+        },
+      },
+    })
+    _G.chat2.tool_registry:add_single_tool("func")
+  ]])
+
+  local prompt_tools_arg = child.lua_get([[_G.prompt_tools_arg]])
+  h.expect_tbl_contains("func", prompt_tools_arg)
+end
+
 T["ToolRegistry"][":loaded"] = new_set()
 
 T["ToolRegistry"][":loaded"]["returns false when no tools loaded"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fixes an issue when tool just added by the user to a chat was not included in tool system prompt's arg.

## AI Usage

Claude Sonnet 4.6 has added the test.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
