### PR TITLE
fix(inline): error in stop keymap handler

### DIFF
--- a/lua/codecompanion/interactions/inline/keymaps.lua
+++ b/lua/codecompanion/interactions/inline/keymaps.lua
@@ -19,7 +19,7 @@ end
 M.stop = {
   callback = function(inline)
     inline:stop()
-    clear_map(config.interactions.inline.keymaps, inline.diff.bufnr)
+    clear_map(config.interactions.inline.keymaps, inline.bufnr)
     log:trace("[Inline] Cancelling the request")
   end,
 }


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fix handler for inline 'stop' keymap.

Triggering 'stop' keymap while doing inline request without this fix result in error:

```
E5108: Error executing lua: ...n.nvim/lua/codecompanion/interactions/inline/keymaps.lua:22: attempt 
to index field 'diff' (a nil value)                                                                 
stack traceback:                                                                                    
        ...n.nvim/lua/codecompanion/interactions/inline/keymaps.lua:22: in function 'rhs'           
        ...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:94: in function <...y/codecompan
ion.nvim/lua/codecompanion/utils/keymaps.lua:91>                                                    
```

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
