### PR TITLE
fix(prompts): sorting user lua prompts

### DIFF
--- a/lua/codecompanion/actions/prompt_library.lua
+++ b/lua/codecompanion/actions/prompt_library.lua
@@ -16,7 +16,12 @@ function M.resolve(context, config)
     end
 
     if not prompt.opts or not prompt.opts.index then
-      sort_index = false
+      if name == "markdown" then
+        prompt.opts = prompt.opts or {}
+        prompt.opts.index = 1
+      else
+        sort_index = false
+      end
     end
 
     if type(prompt.name) == "function" then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fixes sorting user's lua prompts by `opts.index` in action palette.
Defined stable order of user's prompts is very important for UX.

The alternative fix is to add `opts.index = 1` inside main `config.lua`,
but as it is not really used by "markdown" entry it may confuse users learning from default config.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

## Related Issue(s)

Fixes #2815

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
