### PR TITLE
fix(chat): switch to chat tab after closing prev chat

### DIFF
--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -186,7 +186,7 @@ function UI:open(opts)
 
   if self:is_visible() then
     if config.display.chat.window.layout == "tab" and self:is_visible_non_curtab() then
-      vim.cmd("tabnext " .. api.nvim_win_get_tabpage(self.winnr))
+      api.nvim_set_current_tabpage(api.nvim_win_get_tabpage(self.winnr))
     end
     return
   end

--- a/tests/test_cmds.lua
+++ b/tests/test_cmds.lua
@@ -215,6 +215,20 @@ T["cmds_tab"][":CodeCompanionChat Toggle goes to chat from any other tab"] = fun
   expect.reference_screenshot(child.get_screenshot())
 end
 
+T["cmds_tab"][":CodeCompanionChat Toggle after reopen does not error"] = function()
+  -- Reproduce: open chat, close it, reopen, then Toggle twice
+  -- Previously caused E475 because tabnext received a tabpage handle
+  -- instead of a tab index
+  child.lua([[vim.cmd("CodeCompanionChat")]])
+  child.cmd([[q]])
+  child.lua([[vim.cmd("CodeCompanionChat")]])
+  local ok, err = child.lua([[return pcall(function()
+    vim.cmd("CodeCompanionChat Toggle")
+    vim.cmd("CodeCompanionChat Toggle")
+  end)]])
+  h.eq(true, ok)
+end
+
 T["cmds_tab_sticky"] = new_set({
   hooks = {
     pre_once = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fix E475 on `:CodeCompanionChat Toggle` into chat tab after closing previous chat tab.
Repro sequence is in the test.

## AI Usage

Sonnet 4.6.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
