### PR TITLE
fix(prompts): add `: ` to the end of input prompts

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/diff.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/diff.lua
@@ -17,7 +17,7 @@ end
 ---Prompt the user for a rejection reason
 ---@param callback function
 local function get_rejection_reason(callback)
-  ui_utils.input({ prompt = "Rejection reason" }, function(input)
+  ui_utils.input({ prompt = "Rejection reason: " }, function(input)
     callback(input or "")
   end)
 end

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -322,7 +322,7 @@ function Orchestrator:setup_next_tool(input)
             keymap = keys.reject,
             label = labels.reject,
             callback = function()
-              ui_utils.input({ prompt = fmt("Reason for rejecting `%s`", self.tool.name) }, function(i)
+              ui_utils.input({ prompt = fmt("Reason for rejecting `%s`: ", self.tool.name) }, function(i)
                 self.output.rejected(cmd, { reason = i })
                 self:setup_next_tool()
               end)


### PR DESCRIPTION
## Description

Of course, this:
> Rejection reason: this is my rejection reason

is better than this:
> Rejection reasonthis is my rejection reason

## AI Usage

N/A

## Related Issue(s)

N/A

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
