### PR TITLE
feat(prompts): add user prompt to context

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 03
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 05
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -216,3 +216,4 @@
 ---@field start_line number The start line of the selection
 ---@field start_col number The start column of the selection
 ---@field winnr number The window number
+---@field user_prompt string The prompt provided by the user

--- a/lua/codecompanion/utils/context.lua
+++ b/lua/codecompanion/utils/context.lua
@@ -116,6 +116,11 @@ function M.get(bufnr, args)
     lines, start_line, start_col, end_line, end_col = M.get_visual_selection(bufnr)
   end
 
+  local user_prompt = ""
+  if args and args.user_prompt then
+    user_prompt = args.user_prompt
+  end
+
   return {
     bufnr = bufnr,
     buftype = api.nvim_get_option_value("buftype", { buf = bufnr }) or "",
@@ -133,6 +138,7 @@ function M.get(bufnr, args)
     start_col = start_col,
     start_line = start_line,
     winnr = winnr,
+    user_prompt = user_prompt,
   }
 end
 

--- a/tests/utils/test_context.lua
+++ b/tests/utils/test_context.lua
@@ -196,4 +196,28 @@ T["Utils->Context"]["should handle current buffer when no buffer specified"] = f
   h.eq(buf, ctx.bufnr)
 end
 
+T["Utils->Context"]["should return the user's prompt when provided"] = function()
+  local ctx = child.lua([[
+    return _G.context.get(_G.test_buffer, { user_prompt = "This is some prompt" })
+  ]])
+
+  h.eq("This is some prompt", ctx.user_prompt)
+end
+
+T["Utils->Context"]["should return an empty string when the prompt is not provided"] = function()
+  -- Args but no prompt
+  local ctx = child.lua([[
+    return _G.context.get(_G.test_buffer, {})
+  ]])
+
+  h.eq("", ctx.user_prompt)
+
+  -- No args
+  ctx = child.lua([[
+    return _G.context.get(_G.test_buffer)
+  ]])
+
+  h.eq("", ctx.user_prompt)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Previously, when a prompt was called with `:CodeCompanion`, any additional prompting from the user was discarded. For example, `:CodeCompanion /comment Provide a comment for this file` would call the `comment` prompt, but `Provide a comment for this file` was discarded.

This PR provides a new context field, `user_prompt`, that can be placed in the called prompts. This will allow custom prompts to include additional context provided by the caller.

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

I used openai/gpt-oss-120b to explore the codebase and identify where to add the desired context.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

- Closes #2863

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [X] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
