### PR TITLE
feat(ollama): respect OLLAMA_HOST env var for remote connections

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 07
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 09
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1327,9 +1327,10 @@ The configuration for both types of adapters is exactly the same, however they
 sit within their own tables (`adapters.http.*` and `adapters.acp.*`) and have
 different options available. HTTP adapters use `models` to allow users to
 select the specific LLM they’d like to interact with. ACP adapters use
-`commands` to allow users to customize their interaction with agents (e.g.�
-enabling `yolo` mode). As there is a lot of shared functionality between the
-two adapters, it is recommend that you read this page alongside the ACP one.
+`commands` to allow users to customize their interaction with agents
+(e.g. enabling `yolo` mode). As there is a lot of shared functionality between
+the two adapters, it is recommend that you read this page alongside the ACP
+one.
 
 
 CHANGING THE DEFAULT ADAPTER ~
@@ -1383,7 +1384,7 @@ the adapter’s URL, headers, parameters and other fields at runtime.
   <https://github.com/olimorris/codecompanion.nvim/discussions/601>
 Supported `env` value types: - **Plain environment variable name (string)**: if
 the value is the name of an environment variable that has already been set
-(e.g.� `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
+(e.g. `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
 **Command (string prefixed with cmd:)**: any value that starts with `cmd:` will
 be executed via the shell. Example: `"cmd:op read
 op://personal/Gemini/credential --no-newline"`. - **Function**: you can provide
@@ -1560,8 +1561,15 @@ LLAMA.CPP WITH --REASONING-FORMAT DEEPSEEK
 
 OLLAMA (REMOTELY)
 
-To use Ollama remotely, change the URL in the env table, set an API key and
-pass it via an "Authorization" header:
+The simplest way to connect to a remote Ollama instance is to set the
+`OLLAMA_HOST` environment variable (the same variable used by the Ollama CLI):
+
+>bash
+    export OLLAMA_HOST="http://192.168.1.100:11434"
+<
+
+Alternatively, configure it directly in your setup using `extend()`. If you
+need authentication, set an API key and pass it via an "Authorization" header:
 
 >lua
     require("codecompanion").setup({
@@ -3384,7 +3392,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-tools-files| tool, combined with
 the |codecompanion-usage-chat-buffer-editor-context.html-buffer| editor context
@@ -4222,7 +4230,7 @@ message to the LLM.
 
   [!IMPORTANT] With the exception of `#{buffer}` and `#{buffers}`, editor context
   captures a point-in-time snapshot when your message is sent. If the underlying
-  data changes (e.g.� new diagnostics, a different quickfix list), simply use the
+  data changes (e.g. new diagnostics, a different quickfix list), simply use the
   context again in a new message to share the latest state.
 
 #BUFFER ~
@@ -5118,7 +5126,7 @@ These handlers manage tool/function calling:
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>
@@ -7024,7 +7032,7 @@ tool to function. In the case of Anthropic, we insert additional headers.
 <
 
 Some adapter tools can be a `hybrid` in terms of their implementation. That is,
-they’re an adapter tool that requires a client-side component (i.e.� a
+they’re an adapter tool that requires a client-side component (i.e. a
 built-in tool). This is the case for the
 |codecompanion-usage-chat-buffer-agents-tools-memory| tool from Anthropic. To
 allow for this, ensure that the tool definition in `available_tools` has

--- a/doc/configuration/adapters-http.md
+++ b/doc/configuration/adapters-http.md
@@ -362,7 +362,13 @@ require("codecompanion").setup({
 
 ### Ollama (remotely)
 
-To use Ollama remotely, change the URL in the env table, set an API key and pass it via an "Authorization" header:
+The simplest way to connect to a remote Ollama instance is to set the `OLLAMA_HOST` environment variable (the same variable used by the Ollama CLI):
+
+```bash
+export OLLAMA_HOST="http://192.168.1.100:11434"
+```
+
+Alternatively, configure it directly in your setup using `extend()`. If you need authentication, set an API key and pass it via an "Authorization" header:
 
 ```lua
 require("codecompanion").setup({

--- a/lua/codecompanion/adapters/http/ollama/init.lua
+++ b/lua/codecompanion/adapters/http/ollama/init.lua
@@ -26,7 +26,9 @@ return {
     ["Content-Type"] = "application/json",
   },
   env = {
-    url = "http://localhost:11434",
+    url = function()
+      return os.getenv("OLLAMA_HOST") or "http://localhost:11434"
+    end,
   },
   handlers = {
     setup = function(self)

--- a/tests/adapters/http/test_ollama.lua
+++ b/tests/adapters/http/test_ollama.lua
@@ -343,4 +343,21 @@ T["Ollama adapter"]["No Streaming"]["can output for the inline assistant"] = fun
   h.eq("Dynamic Scripting language", adapter.handlers.inline_output(adapter, json).output)
 end
 
+T["Ollama adapter"]["OLLAMA_HOST"] = new_set()
+
+T["Ollama adapter"]["OLLAMA_HOST"]["uses OLLAMA_HOST when set"] = function()
+  local adapter_utils = require("codecompanion.utils.adapters")
+  vim.env.OLLAMA_HOST = "http://192.168.1.100:11434"
+  adapter_utils.get_env_vars(adapter)
+  h.eq("http://192.168.1.100:11434", adapter.env_replaced.url)
+  vim.env.OLLAMA_HOST = nil
+end
+
+T["Ollama adapter"]["OLLAMA_HOST"]["fallback to localhost when OLLAMA_HOST is not set"] = function()
+  local adapter_utils = require("codecompanion.utils.adapters")
+  vim.env.OLLAMA_HOST = nil
+  adapter_utils.get_env_vars(adapter)
+  h.eq("http://localhost:11434", adapter.env_replaced.url)
+end
+
 return T


### PR DESCRIPTION
## Description:
  Automatically read the `OLLAMA_HOST` environment variable (the same variable used by the Ollama CLI) to configure   
  the base URL for the Ollama adapter. This allows users to connect to a remote Ollama instance without any Neovim
  configuration — simply setting `OLLAMA_HOST` in the shell is sufficient. Falls back to `http://localhost:11434` when
   the variable is not set.

  This benefits users running Ollama on a separate machine (e.g. a home server or cloud VM) who expect the standard
  Ollama environment variable to be respected, as it is by the Ollama CLI itself.

  ## AI Usage:
  This PR was developed with the assistance of Claude Code (claude-haiku-4-5) to identify the correct integration
  point and update the documentation.

  ## Related Issues: 
None 

  ## Screenshots: 
Not applicable

  ## Checklist:
  - [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md)   
  guidelines and have adhered to them in this PR                                                                  
  - [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage"       
  section above)                                                                                                  
  - [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code                                        
  - [X] _(optional)_ I've added tests/adapters/http/test_ollama.lua [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this     
  fix/feature                                                                                                     
  - [X] _(optional)_ I've updated the README and/or relevant docs pages     
