### PR TITLE
fix(adapters): handle non-stream content with reasoning for responses

### DIFF
--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -332,6 +332,7 @@ return {
         if not self.opts.stream then
           -- Reasoning
           local reasoning = {}
+          local content = nil
           if json.output then
             for _, item in ipairs(json.output) do
               if item.type == "reasoning" then
@@ -340,6 +341,12 @@ return {
                 for _, block in ipairs(item.summary) do
                   if block.type == "summary_text" then
                     reasoning.content = reasoning.content and (reasoning.content .. "\n\n" .. block.text) or block.text
+                  end
+                end
+              elseif item.type == "message" then
+                for _, block in ipairs(item.content) do
+                  if block.type == "output_text" then
+                    content = content and (content .. "\n\n" .. block.text) or block.text
                   end
                 end
               end
@@ -368,13 +375,6 @@ return {
                 index = index + 1
               end)
           end
-
-          local content = json.output
-              and json.output[1]
-              and json.output[1].content
-              and json.output[1].content[1]
-              and json.output[1].content[1].text
-            or nil
 
           return {
             status = "success",

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -536,16 +536,12 @@ T["Responses"]["No Streaming"]["can process reasoning output"] = function()
   -- Match the format of the actual request
   local json = { body = data }
 
-  h.expect_contains(
-    "**Choosing descriptive terms**",
-    adapter.handlers.response.parse_chat(adapter, json).output.reasoning.content
-  )
+  local output = adapter.handlers.response.parse_chat(adapter, json).output
 
-  h.eq(
-    "rs_0a10a8c968d594670168e91d0204ac8195b26b3e4de997f65c",
-    adapter.handlers.response.parse_chat(adapter, json).output.reasoning.id
-  )
-  h.eq("gAAAAABo6", adapter.handlers.response.parse_chat(adapter, json).output.reasoning.encrypted_content)
+  h.expect_contains("**Choosing descriptive terms**", output.reasoning.content)
+  h.eq("rs_0a10a8c968d594670168e91d0204ac8195b26b3e4de997f65c", output.reasoning.id)
+  h.eq("gAAAAABo6", output.reasoning.encrypted_content)
+  h.eq("Dynamic expressive", output.content)
 end
 
 T["Responses"]["Streaming"] = new_set()


### PR DESCRIPTION
format

<!-- Please do not alter the structure of this PR template -->

## Description

Output text is not necessarily the first block. Deepseek-reasoner met this.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
