### PR TITLE
fix: get_parser don't throw error in nightly

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -469,14 +469,14 @@ function Chat.new(args)
   -- NOTE: Put the parser on the chat buffer for performance reasons
   local ok, chat_parser, yaml_parser
   ok, chat_parser = pcall(vim.treesitter.get_parser, self.bufnr, "markdown")
-  if not ok then
+  if not ok or not chat_parser then
     return log:error("[chat::init::new] Could not find the Markdown Tree-sitter parser")
   end
   self.chat_parser = chat_parser
 
   if show_settings then
     ok, yaml_parser = pcall(vim.treesitter.get_parser, self.bufnr, "yaml", { ignore_injections = false })
-    if not ok then
+    if not ok or not yaml_parser then
       return log:error("Could not find the Yaml Tree-sitter parser")
     end
     self.yaml_parser = yaml_parser


### PR DESCRIPTION
## Description
After https://github.com/neovim/neovim/pull/37276, get_parser don't throw error in nightly

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
