### PR TITLE
Fix acp and slash commands match patterns

### DIFF
--- a/lua/codecompanion/providers/completion/cmp/acp_commands.lua
+++ b/lua/codecompanion/providers/completion/cmp/acp_commands.lua
@@ -18,8 +18,8 @@ function source:get_trigger_characters()
 end
 
 function source:get_keyword_pattern()
-  local escaped = vim.pesc(trigger)
-  return escaped .. [[\w\+]]
+  local escaped = vim.fn.escape(trigger, [[\]])
+  return escaped .. [[\%(\w\|-\)\+]]
 end
 
 function source:complete(params, callback)
@@ -52,7 +52,7 @@ function source:execute(item, callback)
   local line = vim.api.nvim_get_current_line()
 
   -- Remove the trigger character and partial command
-  local before = line:sub(1, col):gsub(string.format("%s%w*$", trigger), "")
+  local before = line:sub(1, col):gsub(vim.pesc(trigger) .. "[-%w]*$", "")
   local after = line:sub(col + 1)
   local new_line = before .. text .. after
 

--- a/lua/codecompanion/providers/completion/cmp/slash_commands.lua
+++ b/lua/codecompanion/providers/completion/cmp/slash_commands.lua
@@ -17,7 +17,7 @@ function source:get_trigger_characters()
 end
 
 function source:get_keyword_pattern()
-  return [[/\w\+]]
+  return [[/\%(\w\|-\)\+]]
 end
 
 function source:complete(params, callback)


### PR DESCRIPTION
Fixes an issue where acp commands (i.e. \ commands) would error and not be correctly shown in chat.

Also fixes cmp completion for \ commands, and allows '-' as a match character for both acp and slash commands, which allows commands like \review-branch or /document-code to correctly show in the cmp completion window.

<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

Previously, typing \ in the chat window would correctly open the cmp completion window, but because the regex was broken, it would match a literal `\w` instead of matching a regex `word` pattern.

Also adds a match for patterns such as \review-branch or /init-readme or other acp / slash commands with hyphens. From my experience, other characters (such as `_`) don't appear in e.g. codex / claude code anyway, so those are not matched. This fixes an issue with nvim-cmp that would not match those patterns correctly before, and therefore `source:execute()` would not be triggered.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

AI authored the PR. I manually checked the implementation.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
