### PR TITLE
feat(cli): add filetype to terminal buffer

### DIFF
--- a/lua/codecompanion/interactions/cli/init.lua
+++ b/lua/codecompanion/interactions/cli/init.lua
@@ -64,6 +64,7 @@ function CLI.create(args)
 
   local bufnr = api.nvim_create_buf(false, true)
   api.nvim_buf_set_name(bufnr, string.format("[CodeCompanion CLI] %d", bufnr))
+  vim.bo[bufnr].filetype = "codecompanion_cli"
 
   local id = math.random(10000000)
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Adds a filetype to the terminal buffer in the CLI interaction

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
