### PR TITLE
feat(tools): memory can have whitelisted paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ doc/.vitepress/cache
 doc/tags*
 doc/node_modules
 
+.codecompanion.lua
 .direnv/
 .testenv/
 .repro/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Neovim plugin (Lua) providing LLM-powered coding assistance: chat, inline transf
 - `make format` — StyLua (120 cols, 2 spaces). Run before committing.
 - `make test` — full test suite (Mini.Test)
 - `make test_file FILE=path` — targeted tests
-- `make docs` — regenerate vimdoc
+- `make docs` — regenerate vimdoc. Run this after changing any docs pages
 
 ## Code Conventions
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -4277,7 +4277,7 @@ MEMORY
 
 
   [!IMPORTANT] For security, all memory operations are restricted to the
-  `/memories` directory
+  `/memories` directory and any whitelisted paths
 The memory tool enables LLMs to store and retrieve information across
 conversations through a memory file directory (`/memories`).
 
@@ -4300,6 +4300,48 @@ To use the tool:
 >md
     Use @{memory} to carry on our conversation about streamlining my dotfiles
 <
+
+
+WHITELISTED PATHS
+
+By default, the memory tool can only access files in `<cwd>/memories/`. You can
+whitelist additional paths so the LLM can read and write to them. Each entry
+maps a path on disk to a virtual prefix that the LLM uses:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        chat = {
+          tools = {
+            ["memory"] = {
+              opts = {
+                whitelist = {
+                  { path = "~/.dotfiles", as = "/dotfiles" },
+                  { path = "/shared/notes", as = "/notes" },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
+With this configuration, the LLM can use `/dotfiles/.zshrc` or `/notes/todo.md`
+as paths in memory tool calls, just as it uses `/memories/file.txt`. Tilde
+(`~`) is expanded automatically. Directory traversal protection applies to all
+whitelisted paths.
+
+You can also mount a single file. This is useful for a personal profile that
+the LLM can learn from and update over time:
+
+>lua
+    whitelist = {
+      { path = "~/.dotfiles/PERSONAL.md", as = "/personal" },
+    },
+<
+
+The LLM can then view and edit it via `/personal`.
 
 
 READ_FILE

--- a/doc/usage/chat-buffer/agents-tools.md
+++ b/doc/usage/chat-buffer/agents-tools.md
@@ -249,7 +249,7 @@ Can you apply the suggested changes to the buffer with @{insert_edit_into_file}?
 ### memory
 
 > [!IMPORTANT]
-> For security, all memory operations are restricted to the `/memories` directory
+> For security, all memory operations are restricted to the `/memories` directory and any whitelisted paths
 
 The memory tool enables LLMs to store and retrieve information across conversations through a memory file directory (`/memories`).
 
@@ -269,6 +269,41 @@ To use the tool:
 ```md
 Use @{memory} to carry on our conversation about streamlining my dotfiles
 ```
+
+#### Whitelisted Paths
+
+By default, the memory tool can only access files in `<cwd>/memories/`. You can whitelist additional paths so the LLM can read and write to them. Each entry maps a path on disk to a virtual prefix that the LLM uses:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      tools = {
+        ["memory"] = {
+          opts = {
+            whitelist = {
+              { path = "~/.dotfiles", as = "/dotfiles" },
+              { path = "/shared/notes", as = "/notes" },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+With this configuration, the LLM can use `/dotfiles/.zshrc` or `/notes/todo.md` as paths in memory tool calls, just as it uses `/memories/file.txt`. Tilde (`~`) is expanded automatically. Directory traversal protection applies to all whitelisted paths.
+
+You can also mount a single file. This is useful for a personal profile that the LLM can learn from and update over time:
+
+```lua
+whitelist = {
+  { path = "~/.dotfiles/PERSONAL.md", as = "/personal" },
+},
+```
+
+The LLM can then view and edit it via `/personal`.
 
 ### read_file
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -264,6 +264,7 @@ The user is working on a %s machine. Please respond with system specific command
           description = "The memory tool enables LLMs to store and retrieve information across conversations through a memory file directory",
           opts = {
             require_approval_before = true,
+            whitelist = {}, -- e.g. { { path = "/absolute/path", as = "/alias" } }
           },
         },
         ["read_file"] = {

--- a/lua/codecompanion/interactions/chat/tools/builtin/memory.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/memory.lua
@@ -14,49 +14,94 @@ local function get_memory_root()
   return vim.fs.joinpath(vim.fn.getcwd(), CONSTANTS.MEMORY_DIR)
 end
 
+---Build a lookup of allowed path prefixes and their absolute roots
+---@param whitelist? { path: string, as: string }[]
+---@return { prefix: string, root: string }[]
+local function get_allowed_paths(whitelist)
+  local allowed = {
+    { prefix = "/" .. CONSTANTS.MEMORY_DIR, root = get_memory_root() },
+  }
+  for _, entry in ipairs(whitelist or {}) do
+    if type(entry.path) == "string" and entry.path ~= "" and type(entry.as) == "string" and entry.as ~= "" then
+      local prefix = vim.startswith(entry.as, "/") and entry.as or ("/" .. entry.as)
+      table.insert(allowed, { prefix = prefix, root = vim.fs.normalize(entry.path) })
+    end
+  end
+
+  -- Sort by prefix length descending so longer prefixes match first.
+  -- This prevents "/memories" from false-matching "/memoriesbackup"
+  table.sort(allowed, function(a, b)
+    return #a.prefix > #b.prefix
+  end)
+
+  return allowed
+end
+
 ---Validate and normalize a memory path to prevent directory traversal
----@param path string The path to validate (should start with /memories)
+---@param path string The path to validate
+---@param whitelist? { path: string, as: string }[]
 ---@return string normalized_path
-local function validate_path(path)
+local function validate_path(path, whitelist)
+  if type(path) ~= "string" or path == "" then
+    error("Path must be a non-empty string")
+  end
+
   path = vim.trim(path)
 
-  -- Path should always start with /memories
-  -- REF: https://docs.claude.com/en/docs/agents-and-tools/tool-use/memory-tool#path-traversal-protection
-  if not vim.startswith(path, "/" .. CONSTANTS.MEMORY_DIR) then
-    error(fmt("Path must start with /%s", CONSTANTS.MEMORY_DIR))
+  -- Reject null bytes which could bypass security checks
+  if path:find("%z") then
+    error("Path contains invalid characters")
   end
 
-  local relative_path = path:sub(#CONSTANTS.MEMORY_DIR + 2) -- Remove "/memories"
-  local absolute_path
-  if relative_path == "" or relative_path == "/" then
-    absolute_path = get_memory_root()
-  else
-    absolute_path = vim.fs.joinpath(get_memory_root(), relative_path)
+  local allowed = get_allowed_paths(whitelist)
+
+  -- Find which allowed prefix this path matches
+  local matched_root
+  for _, entry in ipairs(allowed) do
+    if vim.startswith(path, entry.prefix) then
+      local rest = path:sub(#entry.prefix + 1)
+
+      -- The character after the prefix must be "/" or end-of-string.
+      -- This prevents "/memories" from matching "/memoriesbackup/file.txt"
+      if rest ~= "" and not vim.startswith(rest, "/") then
+        goto continue
+      end
+
+      local relative_path = rest
+      if relative_path == "" or relative_path == "/" then
+        matched_root = vim.fs.normalize(entry.root)
+      else
+        matched_root = vim.fs.normalize(vim.fs.joinpath(entry.root, relative_path))
+      end
+      -- REF: https://docs.claude.com/en/docs/agents-and-tools/tool-use/memory-tool#path-traversal-protection
+      if matched_root:match("%.%.") then
+        error("Path contains invalid directory traversal sequences")
+      end
+      local root_normalized = vim.fs.normalize(entry.root)
+      if not vim.startswith(matched_root, root_normalized) then
+        error(fmt("Invalid path: Must reside within the %s directory", entry.prefix))
+      end
+      return matched_root
+    end
+
+    ::continue::
   end
 
-  local normalized = vim.fs.normalize(absolute_path)
-
-  -- Check for directory traversal attempts
-  -- REF: https://docs.claude.com/en/docs/agents-and-tools/tool-use/memory-tool#path-traversal-protection
-  if normalized:match("%.%.") then
-    error("Path contains invalid directory traversal sequences")
+  -- Build a user-friendly list of valid prefixes
+  local prefixes = {}
+  for _, entry in ipairs(allowed) do
+    table.insert(prefixes, entry.prefix)
   end
-
-  -- Verify the normalized path still resides within memory directory
-  local memory_root = vim.fs.normalize(get_memory_root())
-  if not vim.startswith(normalized, memory_root) then
-    error(fmt("Invalid path: Must reside within the %s directory", CONSTANTS.MEMORY_DIR))
-  end
-
-  return normalized
+  error(fmt("Path must start with one of: %s", table.concat(prefixes, ", ")))
 end
 
 ---Shows directory contents or file contents with optional line ranges
 ---@param path string The file or directory path to view
 ---@param view_range? [number, number] The range of lines to view (start_line, end_line)
+---@param whitelist? { path: string, as: string }[]
 ---@return string content
-local function view(path, view_range)
-  local normalized_path = validate_path(path)
+local function view(path, view_range, whitelist)
+  local normalized_path = validate_path(path, whitelist)
 
   if not file_utils.exists(normalized_path) then
     error(fmt("Path does not exist: %s", path))
@@ -110,9 +155,10 @@ end
 ---Create or overwrite a file with content
 ---@param path string The file path to create
 ---@param file_text string The content to write
+---@param whitelist? { path: string, as: string }[]
 ---@return nil
-local function create(path, file_text)
-  local normalized_path = validate_path(path)
+local function create(path, file_text, whitelist)
+  local normalized_path = validate_path(path, whitelist)
 
   -- Ensure parent directories exist
   local parent_dir = vim.fn.fnamemodify(normalized_path, ":h")
@@ -131,9 +177,10 @@ end
 ---@param path string The file path
 ---@param old_str string The text to find
 ---@param new_str string The text to replace with
+---@param whitelist? { path: string, as: string }[]
 ---@return nil
-local function str_replace(path, old_str, new_str)
-  local normalized_path = validate_path(path)
+local function str_replace(path, old_str, new_str, whitelist)
+  local normalized_path = validate_path(path, whitelist)
 
   if not file_utils.exists(normalized_path) then
     error(fmt("File does not exist: %s", path))
@@ -164,9 +211,10 @@ end
 ---@param path string The file path
 ---@param insert_line number The line number to insert at (1-indexed)
 ---@param insert_text string The text to insert
+---@param whitelist? { path: string, as: string }[]
 ---@return nil
-local function insert(path, insert_line, insert_text)
-  local normalized_path = validate_path(path)
+local function insert(path, insert_line, insert_text, whitelist)
+  local normalized_path = validate_path(path, whitelist)
 
   if not file_utils.exists(normalized_path) then
     error(fmt("File does not exist: %s", path))
@@ -190,13 +238,17 @@ end
 
 ---Delete a file or directory
 ---@param path string The path to delete
+---@param whitelist? { path: string, as: string }[]
 ---@return nil
-local function delete(path)
-  local normalized_path = validate_path(path)
-  local memory_root = vim.fs.normalize(get_memory_root())
+local function delete(path, whitelist)
+  local normalized_path = validate_path(path, whitelist)
 
-  if normalized_path == memory_root then
-    error("Cannot delete the root memory directory")
+  -- Prevent deletion of any root directory (memories or whitelisted)
+  local allowed = get_allowed_paths(whitelist)
+  for _, entry in ipairs(allowed) do
+    if normalized_path == vim.fs.normalize(entry.root) then
+      error(fmt("Cannot delete the root directory: %s", entry.prefix))
+    end
   end
 
   if not file_utils.exists(normalized_path) then
@@ -212,10 +264,11 @@ end
 ---Rename or move a file or directory
 ---@param old_path string The current path
 ---@param new_path string The new path
+---@param whitelist? { path: string, as: string }[]
 ---@return nil
-local function rename(old_path, new_path)
-  local normalized_old = validate_path(old_path)
-  local normalized_new = validate_path(new_path)
+local function rename(old_path, new_path, whitelist)
+  local normalized_old = validate_path(old_path, whitelist)
+  local normalized_new = validate_path(new_path, whitelist)
 
   if not file_utils.exists(normalized_old) then
     error(fmt("Source path does not exist: %s", old_path))
@@ -250,10 +303,16 @@ return {
         return output_msg("error", "No command specified")
       end
 
+      local tool_opts = self.tool and self.tool.opts
+      local whitelist = tool_opts and tool_opts.whitelist
+
       log:trace("[Memory Tool] Executing command: %s", command)
 
       if command == "view" then
-        local ok, output = pcall(view, args.path, args.view_range)
+        if not args.path then
+          return output_msg("error", "The 'view' command requires a 'path' parameter")
+        end
+        local ok, output = pcall(view, args.path, args.view_range, whitelist)
         if not ok then
           log:debug("[Memory Tool] View error: %s", output)
           return output_msg("error", output)
@@ -262,7 +321,10 @@ return {
       end
 
       if command == "create" then
-        local ok, output = pcall(create, args.path, args.file_text)
+        if not args.path then
+          return output_msg("error", "The 'create' command requires a 'path' parameter")
+        end
+        local ok, output = pcall(create, args.path, args.file_text, whitelist)
         if not ok then
           log:debug("[Memory Tool] Create error: %s", output)
           return output_msg("error", output)
@@ -271,7 +333,13 @@ return {
       end
 
       if command == "str_replace" then
-        local ok, output = pcall(str_replace, args.path, args.old_str, args.new_str)
+        if not args.path then
+          return output_msg("error", "The 'str_replace' command requires a 'path' parameter")
+        end
+        if not args.old_str then
+          return output_msg("error", "The 'str_replace' command requires an 'old_str' parameter")
+        end
+        local ok, output = pcall(str_replace, args.path, args.old_str, args.new_str or "", whitelist)
         if not ok then
           log:debug("[Memory Tool] String replace error: %s", output)
           return output_msg("error", output)
@@ -280,7 +348,16 @@ return {
       end
 
       if command == "insert" then
-        local ok, output = pcall(insert, args.path, args.insert_line, args.insert_text)
+        if not args.path then
+          return output_msg("error", "The 'insert' command requires a 'path' parameter")
+        end
+        if not args.insert_line then
+          return output_msg("error", "The 'insert' command requires an 'insert_line' parameter")
+        end
+        if not args.insert_text then
+          return output_msg("error", "The 'insert' command requires an 'insert_text' parameter")
+        end
+        local ok, output = pcall(insert, args.path, args.insert_line, args.insert_text, whitelist)
         if not ok then
           log:debug("[Memory Tool] Insert error: %s", output)
           return output_msg("error", output)
@@ -289,7 +366,10 @@ return {
       end
 
       if command == "delete" then
-        local ok, output = pcall(delete, args.path)
+        if not args.path then
+          return output_msg("error", "The 'delete' command requires a 'path' parameter")
+        end
+        local ok, output = pcall(delete, args.path, whitelist)
         if not ok then
           log:debug("[Memory Tool] Delete error: %s", output)
           return output_msg("error", output)
@@ -298,7 +378,13 @@ return {
       end
 
       if command == "rename" then
-        local ok, output = pcall(rename, args.old_path, args.new_path)
+        if not args.old_path then
+          return output_msg("error", "The 'rename' command requires an 'old_path' parameter")
+        end
+        if not args.new_path then
+          return output_msg("error", "The 'rename' command requires a 'new_path' parameter")
+        end
+        local ok, output = pcall(rename, args.old_path, args.new_path, whitelist)
         if not ok then
           log:debug("[Memory Tool] Rename error: %s", output)
           return output_msg("error", output)
@@ -364,12 +450,36 @@ return {
       },
     },
   },
-  system_prompt = [[- Always check the memory tool for relevant context before answering questions about previous conversations.
+  system_prompt = function()
+    local config = require("codecompanion.config")
+    local tool_config = config.interactions.chat.tools["memory"]
+    local whitelist = tool_config and tool_config.opts and tool_config.opts.whitelist
+
+    local prompt =
+      [[- Always check the memory tool for relevant context before answering questions about previous conversations.
 - Use the memory tool to save important decisions, summaries, or insights from ongoing discussions.
 - When context is unclear, search memory for related topics or keywords before responding.
 - Prefer updating existing memory entries over creating new ones, unless a new topic is introduced.
 - Clearly reference retrieved memory when continuing or summarising conversations.
-- If no relevant memory is found, inform the user and ask if they wish to start a new topic or save new context.]],
+- If no relevant memory is found, inform the user and ask if they wish to start a new topic or save new context.]]
+
+    if whitelist and #whitelist > 0 then
+      local paths = {}
+      for _, entry in ipairs(whitelist) do
+        if entry.path and entry.as then
+          local prefix = vim.startswith(entry.as, "/") and entry.as or ("/" .. entry.as)
+          table.insert(paths, fmt("  - %s (mounted at %s)", entry.path, prefix))
+        end
+      end
+      if #paths > 0 then
+        prompt = prompt
+          .. "\n- In addition to /memories, you can also read and write to these whitelisted paths:\n"
+          .. table.concat(paths, "\n")
+      end
+    end
+
+    return prompt
+  end,
   handlers = {
     ---@param self CodeCompanion.Tool.Memory
     ---@param meta { tools: CodeCompanion.Tools }
@@ -442,10 +552,18 @@ return {
     ---@param meta { tools: CodeCompanion.Tools, cmd: table }
     error = function(self, stderr, meta)
       local chat = meta.tools.chat
-      local errors = stderr.data or "Unknown error"
+
+      local errors
+      if type(stderr) == "table" then
+        errors = table.concat(stderr, "\n")
+      end
+      if not errors or errors == "" then
+        errors = "An unknown error occurred"
+      end
+
       log:debug("[Memory Tool] Error output: %s", errors)
 
-      chat:add_tool_output(self, errors)
+      chat:add_tool_output(self, errors, fmt("Error: %s", errors))
     end,
 
     ---Rejection message back to the LLM

--- a/tests/interactions/chat/tools/builtin/test_memory.lua
+++ b/tests/interactions/chat/tools/builtin/test_memory.lua
@@ -177,7 +177,7 @@ T["view"]["rejects path outside memory directory"] = function()
   local output = child.lua_get("_G.result")
 
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["view"]["rejects directory traversal"] = function()
@@ -202,7 +202,7 @@ T["view"]["rejects directory traversal"] = function()
   local output = child.lua_get("_G.result")
 
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Must reside within the memories directory")
+  h.expect_match(output.data, "Must reside within the /memories directory")
 end
 
 T["view"]["handles non-existent path"] = function()
@@ -414,7 +414,7 @@ T["create"]["rejects path outside memory directory"] = function()
 
   local output = child.lua_get("_G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["create"]["rejects directory traversal"] = function()
@@ -439,7 +439,7 @@ T["create"]["rejects directory traversal"] = function()
 
   local output = child.lua_get("_G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Must reside within the memories directory")
+  h.expect_match(output.data, "Must reside within the /memories directory")
 end
 
 T["str_replace"] = new_set()
@@ -696,7 +696,7 @@ T["str_replace"]["rejects path outside memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["insert"] = new_set()
@@ -1017,7 +1017,7 @@ T["insert"]["rejects path outside memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["insert"]["rejects path outside memory directory"] = function()
@@ -1043,7 +1043,7 @@ T["insert"]["rejects path outside memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["delete"] = new_set()
@@ -1234,7 +1234,7 @@ T["delete"]["fails when trying to delete root memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Cannot delete the root memory directory")
+  h.expect_match(output.data, "Cannot delete the root directory")
 end
 
 T["delete"]["rejects path outside memory directory"] = function()
@@ -1258,7 +1258,7 @@ T["delete"]["rejects path outside memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["delete"]["rejects directory traversal"] = function()
@@ -1282,7 +1282,7 @@ T["delete"]["rejects directory traversal"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Must reside within the memories directory")
+  h.expect_match(output.data, "Must reside within the /memories directory")
 end
 
 T["delete"]["rejects directory traversal"] = function()
@@ -1306,7 +1306,7 @@ T["delete"]["rejects directory traversal"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Must reside within the memories directory")
+  h.expect_match(output.data, "Must reside within the /memories directory")
 end
 
 T["rename"] = new_set()
@@ -1554,7 +1554,7 @@ T["rename"]["rejects old_path outside memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["rename"]["rejects new_path outside memory directory"] = function()
@@ -1583,7 +1583,7 @@ T["rename"]["rejects new_path outside memory directory"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Path must start with /memories")
+  h.expect_match(output.data, "Path must start with one of: /memories")
 end
 
 T["rename"]["rejects directory traversal in old_path"] = function()
@@ -1608,7 +1608,7 @@ T["rename"]["rejects directory traversal in old_path"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Must reside within the memories directory")
+  h.expect_match(output.data, "Must reside within the /memories directory")
 end
 
 T["rename"]["rejects directory traversal in new_path"] = function()
@@ -1637,7 +1637,373 @@ T["rename"]["rejects directory traversal in new_path"] = function()
 
   local output = child.lua("return _G.result")
   h.eq(output.status, "error")
-  h.expect_match(output.data, "Must reside within the memories directory")
+  h.expect_match(output.data, "Must reside within the /memories directory")
+end
+
+T["whitelist"] = new_set()
+
+T["whitelist"]["can view a whitelisted directory"] = function()
+  child.lua([[
+    -- Create a whitelisted directory with a file
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+    vim.fn.writefile({"Whitelisted content"}, vim.fs.joinpath(_G.WHITELIST_DIR, "notes.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } }
+    local args = { command = "view", path = "/notes" }
+
+    -- Simulate self.tool.opts by wrapping
+    local self_mock = { tool = tool }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, args)
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "success")
+  h.expect_match(output.data, "notes%.txt")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["can view a file in a whitelisted directory"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+    vim.fn.writefile({"Line 1", "Line 2"}, vim.fs.joinpath(_G.WHITELIST_DIR, "file.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "view", path = "/notes/file.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "success")
+  h.eq(output.data, "Line 1\nLine 2\n")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["can create a file in a whitelisted directory"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "create", path = "/notes/new.txt", file_text = "New content" })
+  ]])
+
+  local output = child.lua("return _G.result")
+  h.eq(output.status, "success")
+
+  local content = child.lua([[
+    return vim.fn.readfile(vim.fs.joinpath(_G.WHITELIST_DIR, "new.txt"))
+  ]])
+  h.eq(content, { "New content" })
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["can str_replace in a whitelisted file"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+    vim.fn.writefile({"Hello World"}, vim.fs.joinpath(_G.WHITELIST_DIR, "file.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, {
+      command = "str_replace",
+      path = "/notes/file.txt",
+      old_str = "Hello World",
+      new_str = "Goodbye World",
+    })
+  ]])
+
+  local output = child.lua("return _G.result")
+  h.eq(output.status, "success")
+
+  local content = child.lua([[
+    return vim.fn.readfile(vim.fs.joinpath(_G.WHITELIST_DIR, "file.txt"))
+  ]])
+  h.eq(content, { "Goodbye World" })
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["can delete a file in a whitelisted directory"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+    vim.fn.writefile({"Content"}, vim.fs.joinpath(_G.WHITELIST_DIR, "delete_me.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "delete", path = "/notes/delete_me.txt" })
+  ]])
+
+  local output = child.lua("return _G.result")
+  h.eq(output.status, "success")
+
+  local exists = child.lua([[
+    return vim.uv.fs_stat(vim.fs.joinpath(_G.WHITELIST_DIR, "delete_me.txt")) ~= nil
+  ]])
+  h.eq(exists, false)
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["cannot delete the whitelisted root directory"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "delete", path = "/notes" })
+  ]])
+
+  local output = child.lua("return _G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "Cannot delete the root directory")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["rejects traversal out of whitelisted directory"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "view", path = "/notes/../etc/passwd" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "Must reside within the /notes directory")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["rejects paths not matching any allowed prefix"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "view", path = "/etc/passwd" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "Path must start with one of: /memories, /notes")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["memories still works when whitelisted paths are set"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+
+    -- Create a file in the memories directory
+    vim.fn.writefile({"Memory content"}, vim.fs.joinpath(_G.MEMORY_DIR_ABSOLUTE, "note.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "view", path = "/memories/note.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "success")
+  h.eq(output.data, "Memory content\n")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["can rename within whitelisted directory"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+    vim.fn.writefile({"Content"}, vim.fs.joinpath(_G.WHITELIST_DIR, "old.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, {
+      command = "rename",
+      old_path = "/notes/old.txt",
+      new_path = "/notes/new.txt",
+    })
+  ]])
+
+  local output = child.lua("return _G.result")
+  h.eq(output.status, "success")
+
+  local old_exists = child.lua([[
+    return vim.uv.fs_stat(vim.fs.joinpath(_G.WHITELIST_DIR, "old.txt")) ~= nil
+  ]])
+  h.eq(old_exists, false)
+
+  local content = child.lua([[
+    return vim.fn.readfile(vim.fs.joinpath(_G.WHITELIST_DIR, "new.txt"))
+  ]])
+  h.eq(content, { "Content" })
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["prefix without leading slash is normalized"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+    vim.fn.writefile({"Content"}, vim.fs.joinpath(_G.WHITELIST_DIR, "file.txt"))
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    -- as = "notes" without leading slash
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    _G.result = builtin.cmds[1](self_mock, { command = "view", path = "/notes/file.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "success")
+  h.eq(output.data, "Content\n")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["whitelist"]["prevents prefix collision with similar names"] = function()
+  child.lua([[
+    _G.WHITELIST_DIR = vim.fn.tempname()
+    vim.fn.mkdir(_G.WHITELIST_DIR, "p")
+
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    local self_mock = { tool = { opts = { whitelist = { { path = _G.WHITELIST_DIR, as = "/notes" } } } } }
+    setmetatable(self_mock, { __index = builtin })
+
+    -- "/notesbackup/file.txt" should NOT match the "/notes" prefix
+    _G.result = builtin.cmds[1](self_mock, { command = "view", path = "/notesbackup/file.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "Path must start with one of")
+
+  child.lua([[ pcall(vim.fn.delete, _G.WHITELIST_DIR, "rf") ]])
+end
+
+T["validation"] = new_set()
+
+T["validation"]["returns error for missing path on view"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "view" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires a 'path' parameter")
+end
+
+T["validation"]["returns error for missing path on create"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "create", file_text = "content" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires a 'path' parameter")
+end
+
+T["validation"]["returns error for missing old_str on str_replace"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "str_replace", path = "/memories/file.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires an 'old_str' parameter")
+end
+
+T["validation"]["returns error for missing insert_line on insert"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "insert", path = "/memories/file.txt", insert_text = "text" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires an 'insert_line' parameter")
+end
+
+T["validation"]["returns error for missing insert_text on insert"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "insert", path = "/memories/file.txt", insert_line = 1 })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires an 'insert_text' parameter")
+end
+
+T["validation"]["returns error for missing old_path on rename"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "rename", new_path = "/memories/new.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires an 'old_path' parameter")
+end
+
+T["validation"]["returns error for missing new_path on rename"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "rename", old_path = "/memories/old.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "requires a 'new_path' parameter")
+end
+
+T["validation"]["rejects null bytes in path"] = function()
+  child.lua([[
+    local builtin = require("codecompanion.interactions.chat.tools.builtin.memory")
+    _G.result = builtin.cmds[1](builtin, { command = "view", path = "/memories/file\0.txt" })
+  ]])
+
+  local output = child.lua_get("_G.result")
+  h.eq(output.status, "error")
+  h.expect_match(output.data, "invalid characters")
 end
 
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The memory tool enables users to save their conversation history to disk so it can be resumed at a later date.

The tool follows Antropic's [specification](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) to the letter, even restricting the use of directories outside of `/memories`.

This PR relaxes that restriction, enabling users to white list paths and files that memory files can be saved in.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
