### PR TITLE
feat(chat): change system prompt date and make configurable

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3365,6 +3365,19 @@ The plugin comes with the following system prompt:
     The user is working on a ${os} machine. Please respond with system specific commands if applicable.
 <
 
+The format of the date can be changed in your config by altering the
+`date_format` option:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        opts = {
+          date_format = "%A, %d %B %Y", -- Example: "Monday, 01 January 2024"
+        },
+      },
+    })
+<
+
 
 TOOL SYSTEM PROMPT ~
 

--- a/doc/configuration/system-prompt.md
+++ b/doc/configuration/system-prompt.md
@@ -63,6 +63,18 @@ The user's Neovim version is ${version}.
 The user is working on a ${os} machine. Please respond with system specific commands if applicable.
 `````
 
+The format of the date can be changed in your config by altering the `date_format` option:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    opts = {
+      date_format = "%A, %d %B %Y", -- Example: "Monday, 01 January 2024"
+    },
+  },
+})
+```
+
 ## Tool System Prompt
 
 CodeCompanion also ships with a separate system prompt when [tools](/usage/chat-buffer/agents-tools) are used in the chat buffer:

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -58,6 +58,8 @@ local defaults = {
   constants = constants,
   interactions = {
     opts = {
+      date_format = "%A, %d %B %Y", -- The date format to use in system prompts
+
       watcher = {
         enabled = true, -- Reload buffers when an agent modifies files on disk
         debounce = 500, -- Debounce time in milliseconds

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -888,7 +888,7 @@ function Chat:make_system_prompt_context()
   local winid = vim.fn.bufwinid(bufnr)
   local static_ctx = { ---@type CodeCompanion.SystemPrompt.Context|{}
     cwd = winid ~= -1 and vim.fn.getcwd(winid) or vim.fn.getcwd(),
-    date = tostring(os.date("%Y-%m-%d")),
+    date = tostring(os.date(config.interactions.opts.date_format)),
     default_system_prompt = CONSTANTS.SYSTEM_PROMPT,
     language = config.opts.language or "English",
     nvim_version = vim.version().major .. "." .. vim.version().minor .. "." .. vim.version().patch,


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Previously, the date in CodeCompanion was formatted to be `2026-03-18`. However, I think it's more explicit to specify to an LLM, a date of `Wednesday, 18 March 2026`. 

Of course, if a user dislikes this, they can update this in the config.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
