### PR TITLE
refactor(rules): don't expand the path in the chat

### DIFF
--- a/lua/codecompanion/interactions/chat/rules/init.lua
+++ b/lua/codecompanion/interactions/chat/rules/init.lua
@@ -142,8 +142,9 @@ function Rules:read_files(paths)
       local ok, content = pcall(file.read, path)
 
       if ok then
-        -- Find the parser for this file
+        -- Find the parser and original path for this file
         local file_parser = nil
+        local original_path = nil
         for _, file_spec in ipairs(self.files) do
           if type(file_spec) == "table" and file_spec.path then
             local normalized_spec_path = vim.fs.normalize(file_spec.path)
@@ -159,14 +160,20 @@ function Rules:read_files(paths)
               -- Exact path match
               if path == normalized_spec_path then
                 file_parser = file_spec.parser
+                original_path = file_spec.path
                 break
               end
+            end
+          elseif type(file_spec) == "string" then
+            if path == vim.fs.normalize(file_spec) then
+              original_path = file_spec
+              break
             end
           end
         end
 
         table.insert(files, {
-          name = path,
+          name = original_path or path,
           content = content,
           path = path,
           filename = vim.fn.fnamemodify(path, ":t"),


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Prior to this PR, any `~` in the the path of any rules would be expanded in the chat buffer. This didn't look great.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
