### PR TITLE
feat(ui): make acp tool calls cleaner

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 18
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 March 19
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -5534,6 +5534,7 @@ The plugin sets the following highlight groups during setup:
 - `CodeCompanionChatTokens` - Virtual text in the chat buffer showing the token count
 - `CodeCompanionChatTool` - Tools in the chat buffer
 - `CodeCompanionChatToolGroups` - Tool groups in the chat buffer
+- `CodeCompanionChatToolText` - Tool output text in the chat buffer (overrides markdown rendering)
 - `CodeCompanionChatEditorContext` - Editor context in the chat buffer
 - `CodeCompanionVirtualText` - All other virtual text in the plugin
 

--- a/doc/usage/ui.md
+++ b/doc/usage/ui.md
@@ -40,6 +40,7 @@ The plugin sets the following highlight groups during setup:
 - `CodeCompanionChatTokens` - Virtual text in the chat buffer showing the token count
 - `CodeCompanionChatTool` - Tools in the chat buffer
 - `CodeCompanionChatToolGroups` - Tool groups in the chat buffer
+- `CodeCompanionChatToolText` - Tool output text in the chat buffer (overrides markdown rendering)
 - `CodeCompanionChatEditorContext` - Editor context in the chat buffer
 - `CodeCompanionVirtualText` - All other virtual text in the plugin
 

--- a/lua/codecompanion/interactions/chat/acp/formatters.lua
+++ b/lua/codecompanion/interactions/chat/acp/formatters.lua
@@ -285,14 +285,32 @@ local function generate_smart_summary(tool_call, adapter)
   return title
 end
 
+---Clean tool text for display in a markdown buffer
+---@param text string
+---@return string
+local function clean_tool_text(text)
+  if not text or text == "" then
+    return text
+  end
+
+  text = text:gsub("`", "")
+
+  -- Shorten absolute paths
+  local cwd = vim.fn.getcwd()
+  if cwd and cwd ~= "" then
+    text = text:gsub(vim.pesc(cwd) .. "/", "")
+  end
+
+  return text
+end
+
 ---Create a one-line message for tool-call events
 ---@param tool_call table
 ---@param adapter CodeCompanion.ACPAdapter
 ---@return string
 function M.tool_message(tool_call, adapter)
-  -- Normalize the tool call to handle inconsistent data
   local normalized = M.normalize_tool_call(tool_call)
-  return generate_smart_summary(normalized, adapter)
+  return clean_tool_text(generate_smart_summary(normalized, adapter))
 end
 
 ---Create a one-line message for file-write

--- a/lua/codecompanion/interactions/chat/ui/icons.lua
+++ b/lua/codecompanion/interactions/chat/ui/icons.lua
@@ -47,10 +47,16 @@ function Icons.apply(bufnr, line, status, opts)
   -- Clear any existing tool icons on this line to prevent duplicates
   api.nvim_buf_clear_namespace(bufnr, CONSTANTS.NS_TOOL_ICONS, line, line + 1)
 
+  -- Apply a text highlight to override treesitter markdown rendering on tool lines
+  -- (prevents glob patterns like **/* rendering as bold, backtick remnants as code, etc.)
+  local line_text = api.nvim_buf_get_lines(bufnr, line, line + 1, false)[1] or ""
+
   return api.nvim_buf_set_extmark(bufnr, CONSTANTS.NS_TOOL_ICONS, line, 0, {
     virt_text = { { config_entry.icon, config_entry.hl_group } },
     virt_text_pos = opts.virt_text_pos,
-    priority = opts.priority,
+    priority = math.max(opts.priority, 200),
+    hl_group = "CodeCompanionChatToolText",
+    end_col = #line_text,
   })
 end
 

--- a/plugin/codecompanion.lua
+++ b/plugin/codecompanion.lua
@@ -27,6 +27,7 @@ api.nvim_set_hl(0, "CodeCompanionChatToolPending", { link = "DiagnosticWarn", de
 api.nvim_set_hl(0, "CodeCompanionChatToolPendingIcon", { link = "DiagnosticWarn", default = true })
 api.nvim_set_hl(0, "CodeCompanionChatToolSuccess", { link = "DiagnosticOK", default = true })
 api.nvim_set_hl(0, "CodeCompanionChatToolSuccessIcon", { link = "DiagnosticOK", default = true })
+api.nvim_set_hl(0, "CodeCompanionChatToolText", { link = "Comment", default = true })
 api.nvim_set_hl(0, "CodeCompanionChatEditorContext", { link = "Identifier", default = true })
 api.nvim_set_hl(0, "CodeCompanionChatWarn", { link = "DiagnosticWarn", default = true })
 api.nvim_set_hl(0, "CodeCompanionDiffAdd", { link = "DiffAdd", default = true })

--- a/tests/interactions/chat/acp/test_formatters.lua
+++ b/tests/interactions/chat/acp/test_formatters.lua
@@ -261,7 +261,7 @@ T["ACP Formatters"]["tool_message - Real-world Examples"] = function()
         }
       ]],
     [[_G.test_adapter = { opts = { verbose_output = true } }]],
-    "Search: Find `**/*add_buf_message*` — No files found"
+    "Search: Find **/*add_buf_message* — No files found"
   )
 end
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The formatting and output of tool calls for ACP adapters could be messy and lead to formatting quirks if a markdown rendering plugin was installed.

This PR, cleans up the formatting, strips long paths, and applies a new `CodeCompanionChatToolText` highlight group to the whole line.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="3368" height="2240" alt="2026-03-19 09_02_47 - Ghostty@2x" src="https://github.com/user-attachments/assets/373659c5-e8b9-4741-8764-8062a7384b5d" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
