### PR TITLE
Fix markdown image parsing in chat

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1407,6 +1407,9 @@ function Chat:check_images(message)
       -- Replace the image link in the message with "image"
       local to_remove = fmt("[Image](%s)", image.path)
       message.content = vim.trim(message.content:gsub(vim.pesc(to_remove), "image"))
+
+      to_remove = fmt("![%s](%s)", image.text or "", image.path)
+      message.content = vim.trim(message.content:gsub(vim.pesc(to_remove), "image"))
     end
   end
 end

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -119,13 +119,14 @@ function M.headers(chat)
   end
 end
 
----Parse a section of the buffer for Markdown inline links.
+---Parse a section of the buffer for Markdown images.
 ---@param chat CodeCompanion.Chat The chat instance.
 ---@param start_range number The 1-indexed line number from where to start parsing.
 function M.images(chat, start_range)
   local ts_query = vim.treesitter.query.parse(
     "markdown_inline",
     [[
+((image) @image)
 ((inline_link) @link)
   ]]
   )
@@ -138,14 +139,14 @@ function M.images(chat, start_range)
 
   for id, node in ts_query:iter_captures(root, chat.bufnr, start_range - 1, -1) do
     local capture_name = ts_query.captures[id]
-    if capture_name == "link" then
+    if capture_name == "image" or capture_name == "link" then
       local link_label_text = nil
       local link_dest_text = nil
 
       for child in node:iter_children() do
         local child_type = child:type()
 
-        if child_type == "link_text" then
+        if child_type == "link_text" or child_type == "image_description" then
           local text = get_node_text(child, chat.bufnr)
           link_label_text = text
         elseif child_type == "link_destination" then
@@ -154,7 +155,7 @@ function M.images(chat, start_range)
         end
       end
 
-      if link_label_text and link_dest_text then
+      if link_dest_text and (capture_name == "image" or link_label_text == "Image") then
         table.insert(links, { text = link_label_text, path = link_dest_text })
       end
     end

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -165,7 +165,7 @@ T["Chat"]["prompt decorator is applied prior to sending to the LLM"] = function(
   h.eq("<prompt>" .. prompt .. "</prompt>", output)
 end
 
-T["Chat"]["images are replaced in text and base64 encoded"] = function()
+T["Chat"]["CodeCompanion images are replaced in text and base64 encoded"] = function()
   local prompt =
     string.format("What does this [Image](%s) do?", vim.fs.normalize(vim.fn.getcwd()) .. "/tests/stubs/logo.png")
   local message = child.lua(string.format(
@@ -207,6 +207,75 @@ T["Chat"]["images are replaced in text and base64 encoded"] = function()
   }, message.context)
 
   h.expect_starts_with("iVBORw0KGgoAAAANSUhEU", message.content)
+end
+
+T["Chat"]["markdown images are replaced in text and base64 encoded"] = function()
+  local prompt =
+    string.format("What does this ![logo](%s) do?", vim.fs.normalize(vim.fn.getcwd()) .. "/tests/stubs/logo.png")
+  local message = child.lua(string.format(
+    [[
+      _G.chat:add_buf_message({
+        role = "user",
+        content = "%s",
+      })
+      _G.chat:submit()
+      local messages = _G.chat.messages
+      return messages[#messages - 1].content
+  ]],
+    prompt
+  ))
+
+  h.eq("What does this image do?", message)
+
+  message = child.lua([[
+    local messages = _G.chat.messages
+    return messages[#messages]
+  ]])
+
+  h.eq({
+    visible = false,
+  }, message.opts)
+
+  h.eq({
+    cycle = 1,
+    estimated_tokens = message._meta.estimated_tokens,
+    index = message._meta.index,
+    id = message._meta.id,
+    tag = "image",
+  }, message._meta)
+
+  h.eq({
+    id = string.format("<image>%s/tests/stubs/logo.png</image>", vim.fs.normalize(vim.fn.getcwd())),
+    mimetype = "image/png",
+    path = string.format("%s/tests/stubs/logo.png", vim.fs.normalize(vim.fn.getcwd())),
+  }, message.context)
+
+  h.expect_starts_with("iVBORw0KGgoAAAANSUhEU", message.content)
+end
+
+T["Chat"]["ordinary markdown links are not treated as images"] = function()
+  local prompt =
+    string.format("What does this [file](%s) do?", vim.fs.normalize(vim.fn.getcwd()) .. "/tests/stubs/logo.png")
+  local result = child.lua(string.format(
+    [[
+      _G.chat:add_buf_message({
+        role = "user",
+        content = "%s",
+      })
+      _G.chat:submit()
+      local messages = _G.chat.messages
+      return {
+        content = messages[#messages].content,
+        tag = messages[#messages]._meta and messages[#messages]._meta.tag,
+        context_items = vim.tbl_count(_G.chat.context_items),
+      }
+  ]],
+    prompt
+  ))
+
+  h.eq(prompt, result.content)
+  h.eq(nil, result.tag)
+  h.eq(0, result.context_items)
 end
 
 local get_lines = function()


### PR DESCRIPTION
Fix codecompanion's parsing of markdown images, which treats `[Image](path/to/image)` as an image (correctly), `[link](path/to/file)` as an image (incorrectly), and `![alt](path/to/image)` as nothing (incorrectly).

<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

Accept standard markdown image links as correctly formatted images in chat, and don't treat regular file links as images. Also look for the special case `[Image](path/to/image)`, which seems to be the standard way of CodeCompanion to treat an "AI image" path.

The changes might warrant a docs update as well, but since this is the standard way to format images in markdown, it might also be considered common knowledge and not needed.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

PR built with Codex, changes tested manually.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
