### PR TITLE
fix(chat): show tools on chat creation

### DIFF
--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -490,7 +490,8 @@ CodeCompanion.setup = function(opts)
     api.nvim_create_user_command(cmd.cmd, cmd.callback, cmd.opts)
   end
 
-  -- Set up completion
+  -- Load the main completion module first to register its autocmds
+  require("codecompanion.providers.completion")
   local completion = config.interactions.chat.opts.completion_provider
   local ok, completion_module = pcall(require, "codecompanion.providers.completion." .. completion .. ".setup")
   if not ok then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The completions module has been refactored in recent PRs. This led to tools not being available in a brand new chat buffer, yet, being available in subsequent ones.

The fix is to ensure that autocmds are set on setup.

## AI Usage

Opus 4.6 to diagnose the issue

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
