### PR TITLE
tests: fix flaky mcp test

### DIFF
--- a/tests/mcp/test_mcp.lua
+++ b/tests/mcp/test_mcp.lua
@@ -41,7 +41,9 @@ T["MCP"] = MiniTest.new_set()
 
 T["MCP"]["start() starts and initializes the client once"] = function()
   local transformed_config = child.lua([[
-    return MCP.transform_to_acp()
+    local result = MCP.transform_to_acp()
+    table.sort(result, function(a, b) return a.name < b.name end)
+    return result
   ]])
 
   h.eq({


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The MCP tests were flaky owing to the ordering of test outputs.

## AI Usage

Opus 4.6 found and fixed this.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
