### PR TITLE
feat(acp): fire CodeCompanionACPSessionPre event before session establishment

### DIFF
--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -10,6 +10,7 @@ In order to enable a tighter integration between CodeCompanion and your Neovim c
 
 The events that are fired from within the plugin are:
 
+- `CodeCompanionACPSessionPre` - Fired after ACP authentication completes but before a new session is established; allows subscribers to modify the connection (e.g. inject MCP servers) synchronously
 - `CodeCompanionChatACPModeChanged` - Fired after the ACP mode has been changed in the chat
 - `CodeCompanionChatCreated` - Fired after a chat has been created for the first time
 - `CodeCompanionChatOpened` - Fired after a chat has been opened

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -24,6 +24,7 @@ local adapter_utils = require("codecompanion.utils.adapters")
 local config = require("codecompanion.config")
 local jsonrpc = require("codecompanion.utils.jsonrpc")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local TIMEOUTS = {
   DEFAULT = 2e4, -- 20 seconds
@@ -168,6 +169,11 @@ function Connection:connect_and_initialize()
     return nil
   end
 
+  utils.fire("ACPSessionPre", {
+    adapter_modified = self.adapter_modified,
+    agent_capabilities = self._agent_info and self._agent_info.agentCapabilities,
+  })
+
   if not self:_establish_session() then
     return nil
   end
@@ -236,6 +242,11 @@ function Connection:ensure_session()
   if not self:is_ready() then
     return false
   end
+
+  utils.fire("ACPSessionPre", {
+    adapter_modified = self.adapter_modified,
+    agent_capabilities = self._agent_info and self._agent_info.agentCapabilities,
+  })
 
   if not self:_establish_session() then
     return false


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fire the User event 'ACPSessionPre' (which Neovim broadcasts as 'CodeCompanionACPSessionPre') after connect_and_authenticate() succeeds but before _establish_session() runs in both:

- Connection:connect_and_initialize() - initial connection path
- Connection:ensure_session() - reconnection path

This gives consumers a synchronous hook to inspect _agent_info (populated after INITIALIZE RPC) and modify adapter_modified.defaults (e.g. mcpServers) before the session/new request is sent.

The event data includes { connection = self } so handlers have full access to the connection object.

## AI Usage

Ai for documentation updates, adding tests.

## Related Issue(s)

#2932

## Screenshots

n/a

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
