### PR TITLE
fix(ui): file edit approval message

### DIFF
--- a/lua/codecompanion/interactions/chat/acp/request_permission.lua
+++ b/lua/codecompanion/interactions/chat/acp/request_permission.lua
@@ -1,7 +1,4 @@
-local config = require("codecompanion.config")
-local diff_utils = require("codecompanion.diff.utils")
 local log = require("codecompanion.utils.log")
-local ui_utils = require("codecompanion.utils.ui")
 local utils = require("codecompanion.utils")
 
 local labels = require("codecompanion.interactions.chat.tools.labels")
@@ -259,47 +256,36 @@ function M.confirm(chat, request)
   local tool_call = request.tool_call
   local has_diff = tool_call and requires_diff(tool_call)
 
-  local base_prompt = fmt(
-    "%s: %s",
-    utils.capitalize(tool_call and tool_call.kind or "Permission"),
-    tool_call and tool_call.title or "Agent requested permission"
-  )
-
   local permission = { chat = chat, request = request }
   local choices = build_choices(permission, has_diff)
 
   if not has_diff then
-    return approve_in_chat(permission, choices, { prompt = base_prompt })
+    local prompt = fmt(
+      "%s: %s",
+      utils.capitalize(tool_call and tool_call.kind or "Permission"),
+      tool_call and tool_call.title or "Agent requested permission"
+    )
+    return approve_in_chat(permission, choices, { prompt = prompt })
   end
 
   local d = get_diff(tool_call)
+  local title = fmt("Proposed edits for `%s`:", vim.fn.fnamemodify(d.path, ":."))
   local from_lines = vim.split(d.old or "", "\n", { plain = true })
   local to_lines = vim.split(d.new or "", "\n", { plain = true })
-  local changed_lines = diff_utils.changed_lines(from_lines, to_lines)
-  local threshold = config.display.diff.threshold_for_chat
-  local threshold_met = threshold and threshold > 0 and changed_lines > 0 and changed_lines <= threshold
 
-  if threshold_met then
-    -- Show small diffs in the chat buffer
-    local diff_text = diff_utils.unified(from_lines, to_lines)
-    local prompt = fmt(
-      [[%s
-
-`````diff
-%s
-`````]],
-      base_prompt,
-      diff_text
-    )
-    return approve_in_chat(permission, choices, { title = "Proposed Edits", prompt = prompt })
-  elseif ui_utils.buf_is_active(chat.bufnr) then
-    -- If the chat is active, show the diff in the floating window
-    approve_in_chat(permission, choices, { title = "View Proposed Edits", prompt = base_prompt })
-    return open_diff_view(permission)
-  else
-    -- Otherwise, don't force the diff on the user, just show the approval
-    return approve_in_chat(permission, choices, { title = "View Proposed Edits", prompt = base_prompt })
-  end
+  local approval_prompt = require("codecompanion.interactions.chat.helpers.approval_prompt")
+  approval_prompt.present_diff({
+    chat_bufnr = chat.bufnr,
+    from_lines = from_lines,
+    to_lines = to_lines,
+    title = title,
+    approve = function(prompt_opts)
+      approve_in_chat(permission, choices, prompt_opts)
+    end,
+    open_diff_view = function()
+      open_diff_view(permission)
+    end,
+  })
 end
 
 return M

--- a/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
@@ -110,4 +110,28 @@ function M.request(chat, opts)
   return on_done
 end
 
+---Present the diff to the user
+---@param opts { chat_bufnr: number, from_lines: string[], to_lines: string[], title: string, approve: fun(prompt_opts: table), open_diff_view: fun() }
+function M.present_diff(opts)
+  local diff_utils = require("codecompanion.diff.utils")
+
+  local changed_lines = diff_utils.changed_lines(opts.from_lines, opts.to_lines)
+  local threshold = config.display.diff.threshold_for_chat
+  local threshold_met = threshold and threshold > 0 and changed_lines > 0 and changed_lines <= threshold
+
+  if threshold_met then
+    -- Show small diffs in the chat buffer
+    local diff_text = diff_utils.unified(opts.from_lines, opts.to_lines)
+    local prompt = fmt("`````diff\n%s\n`````", diff_text)
+    return opts.approve({ title = opts.title, prompt = prompt })
+  elseif ui_utils.buf_is_active(opts.chat_bufnr) then
+    -- If the chat is active, show the diff in the floating window
+    opts.approve({ title = opts.title, prompt = opts.title })
+    return opts.open_diff_view()
+  else
+    -- Otherwise, don't force the diff on the user, just show the approval
+    return opts.approve({ title = opts.title, prompt = opts.title })
+  end
+end
+
 return M

--- a/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/diff.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/diff.lua
@@ -1,6 +1,5 @@
 local approvals = require("codecompanion.interactions.chat.tools.approvals")
 local config = require("codecompanion.config")
-local diff_utils = require("codecompanion.diff.utils")
 local ui_utils = require("codecompanion.utils.ui")
 
 local fmt = string.format
@@ -136,32 +135,23 @@ function M.review(opts)
     return opts.apply()
   end
 
-  local changed_lines = diff_utils.changed_lines(opts.from_lines, opts.to_lines)
-  local threshold = config.display.diff.threshold_for_chat
-  local threshold_met = threshold and threshold > 0 and changed_lines > 0 and changed_lines <= threshold
+  opts.title = fmt("Proposed edits for `%s`:", opts.title)
 
-  if threshold_met then
-    -- Show small diffs in the chat buffer
-    local diff_text = diff_utils.unified(opts.from_lines, opts.to_lines)
-    opts.title = "Proposed Edits"
-    opts.prompt = fmt("`%s`\n\n`````diff\n%s\n`````", opts.title, diff_text)
-
-    return approve_in_chat(opts.chat, opts)
-  elseif ui_utils.buf_is_active(opts.chat_bufnr) then
-    -- If the chat is active, show the diff in the floating window
-    opts.title = "View Proposed Edits"
-    opts.prompt = opts.title
-    approve_in_chat(opts.chat, opts)
-
-    opts.title = opts.title
-    return open_diff_view(opts)
-  else
-    -- Otherwise, don't force the diff on the user, just show the approval
-    opts.title = "View Proposed Edits"
-    opts.prompt = opts.title
-
-    return approve_in_chat(opts.chat, opts)
-  end
+  local approval_prompt = require("codecompanion.interactions.chat.helpers.approval_prompt")
+  approval_prompt.present_diff({
+    chat_bufnr = opts.chat_bufnr,
+    from_lines = opts.from_lines,
+    to_lines = opts.to_lines,
+    title = opts.title,
+    approve = function(prompt_opts)
+      opts.prompt = prompt_opts.prompt
+      opts.title = prompt_opts.title
+      approve_in_chat(opts.chat, opts)
+    end,
+    open_diff_view = function()
+      open_diff_view(opts)
+    end,
+  })
 end
 
 return M

--- a/tests/interactions/chat/acp/test_permission_request.lua
+++ b/tests/interactions/chat/acp/test_permission_request.lua
@@ -178,8 +178,8 @@ T["diff flow -> approval prompt shows view option"] = function()
     return _G.__approval_opts
   ]])
 
-  -- Small diff triggers inline mode with "Proposed Edits" title
-  h.eq("Proposed Edits", result.title)
+  -- Small diff triggers inline mode with file-based title
+  h.eq("Proposed edits for `file.txt`:", result.title)
   -- Inline diff text is included in the prompt
   h.eq(true, result.prompt:find("diff") ~= nil)
   h.eq("gv", result.choice_keys[1])


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When an LLM or ACP agent edits a file, the prompt to the user, in the chat buffer, wasn't clean.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
