### PR TITLE
perf(chat): improve performance of the chat buffer

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -158,15 +158,16 @@ local function sync_all_buffer_content(chat)
     return
   end
 
+  -- Build a set of context IDs already present in this cycle for O(1) duplicate checks
+  local seen = {}
+  for _, msg in ipairs(chat.messages) do
+    if msg.context and msg.context.id and msg._meta and msg._meta.cycle == chat.cycle then
+      seen[msg.context.id] = true
+    end
+  end
+
   for _, item in ipairs(synced) do
-    -- Don't add the item twice in the same cycle
-    local exists = false
-    vim.iter(chat.messages):each(function(msg)
-      if (msg.context and msg.context.id == item.id) and (msg._meta and msg._meta.cycle == chat.cycle) then
-        exists = true
-      end
-    end)
-    if not exists then
+    if not seen[item.id] then
       require(item.source)
         .new({ Chat = chat })
         :output({ path = item.path, bufnr = item.bufnr, params = item.params }, { sync_all = true })
@@ -827,7 +828,7 @@ function Chat:make_system_prompt_context()
     -- These can be slow-to-run or too complex for a one-liner. So wrap them in
     -- functions and use a metatable to handle the eval when needed.
     adapter = function()
-      return vim.deepcopy(self.adapter)
+      return adapters.make_safe(self.adapter)
     end,
     os = function()
       local machine = vim.uv.os_uname().sysname
@@ -1560,18 +1561,13 @@ function Chat:close()
   utils.fire("ChatAdapter", { bufnr = self.bufnr, id = self.id, adapter = nil })
   utils.fire("ChatModel", { bufnr = self.bufnr, id = self.id, model = nil })
 
-  table.remove(
-    _G.codecompanion_buffers,
-    vim.iter(_G.codecompanion_buffers):enumerate():find(function(_, v)
-      return v == self.bufnr
-    end)
-  )
-  table.remove(
-    _G.codecompanion_chat_metadata,
-    vim.iter(_G.codecompanion_chat_metadata):enumerate():find(function(_, v)
-      return v == self.bufnr
-    end)
-  )
+  for i = #_G.codecompanion_buffers, 1, -1 do
+    if _G.codecompanion_buffers[i] == self.bufnr then
+      table.remove(_G.codecompanion_buffers, i)
+      break
+    end
+  end
+  _G.codecompanion_chat_metadata[self.bufnr] = nil
   chats[self.bufnr] = nil
   registry.remove(self.bufnr)
   pcall(api.nvim_buf_delete, self.bufnr, { force = true })


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I've been meaning to tighten performance on the chat buffer for sometime. It's felt slow when chat history gets big. Every request at a context over 100,000 tokens seems to be delayed by a split second.

I asked Opus 4.6 to conduct a review on the chat class and identify performance improvements. It's findings were:

| Priority | Issue | Impact |
|----------|-------|--------|
| 1 | `vim.deepcopy(self.messages)` on submit | High — scales with conversation length |
| 2 | `check_context()` O(n^2) | High — compounds with many tools/contexts |
| 3 | `make_safe()` called 3x per submit | Medium — builds tables + iterates schema each time |
| 4 | `sync_all_buffer_content` nested iteration | Medium — per-submit cost |
| 5 | `Chat.new()` synchronous initialization | Medium — affects perceived startup time |
| 6 | `_G.codecompanion_buffers` linear scan | Low — only on close, small N |
| 7 | Stable context values recomputed | Low — cheap individually |

The first 3 were all great catches, which I missed. Possibly because I'm too close to the chat class itself (_"can't see the wood for the trees"_) and the fact I hadn't appreciated the [impact](https://github.com/neovim/neovim/blob/9383a096eb7eef0693505508a0414dd3ff2221eb/runtime/lua/vim/_core/shared.lua#L17) of what `vim.deepcopy` does when it traverses a complex table structure.

For those who are still unsure of what value AI brings to their codebase, I'd reference the commits in this PR and the overall scope which I gave Opus 4.6. I liken it to having an experienced pair of eyes look at my code for what it is with no pre-conceived ideas and biases.

## AI Usage

Opus 4.6 (via Claude Code)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
