### PR TITLE
fix(ui): stop duplicate approval messages

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
@@ -126,11 +126,11 @@ function M.present_diff(opts)
     return opts.approve({ title = opts.title, prompt = prompt })
   elseif ui_utils.buf_is_active(opts.chat_bufnr) then
     -- If the chat is active, show the diff in the floating window
-    opts.approve({ title = opts.title, prompt = opts.title })
+    opts.approve({ title = opts.title })
     return opts.open_diff_view()
   else
     -- Otherwise, don't force the diff on the user, just show the approval
-    return opts.approve({ title = opts.title, prompt = opts.title })
+    return opts.approve({ title = opts.title })
   end
 end
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Once again, try and stop duplicate approval messages.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
