### PR TITLE
Fix filesystems reads / writes with empty sessionId

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -759,11 +759,11 @@ function Connection:write_message(data)
   return true
 end
 
----Check if params contain a mismatched sessionId
+---Check if params target the active session
 ---@param params table
----@return boolean valid true if sessionId matches or is absent
+---@return boolean valid true if an active session exists and sessionId matches it
 function Connection:_has_valid_session_id(params)
-  return not params.sessionId or not self.session_id or params.sessionId == self.session_id
+  return self.session_id ~= nil and params.sessionId == self.session_id
 end
 
 ---Handle fs/read_text_file requests

--- a/tests/acp/test_acp.lua
+++ b/tests/acp/test_acp.lua
@@ -446,6 +446,37 @@ T["ACP Responses"]["fs/read_text_file rejects invalid sessionId"] = function()
   h.eq(result.error.code, -32602)
 end
 
+T["ACP Responses"]["fs/read_text_file rejects requests without an active session"] = function()
+  local result = child.lua([[
+    local called = false
+    package.loaded["codecompanion.interactions.chat.acp.fs"] = {
+      read_text_file = function(path)
+        called = true
+        return true, "should_not_be_called"
+      end
+    }
+    local connection = create_test_connection()
+    local sent = {}
+    function connection:write_message(data)
+      table.insert(sent, vim.trim(data))
+      return true
+    end
+    local req = vim.json.encode({
+      jsonrpc = "2.0", id = 61, method = "fs/read_text_file",
+      params = { sessionId = "missing-session", path = "/tmp/x" }
+    })
+    connection:buffer_stdout_and_dispatch(req .. "\n")
+    return {
+      called = called,
+      reply = vim.json.decode(sent[#sent]),
+    }
+  ]])
+
+  h.is_false(result.called)
+  h.eq(result.reply.id, 61)
+  h.eq(result.reply.error.code, -32602)
+end
+
 T["ACP Responses"]["fs/write_text_file and responds with null"] = function()
   local result = child.lua([[
     local writes = {}
@@ -531,6 +562,47 @@ T["ACP Responses"]["fs/write_text_file rejects invalid sessionId"] = function()
   -- JSON-RPC error response expected
   h.eq(type(result[1].error), "table")
   h.eq(result[1].error.code, -32602)
+end
+
+T["ACP Responses"]["fs/write_text_file rejects requests without an active session"] = function()
+  local result = child.lua([[
+    local called = false
+    package.loaded["codecompanion.interactions.chat.acp.fs"] = {
+      write_text_file = function(path, content)
+        called = true
+        return true
+      end
+    }
+
+    local connection = create_test_connection()
+
+    local sent = {}
+    function connection:write_message(data)
+      table.insert(sent, vim.trim(data))
+      return true
+    end
+
+    local req = vim.json.encode({
+      jsonrpc = "2.0",
+      id = 71,
+      method = "fs/write_text_file",
+      params = {
+        sessionId = "missing-session",
+        path = "/tmp/cc_write_bad.lua",
+        content = "nope",
+      }
+    })
+    connection:buffer_stdout_and_dispatch(req .. "\n")
+
+    return {
+      called = called,
+      reply = vim.json.decode(sent[#sent]),
+    }
+  ]])
+
+  h.is_false(result.called)
+  h.eq(result.reply.id, 71)
+  h.eq(result.reply.error.code, -32602)
 end
 
 T["ACP Responses"]["fs/write_text_file failure returns JSON-RPC error"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

This fixes a small issue regarding what is considered an active / valid session, when a read / write request arrives. The old check would allow invalid sessions or sessions with an empty sessionId to pass, however fs reads / writes should really be session-scoped, as per the spec.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

Codex

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages