### PR TITLE
fix(acp): terminate processes

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -142,7 +142,7 @@ function Connection:connect_and_authenticate()
     self._initialized = true
 
     api.nvim_create_autocmd("VimLeavePre", {
-      group = api.nvim_create_augroup("codecompanion.acp.disconnect", { clear = true }),
+      group = api.nvim_create_augroup("codecompanion.acp.disconnect", { clear = false }),
       callback = function()
         pcall(function()
           return self:disconnect()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When a user had multiple ACP instances open in CodeCompanion and closed Neovim, only one of those processes would be terminated. This was due to an error in my `VimLeavePre` command and `{ clear = true }` which was failing to allow subsequent ACP processed from appending `self:disconnect()` to the group.

## AI Usage

None

## Related Issue(s)

#2944

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
