### PR TITLE
fix(acp): slash commands in chat buffer

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/init.lua
+++ b/lua/codecompanion/interactions/chat/helpers/init.lua
@@ -9,13 +9,18 @@ local M = {}
 local api = vim.api
 local fmt = string.format
 
----Create a new ACP connection for the given chat
+---Establishes the connection, authenticates, creates a session and links the buffer
 ---@param chat CodeCompanion.Chat The chat instance
 ---@return boolean
 function M.create_acp_connection(chat)
   local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
   local handler = ACPHandler.new(chat)
-  return handler:ensure_connection()
+
+  if not handler:ensure_connection() then
+    return false
+  end
+
+  return handler:ensure_session()
 end
 
 ---Format the given role without any separator

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -731,15 +731,7 @@ function Chat:change_adapter(adapter)
   self.ui.adapter = self.adapter
 
   if self.adapter.type == "acp" then
-    -- Ensure the ACP connection and session are created so users can select a model
     helpers.create_acp_connection(self)
-    if self.acp_connection then
-      self.acp_connection:ensure_session()
-
-      local acp_commands = require("codecompanion.interactions.chat.acp.commands")
-      acp_commands.link_buffer_to_session(self.bufnr, self.acp_connection.session_id)
-    end
-
     helpers.remove_mcp_tools(self)
   end
 

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/command.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/command.lua
@@ -54,7 +54,15 @@ function SlashCommand:execute()
     local command = Chat.adapter.commands[selected]
     if command then
       Chat.adapter.commands.selected = command
-      Chat.acp_connection = nil
+
+      -- Disconnect the existing ACP process before starting a new one
+      if Chat.acp_connection then
+        pcall(function()
+          Chat.acp_connection:disconnect()
+        end)
+        Chat.acp_connection = nil
+      end
+
       require("codecompanion.interactions.chat.helpers").create_acp_connection(Chat)
       utils.notify(string.format("Switched to `%s` command", selected))
     end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fixes the issue of slash commands not being available in the chat buffer when the default adapter is an ACP one.

@alexghergh, this PR resolves the ACP slash commands and adapter, mode and command changes for me. Also confirmed you can go from http->ACP adapter in the same chat buffer.

Can you test this out?

## AI Usage

None

## Related Issue(s)

#2948

## Screenshots

https://github.com/user-attachments/assets/61804f5f-d7bb-4cfa-b017-8462328bc235

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
