### PR TITLE
fix(background): pass full response to parse handler, not just body

### DIFF
--- a/lua/codecompanion/interactions/background/init.lua
+++ b/lua/codecompanion/interactions/background/init.lua
@@ -96,7 +96,7 @@ local function ask_sync(background, messages, opts)
   end
 
   local parse_handler = opts.parse_handler or "parse_chat"
-  local result = adapters.call_handler(background.adapter, parse_handler, response.body)
+  local result = adapters.call_handler(background.adapter, parse_handler, response)
   return result, nil
 end
 
@@ -128,7 +128,7 @@ local function ask_async(background, messages, opts)
       return
     end
 
-    local result = adapters.call_handler(adapter, parse_handler, response.body)
+    local result = adapters.call_handler(adapter, parse_handler, response)
     original_on_done(result, meta)
   end
 


### PR DESCRIPTION
## Description

Both ask_sync and ask_async were passing `response.body` (a raw JSON string) to the adapter's parse handler (e.g. `chat_output`).  In non-streaming mode the handler expects the full response table `{body, status, headers, …}` and internally does `data = data.body`. Passing the pre-extracted string caused `data.body` to resolve to nil, silently breaking all background interactions (e.g. auto-title generation never produced a title).

Pass the full `response` table so the handler can extract `.body` itself, consistent with how the main chat HTTP path works.

<!-- Please do not alter the structure of this PR template -->


<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

Yes, Claude Opus 4.6 through CC ;)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

N/A

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
