### PR TITLE
fix: Update chat metadata after ACP session setup

### DIFF
--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -96,6 +96,7 @@ function ACPHandler:ensure_session()
   -- Map bufnr -> session_id so completion providers can look up ACP commands for this buffer
   local acp_commands = require("codecompanion.interactions.chat.acp.commands")
   acp_commands.link_buffer_to_session(self.chat.bufnr, conn.session_id)
+  self.chat:update_metadata()
 
   return true
 end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fix metadata staleness after an ACP session is created. In practice, after an ACP session is created, model and mode remain stale because `ensure_acp_session` does not update those.

A chat metadata update _is_ called earlier after an ACP connection is established, however that is too early to update mode / model information as well.

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

Codex

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
