### PR TITLE
tests: pin tree-sitter dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ deps/plenary.nvim:
 deps/nvim-treesitter:
 	@mkdir -p deps
 	git clone --filter=blob:none https://github.com/nvim-treesitter/nvim-treesitter.git $@
+	cd $@ && git checkout 7caec27
 
 deps/mini.nvim:
 	@mkdir -p deps


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

`nvim-treesitter` now only supports `0.12.0` and above. Pinning to an older version in the tests.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
