### PR TITLE
refactor(chat): switch to normal mode when submitting

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1119,6 +1119,11 @@ function Chat:submit(opts)
     return log:debug("Chat request already in progress")
   end
 
+  -- The chat buffer can be submitted in insert mode, but we want to ensure that
+  -- we revert to normal mode so the user can scroll the chat buffer without
+  -- unintentionally hitting the "modifiable is off" error
+  vim.cmd("stopinsert")
+
   opts = opts or {}
 
   if opts.callback then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

You're in insert mode. You press `<C-CR>` to submit the buffer. You try and scroll the buffer to read the LLM's response. _"Cannot make changes, 'modifiable' is off"_. F*ck. I'm still in insert mode.

Not anymore.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
