### PR TITLE
fix(chat): duplicate rules

### DIFF
--- a/lua/codecompanion/interactions/chat/rules/helpers.lua
+++ b/lua/codecompanion/interactions/chat/rules/helpers.lua
@@ -141,7 +141,7 @@ end
 ---@return nil
 function M.add_context(files, chat)
   for _, file in ipairs(files) do
-    local id = "<rules>" .. file.name .. "</rules>"
+    local id = "<rules>" .. file.path .. "</rules>"
     local context_exists = chat_helpers.has_context(id, chat.messages)
     if not context_exists then
       if file.system_prompt and file.system_prompt ~= "" then
@@ -179,7 +179,7 @@ function M.add_files_or_buffers(included_files, chat)
 
     -- Use <rules> ID format to match add_context() and prevent duplicates
     -- when a file is both directly listed and referenced via @include
-    local id = "<rules>" .. path .. "</rules>"
+    local id = "<rules>" .. vim.fn.fnamemodify(path, ":.") .. "</rules>"
     local context_exists = chat_helpers.has_context(id, chat.messages)
     if context_exists then
       return

--- a/lua/codecompanion/interactions/chat/rules/init.lua
+++ b/lua/codecompanion/interactions/chat/rules/init.lua
@@ -9,7 +9,7 @@ local parsers = require("codecompanion.interactions.chat.rules.parsers")
 ---@field filename string The filename of the rules file
 ---@field meta? {included_files: string[]} Additional metadata about the rules file
 ---@field parser string|nil The parser to use for the rules file
----@field path string The full, normalized file path of the rules file
+---@field path string The file path relative to the current working directory
 ---@field system_prompt? string The extracted system prompt from the rules file
 
 ---@class CodeCompanion.Chat.Rules
@@ -175,7 +175,7 @@ function Rules:read_files(paths)
         table.insert(files, {
           name = original_path or path,
           content = content,
-          path = path,
+          path = vim.fn.fnamemodify(path, ":p:."),
           filename = vim.fn.fnamemodify(path, ":t"),
           parser = file_parser,
         })


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

There was an error with how the id for rules attachments was being added to the context table in a chat buffer. The impact was duplicate attachments and rules files could end up in the chat.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
