### PR TITLE
feat(chat): show tool approval feedback

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
@@ -1,4 +1,5 @@
 local config = require("codecompanion.config")
+local labels = require("codecompanion.interactions.chat.tools.labels")
 local log = require("codecompanion.utils.log")
 local ui_utils = require("codecompanion.utils.ui")
 local utils = require("codecompanion.utils")
@@ -83,6 +84,14 @@ function M.request(chat, opts)
     end
     resolved = true
     cleanup_keymaps(bufnr, opts.choices)
+    local is_rejection = labels.is_rejection(choice_label)
+    local icons = config.display.chat.icons
+    local icon = is_rejection and icons.tool_failure or icons.tool_success
+    local status = is_rejection and "failed" or "completed"
+    chat:add_buf_message(
+      { content = fmt("%s%s\n\n", icon, choice_label) },
+      { _icon_info = { has_icon = true, status = status } }
+    )
     utils.fire("ToolApprovalFinished", { bufnr = bufnr, choice = choice_label })
   end
 

--- a/lua/codecompanion/interactions/chat/tools/labels.lua
+++ b/lua/codecompanion/interactions/chat/tools/labels.lua
@@ -7,6 +7,13 @@ M.reject = "Reject"
 M.reject_always = "Reject always"
 M.cancel = "Cancel"
 
+---Check if a label represents a rejection
+---@param label string
+---@return boolean
+function M.is_rejection(label)
+  return label == M.reject or label == M.reject_always or label == M.cancel
+end
+
 ---Get the resolved keymap keys from shared config
 ---@return table<string, string>
 function M.keymaps()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When a user approves/rejects a tool call, their decision is not shown in the chat buffer. This PR addresses that.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="3368" height="2240" alt="2026-04-04 21_55_37 - Ghostty@2x" src="https://github.com/user-attachments/assets/c39d138d-8df9-4cc6-8b7e-02a5448c21e7" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
