### PR TITLE
fix(gemini): map thinkingLevel to thinkingBudget for Gemini 2.5 models

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 08
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 09
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -493,7 +493,7 @@ use a rich prompt input field complete with |codecompanion--editor-context|.
 Save with `:w` to send the prompt to the agent, or `:w!` to send and
 auto-submit it.
 
-Adding `!` to the command (e.g.� `:CodeCompanionCLI! <prompt>`) will
+Adding `!` to the command (e.g. `:CodeCompanionCLI! <prompt>`) will
 auto-submit the prompt and keep your cursor in the current buffer. You can also
 specify which agent to use with `:CodeCompanionCLI agent=<agent name>`.
 
@@ -1436,9 +1436,10 @@ The configuration for both types of adapters is exactly the same, however they
 sit within their own tables (`adapters.http.*` and `adapters.acp.*`) and have
 different options available. HTTP adapters use `models` to allow users to
 select the specific LLM they’d like to interact with. ACP adapters use
-`commands` to allow users to customize their interaction with agents (e.g.�
-enabling `yolo` mode). As there is a lot of shared functionality between the
-two adapters, it is recommend that you read this page alongside the ACP one.
+`commands` to allow users to customize their interaction with agents
+(e.g. enabling `yolo` mode). As there is a lot of shared functionality between
+the two adapters, it is recommend that you read this page alongside the ACP
+one.
 
 
 CHANGING THE DEFAULT ADAPTER ~
@@ -1492,7 +1493,7 @@ the adapter’s URL, headers, parameters and other fields at runtime.
   <https://github.com/olimorris/codecompanion.nvim/discussions/601>
 Supported `env` value types: - **Plain environment variable name (string)**: if
 the value is the name of an environment variable that has already been set
-(e.g.� `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
+(e.g. `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
 **Command (string prefixed with cmd:)**: any value that starts with `cmd:` will
 be executed via the shell. Example: `"cmd:op read
 op://personal/Gemini/credential --no-newline"`. - **Function**: you can provide
@@ -3439,7 +3440,7 @@ The fastest way to copy an LLM’s code output is with `gy`. This will yank the
 nearest codeblock.
 
 
-APPLYING AN LLM�S EDITS TO A BUFFER OR FILE ~
+APPLYING AN LLM’S EDITS TO A BUFFER OR FILE ~
 
 The |codecompanion-usage-chat-buffer-agents-tools-files| tool, combined with
 the |codecompanion-usage-chat-buffer-editor-context.html-buffer| editor context
@@ -4328,7 +4329,7 @@ message to the LLM.
 
   [!IMPORTANT] With the exception of `#{buffer}` and `#{buffers}`, editor context
   captures a point-in-time snapshot when your message is sent. If the underlying
-  data changes (e.g.� new diagnostics, a different quickfix list), simply use the
+  data changes (e.g. new diagnostics, a different quickfix list), simply use the
   context again in a new message to share the latest state.
 
 #BUFFER ~
@@ -5604,7 +5605,7 @@ These handlers manage tool/function calling:
   as a great reference to understand how they’re working with the output of the
   API
 
-OPENAI�S API OUTPUT
+OPENAI’S API OUTPUT
 
 If we reference the OpenAI documentation
 <https://platform.openai.com/docs/guides/text-generation/chat-completions-api>
@@ -7512,7 +7513,7 @@ tool to function. In the case of Anthropic, we insert additional headers.
 <
 
 Some adapter tools can be a `hybrid` in terms of their implementation. That is,
-they’re an adapter tool that requires a client-side component (i.e.� a
+they’re an adapter tool that requires a client-side component (i.e. a
 built-in tool). This is the case for the
 |codecompanion-usage-chat-buffer-agents-tools-memory| tool from Anthropic. To
 allow for this, ensure that the tool definition in `available_tools` has

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 09
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 10
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -62,6 +62,34 @@ local function decode_args(args)
   return {}
 end
 
+---Gemini 2.5 models use `generationConfig.thinkingConfig = { thinkingBudget = N }`
+---rather than a raw thinking level. Models opt into this budget-based shape via
+---`opts.thinking_budget`, which selects a row from `THINKING_LEVEL_BUDGETS`.
+---Other reasoning models continue to use the `{ thinkingLevel = "<level>" }` shape.
+---
+---Gemini 2.5 Pro cannot fully disable thinking: the API rejects thinkingBudget = 0,
+---so `none` maps to 128 — the minimum valid budget — rather than a true off state.
+local THINKING_LEVEL_BUDGETS = {
+  pro = { none = 128, low = 1024, medium = 8192, high = 24576 },
+  flash = { none = 0, low = 1024, medium = 8192, high = 24576 },
+  flash_lite = { none = 0, low = 512, medium = 8192, high = 24576 },
+}
+
+local function resolve_thinking_config(opts, level)
+  local tier = type(opts.thinking_budget) == "string" and opts.thinking_budget
+  if not tier then
+    return { thinkingLevel = level }
+  end
+
+  local budgets = THINKING_LEVEL_BUDGETS[tier]
+  local budget = budgets and budgets[level]
+  if budget == nil then
+    return nil
+  end
+
+  return { thinkingBudget = budget }
+end
+
 ---@class CodeCompanion.HTTPAdapter.Gemini: CodeCompanion.HTTPAdapter
 return {
   name = "gemini",
@@ -123,6 +151,28 @@ return {
     ---@param messages table
     ---@return table
     form_parameters = function(self, params, messages)
+      local level = self.temp and self.temp.thinkingLevel
+      if not level then
+        return params
+      end
+
+      local model = self.schema.model.default
+      if type(model) == "function" then
+        model = model(self)
+      end
+      local choice = self.schema.model.choices[model]
+      local opts = type(choice) == "table" and type(choice.opts) == "table" and choice.opts or {}
+      if not opts.can_reason then
+        return params
+      end
+
+      local thinking_config = resolve_thinking_config(opts, level)
+      if thinking_config == nil then
+        return params
+      end
+
+      params.generationConfig = params.generationConfig or {}
+      params.generationConfig.thinkingConfig = thinking_config
       return params
     end,
 
@@ -466,17 +516,17 @@ return {
         ["gemini-2.5-pro"] = {
           formatted_name = "Gemini 2.5 Pro",
           meta = { context_window = 1048576 },
-          opts = { can_reason = true, has_vision = true },
+          opts = { can_reason = true, has_vision = true, thinking_budget = "pro" },
         },
         ["gemini-2.5-flash"] = {
           formatted_name = "Gemini 2.5 Flash",
           meta = { context_window = 1048576 },
-          opts = { can_reason = true, has_vision = true },
+          opts = { can_reason = true, has_vision = true, thinking_budget = "flash" },
         },
         ["gemini-2.5-flash-lite"] = {
           formatted_name = "Gemini 2.5 Flash Lite",
           meta = { context_window = 1048576 },
-          opts = { can_reason = true, has_vision = true },
+          opts = { can_reason = true, has_vision = true, thinking_budget = "flash_lite" },
         },
 
         -- Older models
@@ -531,7 +581,7 @@ return {
     },
     thinkingLevel = {
       order = 6,
-      mapping = "body.generationConfig.thinkingConfig",
+      mapping = "temp",
       type = "string",
       optional = true,
       ---@type fun(self: CodeCompanion.HTTPAdapter): boolean

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -62,20 +62,17 @@ local function decode_args(args)
   return {}
 end
 
----Gemini 2.5 models use `generationConfig.thinkingConfig = { thinkingBudget = N }`
----rather than a raw thinking level. Models opt into this budget-based shape via
----`opts.thinking_budget`, which selects a row from `THINKING_LEVEL_BUDGETS`.
----Other reasoning models continue to use the `{ thinkingLevel = "<level>" }` shape.
----
----Gemini 2.5 Pro cannot fully disable thinking: the API rejects thinkingBudget = 0,
----so `none` maps to 128 — the minimum valid budget — rather than a true off state.
+---Budget mappings for Gemini 2.5 thinking config: https://ai.google.dev/gemini-api/docs/thinking
 local THINKING_LEVEL_BUDGETS = {
   pro = { none = 128, low = 1024, medium = 8192, high = 24576 },
   flash = { none = 0, low = 1024, medium = 8192, high = 24576 },
   flash_lite = { none = 0, low = 512, medium = 8192, high = 24576 },
 }
 
-local function resolve_thinking_config(opts, level)
+---@param level string The thinking level (e.g. "none", "low", "medium", "high")
+---@param opts table Adapter opts containing an optional `thinking_budget` tier key
+---@return table|nil
+local function resolve_thinking_config(level, opts)
   local tier = type(opts.thinking_budget) == "string" and opts.thinking_budget
   if not tier then
     return { thinkingLevel = level }
@@ -166,7 +163,7 @@ return {
         return params
       end
 
-      local thinking_config = resolve_thinking_config(opts, level)
+      local thinking_config = resolve_thinking_config(level, opts)
       if thinking_config == nil then
         return params
       end

--- a/tests/adapters/http/test_gemini.lua
+++ b/tests/adapters/http/test_gemini.lua
@@ -463,4 +463,111 @@ T["Gemini adapter"]["No Streaming"]["can output for the inline assistant"] = fun
   h.expect_starts_with("Elegant, dynamic.", adapter.handlers.inline_output(adapter, json).output)
 end
 
+T["Gemini adapter"]["form_parameters maps thinkingLevel to thinkingBudget on Gemini 2.5 Flash"] = function()
+  adapter.schema.model.default = "gemini-2.5-flash"
+  local cases = {
+    { level = "none", budget = 0 },
+    { level = "low", budget = 1024 },
+    { level = "medium", budget = 8192 },
+    { level = "high", budget = 24576 },
+  }
+
+  for _, case in ipairs(cases) do
+    adapter.temp = { thinkingLevel = case.level }
+    local params = adapter.handlers.form_parameters(adapter, {}, {})
+    h.eq(
+      { thinkingBudget = case.budget },
+      params.generationConfig.thinkingConfig,
+      string.format("thinkingLevel '%s' should set thinkingBudget = %d", case.level, case.budget)
+    )
+  end
+end
+
+T["Gemini adapter"]["form_parameters maps thinkingLevel to thinkingBudget on Gemini 2.5 Flash-Lite"] = function()
+  adapter.schema.model.default = "gemini-2.5-flash-lite"
+  local cases = {
+    { level = "none", budget = 0 },
+    { level = "low", budget = 512 },
+    { level = "medium", budget = 8192 },
+    { level = "high", budget = 24576 },
+  }
+
+  for _, case in ipairs(cases) do
+    adapter.temp = { thinkingLevel = case.level }
+    local params = adapter.handlers.form_parameters(adapter, {}, {})
+    h.eq(
+      { thinkingBudget = case.budget },
+      params.generationConfig.thinkingConfig,
+      string.format("thinkingLevel '%s' should set thinkingBudget = %d", case.level, case.budget)
+    )
+  end
+end
+
+T["Gemini adapter"]["form_parameters maps thinkingLevel to thinkingBudget on Gemini 2.5 Pro"] = function()
+  adapter.schema.model.default = "gemini-2.5-pro"
+  -- 'none' maps to 128 (not 0) because the API rejects thinkingBudget = 0 on 2.5 Pro.
+  local cases = {
+    { level = "none", budget = 128 },
+    { level = "low", budget = 1024 },
+    { level = "medium", budget = 8192 },
+    { level = "high", budget = 24576 },
+  }
+
+  for _, case in ipairs(cases) do
+    adapter.temp = { thinkingLevel = case.level }
+    local params = adapter.handlers.form_parameters(adapter, {}, {})
+    h.eq(
+      { thinkingBudget = case.budget },
+      params.generationConfig.thinkingConfig,
+      string.format("thinkingLevel '%s' should set thinkingBudget = %d", case.level, case.budget)
+    )
+  end
+end
+
+T["Gemini adapter"]["form_parameters uses thinkingLevel object shape on Gemini 3.x"] = function()
+  for _, model in ipairs({ "gemini-3.1-pro-preview", "gemini-3.1-flash-lite-preview", "gemini-3-flash-preview" }) do
+    adapter.schema.model.default = model
+    adapter.temp = { thinkingLevel = "high" }
+    local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+    h.eq(
+      { thinkingLevel = "high" },
+      params.generationConfig.thinkingConfig,
+      string.format("%s should serialize thinkingConfig using thinkingLevel", model)
+    )
+    h.eq(nil, params.generationConfig.thinkingConfig.thinkingBudget)
+  end
+end
+
+T["Gemini adapter"]["form_parameters skips thinkingConfig on non-reasoning models"] = function()
+  for _, model in ipairs({ "gemini-2.0-flash", "gemini-1.5-pro", "gemini-1.5-flash" }) do
+    adapter.schema.model.default = model
+    adapter.temp = { thinkingLevel = "high" }
+    local params = adapter.handlers.form_parameters(adapter, {}, {})
+    h.eq(nil, params.generationConfig, model .. " should not set thinkingConfig")
+  end
+end
+
+T["Gemini adapter"]["form_parameters preserves existing generationConfig keys when adding thinkingConfig"] = function()
+  adapter.schema.model.default = "gemini-2.5-flash"
+  adapter.temp = { thinkingLevel = "medium" }
+  local params = {
+    generationConfig = {
+      temperature = 0.7,
+      maxOutputTokens = 1024,
+    },
+  }
+  local out = adapter.handlers.form_parameters(adapter, params, {})
+  h.eq(0.7, out.generationConfig.temperature)
+  h.eq(1024, out.generationConfig.maxOutputTokens)
+  h.eq({ thinkingBudget = 8192 }, out.generationConfig.thinkingConfig)
+end
+
+T["Gemini adapter"]["form_parameters does not set thinkingConfig when thinkingLevel is absent"] = function()
+  adapter.schema.model.default = "gemini-2.5-flash"
+  adapter.temp = {}
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+  h.eq(nil, params.generationConfig)
+end
+
 return T


### PR DESCRIPTION
## Description

This fixes Gemini reasoning config serialization for `gemini-2.5-*` models.

Previously, the adapter mapped `thinkingLevel` directly into `generationConfig.thinkingConfig`, which caused Gemini 2.5 requests to fail because those models expect `thinkingConfig` to contain a numeric `thinkingBudget`. This change moves `thinkingLevel` handling into `form_parameters`, where the adapter now builds the correct `thinkingConfig` shape for Gemini 2.5 models while preserving the existing `{ thinkingLevel = ... }` shape for other reasoning models, including Gemini 3.x.

A model-specific budget mapping is added for Gemini 2.5 Pro, Flash, and Flash-Lite. Serialization is also guarded so `thinkingConfig` is only added for reasoning models and only when `thinkingLevel` is present.

Test coverage was added for the Gemini 2.5 budget mappings, the existing Gemini 3.x `thinkingLevel` shape, non-reasoning models, preservation of existing `generationConfig` keys, and the absence of `thinkingConfig` when `thinkingLevel` is unset.

*Note: for `gemini-2.5-pro`, **`none`** maps to **`128`**, not `0`, because the API rejects `thinkingBudget = 0`.*

Docs were regenerated via `make all` per the project guidelines, otherwise untouched.

### References

[https://ai.google.dev/gemini-api/docs/thinking](https://ai.google.dev/gemini-api/docs/thinking)

## AI Usage

I used `claude-opus-4-6` to cross-check this change against the request-shaping patterns used in `lua/codecompanion/adapters/http/anthropic.lua` and to draft the test cases. I reviewed and revised those tests before including them. I also used `gpt-5-4` for wording and review feedback, but the implementation and final changes are mine.

## Related Issue(s)

[https://github.com/olimorris/codecompanion.nvim/discussions/2994](https://github.com/olimorris/codecompanion.nvim/discussions/2994)

## Screenshots

N/A

## Checklist

* [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
* [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
* [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
* [x] *(optional)* I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
* [ ] *(optional)* I've updated the README and/or relevant docs pages
