### PR TITLE
feat(ui): update approval formatting

### DIFF
--- a/lua/codecompanion/adapters/acp/init.lua
+++ b/lua/codecompanion/adapters/acp/init.lua
@@ -1,6 +1,9 @@
 local config = require("codecompanion.config")
+local formatter = require("codecompanion.interactions.chat.acp.formatters")
 local log = require("codecompanion.utils.log")
 local shared = require("codecompanion.adapters.shared")
+
+local fmt = string.format
 
 ---@class CodeCompanion.ACPAdapter
 ---@field name string The name of the adapter
@@ -20,6 +23,7 @@ local shared = require("codecompanion.adapters.shared")
 ---@field handlers.auth? fun(self: CodeCompanion.ACPAdapter): boolean Manually handle authentication
 ---@field handlers.on_exit? fun(self: CodeCompanion.ACPAdapter, data: table): table|nil
 ---@field handlers.teardown? fun(self: CodeCompanion.ACPAdapter): any
+---@field handlers.format_approval_prompt? fun(self: CodeCompanion.ACPAdapter, tool_call: table): CodeCompanion.Chat.ApprovalPrompt
 ---@field protocol? table Implement the ACP protocol in the adapter
 ---@field protocol.authenticate? fun(self: CodeCompanion.ACPAdapter): nil Authenticate with the adapter via ACP
 ---@field protocol.new_session? fun(self: CodeCompanion.ACPAdapter): nil Start a new ACP session with the adapter
@@ -37,6 +41,79 @@ function Adapter.new(args)
 end
 
 Adapter.map_roles = shared.map_roles
+
+---Default formatting for ACP tool approval prompts
+---Adapters can override this by defining their own format_approval_prompt method
+---@param tool_call table The ACP tool_call object
+---@return CodeCompanion.Chat.ApprovalPrompt
+function Adapter:format_approval_prompt(tool_call)
+  if self.handlers and self.handlers.format_approval_prompt then
+    return self.handlers.format_approval_prompt(self, tool_call)
+  end
+
+  local kind = tool_call and tool_call.kind or "permission"
+  local title = tool_call and tool_call.title or "Agent requested permission"
+  local title = fmt("%s: %s", formatter.fmt_kind(kind), title)
+
+  local lines = {}
+
+  local location_labels = {
+    read = "Reading",
+    edit = "Editing",
+    write = "Writing",
+    delete = "Deleting",
+    move = "Moving",
+    execute = "Running in",
+    search = "Searching",
+    fetch = "Fetching",
+  }
+  local label = location_labels[kind] or "Path"
+
+  if tool_call and tool_call.locations and #tool_call.locations > 0 then
+    for _, location in ipairs(tool_call.locations) do
+      if location.path then
+        local path = vim.fn.fnamemodify(location.path, ":.")
+        if location.line then
+          table.insert(lines, fmt("**%s:** `%s:%d`", label, path, location.line))
+        else
+          table.insert(lines, fmt("**%s:** `%s`", label, path))
+        end
+      end
+    end
+  end
+
+  local args = tool_call and tool_call.rawInput or {}
+  local details = vim.deepcopy(args)
+
+  if type(details) == "table" and next(details) then
+    if details.description then
+      vim.list_extend(lines, { "", details.description })
+      details.description = nil
+    end
+
+    if details.plan then
+      vim.list_extend(lines, { "", "**Plan**:", "", details.plan })
+      details.plan = nil
+    end
+
+    if details.command then
+      title = formatter.fmt_kind(kind)
+      vim.list_extend(lines, { "", "**Command**:", "", "````bash", details.command, "````" })
+      details.command = nil
+    end
+
+    if next(details) then
+      vim.list_extend(lines, { "", "### Arguments", "````json" })
+      vim.list_extend(lines, vim.split(vim.json.encode(details, { indent = "  " }), "\n"))
+      vim.list_extend(lines, { "````" })
+    end
+  end
+
+  return {
+    title = title,
+    body = #lines > 0 and table.concat(lines, "\n") or nil,
+  }
+end
 
 ---Extend an existing adapter
 ---@param adapter table|string|function

--- a/lua/codecompanion/interactions/chat/acp/formatters.lua
+++ b/lua/codecompanion/interactions/chat/acp/formatters.lua
@@ -104,7 +104,7 @@ end
 ---Make the kind element of a tool call, pretty
 ---@param kind string|nil
 ---@return string
-local function fmt_kind(kind)
+function M.fmt_kind(kind)
   if not kind or kind == "" then
     return "Tool"
   end
@@ -161,7 +161,7 @@ end
 ---@param tool_call table
 ---@return string
 function M.short_title(tool_call)
-  local kind = fmt_kind(tool_call.kind or "tool")
+  local kind = M.fmt_kind(tool_call.kind or "tool")
   local p = diff_path(tool_call)
   if p then
     return ("%s: %s"):format(kind, relpath(p))
@@ -326,7 +326,7 @@ end
 ---@param tool_call table
 ---@return string
 function M.enhanced_title(tool_call)
-  local kind = fmt_kind(tool_call.kind or "tool")
+  local kind = M.fmt_kind(tool_call.kind or "tool")
 
   -- Check for diff path first
   local p = diff_path(tool_call)

--- a/lua/codecompanion/interactions/chat/acp/request_permission.lua
+++ b/lua/codecompanion/interactions/chat/acp/request_permission.lua
@@ -260,12 +260,20 @@ function M.confirm(chat, request)
   local choices = build_choices(permission, has_diff)
 
   if not has_diff then
-    local prompt = fmt(
-      "%s: %s",
-      utils.capitalize(tool_call and tool_call.kind or "Permission"),
-      tool_call and tool_call.title or "Agent requested permission"
-    )
-    return approve_in_chat(permission, choices, { prompt = prompt })
+    local adapter = chat.adapter
+    local result = adapter and adapter.format_approval_prompt and adapter:format_approval_prompt(tool_call)
+      or {
+        title = fmt(
+          "%s: %s",
+          utils.capitalize(tool_call and tool_call.kind or "Permission"),
+          tool_call and tool_call.title or "Agent requested permission"
+        ),
+      }
+
+    return approve_in_chat(permission, choices, {
+      title = result.title,
+      prompt = result.body,
+    })
   end
 
   local d = get_diff(tool_call)

--- a/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
@@ -48,6 +48,10 @@ local function clear_processing_msg(bufnr)
   ui_utils.clear_notification(bufnr, { namespace = TOOLS_NS .. "_" .. tostring(bufnr) })
 end
 
+---@class CodeCompanion.Chat.ApprovalPrompt
+---@field title string The confirmation title shown to the user
+---@field body? string Optional rich markdown body with tool details
+
 ---@class CodeCompanion.Chat.ApprovalChoice
 ---@field keymap string The keymap to trigger this choice
 ---@field label string Display label (e.g. "Always accept")

--- a/lua/codecompanion/interactions/chat/tools/builtin/ask_questions.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/ask_questions.lua
@@ -208,10 +208,19 @@ return {
   output = {
     ---@param self CodeCompanion.Tool.AskQuestions
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return string
+    ---@return CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
       local count = self.args and self.args.questions and #self.args.questions or 0
-      return fmt("Ask you %d question%s?", count, count == 1 and "" or "s")
+      local title = fmt("Ask you %d question%s?", count, count == 1 and "" or "s")
+      if count > 0 then
+        local lines = {}
+        for i, q in ipairs(self.args.questions) do
+          table.insert(lines, fmt("%d. %s", i, q))
+        end
+        return { title = title, body = table.concat(lines, "\n") }
+      end
+
+      return { title = title }
     end,
 
     ---@param self CodeCompanion.Tool.AskQuestions

--- a/lua/codecompanion/interactions/chat/tools/builtin/cmd_tool.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/cmd_tool.lua
@@ -72,9 +72,14 @@ local function cmd_tool(spec)
     ---Prompt the user to approve the execution of the command
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return string
+    ---@return CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Run the command `%s`?", spec.build_cmd(self.args))
+      local cmd = spec.build_cmd(self.args)
+
+      return {
+        title = fmt("Run the command `%s`?", cmd),
+        body = table.concat({ "### Command", "", "````bash", cmd, "````" }, "\n"),
+      }
     end,
 
     ---Rejection message back to the LLM

--- a/lua/codecompanion/interactions/chat/tools/builtin/create_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/create_file.lua
@@ -143,9 +143,19 @@ return {
     ---The message which is shared with the user when asking for their approval
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Create a file at `%s`?", vim.fn.fnamemodify(self.args.filepath, ":."))
+      local display_path = vim.fn.fnamemodify(self.args.filepath, ":.")
+      local lines = { fmt("**Path:** `%s`", self.args.filepath) }
+      if self.args.content then
+        local file_ext = vim.fn.fnamemodify(self.args.filepath, ":e")
+        vim.list_extend(lines, { "", "### Content", "", fmt("````%s", file_ext), self.args.content, "````" })
+      end
+
+      return {
+        title = fmt("Create a file at `%s`?", display_path),
+        body = table.concat(lines, "\n"),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.CreateFile

--- a/lua/codecompanion/interactions/chat/tools/builtin/delete_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/delete_file.lua
@@ -98,9 +98,12 @@ return {
     ---The message which is shared with the user when asking for their approval
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Delete the file at `%s`?", vim.fn.fnamemodify(self.args.filepath, ":."))
+      return {
+        title = fmt("Delete the file at `%s`?", vim.fn.fnamemodify(self.args.filepath, ":.")),
+        body = fmt("**Path:** `%s`", self.args.filepath),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.DeleteFile

--- a/lua/codecompanion/interactions/chat/tools/builtin/fetch_webpage.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/fetch_webpage.lua
@@ -84,6 +84,16 @@ return {
   },
   output = {
     ---@param self CodeCompanion.Tool.FetchWebpage
+    ---@param meta { tools: CodeCompanion.Tools }
+    ---@return CodeCompanion.Chat.ApprovalPrompt
+    prompt = function(self, meta)
+      return {
+        title = fmt("Fetch webpage `%s`?", self.args.url),
+        body = fmt("**URL:** `%s`", self.args.url),
+      }
+    end,
+
+    ---@param self CodeCompanion.Tool.FetchWebpage
     ---@param stdout table The output from the command
     ---@param meta { tools: CodeCompanion.Tools, cmd: table }
     success = function(self, stdout, meta)

--- a/lua/codecompanion/interactions/chat/tools/builtin/file_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/file_search.lua
@@ -116,9 +116,12 @@ return {
     ---The message which is shared with the user when asking for their approval
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Search the cwd for `%s`?", self.args.query)
+      return {
+        title = fmt("Search the cwd for `%s`?", self.args.query),
+        body = fmt("**Query:** `%s`", self.args.query),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.FileSearch

--- a/lua/codecompanion/interactions/chat/tools/builtin/get_changed_files.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/get_changed_files.lua
@@ -134,8 +134,9 @@ return {
   output = {
     ---@param self CodeCompanion.Tool.GetChangedFiles
     ---@param meta { tools: CodeCompanion.Tools }
+    ---@return CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return "Get changed files in the git repository?"
+      return { title = "Get changed files in the git repository?" }
     end,
 
     ---@param self CodeCompanion.Tool.GetChangedFiles

--- a/lua/codecompanion/interactions/chat/tools/builtin/get_diagnostics.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/get_diagnostics.lua
@@ -185,9 +185,12 @@ return {
     ---The message which is shared with the user when asking for their approval
     ---@param self CodeCompanion.Tool.GetDiagnostics
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Get diagnostics for `%s`?", vim.fn.fnamemodify(self.args.filepath, ":."))
+      return {
+        title = fmt("Get diagnostics for `%s`?", vim.fn.fnamemodify(self.args.filepath, ":.")),
+        body = fmt("**Path:** `%s`", self.args.filepath),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.GetDiagnostics

--- a/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
@@ -207,9 +207,19 @@ return {
     ---The message which is shared with the user when asking for their approval
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Grep search for `%s`?", self.args.query)
+      local lines = { fmt("**Query:** `%s`", self.args.query) }
+
+      if self.args.include_pattern then
+        table.insert(lines, "")
+        table.insert(lines, fmt("**Pattern:** `%s`", self.args.include_pattern))
+      end
+
+      return {
+        title = fmt("Grep search for `%s`?", self.args.query),
+        body = table.concat(lines, "\n"),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.GrepSearch

--- a/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/init.lua
@@ -309,12 +309,16 @@ return {
 
     ---@param self CodeCompanion.Tool.InsertEditIntoFile
     ---@param meta {tools: CodeCompanion.Tools}
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
       local args = self.args
       local display_path = vim.fn.fnamemodify(args.filepath, ":.")
       local edit_count = args.edits and #args.edits or 0
-      return fmt("Apply %d edit(s) to `%s`?", edit_count, display_path)
+
+      return {
+        title = fmt("Apply %d edit(s) to `%s`?", edit_count, display_path),
+        body = fmt("**Path:** `%s`", args.filepath),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.InsertEditIntoFile

--- a/lua/codecompanion/interactions/chat/tools/builtin/memory.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/memory.lua
@@ -492,26 +492,51 @@ return {
     ---The message shared with the user when asking for approval
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
       local args = self.args
       local command = args.command
 
       if command == "view" then
-        return fmt("View %s?", args.path)
+        return {
+          title = fmt("View %s?", args.path),
+          body = fmt("**Path:** `%s`", args.path),
+        }
       elseif command == "create" then
-        return fmt("Create file at %s?", args.path)
+        local lines = { fmt("**Path:** `%s`", args.path) }
+        if args.file_text then
+          vim.list_extend(lines, { "", "### Content", "", "````", args.file_text, "````" })
+        end
+
+        return {
+          title = fmt("Create file at %s?", args.path),
+          body = table.concat(lines, "\n"),
+        }
       elseif command == "str_replace" then
-        return fmt("Replace text in %s?", args.path)
+        return {
+          title = fmt("Replace text in %s?", args.path),
+          body = fmt("**Path:** `%s`", args.path),
+        }
       elseif command == "insert" then
-        return fmt("Insert text at line %d in %s?", args.insert_line or 0, args.path)
+        return {
+          title = fmt("Insert text at line %d in %s?", args.insert_line or 0, args.path),
+          body = fmt("**Path:** `%s`", args.path),
+        }
       elseif command == "delete" then
-        return fmt("Delete %s?", args.path)
+        return {
+          title = fmt("Delete %s?", args.path),
+          body = fmt("**Path:** `%s`", args.path),
+        }
       elseif command == "rename" then
-        return fmt("Rename %s to %s?", args.old_path, args.new_path)
+        return {
+          title = fmt("Rename %s to %s?", args.old_path, args.new_path),
+          body = fmt("**Old Path:** `%s`\n**New Path:** `%s`", args.old_path, args.new_path),
+        }
       end
 
-      return "Execute memory command?"
+      return {
+        title = "Execute memory command?",
+      }
     end,
 
     ---@param self CodeCompanion.Tool.Memory

--- a/lua/codecompanion/interactions/chat/tools/builtin/read_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/read_file.lua
@@ -178,9 +178,14 @@ return {
     ---The message which is shared with the user when asking for their approval
     ---@param self CodeCompanion.Tools.Tool
     ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
+    ---@return nil|CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Read `%s`?", vim.fn.fnamemodify(self.args.filepath, ":."))
+      local display_path = vim.fn.fnamemodify(self.args.filepath, ":.")
+
+      return {
+        title = fmt("Read `%s`?", display_path),
+        body = fmt("**Path:** `%s`", self.args.filepath),
+      }
     end,
 
     ---@param self CodeCompanion.Tool.ReadFile

--- a/lua/codecompanion/interactions/chat/tools/builtin/run_command.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/run_command.lua
@@ -54,9 +54,12 @@ return cmd_tool({
 
     ---@param self CodeCompanion.Tool.RunCommand
     ---@param meta {tools: CodeCompanion.Tools}
-    ---@return string
+    ---@return CodeCompanion.Chat.ApprovalPrompt
     prompt = function(self, meta)
-      return fmt("Run the command `%s`?", self.args.cmd)
+      return {
+        title = fmt("Run the command `%s`?", self.args.cmd),
+        body = table.concat({ "### Command", "", "````bash", self.args.cmd, "````" }, "\n"),
+      }
     end,
 
     ---Rejection message back to the LLM

--- a/lua/codecompanion/interactions/chat/tools/builtin/web_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/web_search.lua
@@ -87,6 +87,16 @@ return {
   },
   output = {
     ---@param self CodeCompanion.Tool.WebSearch
+    ---@param meta { tools: CodeCompanion.Tools }
+    ---@return CodeCompanion.Chat.ApprovalPrompt
+    prompt = function(self, meta)
+      return {
+        title = fmt("Search the web for `%s`?", self.args.query),
+        body = fmt("**Query:** `%s`", self.args.query),
+      }
+    end,
+
+    ---@param self CodeCompanion.Tool.WebSearch
     ---@param stdout table The output from the command
     ---@param meta { tools: CodeCompanion.Tools, cmd: table }
     success = function(self, stdout, meta)

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -199,7 +199,14 @@ function Orchestrator:_setup_handlers()
         return
       end
       if self.tool.output and self.tool.output.prompt then
-        return self.tool.output.prompt(self.tool, { tools = self.tools })
+        local result = self.tool.output.prompt(self.tool, { tools = self.tools })
+        if type(result) == "table" then
+          return result
+        end
+
+        return {
+          title = result,
+        }
       end
     end,
 
@@ -291,9 +298,10 @@ function Orchestrator:setup_next_tool(input)
     if require_approval_before then
       log:debug("[Orchestrator::setup_next_tool] Asking for approval")
 
-      local prompt = self.output.prompt()
-      if prompt == nil or prompt == "" then
-        prompt = ("Run the %q tool?"):format(self.tool.name)
+      local prompt_result = self.output.prompt() or {}
+      local title = prompt_result.title
+      if not title or title == "" then
+        title = ("Run the %q tool?"):format(self.tool.name)
       end
 
       local labels = require("codecompanion.interactions.chat.tools.labels")
@@ -301,7 +309,8 @@ function Orchestrator:setup_next_tool(input)
       require("codecompanion.interactions.chat.helpers.approval_prompt").request(self.tools.chat, {
         id = self.id,
         name = self.tool.name,
-        prompt = prompt,
+        title = title,
+        prompt = prompt_result.body,
         choices = {
           {
             keymap = keys.always_accept,

--- a/tests/interactions/chat/tools/runtime/test_user_approval.lua
+++ b/tests/interactions/chat/tools/runtime/test_user_approval.lua
@@ -38,7 +38,7 @@ T["Tools"]["user approval"]["prompts a user when tool requires approval"] = func
     local ap = require("codecompanion.interactions.chat.helpers.approval_prompt")
     ap.request = function(_, opts)
       _G.ui_called = true
-      _G.ui_prompt = opts.prompt
+      _G.ui_prompt = opts.title
       -- Auto-select "Approve" (g2)
       for _, choice in ipairs(opts.choices) do
         if choice.keymap == "g2" then

--- a/tests/mcp/test_mcp_tools.lua
+++ b/tests/mcp/test_mcp_tools.lua
@@ -344,7 +344,7 @@ T["MCP Tools"]["allows overriding tool options and behavior"] = function()
     local confirmations = {}
     local ap = require("codecompanion.interactions.chat.helpers.approval_prompt")
     ap.request = function(_, opts)
-      table.insert(confirmations, opts.prompt)
+      table.insert(confirmations, opts.title)
       -- Auto-select "Approve" (g2)
       for _, choice in ipairs(opts.choices) do
         if choice.keymap == "g2" then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

https://github.com/olimorris/codecompanion.nvim/pull/2997 revised.

The main story is again having approvals dump out more detail in the beautiful new approval prompt.

- This should now have every orchestrator tool specifically overriding their prompt property so that it yields a meaningful title and body.
- ACP tools still share a default formatting, but now it is attached to the base adapter, so the formatting can be extended per adapter, since these things are not very standardized.

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->
- Claude Opus 4.6 for moving things over to a new branch and doing the repetitive prompts for http adapter.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->
<img width="1669" height="478" alt="image" src="https://github.com/user-attachments/assets/489b09a9-5942-47a7-a261-ab39ce1334d3" />
<img width="1673" height="783" alt="image" src="https://github.com/user-attachments/assets/4c429b60-a7a4-4e90-8180-531de543f9d3" />



## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
