### PR TITLE
fix(acp): gracefully clean the queue on interrupt to stop

### DIFF
--- a/lua/codecompanion/acp/prompt_builder.lua
+++ b/lua/codecompanion/acp/prompt_builder.lua
@@ -201,6 +201,7 @@ function PromptBuilder:handle_permission_request(id, params)
   if not id or not params then
     return
   end
+
   local tool_call = params.toolCall
   local options = params.options or {}
 
@@ -248,7 +249,9 @@ function PromptBuilder:handle_error(error)
     utils.fire("RequestFinished", self.options)
   end
 
-  self.connection._active_prompt = nil
+  if self.connection._active_prompt == self then
+    self.connection._active_prompt = nil
+  end
 end
 
 ---Handle done event from the server
@@ -281,7 +284,9 @@ function PromptBuilder:handle_done(stop_reason)
     self.options.status = status
     utils.fire("RequestFinished", self.options)
   end
-  self.connection._active_prompt = nil
+  if self.connection._active_prompt == self then
+    self.connection._active_prompt = nil
+  end
 end
 
 ---Cancel the prompt
@@ -297,7 +302,15 @@ function PromptBuilder:cancel()
       utils.fire("RequestFinished", self.options)
     end
   end
-  self.connection._active_prompt = nil
+
+  -- Keep _active_prompt alive so the agent's completion response can drain
+  -- through handle_done. Set a timeout to clean up if the agent never responds.
+  vim.defer_fn(function()
+    if self.connection._active_prompt == self then
+      log:debug("[acp::prompt_builder] Cancel timeout: cleaning up active prompt")
+      self.connection._active_prompt = nil
+    end
+  end, 5000)
 end
 
 PromptBuilder.new = PromptBuilder.new

--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -284,6 +284,11 @@ end
 ---@param request table
 ---@return nil
 function ACPHandler:handle_permission_request(request)
+  if self.chat.status == "cancelling" then
+    request.respond(nil, true)
+    return
+  end
+
   local tool_call = request.tool_call
 
   if
@@ -305,6 +310,11 @@ end
 
 ---Handle completion
 function ACPHandler:handle_completion()
+  -- Ignore completions from a stale handler (e.g. a late cancel ack after a new request started)
+  if self.chat._acp_handler ~= self then
+    return
+  end
+
   if not self.chat.status or self.chat.status == "" then
     self.chat.status = "success"
   end
@@ -315,6 +325,10 @@ end
 ---Handle errors
 ---@param error string
 function ACPHandler:handle_error(error)
+  if self.chat._acp_handler ~= self then
+    return
+  end
+
   self.chat.status = "error"
   log:error("[ACP::Handler] %s", error)
 

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1127,7 +1127,7 @@ function Chat:_submit_http(payload)
     end,
     on_error = function(err)
       if self.status == CONSTANTS.STATUS_CANCELLING then
-        return
+        return self:done(output, nil, nil, nil, { status = "stopped" })
       end
       self.status = CONSTANTS.STATUS_ERROR
       log:error("[chat::_submit_http] Error: %s", (err and (err.stderr or err.message)) or "unknown")
@@ -1145,6 +1145,7 @@ end
 ---@return nil
 function Chat:_submit_acp(payload)
   local acp_handler = require("codecompanion.interactions.chat.acp.handler").new(self)
+  self._acp_handler = acp_handler
   self.current_request = acp_handler:submit(payload)
 end
 
@@ -1222,6 +1223,7 @@ function Chat:submit(opts)
       vim.cmd("stopinsert")
     end
     self.ui:lock_buf()
+    self.ui:reset_cursor_state()
     self.header_line = api.nvim_buf_line_count(self.bufnr) + 2 -- this accounts for the LLM header
   end
 
@@ -1286,6 +1288,7 @@ end
 ---@return nil
 function Chat:done(output, reasoning, tools, meta, opts)
   opts = opts or {}
+  log:warn("[chat::done] status=%s, has_output=%s, opts=%s\n%s", self.status, output and #output or "nil", vim.inspect(opts), debug.traceback("", 2))
   self.current_request = nil
 
   -- Commonly, a status may not be set if the message exceeds a token limit
@@ -1542,22 +1545,14 @@ function Chat:stop()
   end)
 
   if self.current_request then
-    local handle = self.current_request
-    self.current_request = nil
-
     pcall(function()
-      if handle and type(handle.cancel) == "function" then
-        handle.cancel()
+      if self.current_request and type(self.current_request.cancel) == "function" then
+        self.current_request.cancel()
       end
     end)
 
     adapters.call_handler(self.adapter, "on_exit")
   end
-
-  vim.schedule(function()
-    log:debug("Chat request cancelled")
-    self:done(nil, nil, nil, nil, { status = "stopped" })
-  end)
 end
 
 ---Close the current chat buffer and clean up any resources

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -623,6 +623,13 @@ function UI:move_cursor(cursor_has_moved)
   end
 end
 
+---Reset cursor tracking state so auto-scroll resumes on next response
+---@return nil
+function UI:reset_cursor_state()
+  self.cursor.has_moved = false
+  self.cursor.pos = nil
+end
+
 ---Lock the chat buffer from editing
 ---@return nil
 function UI:lock_buf()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Currently, there is a race condition on interrupting an ACP request, which I think was introduced with `v19+`.

So the flow is something like as follows.

- You interrupt a tool request in the middle with stop.
- Prompt immedeately becomes available, you can send a new prompt, nothing happens.
- You press send again, the hidden conversation surfaces out.
- But all the tool requests and things are not catched, so it is in a limbo state.

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
