### PR TITLE
fix(chat): add prompt tools when running prompt slash commands

### DIFF
--- a/doc/usage/prompt-library.md
+++ b/doc/usage/prompt-library.md
@@ -22,3 +22,5 @@ Where `docs` is the `alias` of the prompt.
 
 If your prompt library entries have an `alias` defined then you can invoke them using a slash command. In the cmd line `:CodeCompanion /<alias>` or `/<alias>` if you're in the chat buffer.
 
+When invoked this way, any tools declared on the prompt are added to the current chat buffer before the prompt content is inserted.
+

--- a/lua/codecompanion/interactions/chat/slash_commands/init.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/init.lua
@@ -5,6 +5,22 @@ local log = require("codecompanion.utils.log")
 
 local api = vim.api
 
+---Add prompt-declared tools to the current chat
+---@param chat CodeCompanion.Chat
+---@param prompt_config table
+local function add_prompt_tools(chat, prompt_config)
+  local prompt_tools = prompt_config.tools or {}
+  local tools_config = chat.tools.tools_config
+
+  vim.iter(prompt_tools):each(function(tool_name)
+    if tools_config.groups and tools_config.groups[tool_name] then
+      chat.tool_registry:add_group(tool_name, { config = tools_config })
+    elseif tools_config[tool_name] then
+      chat.tool_registry:add_single_tool(tool_name, { config = tools_config[tool_name] })
+    end
+  end)
+end
+
 ---Resolve a path to the correct module
 ---@param path string The module or file path
 ---@return table|nil
@@ -176,6 +192,8 @@ end
 ---@return nil
 function SlashCommands.run(selected, chat)
   if selected.from_prompt_library then
+    add_prompt_tools(chat, selected.config)
+
     local context = selected.config.context
     if context then
       interactions.add_context(selected.config, chat)

--- a/tests/interactions/chat/test_context.lua
+++ b/tests/interactions/chat/test_context.lua
@@ -63,6 +63,43 @@ T["Context"]["Cannot be added twice with the same id"] = function()
   h.eq(1, child.lua_get([[#_G.chat.context_items]]), "Should only have 1 context item")
 end
 
+T["Context"]["Prompt-library slash commands add a single tool"] = function()
+  child.lua([[
+    local SlashCommands = require("codecompanion.interactions.chat.slash_commands")
+
+    SlashCommands.run({
+      from_prompt_library = true,
+      config = {
+        tools = { "weather" },
+        prompts = {},
+      },
+      context = {},
+    }, _G.chat)
+  ]])
+
+  local in_use = child.lua_get([[_G.chat.tool_registry.in_use]])
+  h.expect_tbl_contains("weather", in_use)
+end
+
+T["Context"]["Prompt-library slash commands add a tool group"] = function()
+  child.lua([[
+    local SlashCommands = require("codecompanion.interactions.chat.slash_commands")
+
+    SlashCommands.run({
+      from_prompt_library = true,
+      config = {
+        tools = { "senior_dev" },
+        prompts = {},
+      },
+      context = {},
+    }, _G.chat)
+  ]])
+
+  local in_use = child.lua_get([[_G.chat.tool_registry.in_use]])
+  h.expect_tbl_contains("func", in_use)
+  h.expect_tbl_contains("cmd", in_use)
+end
+
 T["Context"]["Can be deleted"] = function()
   child.lua([[
     -- Add context_items


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When a prompt library entry is invoked via a slash command, any tools declared
on that prompt were not being added to the active chat buffer first.

This PR fixes that by registering prompt-declared tools before the prompt
content is inserted.

Changes included:
- add prompt tools in `SlashCommands.run()` for prompt-library entries
- support both single tools and tool groups
- add tests covering both cases
- document the behavior in `prompt-library.md`

This makes slash-command usage consistent with prompt definitions that rely on
tools being available in the current chat.


<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

GPT-5.4 was used mostly for tests, docs, and general boilerplate such as
docstrings.
<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![Peek 2026-04-09 20-45](https://github.com/user-attachments/assets/7eb21454-fe09-40e9-8baa-642f96e8c5c2)

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
