### PR TITLE
refactor: add more granular logs

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -142,6 +142,7 @@ function Connection:connect_and_authenticate()
     end
 
     self._initialized = true
+    log:debug("[acp] Initialized (protocol_version=%s)", initialized.protocolVersion or "unknown")
 
     api.nvim_create_autocmd("VimLeavePre", {
       group = api.nvim_create_augroup("codecompanion.acp.disconnect", { clear = false }),
@@ -234,6 +235,7 @@ function Connection:_authenticate()
     self._authenticated = true
   end
 
+  log:debug("[acp] Authenticated")
   return true
 end
 
@@ -398,6 +400,7 @@ function Connection:_establish_session()
     apply_session_metadata(new_session, "New session")
   end
 
+  log:debug("[acp] Session established: %s", self.session_id)
   return true
 end
 
@@ -518,6 +521,7 @@ function Connection:start_agent_process()
   end
 
   self._state.handle = sysobj
+  log:debug("[acp] Process started: %s", table.concat(self.adapter_modified.command, " "))
   return true
 end
 
@@ -913,6 +917,8 @@ end
 ---@param code number
 ---@param signal number
 function Connection:handle_process_exit(code, signal)
+  log:debug("[acp] Process exited (code=%s, signal=%s)", code, signal)
+
   if self.adapter_modified and self.adapter_modified.handlers and self.adapter_modified.handlers.on_exit then
     self.adapter_modified.handlers.on_exit(self.adapter_modified, code)
   end

--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -221,7 +221,7 @@ end
 function ACPHandler:process_tool_call(tool_call)
   local id = tool_call.toolCallId
 
-  log:trace("[ACP::Handler] Processing tool call %s", tool_call)
+  log:debug("[ACP::Handler] Processing tool call %s", utils.truncate(tool_call))
 
   local merged = merge_tool_call(self.tools[id], tool_call)
   tool_call = merged
@@ -298,7 +298,15 @@ function ACPHandler:handle_permission_request(request)
     end
   end
 
-  log:debug("[ACPHandler::handle_permission_request] Asking for approval")
+  log:debug(
+    "[ACP::Handler] Permission Request\n  id: %s\n  kind: %s\n  %s\n  options: %s",
+    tool_call and tool_call.toolCallId or "unknown",
+    tool_call and tool_call.kind or "unknown",
+    tool_call and tool_call.title or "No title",
+    vim.inspect(vim.tbl_map(function(o)
+      return o.kind
+    end, request.options or {}))
+  )
 
   return require("codecompanion.interactions.chat.acp.request_permission").confirm(self.chat, request)
 end

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -270,4 +270,27 @@ function M.pluralize(count, word)
   return count == 1 and word or word .. "s"
 end
 
+---Deep copy a table, truncating any string values
+---@param tbl table
+---@param max_len? number
+---@return table
+function M.truncate(tbl, max_len)
+  if not max_len then
+    max_len = 255
+  end
+
+  local output = {}
+  for k, v in pairs(tbl) do
+    if type(v) == "table" then
+      output[k] = M.truncate(v, max_len)
+    elseif type(v) == "string" and #v > max_len then
+      output[k] = v:sub(1, max_len) .. "...[truncated]"
+    else
+      output[k] = v
+    end
+  end
+
+  return output
+end
+
 return M


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Add some more granular logging to the ACP interaction.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
