### PR TITLE
feat(chat): add ACP `show_model_choices` setting

### DIFF
--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -208,6 +208,24 @@ require("codecompanion").setup({
 })
 ```
 
+## Controlling Model Choices
+
+When switching between adapters, the plugin typically displays all available model choices for the selected adapter. If you want to simplify the interface and have the default model automatically chosen (without showing any model selection UI), you can set the `show_model_choices` option to `false`:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      opts = {
+        show_model_choices = false,
+      },
+    },
+  },
+})
+```
+
+With `show_model_choices = false`, the default model (as reported by the ACP agent) will be automatically selected when changing adapters, and no model selection will be shown to the user.
+
 ## Setup: Auggie CLI from Augment Code
 
 To use [Auggie CLI](https://docs.augmentcode.com/cli/overview) within CodeCompanion, you simply need to follow their [Getting Started](https://docs.augmentcode.com/cli/overview#getting-started) guide.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -51,6 +51,7 @@ local defaults = {
       opencode = "opencode",
       opts = {
         show_presets = true,
+        show_model_choices = true, -- Show model choices when changing adapter
       },
     },
     opts = {

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -125,6 +125,15 @@ end
 ---@param connection CodeCompanion.ACP.Connection
 ---@return table|nil
 function M.list_acp_models(connection)
+  local show_choices = config.adapters
+    and config.adapters.acp
+    and config.adapters.acp.opts
+    and config.adapters.acp.opts.show_model_choices
+
+  if not show_choices then
+    return nil
+  end
+
   local models = connection:get_models()
   if not models or vim.tbl_count(models.availableModels) < 2 then
     return nil


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR adds the `show_model_choices` option to ACP adapters and updates
adapter switching to respect that setting when listing ACP models.

This change makes ACP behavior consistent with HTTP adapters, which already
support `show_model_choices`. It gives users a simple way to hide model
selection when changing adapters and keep the default model instead.


## AI Usage

opus 4.6 with claude_code ACP adapter

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![Peek 2026-04-11 00-01](https://github.com/user-attachments/assets/5927446b-940d-4140-9fbd-040311d4cf6c)


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
