### PR TITLE
fix(acp): parallel tool calls that require approval

### DIFF
--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -1,4 +1,5 @@
 local Queue = require("codecompanion.utils.queue")
+
 local config = require("codecompanion.config")
 local formatter = require("codecompanion.interactions.chat.acp.formatters")
 local log = require("codecompanion.utils.log")
@@ -11,7 +12,7 @@ local watch = require("codecompanion.interactions.shared.watch")
 ---@field reasoning table Reasoning output from the Agent
 ---@field tools table<string, table> Cache of tool calls by their ID
 ---@field ui_state table<string, table> Cache of tool call UI states (line_number, icon_id) by tool call ID
----@field _permission {queue: CodeCompanion.Queue, active: boolean} Internal state for managing permission requests
+---@field _permission { queue: CodeCompanion.Queue, active: boolean } Internal state for managing permission requests
 local ACPHandler = {}
 
 ---@param chat CodeCompanion.Chat
@@ -190,7 +191,7 @@ function ACPHandler:create_and_send_prompt(payload)
       self:handle_permission_request(request)
     end)
     :on_complete(function()
-      self:handle_completion()
+      self:handle_complete()
     end)
     :on_error(function(error)
       self:handle_error(error)
@@ -201,6 +202,7 @@ end
 
 ---Handle incoming message chunks
 ---@param content string
+---@return nil
 function ACPHandler:handle_message_chunk(content)
   table.insert(self.output, content)
   self.chat:add_buf_message(
@@ -211,6 +213,7 @@ end
 
 ---Handle incoming thought chunks
 ---@param content string
+---@return nil
 function ACPHandler:handle_thought_chunk(content)
   table.insert(self.reasoning, content)
   if config.display.chat.show_reasoning then
@@ -286,12 +289,7 @@ function ACPHandler:process_tool_call(tool_call)
   self.ui_state[id] = { line_number = line_number, icon_id = icon_id }
 end
 
----Queue a permission request and present it when ready.
----Agents may send multiple permission requests concurrently. Because the
----approval UI uses buffer-local keymaps, presenting more than one at a time
----would cause the second set of keymaps to overwrite the first, leaving
----the earlier request unresolvable and the agent hanging. We queue them
----and present one at a time.
+---Queue a permission request and process when ready
 ---@param request table
 ---@return nil
 function ACPHandler:handle_permission_request(request)
@@ -332,10 +330,10 @@ function ACPHandler:_process_next_permission()
     end, request.options or {}))
   )
 
-  -- Wrap respond so we present the next queued permission after the user decides
-  local original_respond = request.respond
+  -- Ensure that the next item in the queue is processed after the user's response
+  local send_response = request.respond
   request.respond = function(option_id, canceled)
-    original_respond(option_id, canceled)
+    send_response(option_id, canceled)
     self._permission.active = false
     self:_process_next_permission()
   end
@@ -343,7 +341,7 @@ function ACPHandler:_process_next_permission()
   return require("codecompanion.interactions.chat.acp.request_permission").confirm(self.chat, request)
 end
 
----Reject all queued permission requests (e.g. on error or completion with pending items)
+---Clear any requests in the queue
 ---@return nil
 function ACPHandler:_clear_permission_queue()
   while not self._permission.queue:is_empty() do
@@ -353,8 +351,9 @@ function ACPHandler:_clear_permission_queue()
   self._permission.active = false
 end
 
----Handle completion
-function ACPHandler:handle_completion()
+---Handle the prompt response when it's complete
+---@return nil
+function ACPHandler:handle_complete()
   self:_clear_permission_queue()
 
   if not self.chat.status or self.chat.status == "" then
@@ -366,6 +365,7 @@ end
 
 ---Handle errors
 ---@param error string
+---@return nil
 function ACPHandler:handle_error(error)
   self:_clear_permission_queue()
 

--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -1,3 +1,4 @@
+local Queue = require("codecompanion.utils.queue")
 local config = require("codecompanion.config")
 local formatter = require("codecompanion.interactions.chat.acp.formatters")
 local log = require("codecompanion.utils.log")
@@ -10,6 +11,7 @@ local watch = require("codecompanion.interactions.shared.watch")
 ---@field reasoning table Reasoning output from the Agent
 ---@field tools table<string, table> Cache of tool calls by their ID
 ---@field ui_state table<string, table> Cache of tool call UI states (line_number, icon_id) by tool call ID
+---@field _permission {queue: CodeCompanion.Queue, active: boolean} Internal state for managing permission requests
 local ACPHandler = {}
 
 ---@param chat CodeCompanion.Chat
@@ -21,6 +23,10 @@ function ACPHandler.new(chat)
     reasoning = {},
     tools = {},
     ui_state = {},
+    _permission = {
+      active = false,
+      queue = Queue.new(),
+    },
   }, { __index = ACPHandler })
 
   return self --[[@type CodeCompanion.Chat.ACPHandler]]
@@ -280,12 +286,31 @@ function ACPHandler:process_tool_call(tool_call)
   self.ui_state[id] = { line_number = line_number, icon_id = icon_id }
 end
 
----Handle permission requests from the agent
+---Queue a permission request and present it when ready.
+---Agents may send multiple permission requests concurrently. Because the
+---approval UI uses buffer-local keymaps, presenting more than one at a time
+---would cause the second set of keymaps to overwrite the first, leaving
+---the earlier request unresolvable and the agent hanging. We queue them
+---and present one at a time.
 ---@param request table
 ---@return nil
 function ACPHandler:handle_permission_request(request)
-  local tool_call = request.tool_call
+  self._permission.queue:push(request)
+  self:_process_next_permission()
+end
 
+---Pop the next permission request from the queue and present it
+---@return nil
+function ACPHandler:_process_next_permission()
+  if self._permission.active or self._permission.queue:is_empty() then
+    return
+  end
+
+  self._permission.active = true
+  local request = self._permission.queue:pop()
+
+  -- Merge cached tool call data so the diff UI can activate
+  local tool_call = request.tool_call
   if
     type(tool_call) == "table"
     and tool_call.toolCallId
@@ -293,7 +318,6 @@ function ACPHandler:handle_permission_request(request)
   then
     local cached = self.tools[tool_call.toolCallId]
     if cached then
-      -- Merge the cached tool call details into the request's tool call to enable the diff UI to activate
       request.tool_call = merge_tool_call(cached, tool_call)
     end
   end
@@ -308,11 +332,31 @@ function ACPHandler:handle_permission_request(request)
     end, request.options or {}))
   )
 
+  -- Wrap respond so we present the next queued permission after the user decides
+  local original_respond = request.respond
+  request.respond = function(option_id, canceled)
+    original_respond(option_id, canceled)
+    self._permission.active = false
+    self:_process_next_permission()
+  end
+
   return require("codecompanion.interactions.chat.acp.request_permission").confirm(self.chat, request)
+end
+
+---Reject all queued permission requests (e.g. on error or completion with pending items)
+---@return nil
+function ACPHandler:_clear_permission_queue()
+  while not self._permission.queue:is_empty() do
+    local request = self._permission.queue:pop()
+    pcall(request.respond, nil, true)
+  end
+  self._permission.active = false
 end
 
 ---Handle completion
 function ACPHandler:handle_completion()
+  self:_clear_permission_queue()
+
   if not self.chat.status or self.chat.status == "" then
     self.chat.status = "success"
   end
@@ -323,6 +367,8 @@ end
 ---Handle errors
 ---@param error string
 function ACPHandler:handle_error(error)
+  self:_clear_permission_queue()
+
   self.chat.status = "error"
   log:error("[ACP::Handler] %s", error)
 

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -303,7 +303,7 @@ T["ACPHandler"]["coordinates completion flow"] = function()
     handler:handle_message_chunk("Response part 1")
     handler:handle_message_chunk(" and part 2")
     handler:handle_thought_chunk("My reasoning")
-    handler:handle_completion("end_turn")
+    handler:handle_complete("end_turn")
 
     return {
       status = chat.status,
@@ -835,7 +835,7 @@ T["ACPHandler"]["Permission Queue"]["clears queue on completion"] = function()
 
     -- Simulate completion while requests are still queued
     chat.done = function() end
-    handler:handle_completion()
+    handler:handle_complete()
 
     return {
       queue_empty = handler._permission.queue:is_empty(),

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -672,6 +672,241 @@ T["ACPHandler"]["handles no connection"] = function()
   h.eq("\\cost", result.content)
 end
 
+T["ACPHandler"]["Permission Queue"] = new_set()
+
+T["ACPHandler"]["Permission Queue"]["queues concurrent requests and presents one at a time"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+
+    -- Track which requests reach the permission UI
+    local confirmed = {}
+    package.loaded["codecompanion.interactions.chat.acp.request_permission"] = {
+      confirm = function(chat_arg, request)
+        table.insert(confirmed, request)
+      end
+    }
+
+    -- Send three permission requests concurrently
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_1", kind = "edit", title = "Edit file A" },
+      options = { { kind = "allow_once", optionId = "allow", name = "Allow" } },
+      respond = function() end,
+    })
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_2", kind = "edit", title = "Edit file B" },
+      options = { { kind = "allow_once", optionId = "allow", name = "Allow" } },
+      respond = function() end,
+    })
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_3", kind = "edit", title = "Edit file C" },
+      options = { { kind = "allow_once", optionId = "allow", name = "Allow" } },
+      respond = function() end,
+    })
+
+    return {
+      confirmed_count = #confirmed,
+      first_id = confirmed[1] and confirmed[1].tool_call.toolCallId,
+      queue_count = handler._permission.queue:count(),
+      active = handler._permission.active,
+    }
+  ]])
+
+  h.eq(1, result.confirmed_count)
+  h.eq("tool_1", result.first_id)
+  h.eq(2, result.queue_count)
+  h.is_true(result.active)
+end
+
+T["ACPHandler"]["Permission Queue"]["presents next request after user responds"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+
+    local confirmed = {}
+    package.loaded["codecompanion.interactions.chat.acp.request_permission"] = {
+      confirm = function(chat_arg, request)
+        table.insert(confirmed, request)
+      end
+    }
+
+    local responses = {}
+    local make_respond = function(id)
+      return function(option_id, canceled)
+        table.insert(responses, { id = id, option_id = option_id, canceled = canceled })
+      end
+    end
+
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_1" },
+      options = { { kind = "allow_once", optionId = "allow", name = "Allow" } },
+      respond = make_respond("tool_1"),
+    })
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_2" },
+      options = { { kind = "allow_once", optionId = "allow", name = "Allow" } },
+      respond = make_respond("tool_2"),
+    })
+
+    -- Simulate user accepting the first request
+    confirmed[1].respond("allow", false)
+
+    return {
+      confirmed_count = #confirmed,
+      second_id = confirmed[2] and confirmed[2].tool_call.toolCallId,
+      responses = responses,
+      queue_empty = handler._permission.queue:is_empty(),
+      active = handler._permission.active,
+    }
+  ]])
+
+  h.eq(2, result.confirmed_count)
+  h.eq("tool_2", result.second_id)
+  h.eq("tool_1", result.responses[1].id)
+  h.eq("allow", result.responses[1].option_id)
+  h.is_true(result.queue_empty)
+  h.is_true(result.active)
+end
+
+T["ACPHandler"]["Permission Queue"]["clears queue on completion"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+
+    local confirmed = {}
+    package.loaded["codecompanion.interactions.chat.acp.request_permission"] = {
+      confirm = function(chat_arg, request)
+        table.insert(confirmed, request)
+      end
+    }
+
+    local rejected = {}
+    local make_respond = function(id)
+      return function(option_id, canceled)
+        if canceled then
+          table.insert(rejected, id)
+        end
+      end
+    end
+
+    -- Queue up three requests
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_1" },
+      options = {},
+      respond = make_respond("tool_1"),
+    })
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_2" },
+      options = {},
+      respond = make_respond("tool_2"),
+    })
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_3" },
+      options = {},
+      respond = make_respond("tool_3"),
+    })
+
+    -- Simulate completion while requests are still queued
+    chat.done = function() end
+    handler:handle_completion()
+
+    return {
+      queue_empty = handler._permission.queue:is_empty(),
+      active = handler._permission.active,
+      rejected = rejected,
+    }
+  ]])
+
+  h.is_true(result.queue_empty)
+  h.is_false(result.active)
+  h.eq({ "tool_2", "tool_3" }, result.rejected)
+end
+
+T["ACPHandler"]["Permission Queue"]["clears queue on error"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+
+    local confirmed = {}
+    package.loaded["codecompanion.interactions.chat.acp.request_permission"] = {
+      confirm = function(chat_arg, request)
+        table.insert(confirmed, request)
+      end
+    }
+
+    local rejected = {}
+    local make_respond = function(id)
+      return function(option_id, canceled)
+        if canceled then
+          table.insert(rejected, id)
+        end
+      end
+    end
+
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_1" },
+      options = {},
+      respond = make_respond("tool_1"),
+    })
+    handler:handle_permission_request({
+      tool_call = { toolCallId = "tool_2" },
+      options = {},
+      respond = make_respond("tool_2"),
+    })
+
+    -- Stub add_buf_message and done
+    chat.add_buf_message = function() end
+    chat.done = function() end
+    handler:handle_error("Something went wrong")
+
+    return {
+      queue_empty = handler._permission.queue:is_empty(),
+      active = handler._permission.active,
+      rejected = rejected,
+    }
+  ]])
+
+  h.is_true(result.queue_empty)
+  h.is_false(result.active)
+  h.eq({ "tool_2" }, result.rejected)
+end
+
 T["ACPHandler"]["Config Options"] = new_set()
 
 T["ACPHandler"]["Config Options"]["updates metadata with config options"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

It appears that recent changes to Codex have led to it issuing parallel tool calls that require user approvals. CodeCompanion had no ability to handle this so would show approvals for a single tool call only, ignoring the others.

The PR fixes that by utilising a `CodeCompanion.Queue`.

## AI Usage

Opus 4.6

## Related Issue(s)

#3014

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
