### PR TITLE
lua: fix typo

### DIFF
--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -279,7 +279,7 @@ function Adapter.set_model(args)
   -- Set the model dictionary as a convenience for the user. This can be string
   -- or function values. If they're functions, these are likely to make http
   -- requests to obtain a list of available models. This is expensive, so
-  -- we dont't execute them here. Instead, let the user decide when to.
+  -- we don't execute them here. Instead, let the user decide when to.
   if adapter.schema and adapter.schema.model then
     adapter.model = {}
     local model = adapter.schema.model.default


### PR DESCRIPTION
## Description

Fix a typo found with the codespell tool.

## AI Usage

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
