### PR TITLE
Add KiloCode ACP adapter

### DIFF
--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -397,3 +397,19 @@ You can specify a custom model in your `~/.config/opencode/config.json` file:
 }
 ```
 
+## Setup: Kilo Code
+
+To use [Kilo Code](https://kilo.ai) in CodeCompanion, ensure you've followed
+their documentation to
+[install](https://kilo.ai/docs/getting-started/installing#cli) and
+[configure](https://kilo.ai/docs/getting-started/setup-authentication#cli) it. Then ensure that in your
+chat buffer you select the `kilocode` adapter.
+
+You can specify a custom model in your `~/.config/kilo/kilo.json` file:
+
+```json
+{
+    "$schema": "https://kilo.ai/config.json",
+    "model": "kilo/kilo-auto/free",
+}
+```

--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -372,6 +372,19 @@ require("codecompanion").setup({
 
 To use [Goose](https://block.github.io/goose/) in CodeCompanion, ensure you've followed their [documentation](https://block.github.io/goose/docs/getting-started/installation/) to setup and install Goose CLI. Then ensure that in your chat buffer you select the `goose` adapter.
 
+## Setup: Kilo Code
+
+To use [Kilo Code](https://kilo.ai) in CodeCompanion, ensure you've followed their documentation to [install](https://kilo.ai/docs/getting-started/installing#cli) and [configure](https://kilo.ai/docs/getting-started/setup-authentication#cli) it. Then ensure that in your chat buffer you select the `kilocode` adapter.
+
+You can specify a custom model in your `~/.config/kilo/kilo.json` file:
+
+```json
+{
+    "$schema": "https://kilo.ai/config.json",
+    "model": "kilo/kilo-auto/free",
+}
+```
+
 ## Setup: Kimi CLI
 
 Install [Kimi CLI](https://github.com/MoonshotAI/kimi-cli?tab=readme-ov-file#installation) as per their instructions. Then in the CLI, run `kimi` followed by `/login` to configure your API key. Then ensure that in your chat buffer you select the `kimi_cli` adapter.
@@ -394,22 +407,5 @@ You can specify a custom model in your `~/.config/opencode/config.json` file:
 {
     "$schema": "https://opencode.ai/config.json",
     "model": "github-copilot/claude-sonnet-4.5",
-}
-```
-
-## Setup: Kilo Code
-
-To use [Kilo Code](https://kilo.ai) in CodeCompanion, ensure you've followed
-their documentation to
-[install](https://kilo.ai/docs/getting-started/installing#cli) and
-[configure](https://kilo.ai/docs/getting-started/setup-authentication#cli) it. Then ensure that in your
-chat buffer you select the `kilocode` adapter.
-
-You can specify a custom model in your `~/.config/kilo/kilo.json` file:
-
-```json
-{
-    "$schema": "https://kilo.ai/config.json",
-    "model": "kilo/kilo-auto/free",
 }
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -21,7 +21,7 @@ CodeCompanion is a plugin which enables you to code with AI, using LLMs and agen
 - :speech_balloon: [Copilot Chat](https://github.com/features/copilot) meets [Zed AI](https://zed.dev/blog/zed-ai), in Neovim
 - :zap: Integrates Neovim with LLMs and Agents in the CLI
 - :electric_plug: Support for LLMs from Anthropic, Copilot, GitHub Models, DeepSeek, Gemini, Mistral AI, Novita, Ollama, OpenAI, Azure OpenAI, HuggingFace and xAI out of the box (or bring your own!)
-- :robot: Support for [Agent Client Protocol](https://agentclientprotocol.com/overview/introduction), enabling coding with agents like [Augment Code](https://docs.augmentcode.com/cli/overview), [Cagent](https://github.com/docker/cagent) from Docker, [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Cline CLI](https://docs.cline.bot/home), [Codex](https://openai.com/codex), [Copilot CLI](https://github.com/features/copilot/cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Goose](https://block.github.io/goose/), [Cursor CLI](https://cursor.com/docs/cli/overview), [Kimi CLI](https://github.com/MoonshotAI/kimi-cli), [Kiro](https://kiro.dev/cli/), [Mistral Vibe](https://github.com/mistralai/mistral-vibe) and [OpenCode](https://opencode.ai)
+- :robot: Support for [Agent Client Protocol](https://agentclientprotocol.com/overview/introduction), enabling coding with agents like [Augment Code](https://docs.augmentcode.com/cli/overview), [Cagent](https://github.com/docker/cagent) from Docker, [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [Cline CLI](https://docs.cline.bot/home), [Codex](https://openai.com/codex), [Copilot CLI](https://github.com/features/copilot/cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Goose](https://block.github.io/goose/), [Cursor CLI](https://cursor.com/docs/cli/overview), [Kilo Code](https://kilo.ai), [Kimi CLI](https://github.com/MoonshotAI/kimi-cli), [Kiro](https://kiro.dev/cli/), [Mistral Vibe](https://github.com/mistralai/mistral-vibe) and [OpenCode](https://opencode.ai)
 - :heart_hands: User contributed and supported [adapters](/configuration/adapters-http#community-adapters)
 - :battery: Support for [Model Context Protocol (MCP)](/model-context-protocol)
 - :rocket: [Inline transformations](/usage/inline.html), code creation and refactoring
@@ -50,12 +50,13 @@ CodeCompanion uses [HTTP](configuration/adapters-http) and [ACP](configuration/a
 - Cline CLI (`cline_cli`)
 - Codex (`codex`) - Requires an API key
 - Copilot (`copilot`) - Requires a token which is created via `:Copilot setup` in [Copilot.vim](https://github.com/github/copilot.vim)
+- DeepSeek (`deepseek`) - Requires an API key
+- Gemini (`gemini`) - Requires an API key
 - Gemini CLI (`gemini_cli`) - Requires an API key or a Gemini Pro subscription
 - GitHub Models (`githubmodels`) - Requires [`gh`](https://github.com/cli/cli) to be installed and logged in
 - Goose (`goose`) - Requires an API key
-- DeepSeek (`deepseek`) - Requires an API key
-- Gemini (`gemini`) - Requires an API key
 - HuggingFace (`huggingface`) - Requires an API key
+- Kilo Code (`kilocode`) - Requires an API key
 - Kimi CLI (`kimi_cli`) - Requires an API key
 - Mistral AI (`mistral`) - Requires an API key or a Le Chat Pro subscription
 - Novita (`novita`) - Requires an API key

--- a/lua/codecompanion/adapters/acp/kilocode.lua
+++ b/lua/codecompanion/adapters/acp/kilocode.lua
@@ -1,0 +1,62 @@
+local helpers = require("codecompanion.adapters.acp.helpers")
+
+---@class CodeCompanion.ACPAdapter.KiloCode: CodeCompanion.ACPAdapter
+return {
+  name = "kilocode",
+  formatted_name = "Kilo Code",
+  type = "acp",
+  roles = {
+    llm = "assistant",
+    user = "user",
+  },
+  opts = {
+    vision = true,
+  },
+  commands = {
+    default = {
+      "kilo",
+      "acp",
+    },
+  },
+  defaults = {
+    mcpServers = {},
+    timeout = 20000, -- 20 seconds
+  },
+  parameters = {
+    protocolVersion = 1,
+    clientCapabilities = {
+      fs = { readTextFile = true, writeTextFile = true },
+    },
+    clientInfo = {
+      name = "CodeCompanion.nvim",
+      version = "1.0.0",
+    },
+  },
+  handlers = {
+    ---@param self CodeCompanion.ACPAdapter
+    ---@return boolean
+    setup = function(self)
+      return true
+    end,
+
+    ---@param self CodeCompanion.ACPAdapter
+    ---@return boolean
+    auth = function(self)
+      -- Declaring auth a success
+      return true
+    end,
+
+    ---@param self CodeCompanion.ACPAdapter
+    ---@param messages table
+    ---@param capabilities table
+    ---@return table
+    form_messages = function(self, messages, capabilities)
+      return helpers.form_messages(self, messages, capabilities)
+    end,
+
+    ---@param self CodeCompanion.ACPAdapter
+    ---@param code number
+    ---@return nil
+    on_exit = function(self, code) end,
+  },
+}


### PR DESCRIPTION
## Description

Add a new ACP adapter implementation for Kilo Code at lua/codecompanion/adapters/acp/kilocode.lua.

- Registers adapter metadata (name, formatted_name, type, roles).
- Enables vision option and sets default command ("kilo acp").
- Adds sensible defaults: empty mcpServers and 20s timeout.
- Supplies adapter parameters (protocolVersion, clientCapabilities, clientInfo).
- Implements basic handlers: setup, auth (always succeeds), form_messages (delegates to acp.helpers), and noop on_exit.

## AI Usage

Update documentation and wrote commit messages with AI assistance.

## Related Issue(s)

#3033

## Screenshots

No visual change.

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [X] _(optional)_ I've updated the README and/or relevant docs pages
