### PR TITLE
docs(installation): wrap vim.pack.add args in a list

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,5 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 09
+*codecompanion.txt*
+                                  For NVIM v0.11    Last change: 2026 April 15
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -493,9 +494,9 @@ use a rich prompt input field complete with |codecompanion--editor-context|.
 Save with `:w` to send the prompt to the agent, or `:w!` to send and
 auto-submit it.
 
-Adding `!` to the command (e.g.� `:CodeCompanionCLI! <prompt>`) will
-auto-submit the prompt and keep your cursor in the current buffer. You can also
-specify which agent to use with `:CodeCompanionCLI agent=<agent name>`.
+Adding `!` to the command (e.g. `:CodeCompanionCLI! <prompt>`) will auto-submit
+the prompt and keep your cursor in the current buffer. You can also specify
+which agent to use with `:CodeCompanionCLI agent=<agent name>`.
 
 
 INLINE ~
@@ -887,7 +888,7 @@ CURRENT LIMITATIONS                    *codecompanion-acp-current-limitations*
     `terminal/output`, `terminal/release`, etc.) are not implemented. CodeCompanion
     doesn’t advertise terminal capabilities to agents.
 - **Agent Plan Rendering**: Plan
-    <https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
+<https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
     received and logged, but they’re not currently rendered in the chat buffer
     UI.
 - **Audio Content**: Audio can’t be sent or received
@@ -1436,7 +1437,7 @@ The configuration for both types of adapters is exactly the same, however they
 sit within their own tables (`adapters.http.*` and `adapters.acp.*`) and have
 different options available. HTTP adapters use `models` to allow users to
 select the specific LLM they’d like to interact with. ACP adapters use
-`commands` to allow users to customize their interaction with agents (e.g.�
+`commands` to allow users to customize their interaction with agents (e.g.
 enabling `yolo` mode). As there is a lot of shared functionality between the
 two adapters, it is recommend that you read this page alongside the ACP one.
 
@@ -1492,7 +1493,7 @@ the adapter’s URL, headers, parameters and other fields at runtime.
   <https://github.com/olimorris/codecompanion.nvim/discussions/601>
 Supported `env` value types: - **Plain environment variable name (string)**: if
 the value is the name of an environment variable that has already been set
-(e.g.� `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
+(e.g. `"HOME"` or `"GEMINI_API_KEY"`), the plugin will read the value. -
 **Command (string prefixed with cmd:)**: any value that starts with `cmd:` will
 be executed via the shell. Example: `"cmd:op read
 op://personal/Gemini/credential --no-newline"`. - **Function**: you can provide
@@ -4328,7 +4329,7 @@ message to the LLM.
 
   [!IMPORTANT] With the exception of `#{buffer}` and `#{buffers}`, editor context
   captures a point-in-time snapshot when your message is sent. If the underlying
-  data changes (e.g.� new diagnostics, a different quickfix list), simply use the
+  data changes (e.g. new diagnostics, a different quickfix list), simply use the
   context again in a new message to share the latest state.
 
 #BUFFER ~
@@ -5104,7 +5105,7 @@ LIST OF EVENTS ~
 The events that are fired from within the plugin are:
 
 - `CodeCompanionACPConnected` - Fired after the ACP connection is authenticated and ready to use
-- `CodeCompanionACPSessionPre` - Fired after ACP authentication completes but before a new session is established; allows subscribers to modify the connection (e.g. inject MCP servers) synchronously
+- `CodeCompanionACPSessionPre` - Fired after ACP authentication completes but before a new session is established; allows subscribers to modify the connection (e.g. inject MCP servers) synchronously
 - `CodeCompanionACPSessionPost` - Fired after a new ACP session has been established
 - `CodeCompanionChatACPModeChanged` - Fired after the ACP mode has been changed in the chat
 - `CodeCompanionACPChatRestored` - Fired after an ACP session has been restored
@@ -5116,7 +5117,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionChatDone` - Fired after a chat has received the response
 - `CodeCompanionChatStopped` - Fired after a chat has been stopped
 - `CodeCompanionChatCleared` - Fired after a chat has been cleared
-- `CodeCompanionChatRestored` - Fired after a chat has been restored to an editable state (e.g. when `on_before_submit` prevents submission)
+- `CodeCompanionChatRestored` - Fired after a chat has been restored to an editable state (e.g. when `on_before_submit` prevents submission)
 - `CodeCompanionChatAdapter` - Fired after the adapter has been set in the chat
 - `CodeCompanionChatModel` - Fired after the model has been set in the chat
 - `CodeCompanionCLICreated` - Fired after a CLI buffer has been created for the first time
@@ -5312,6 +5313,9 @@ SLASH COMMANDS ~
 If your prompt library entries have an `alias` defined then you can invoke them
 using a slash command. In the cmd line `:CodeCompanion /<alias>` or `/<alias>`
 if you’re in the chat buffer.
+
+When invoked this way, any tools declared on the prompt are added to the
+current chat buffer before the prompt content is inserted.
 
 
 USER INTERFACE                            *codecompanion-usage-user-interface*
@@ -7512,7 +7516,7 @@ tool to function. In the case of Anthropic, we insert additional headers.
 <
 
 Some adapter tools can be a `hybrid` in terms of their implementation. That is,
-they’re an adapter tool that requires a client-side component (i.e.� a
+they’re an adapter tool that requires a client-side component (i.e. a
 built-in tool). This is the case for the
 |codecompanion-usage-chat-buffer-agents-tools-memory| tool from Anthropic. To
 allow for this, ensure that the tool definition in `available_tools` has

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -27,12 +27,12 @@ The plugin can be installed with the plugin manager of your choice. It is recomm
 ::: code-group
 
 ```lua [vim.pack]
-vim.pack.add("https://www.github.com/nvim-lua/plenary.nvim")
-vim.pack.add("https://github.com/nvim-treesitter/nvim-treesitter")
-vim.pack.add({
+vim.pack.add({ "https://www.github.com/nvim-lua/plenary.nvim" })
+vim.pack.add({ "https://github.com/nvim-treesitter/nvim-treesitter" })
+vim.pack.add({ {
   src = "https://www.github.com/olimorris/codecompanion.nvim",
   version = vim.version.range("^19.0.0")
-})
+} })
 
 -- Somewhere in your config
 require("codecompanion").setup()


### PR DESCRIPTION
## Description

`vim.pack.add` expects a list of specs, but the current installation snippet passes bare strings / a single spec table. All three `vim.pack.add` calls in the snippet trigger the same error on Neovim 0.12:

```
vim/pack.lua: specs: expected list, got string/table
```

Before:

```lua
vim.pack.add("https://www.github.com/nvim-lua/plenary.nvim")
vim.pack.add("https://github.com/nvim-treesitter/nvim-treesitter")
vim.pack.add({
  src = "https://www.github.com/olimorris/codecompanion.nvim",
  version = vim.version.range("^19.0.0")
})
```

After — each arg is wrapped in an outer list so the snippet works as copy-pasted:

```lua
vim.pack.add({ "https://www.github.com/nvim-lua/plenary.nvim" })
vim.pack.add({ "https://github.com/nvim-treesitter/nvim-treesitter" })
vim.pack.add({ {
  src = "https://www.github.com/olimorris/codecompanion.nvim",
  version = vim.version.range("^19.0.0")
} })
```

## AI Usage

Used Claude Code to spot the mismatch after hitting the runtime error locally and to draft this description.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run \`make all\` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages