### PR TITLE
Improve keymap documentation

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                  For NVIM v0.11    Last change: 2026 April 15
+                                  For NVIM v0.11    Last change: 2026 April 16
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3688,33 +3688,32 @@ that’s sent to the LLM.
 
 KEYMAPS ~
 
-The plugin has a host of keymaps available in the chat buffer. Pressing `?` in
-the chat buffer will conveniently display all of them to you.
+The plugin has a host of keymaps available in the chat buffer. The keymaps
+available to the user in normal mode are:
 
-The keymaps available to the user in normal mode are:
-
-- `<CR>|<C-s>` to send a message to the LLM
-- `<C-c>` to close the chat buffer
-- `q` to stop the current request
-- `ga` to change the adapter for the currentchat
-- `gba` to sync the entire buffer on every turn
-- `gbd` to sync only a buffers diff on every turn
-- `gc` to insert a codeblock in the chat buffer
-- `gd` to view/debug the chat buffer’s contents
-- `gf` to fold any codeblocks in the chat buffer
-- `gM` to clear all rules from the chat buffer
-- `gr` to regenerate the last response
-- `gR` to go to the file under cursor. If the file is already opened, it’ll jump
-    to the existing window. Otherwise, it’ll be opened in a new tab.
-- `gs` to toggle the system prompt on/off
-- `gS` to show copilot usage stats
-- `gta` to toggle auto tool mode
-- `gx` to clear the chat buffer’s contents
-- `gy` to yank the last codeblock in the chat buffer
-- `[[` to move to the previous header
-- `]]` to move to the next header
-- `{` to move to the previous chat
-- `}` to move to the next chat
+- `options`: `?` to display all available keymaps
+- `send`: `<CR>|<C-s>` to send a message to the LLM
+- `close`: `<C-c>` to close the chat buffer
+- `stop`: `q` to stop the current request
+- `change_adapter`: `ga` to change the adapter for the currentchat
+- `buffer_sync_all`: `gba` to sync the entire buffer on every turn
+- `buffer_sync_diff`: `gbd` to sync only a buffers diff on every turn
+- `codeblock`: `gc` to insert a codeblock in the chat buffer
+- `debug`: `gd` to view/debug the chat buffer’s contents
+- `fold_code`: `gf` to fold any codeblocks in the chat buffer
+- `rules`: `gM` to clear all rules from the chat buffer
+- `regenerate`: `gr` to regenerate the last response
+- `goto_file_under_cursor`: `gR` to go to the file under cursor. If the file
+    is already opened, it’ll jump to the existing window. Otherwise, it’ll be
+    opened in a new tab.
+- `system_prompt`: `gs` to toggle the system prompt on/off
+- `copilot_stats`: `gS` to show copilot usage stats
+- `clear`: `gx` to clear the chat buffer’s contents
+- `yank_code`: `gy` to yank the last codeblock in the chat buffer
+- `previous_header`: `[[` to move to the previous header
+- `next_header`: `]]` to move to the next header
+- `previous_chat`: `{` to move to the previous chat
+- `next_chat`: `}` to move to the next chat
 
 To disable a keymap, you can set it to `false` in your configuration:
 

--- a/doc/usage/chat-buffer/index.md
+++ b/doc/usage/chat-buffer/index.md
@@ -118,34 +118,33 @@ Many LLMs have the ability to receive images as input (sometimes referred to as 
 
 If your adapter and model doesn't support images, then CodeCompanion will endeavour to ensure that the image is not included in the messages payload that's sent to the LLM.
 
-## Keymaps
+## KEYMAPS
 
-The plugin has a host of keymaps available in the chat buffer. Pressing `?` in the chat buffer will conveniently display all of them to you.
+The plugin has a host of keymaps available in the chat buffer. The keymaps available to the user in normal mode are:
 
-The keymaps available to the user in normal mode are:
-
-- `<CR>|<C-s>` to send a message to the LLM
-- `<C-c>` to close the chat buffer
-- `q` to stop the current request
-- `ga` to change the adapter for the currentchat
-- `gba` to sync the entire buffer on every turn
-- `gbd` to sync only a buffers diff on every turn
-- `gc` to insert a codeblock in the chat buffer
-- `gd` to view/debug the chat buffer's contents
-- `gf` to fold any codeblocks in the chat buffer
-- `gM` to clear all rules from the chat buffer
-- `gr` to regenerate the last response
-- `gR` to go to the file under cursor. If the file is already opened, it'll jump
-  to the existing window. Otherwise, it'll be opened in a new tab.
-- `gs` to toggle the system prompt on/off
-- `gS` to show copilot usage stats
-- `gta` to toggle auto tool mode
-- `gx` to clear the chat buffer's contents
-- `gy` to yank the last codeblock in the chat buffer
-- `[[` to move to the previous header
-- `]]` to move to the next header
-- `{` to move to the previous chat
-- `}` to move to the next chat
+- `options`: `?` to display all available keymaps
+- `send`: `<CR>|<C-s>` to send a message to the LLM
+- `close`: `<C-c>` to close the chat buffer
+- `stop`: `q` to stop the current request
+- `change_adapter`: `ga` to change the adapter for the currentchat
+- `buffer_sync_all`: `gba` to sync the entire buffer on every turn
+- `buffer_sync_diff`: `gbd` to sync only a buffers diff on every turn
+- `codeblock`: `gc` to insert a codeblock in the chat buffer
+- `debug`: `gd` to view/debug the chat buffer’s contents
+- `fold_code`: `gf` to fold any codeblocks in the chat buffer
+- `rules`: `gM` to clear all rules from the chat buffer
+- `regenerate`: `gr` to regenerate the last response
+- `goto_file_under_cursor`: `gR` to go to the file under cursor. If the file
+    is already opened, it’ll jump to the existing window. Otherwise, it’ll be
+    opened in a new tab.
+- `system_prompt`: `gs` to toggle the system prompt on/off
+- `copilot_stats`: `gS` to show copilot usage stats
+- `clear`: `gx` to clear the chat buffer’s contents
+- `yank_code`: `gy` to yank the last codeblock in the chat buffer
+- `previous_header`: `[[` to move to the previous header
+- `next_header`: `]]` to move to the next header
+- `previous_chat`: `{` to move to the previous chat
+- `next_chat`: `}` to move to the next chat
 
 To disable a keymap, you can set it to `false` in your configuration:
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Adds the key names to the help doc for setting chat buffer keymaps. As far as I can tell the list of these aren't currently documented anywhere.

## AI Usage

None

## Related Issue(s)

Not an issue, but would prevent inquiries of [like this](https://github.com/olimorris/codecompanion.nvim/discussions/3018) which I submitted that prompted this

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
