### PR TITLE
fix(chat): nil tool name in `on_tool_output`

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1631,7 +1631,7 @@ function Chat:add_tool_output(tool, for_llm, for_user)
   log:debug("Tool output: %s", tool_call)
 
   -- Allow users to modify the tool output before it's added to the message history
-  local args = { tool = tool_call.name, for_llm = for_llm, for_user = for_user }
+  local args = { tool = tool.name, for_llm = for_llm, for_user = for_user }
   self:dispatch("on_tool_output", args)
   for_llm = args.for_llm
   for_user = args.for_user

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -566,4 +566,44 @@ T["Chat"]["on_before_submit leaves buffer editable after cancellation"] = functi
   h.eq(true, result.modifiable)
 end
 
+T["Chat"]["on_tool_output callback receives correct args"] = function()
+  local result = child.lua([[
+    local chat = _G.chat
+    local callback_args = {}
+
+    chat:add_callback("on_tool_output", function(c, args)
+      callback_args = {
+        tool = args.tool,
+        for_llm = args.for_llm,
+        for_user = args.for_user,
+      }
+      args.for_llm = "Modified: " .. args.for_llm
+    end)
+
+    local tool = {
+      name = "weather",
+      function_call = {
+        _index = 0,
+        ["function"] = {
+          arguments = '{"location": "London", "units": "celsius"}',
+          name = "weather",
+        },
+        id = "call_RJU6xfk0OzQF3Gg9cOFS5RY7",
+        type = "function",
+      },
+    }
+    chat:add_tool_output(tool, "LLM output", "User output")
+
+    return {
+      callback_args = callback_args,
+      message_content = chat.messages[#chat.messages].content,
+    }
+  ]])
+
+  h.eq(result.callback_args.tool, "weather")
+  h.eq(result.callback_args.for_llm, "LLM output")
+  h.eq(result.callback_args.for_user, "User output")
+  h.eq(result.message_content, "Modified: LLM output")
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description
Fix the `tool` parameter in `on_tool_output` callback always being `nil`.

**Root cause:** In `Chat:add_tool_output` method, the callback args used `tool_call.name`, but `tool_call` is the raw LLM tool call object (i.e., `tool.function_call`) which doesn't have a top-level `.name` property.

**Fix:** Changed `tool_call.name` to `tool.name`, which is correctly set in both `_handle_tool_error` and `_resolve_and_prepare_tool`.

**Files changed:**
- `lua/codecompanion/interactions/chat/init.lua` — single-line fix
- `tests/interactions/chat/tools/builtin/test_tool_output.lua` — added test for callback parameters

## AI Usage
Used CodeCompanion + GLM5 to help diagnose the issue and write the test case.

## Related Issue(s)
N/A

## Screenshots
N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
