### PR TITLE
refactor: include path when sharing rules

### DIFF
--- a/.codecompanion/rules.md
+++ b/.codecompanion/rules.md
@@ -6,28 +6,28 @@ Rules files are markdown files that contain context about a specific feature or 
 
 ## Init
 
-@./lua/codecompanion/interactions/chat/rules/init.lua
+@./lua/codecompanion/interactions/shared/rules/init.lua
 
 This picks up the rules from a users config and contains methods which allows them to be added to the chat buffer's context.
 
 ## Helpers
 
-@./lua/codecompanion/interactions/chat/rules/helpers.lua
+@./lua/codecompanion/interactions/shared/rules/helpers.lua
 
 This contains some helper functions that allow rules files to add context to the chat buffer.
 
 ## Parsers
 
-@./lua/codecompanion/interactions/chat/rules/parsers/init.lua
-@./lua/codecompanion/interactions/chat/rules/parsers/claude.lua
-@./lua/codecompanion/interactions/chat/rules/parsers/codecompanion.lua
-@./lua/codecompanion/interactions/chat/rules/parsers/none.lua
+@./lua/codecompanion/interactions/shared/rules/parsers/init.lua
+@./lua/codecompanion/interactions/shared/rules/parsers/claude.lua
+@./lua/codecompanion/interactions/shared/rules/parsers/codecompanion.lua
+@./lua/codecompanion/interactions/shared/rules/parsers/none.lua
 
 These are the files that allow CodeCompanion to read a user's markdown rule file and extract its content according to the parser, ready for sharing in the chat buffer. For example, with the Claude parser, file paths are extracted and those files are then shared as buffer or file context with the LLM, alongside any text.
 
 ## Slash Command
 
-@./lua/codecompanion/interactions/chat/slash_commands/builtin/rules.lua
+@./lua/codecompanion/interactions/shared/slash_commands/rules.lua
 
 This slash command allows users to select a given rule and load it into the chat buffer
 

--- a/lua/codecompanion/interactions/shared/rules/helpers.lua
+++ b/lua/codecompanion/interactions/shared/rules/helpers.lua
@@ -6,6 +6,8 @@ local file_utils = require("codecompanion.utils.files")
 local log = require("codecompanion.utils.log")
 local utils = require("codecompanion.utils")
 
+local fmt = string.format
+
 local M = {}
 
 ---Recursively expand rules groups (supports groups of groups)
@@ -150,7 +152,9 @@ function M.add_context(files, chat)
           { visible = false, context = { id = id }, _meta = { tag = "rules" } }
         )
       end
-      chat:add_context({ content = file.content }, "rules", id, {
+
+      local content = fmt("Sharing `%s`:\n\n---\n%s\n---", file.path, file.content)
+      chat:add_context({ content = content }, "rules", id, {
         path = file.path,
       })
     end

--- a/tests/interactions/shared/rules/test_rules.lua
+++ b/tests/interactions/shared/rules/test_rules.lua
@@ -305,7 +305,9 @@ T["Rules:make()"]["integration: rules is added to a real chat messages stack"] =
   h.eq(#messages, 2)
   h.eq(last_message._meta.tag, "rules")
   h.eq(last_message.context.id, "<rules>" .. vim.fs.normalize(tmp) .. "</rules>")
-  h.eq(last_message.content, content .. "\n")
+
+  local relative_path = vim.fn.fnamemodify(vim.fs.normalize(tmp), ":p:.")
+  h.eq(last_message.content, string.format("Sharing `%s`:\n\n---\n%s\n\n---", relative_path, content))
 end
 
 T["Rules:make()"]["integration: rules is added when chat is toggled"] = function()
@@ -347,7 +349,9 @@ T["Rules:make()"]["integration: rules is added when chat is toggled"] = function
   h.eq(#messages, 2)
   h.eq(last_message._meta.tag, "rules")
   h.eq(last_message.context.id, "<rules>" .. vim.fs.normalize(tmp) .. "</rules>")
-  h.eq(last_message.content, content .. "\n")
+
+  local relative_path = vim.fn.fnamemodify(vim.fs.normalize(tmp), ":p:.")
+  h.eq(last_message.content, string.format("Sharing `%s`:\n\n---\n%s\n\n---", relative_path, content))
 end
 
 T["add_files_or_buffers() prevents duplicate files from being added"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When sharing rules files, it can be helpful to include the actual file path so the LLM can understand if nested rules files have also been shared. 

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
