### PR TITLE
fix(chat): scope folds to buffer

### DIFF
--- a/lua/codecompanion/interactions/chat/ui/folds.lua
+++ b/lua/codecompanion/interactions/chat/ui/folds.lua
@@ -40,16 +40,18 @@ function Folds:setup(winnr)
 end
 
 ---Global method which Neovim calls to display folded text
----@return table
+---@return table|string
 function Folds.fold_text()
   local bufnr = api.nvim_get_current_buf()
-  local start = vim.v.foldstart - 1
-  local folds = Folds.fold_summaries[bufnr] or {}
-  local fold_data = folds[start]
 
+  if vim.bo[bufnr].filetype ~= "codecompanion" then
+    return vim.fn.foldtext()
+  end
+
+  local folds = Folds.fold_summaries[bufnr]
+  local fold_data = folds and folds[vim.v.foldstart - 1]
   if not fold_data then
-    -- Fallback for legacy data
-    return Folds._format_fold_text("Unknown", "context")
+    return vim.fn.foldtext()
   end
 
   return Folds._format_fold_text(fold_data.content, fold_data.type)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Folds are applied at a window level. This resulted in CodeCompanion's folding function being persisted to non-CodeCompanion buffers. 

## AI Usage

Opus 4.6

## Related Issue(s)

#3056

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
