### PR TITLE
fix(prompts): capitalize and move space in BTW promp

### DIFF
--- a/lua/codecompanion/interactions/chat/keymaps/init.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/init.lua
@@ -623,7 +623,7 @@ M.goto_file_under_cursor = {
 
 M.btw = {
   callback = function(chat)
-    vim.ui.input({ prompt = "btw ..." }, function(input)
+    vim.ui.input({ prompt = "BTW... " }, function(input)
       if input and input ~= "" then
         chat:btw(input)
       end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Similarly to #2857, this fixes prompt from:

> `btw ...my message`

to:

> `BTW... my message`

## AI Usage

N/A

## Related Issue(s)

#2857 

## Screenshots

N/A

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
