### PR TITLE
fix(adapters): resolve dynamic model choices before indexing

### DIFF
--- a/lua/codecompanion/interactions/chat/helpers/init.lua
+++ b/lua/codecompanion/interactions/chat/helpers/init.lua
@@ -1,4 +1,5 @@
 local config = require("codecompanion.config")
+local adapter_utils = require("codecompanion.utils.adapters")
 
 local Path = require("plenary.path")
 local buf_utils = require("codecompanion.utils.buffers")
@@ -353,17 +354,21 @@ function M.trigger_context_management(adapter)
     return 0
   end
 
-  local ok
   local trigger_tokens = config.interactions.chat.opts.context_management.trigger
   if trigger_tokens < 1 then
-    ok, trigger_tokens = pcall(function()
-      return math.floor(trigger_tokens * adapter.schema.model.choices[adapter.schema.model.default].meta.context_window)
-    end)
+    local model = adapter_utils.model(adapter)
+    local model_opts = adapter_utils.model_choice(adapter)
 
-    if not ok then
-      log:error("Could not get evaluate the trigger for context management in the `%s` adapter", adapter.name)
+    if not model_opts or not model_opts.meta or not model_opts.meta.context_window then
+      log:error(
+        "Could not evaluate the trigger for context management in the `%s` adapter using model `%s`",
+        adapter.name,
+        model or "unknown"
+      )
       return 0
     end
+
+    trigger_tokens = math.floor(trigger_tokens * model_opts.meta.context_window)
   end
 
   return trigger_tokens

--- a/lua/codecompanion/utils/adapters.lua
+++ b/lua/codecompanion/utils/adapters.lua
@@ -414,14 +414,25 @@ end
 ---@param adapter CodeCompanion.HTTPAdapter
 ---@return string
 function M.model(adapter)
-  return adapter.schema.model.default
+  local model = adapter.schema.model.default
+  if type(model) == "function" then
+    model = model(adapter)
+  end
+
+  return model
 end
 
 ---Helper function to return the model from the choices
 ---@param adapter CodeCompanion.HTTPAdapter
----@return table
-function M.model_choice(adapter)
-  return adapter.schema.model.choices[M.model(adapter)]
+---@param opts? table
+---@return table|nil
+function M.model_choice(adapter, opts)
+  local choices = adapter.schema.model.choices
+  if type(choices) == "function" then
+    choices = choices(adapter, opts)
+  end
+
+  return choices and choices[M.model(adapter)]
 end
 
 return M

--- a/tests/adapters/test_adapters.lua
+++ b/tests/adapters/test_adapters.lua
@@ -217,6 +217,44 @@ T["HTTP Adapter"]["can form environment variables"] = function()
   h.eq(os.getenv("HOME"), result.env_replaced.home)
 end
 
+T["HTTP Adapter"]["can resolve dynamic model defaults and choices"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.utils.adapters")
+    local adapter = {
+      schema = {
+        model = {
+          default = function(self)
+            return "gpt-5-codex"
+          end,
+          choices = function(self, opts)
+            return {
+              ["gpt-5-codex"] = {
+                opts = {
+                  can_manage_context = true,
+                },
+              },
+            }
+          end,
+        },
+      },
+    }
+
+    return {
+      model = utils.model(adapter),
+      model_choice = utils.model_choice(adapter),
+    }
+  ]])
+
+  h.eq({
+    model = "gpt-5-codex",
+    model_choice = {
+      opts = {
+        can_manage_context = true,
+      },
+    },
+  }, result)
+end
+
 T["HTTP Adapter"]["can set environment variables in the adapter"] = function()
   local result = child.lua([[
     local utils = require("codecompanion.utils.adapters")

--- a/tests/interactions/chat/helpers/test_helpers.lua
+++ b/tests/interactions/chat/helpers/test_helpers.lua
@@ -62,4 +62,40 @@ T["format_viewport_for_llm works"] = function()
   h.expect_match(result, "lines 1 to 2")
 end
 
+T["trigger_context_management works with dynamic model choices"] = function()
+  local result = child.lua([[
+    local config = require("codecompanion.config")
+    local original_trigger = config.interactions.chat.opts.context_management.trigger
+    config.interactions.chat.opts.context_management.trigger = 0.5
+
+    local adapter = {
+      type = "http",
+      name = "test",
+      schema = {
+        model = {
+          default = function(self)
+            return "test-model"
+          end,
+          choices = function(self, opts)
+            return {
+              ["test-model"] = {
+                meta = {
+                  context_window = 100000,
+                },
+              },
+            }
+          end,
+        },
+      },
+    }
+
+    local ok, trigger = pcall(_G.helpers.trigger_context_management, adapter)
+    config.interactions.chat.opts.context_management.trigger = original_trigger
+    assert(ok, trigger)
+    return trigger
+  ]])
+
+  h.eq(50000, result)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR fixes a crash that happens when submitting a prompt through `copilot`-based setups where `schema.model.choices` is provided as a function.

The shared adapter helper assumed `choices` was always a table and tried to index it directly with the selected model name. That worked for static schemas, but it crashed for dynamic schemas like Copilot's.

### Root cause

Some adapters define model metadata lazily:

```lua
choices = function(self, opts)
  return {
    ["gpt-5.4-mini"] = {
      opts = {
        can_manage_context = true,
      },
    },
  }
end
```

The broken code treated `choices` as if it were already a table:

```lua
adapter.schema.model.choices[model]
```

If `choices` is a function, that indexing raises `attempt to index field 'choices' (a function value)`.

### Fix

I changed the shared adapter helper so it:

1. resolves `schema.model.default` if it is a function
2. resolves `schema.model.choices` if it is a function
3. then looks up the selected model in the returned table

This keeps dynamic schema definitions working while preserving static ones.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->

GitHub Copilot CLI and GPT-5.4 mini

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

Fixes #3067 

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
