### PR TITLE
fix(chat): resolve model choices

### DIFF
--- a/lua/codecompanion/utils/adapters.lua
+++ b/lua/codecompanion/utils/adapters.lua
@@ -419,9 +419,13 @@ end
 
 ---Helper function to return the model from the choices
 ---@param adapter CodeCompanion.HTTPAdapter
----@return table
+---@return table?
 function M.model_choice(adapter)
-  return adapter.schema.model.choices[M.model(adapter)]
+  local choices = adapter.schema.model.choices
+  if type(choices) ~= "table" then
+    return nil
+  end
+  return choices[M.model(adapter)]
 end
 
 return M

--- a/tests/adapters/test_adapters.lua
+++ b/tests/adapters/test_adapters.lua
@@ -969,6 +969,47 @@ T["Adapter"]["call_handler"]["handles multiple arguments correctly"] = function(
   }, result)
 end
 
+T["Adapter"]["model_choice"] = new_set()
+
+T["Adapter"]["model_choice"]["returns nil when choices is a function"] = function()
+  local result = child.lua([[
+    local adapter = {
+      schema = {
+        model = {
+          default = "gpt-5.4-mini",
+          choices = function(self, opts)
+            return {}
+          end,
+        },
+      },
+    }
+
+    return utils.model_choice(adapter)
+  ]])
+
+  h.eq(vim.NIL, result)
+end
+
+T["Adapter"]["model_choice"]["returns model opts when choices is a table"] = function()
+  local result = child.lua([[
+    local adapter = {
+      schema = {
+        model = {
+          default = "gpt-4o",
+          choices = {
+            ["gpt-4o"] = { opts = { can_reason = false } },
+            ["o1"] = { opts = { can_reason = true } },
+          },
+        },
+      },
+    }
+
+    return utils.model_choice(adapter)
+  ]])
+
+  h.eq({ opts = { can_reason = false } }, result)
+end
+
 T["Adapter"]["call_handler"]["works without arguments"] = function()
   local result = child.lua([[
     local adapters = require("codecompanion.adapters")


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As per the issue below, `model_choice()` (a recently added utility) crashes when choices is a function instead of a table.

## AI Usage

Sonnet 4.6

## Related Issue(s)

#3067

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
