### PR TITLE
fix(chat): cancelling avoids orphan tool calls

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -980,16 +980,16 @@ function Chat:add_message(data, opts)
   return self
 end
 
----Check if any tool calls in messages are missing their results
----@return boolean
-function Chat:has_orphaned_tool_calls()
+---Find tool calls in messages that are missing matching results
+---@return table<string, table> Map of call_id to the call object
+function Chat:_orphaned_tool_calls()
   local pending = {}
 
   for _, msg in ipairs(self.messages) do
     if msg.tools and msg.tools.calls then
       for _, call in ipairs(msg.tools.calls) do
         if call.id then
-          pending[call.id] = true
+          pending[call.id] = call
         end
       end
     end
@@ -998,7 +998,35 @@ function Chat:has_orphaned_tool_calls()
     end
   end
 
-  return next(pending) ~= nil
+  return pending
+end
+
+---Check if any tool calls in messages are missing their results
+---@return boolean
+function Chat:has_orphaned_tool_calls()
+  return next(self:_orphaned_tool_calls()) ~= nil
+end
+
+---Prevent any orphaned tool calls by "completing" them with a cancelled message
+---@return nil
+function Chat:_complete_orphaned_tool_calls()
+  local pending = self:_orphaned_tool_calls()
+  if next(pending) == nil then
+    return
+  end
+
+  for id, call in pairs(pending) do
+    local output = adapters.call_handler(self.adapter, "format_response", call, "Cancelled by user")
+    if output then
+      output.opts = vim.tbl_extend("force", output.opts or {}, { visible = false })
+      output._meta = {
+        cycle = self.cycle,
+        id = make_id({ call_id = id, content = output.content, role = output.role }),
+      }
+      table.insert(self.messages, output)
+      log:debug("[chat::_complete_orphaned_tool_calls] Completed tool call result for tool call %s", id)
+    end
+  end
 end
 
 ---Run checkpoint callbacks, passing mutable chat state
@@ -1327,6 +1355,10 @@ function Chat:done(output, reasoning, tools, meta, opts)
   self.current_request = nil
 
   self:_clear_status()
+
+  if opts.status == "stopped" then
+    self:_complete_orphaned_tool_calls()
+  end
 
   -- Commonly, a status may not be set if the message exceeds a token limit
   if not self.status or self.status == "" then

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -507,14 +507,17 @@ T["Chat"]["has_orphaned_tool_calls returns true when a call has no result"] = fu
         },
       },
     })
+
     -- Only provide a result for call_1
     table.insert(_G.chat.messages, {
       role = "tool",
       content = "file contents",
       tools = { call_id = "call_1", type = "tool_result" },
     })
+
     return _G.chat:has_orphaned_tool_calls()
   ]])
+
   h.eq(true, result)
 end
 

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -544,6 +544,61 @@ T["Chat"]["has_orphaned_tool_calls returns false when all calls have results"] =
   h.eq(false, result)
 end
 
+T["Chat"]["_complete_orphaned_tool_calls synthesizes cancelled results"] = function()
+  local result = child.lua([[
+    table.insert(_G.chat.messages, {
+      role = "llm",
+      tools = {
+        calls = {
+          { id = "call_1", ["function"] = { name = "read_file", arguments = "{}" } },
+          { id = "call_2", ["function"] = { name = "read_file", arguments = "{}" } },
+        },
+      },
+    })
+    -- Provide a result only for call_1
+    table.insert(_G.chat.messages, {
+      role = "tool",
+      content = "result 1",
+      tools = { call_id = "call_1", type = "tool_result" },
+    })
+
+    _G.chat:_complete_orphaned_tool_calls()
+
+    local synthesized
+    for _, msg in ipairs(_G.chat.messages) do
+      if msg.tools and msg.tools.call_id == "call_2" then
+        synthesized = msg
+      end
+    end
+
+    return {
+      has_orphans = _G.chat:has_orphaned_tool_calls(),
+      synthesized_content = synthesized and synthesized.content,
+      synthesized_visible = synthesized and synthesized.opts and synthesized.opts.visible,
+    }
+  ]])
+  h.eq(false, result.has_orphans)
+  h.eq("Cancelled by user", result.synthesized_content)
+  h.eq(false, result.synthesized_visible)
+end
+
+T["Chat"]["done with stopped status completes orphaned tool calls"] = function()
+  local result = child.lua([[
+    table.insert(_G.chat.messages, {
+      role = "llm",
+      tools = {
+        calls = {
+          { id = "call_1", ["function"] = { name = "read_file", arguments = "{}" } },
+        },
+      },
+    })
+    _G.chat.status = "cancelling"
+    _G.chat:done(nil, nil, nil, nil, { status = "stopped" })
+    return _G.chat:has_orphaned_tool_calls()
+  ]])
+  h.eq(false, result)
+end
+
 T["Chat"]["on_before_submit leaves buffer editable after cancellation"] = function()
   local result = child.lua([[
     local chat = _G.chat


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Previously, if a user cancelled a request in the middle of a tool call, there was a chance they could be orphaned. For most LLMs, this results in broken requests and the user would have to manually edit the chat history via the debug window. This PR prevents that by finding orphan tools and letting the LLM know that they were cancelled.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
