### PR TITLE
fix(chat): hide tool context for ACP chats

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -719,6 +719,7 @@ function Chat:change_adapter(adapter, cb)
   end
 
   self:set_system_prompt()
+  self.tool_registry:update_context_visibility()
   self:update_metadata()
   self:apply_settings()
   fire()

--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -32,6 +32,13 @@ local function group_id(name)
   return fmt("<group>%s</group>", name)
 end
 
+---Determine if tool context should be visible for a chat adapter
+---@param chat CodeCompanion.Chat The chat buffer
+---@return boolean
+local function tool_context_visible(chat)
+  return not (chat.adapter and chat.adapter.type == "acp")
+end
+
 ---@class CodeCompanion.Chat.ToolsArgs
 ---@field chat CodeCompanion.Chat
 ---@field ctx CodeCompanion.SystemPrompt.Context
@@ -56,6 +63,12 @@ end
 ---@param opts? table Optional parameters for the context_item
 ---@return nil
 local function add_context(chat, id, opts)
+  opts = opts or {}
+  if opts.visible == nil then
+    opts.visible = tool_context_visible(chat)
+    opts._tool_context_auto_visibility = true
+  end
+
   chat.context:add({
     source = "tool",
     name = "tool",
@@ -121,7 +134,8 @@ end
 function ToolRegistry:add_single_tool(tool, opts)
   opts = opts or {}
   if opts.visible == nil then
-    opts.visible = true
+    opts.visible = tool_context_visible(self.chat)
+    opts._tool_context_auto_visibility = true
   end
 
   local tool_config = opts.config or config.interactions.chat.tools[tool]
@@ -162,6 +176,25 @@ function ToolRegistry:add_single_tool(tool, opts)
   end
 
   utils.fire("ChatToolAdded", { bufnr = self.chat.bufnr, id = self.chat.id, tool = tool })
+
+  return self
+end
+
+---Update automatically managed tool context visibility for the current adapter
+---@return CodeCompanion.Chat.ToolRegistry
+function ToolRegistry:update_context_visibility()
+  local visible = tool_context_visible(self.chat)
+
+  for _, context in ipairs(self.chat.context_items or {}) do
+    if context.source == "tool" and context.opts and context.opts._tool_context_auto_visibility then
+      context.opts.visible = visible
+    end
+  end
+
+  if self.chat.bufnr and vim.api.nvim_buf_is_valid(self.chat.bufnr) then
+    self.chat.context:clear_rendered()
+    self.chat.context:render()
+  end
 
   return self
 end
@@ -216,7 +249,11 @@ function ToolRegistry:add_group(group, opts)
   for _, tool in ipairs(group_config.tools) do
     local tool_cfg = tools_config[tool]
     if tool_cfg then
-      if self:add_single_tool(tool, { config = tool_cfg, visible = not collapse_tools }) then
+      local tool_opts = { config = tool_cfg }
+      if collapse_tools then
+        tool_opts.visible = false
+      end
+      if self:add_single_tool(tool, tool_opts) then
         table.insert(added_tools, tool)
       end
     end

--- a/tests/interactions/chat/tools/test_tool_registry.lua
+++ b/tests/interactions/chat/tools/test_tool_registry.lua
@@ -47,6 +47,21 @@ T["ToolRegistry"][":add"]["adds a group to the registry"] = function()
   h.expect_tbl_contains("cmd", registry)
 end
 
+T["ToolRegistry"][":add"]["renders collapsed tool group without member tools"] = function()
+  child.lua([[
+    _G.chat.tool_registry:add("senior_dev")
+    _G.chat.context:render()
+    _G.buf_lines = h.get_buf_lines(_G.chat.bufnr)
+  ]])
+
+  local lines = child.lua_get([[_G.buf_lines]])
+  local content = table.concat(lines, "\n")
+
+  h.expect_contains("senior_dev", content)
+  h.eq(nil, content:find("<tool>func</tool>", 1, true))
+  h.eq(nil, content:find("<tool>cmd</tool>", 1, true))
+end
+
 T["ToolRegistry"][":add"]["renders tool in the chat buffer"] = function()
   child.lua([[
     _G.chat.tool_registry:add("func")
@@ -58,6 +73,82 @@ T["ToolRegistry"][":add"]["renders tool in the chat buffer"] = function()
   local content = table.concat(lines, "\n")
 
   h.expect_contains("func", content)
+end
+
+T["ToolRegistry"][":add"]["hides tool context for ACP chats"] = function()
+  child.lua([[
+    _G.chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        roles = { user = "user", assistant = "assistant" },
+        handlers = {
+          form_messages = function()
+            return {}
+          end,
+        },
+      },
+    })
+    _G.chat.tool_registry:add("func")
+    _G.chat.context:render()
+    _G.buf_lines = h.get_buf_lines(_G.chat.bufnr)
+  ]])
+
+  local lines = child.lua_get([[_G.buf_lines]])
+  local content = table.concat(lines, "\n")
+
+  h.expect_tbl_contains("func", child.lua_get([[_G.chat.tool_registry.in_use]]))
+  h.eq(nil, content:find("func", 1, true))
+end
+
+T["ToolRegistry"][":add"]["hides tool group context for ACP chats"] = function()
+  child.lua([[
+    _G.chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        roles = { user = "user", assistant = "assistant" },
+        handlers = {
+          form_messages = function()
+            return {}
+          end,
+        },
+      },
+    })
+    _G.chat.tool_registry:add("senior_dev")
+    _G.chat.context:render()
+    _G.buf_lines = h.get_buf_lines(_G.chat.bufnr)
+  ]])
+
+  local lines = child.lua_get([[_G.buf_lines]])
+  local content = table.concat(lines, "\n")
+
+  h.expect_tbl_contains("func", child.lua_get([[_G.chat.tool_registry.in_use]]))
+  h.expect_tbl_contains("cmd", child.lua_get([[_G.chat.tool_registry.in_use]]))
+  h.eq(nil, content:find("senior_dev", 1, true))
+  h.eq(nil, content:find("func", 1, true))
+  h.eq(nil, content:find("cmd", 1, true))
+end
+
+T["ToolRegistry"][":add"]["updates tool context visibility when switching to ACP"] = function()
+  child.lua([[
+    _G.chat.tool_registry:add("senior_dev")
+    _G.http_visible = _G.chat.context_items[1].opts.visible
+
+    _G.chat.adapter = { name = "test_acp", type = "acp" }
+    _G.chat.tool_registry:update_context_visibility()
+    _G.acp_visible = _G.chat.context_items[1].opts.visible
+
+    _G.chat.adapter = { name = "test_adapter", type = "http" }
+    _G.chat.tool_registry:update_context_visibility()
+    _G.http_again_visible = _G.chat.context_items[1].opts.visible
+  ]])
+
+  h.eq(true, child.lua_get([[_G.http_visible]]))
+  h.eq(false, child.lua_get([[_G.acp_visible]]))
+  h.eq(true, child.lua_get([[_G.http_again_visible]]))
 end
 
 T["ToolRegistry"][":add"]["returns nil for unknown name"] = function()


### PR DESCRIPTION
## Summary
- hide tool and tool-group context entries by default when the chat adapter is ACP
- keep HTTP chat tool context behavior unchanged
- add regression coverage for ACP single tools and tool groups

## Test
- make test_file FILE=tests/interactions/chat/tools/test_tool_registry.lua