### PR TITLE
feat(acp): allow hiding model choices when switching adapters

### DIFF
--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -208,6 +208,24 @@ require("codecompanion").setup({
 })
 ```
 
+## Controlling Model Choices
+
+When switching between ACP adapters, the plugin typically displays all available model choices for the selected adapter. If you want to keep the current/default ACP model automatically chosen and skip the model selection UI, you can set `show_model_choices` to `false`:
+
+```lua
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      opts = {
+        show_model_choices = false,
+      },
+    },
+  },
+})
+```
+
+With `show_model_choices = false`, CodeCompanion will keep using the ACP session's current/default model when changing adapters instead of prompting for a model.
+
 ## Setup: Auggie CLI from Augment Code
 
 To use [Auggie CLI](https://docs.augmentcode.com/cli/overview) within CodeCompanion, you simply need to follow their [Getting Started](https://docs.augmentcode.com/cli/overview#getting-started) guide.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -51,6 +51,7 @@ local defaults = {
       opencode = "opencode",
       opts = {
         show_presets = true,
+        show_model_choices = true, -- Show model choices when changing adapter
       },
     },
     opts = {

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -126,6 +126,17 @@ end
 ---@return table|nil
 function M.list_acp_models(connection)
   local models = connection:get_models()
+  local show_choices = not (
+    config.adapters
+    and config.adapters.acp
+    and config.adapters.acp.opts
+    and config.adapters.acp.opts.show_model_choices == false
+  )
+
+  if not show_choices then
+    return nil
+  end
+
   if not models or vim.tbl_count(models.availableModels) < 2 then
     return nil
   end

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -68,6 +68,9 @@ return {
         command = { "node", "test-agent.js" },
         roles = { user = "user", assistant = "assistant" },
       },
+      opts = {
+        show_model_choices = true,
+      },
     },
     opts = {
       cmd_timeout = 10e3,

--- a/tests/interactions/chat/test_keymaps.lua
+++ b/tests/interactions/chat/test_keymaps.lua
@@ -194,4 +194,27 @@ T["Keymaps"]["change_adapter"]["list_acp_models returns nil when < 2 models"] = 
   h.expect_truthy(result)
 end
 
+T["Keymaps"]["change_adapter"]["list_acp_models returns nil when model choices are hidden"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    config.adapters.acp.opts.show_model_choices = false
+
+    local acp_connection = {
+      get_models = function(self)
+        return {
+          availableModels = {
+            { modelId = "default", name = "Default" },
+            { modelId = "opus", name = "Opus" },
+          },
+          currentModelId = "default",
+        }
+      end
+    }
+
+    return change_adapter.list_acp_models(acp_connection) == nil
+  ]])
+
+  h.expect_truthy(result)
+end
+
 return T


### PR DESCRIPTION
## Summary
Add `adapters.acp.opts.show_model_choices` so ACP adapter switching can skip the model selector and keep the ACP session's current/default model, matching the existing HTTP adapter behavior.

## Changes
- add `adapters.acp.opts.show_model_choices` with default `true`
- make ACP adapter switching respect the new option
- document the new ACP setting
- add coverage for the hidden-model-choice path

## Testing
- `make test_file FILE=tests/interactions/chat/test_keymaps.lua`