### PR TITLE
fix(adapters): conform to standard tool structure

### DIFF
--- a/.codecompanion/adapters/adapters.md
+++ b/.codecompanion/adapters/adapters.md
@@ -108,6 +108,25 @@ This structure provides clear separation of concerns:
 - **response**: Pure transformations for parsing responses (chat, inline, tokens)
 - **tools**: Tool-specific operations (formatting calls and responses)
 
+### Canonical Tool-Result Shape
+
+Tool result messages produced by `format_response` are stored in `chat.messages` and re-read by every adapter's `build_messages`/`form_messages`. To keep messages portable across adapters, every adapter must write to the same canonical shape:
+
+```lua
+{
+  role    = "tool",
+  content = output,
+  tools = {
+    call_id = tool_call.id,                  -- required: matches the LLM's tool call
+    name    = tool_call["function"].name,    -- required: function name (Gemini uses this)
+    is_error = false,                        -- optional: Anthropic uses this
+  },
+  opts = { visible = false },
+}
+```
+
+Adapter-specific extras (e.g. OpenAI Responses' `id`) are allowed but ignored by other adapters. When reading these messages back, an adapter should treat any message with `role == "tool"` as a tool result — never gate on adapter-specific fields.
+
 ### Calling Handlers
 
 Throughout CodeCompanion, handlers are called using the `adapters.call_handler()` function, which provides backwards compatibility:

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -245,14 +245,13 @@ return {
         -- 6. Treat 'tool' role as user and convert tool results to Anthropic format
         if m.role == "tool" then
           m.role = self.roles.user
-          -- Convert tool result from CodeCompanion format to Anthropic format
-          if m.tools and m.tools.type == "tool_result" then
+          if m.tools then
             -- Handle content that might already be in Anthropic's format
             if type(m.content) == "table" and m.content.type == "tool_result" then
               -- Already in Anthropic format, keep it as-is but ensure it's in an array
               m.content = { m.content }
             else
-              -- Convert from CodeCompanion format to Anthropic format
+              -- Convert from the canonical tool-result shape to Anthropic's format
               m.content = {
                 {
                   type = "tool_result",
@@ -624,9 +623,9 @@ return {
           role = "tool",
           content = output,
           tools = {
-            type = "tool_result",
             call_id = tool_call.id,
             is_error = false,
+            name = tool_call["function"].name,
           },
           -- Chat Buffer option: To tell the chat buffer that this shouldn't be visible
           opts = { visible = false },
@@ -667,7 +666,7 @@ return {
         ["claude-haiku-4-5"] = {
           formatted_name = "Claude Haiku 4.5",
           meta = { context_window = 200000, max_tokens = 64000 },
-          opts = { can_reason = true, has_vision = true },
+          opts = { can_reason = false, has_vision = true },
         },
 
         -- Legacy models

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -363,6 +363,7 @@ return {
           role = self.roles.tool or "tool",
           tools = {
             call_id = tool_call.id,
+            name = tool_call["function"].name,
           },
           content = output,
           opts = { visible = false },

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -573,8 +573,9 @@ return {
         return {
           role = self.roles.tool or "tool",
           tools = {
-            id = tool_call.id,
             call_id = tool_call.call_id,
+            id = tool_call.id,
+            name = tool_call["function"].name,
           },
           content = output,
           opts = { visible = false },

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -701,12 +701,33 @@ end
 ---Change the adapter in the chat buffer
 ---@param adapter string
 ---@param cb? function
+---@return boolean swapped Whether the adapter was actually swapped
 function Chat:change_adapter(adapter, cb)
   local function fire()
     return utils.fire("ChatAdapter", { bufnr = self.bufnr, adapter = adapters.make_safe(self.adapter) })
   end
 
-  self.adapter = require("codecompanion.adapters").resolve(adapter)
+  local new_adapter = require("codecompanion.adapters").resolve(adapter)
+
+  -- Block adapter swaps once tool calls or reasoning have happened. Adapter-
+  -- specific state (tool-call signatures, encrypted reasoning blobs) cannot
+  -- be carried into a different vendor's API. Model swaps within the same
+  -- adapter are unaffected.
+  if self.adapter.name ~= new_adapter.name then
+    local has_state = vim.iter(self.messages or {}):any(function(m)
+      return m.reasoning ~= nil or (m.tools and m.tools.calls ~= nil)
+    end)
+    if has_state then
+      utils.notify(
+        fmt("Adapter cannot be changed after tool executions. Start a new chat to use `%s`", new_adapter.name),
+        vim.log.levels.WARN
+      )
+      return false
+    end
+  end
+
+  self.acp_connection = nil
+  self.adapter = new_adapter
   self.ui.adapter = self.adapter
 
   if self.adapter.type == "acp" then
@@ -722,6 +743,7 @@ function Chat:change_adapter(adapter, cb)
   self:update_metadata()
   self:apply_settings()
   fire()
+  return true
 end
 
 ---Set a model in the chat buffer

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -244,7 +244,6 @@ function M.callback(chat)
     end
 
     if current_adapter ~= selected_adapter then
-      chat.acp_connection = nil -- Ensure we reset this
       chat:change_adapter(selected_adapter, on_adapter_ready)
     else
       return on_adapter_ready()

--- a/tests/adapters/http/test_openai.lua
+++ b/tests/adapters/http/test_openai.lua
@@ -156,6 +156,7 @@ T["OpenAI adapter"]["can output tool call"] = function()
     role = "tool",
     tools = {
       call_id = "call_RJU6xfk0OzQF3Gg9cOFS5RY7",
+      name = "weather",
     },
   }, adapter.handlers.tools.output_response(adapter, tool_call, output))
 end

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -57,8 +57,9 @@ T["Responses"]["can output tool calls"] = function()
     },
     role = "tool",
     tools = {
-      id = "fc_0cf9af0f913994140068e27139a1948193bbf214a9664ec92c",
       call_id = "call_a9oyUMlFhnX8HvqzlfIx5Uek",
+      id = "fc_0cf9af0f913994140068e27139a1948193bbf214a9664ec92c",
+      name = "weather",
     },
   }, adapter.handlers.tools.format_response(adapter, tool_call, output))
 end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

In the past year, adapters such as Gemini and OpenAI Responses have embedded reasoning and thought signatures in their tool call requests. These are, of course, unique to them. This now means that if a user starts a chat with Gemini and executes a tool call, and attempts to move the chat over to OpenAI Responses, then they'd receive an error back from the server.

This PR does two things:

1. Firstly, it ensures that the tool structure on the chat messages is consistent across all adapters
2. It prevents users from switching adapters after a tool call or reasoning has taken place.

I plan on adding a `/fork` slash command to allow users to create a duplicate of the current chat, prior to any tool calling.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
