### PR TITLE
feat(chat): add `/fork` slash command

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 27
+*codecompanion.txt*          For NVIM v0.11         Last change: 2026 April 29
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -4794,6 +4794,15 @@ instead of file contents.
 - Select multiple files: `⇥ tab`
 
 Please note that these mappings may be different depending on your provider.
+
+
+/FORK ~
+
+The `fork` slash command, specific to `http` adapters, allows you to duplicate
+the current chat buffer, copying the message history and preserving tools and
+context in the process. This enables you to branch the conversation and
+experiment with different prompts, models or even adapters without losing the
+original conversation.
 
 
 /HELP ~

--- a/doc/usage/chat-buffer/slash-commands.md
+++ b/doc/usage/chat-buffer/slash-commands.md
@@ -62,6 +62,10 @@ This slash command is also available in the [CLI prompt input](/usage/cli#slash-
 
 Please note that these mappings may be different depending on your provider.
 
+## /fork
+
+The _fork_ slash command, specific to _http_ adapters, allows you to duplicate the current chat buffer, copying the message history and preserving tools and context in the process. This enables you to branch the conversation and experiment with different prompts, models or even adapters without losing the original conversation.
+
 ## /help
 
 The _help_ slash command allows you to add content from a vim help file (`:h helpfile`), to the chat buffer, by searching for help tags. Currently this is only available for _Telescope_, _mini.pick_, _fzf_lua_ and _snacks.nvim_ providers. By default, the slash command will prompt you to trim a help file that is over 1,000 lines in length.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -429,6 +429,19 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
             provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
           },
         },
+        ["fork"] = {
+          path = "interactions.chat.slash_commands.builtin.fork",
+          description = "Fork the current chat into a new chat buffer",
+          enabled = function(opts)
+            if opts.adapter and opts.adapter.type == "http" then
+              return true
+            end
+            return false
+          end,
+          opts = {
+            contains_code = false,
+          },
+        },
         ["file"] = {
           path = "interactions.shared.slash_commands.file",
           description = "Insert a file",

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/fork.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/fork.lua
@@ -1,0 +1,79 @@
+local config = require("codecompanion.config")
+local utils = require("codecompanion.utils")
+
+---@class CodeCompanion.SlashCommand.Fork
+---@field Chat CodeCompanion.Chat
+---@field config table
+---@field context table
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommandArgs
+function SlashCommand.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+
+  return self
+end
+
+function SlashCommand:execute()
+  if vim.tbl_isempty(self.Chat.messages) then
+    return utils.notify("No messages to fork", vim.log.levels.WARN)
+  end
+
+  vim.ui.input({ default = self.Chat.title, prompt = " Fork Title " }, function(name)
+    if name == nil then
+      return
+    end
+    self:output(name)
+  end)
+end
+
+---Fork the current chat into a new chat buffer
+---@param name string The name for the forked chat
+---@return nil
+function SlashCommand:output(name)
+  local source = self.Chat
+
+  local messages = vim.deepcopy(source.messages or {})
+
+  -- Append an empty user message so that the chat starts with user input
+  table.insert(messages, {
+    content = "",
+    role = config.constants.USER_ROLE,
+  })
+
+  local title = (name ~= "") and name or ("Fork of: " .. (source.title or ("Chat " .. source.id)))
+
+  local Chat = require("codecompanion.interactions.chat")
+  local forked = Chat.new({
+    adapter = source.adapter,
+    last_role = config.constants.USER_ROLE,
+    messages = messages,
+    settings = source.settings and vim.deepcopy(source.settings) or nil,
+    stop_context_insertion = true,
+    title = title,
+  })
+
+  -- This ensures we respect any conditionals on the chat class
+  if not forked then
+    return
+  end
+
+  forked:set_title(forked.title) -- Needed for description as well
+
+  local context_items = vim.deepcopy(source.context_items or {})
+  if not vim.tbl_isempty(context_items) then
+    forked.context_items = context_items
+  end
+
+  forked.tool_registry.groups = vim.deepcopy(source.tool_registry.groups)
+  forked.tool_registry.in_use = vim.deepcopy(source.tool_registry.in_use)
+  forked.tool_registry.schemas = vim.deepcopy(source.tool_registry.schemas)
+
+  forked.context:render()
+end
+
+return SlashCommand


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR enables you to fork a chat buffer, essentially branching from its current state. This can be useful if you wish to take a conversation in a different direction and preserve the current state for use later on.

## AI Usage

Sonnet 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
