### PR TITLE
feat(chat): action palette has static items

### DIFF
--- a/lua/codecompanion/interactions/chat/action_palette.lua
+++ b/lua/codecompanion/interactions/chat/action_palette.lua
@@ -23,6 +23,21 @@ local function format_keys(modes)
   return table.concat(segments, "  ")
 end
 
+---Build the static items shown in every chat command palette
+---@return table
+local function static_items()
+  return {
+    {
+      callback = function()
+        require("codecompanion").actions()
+      end,
+      description = "Open the action palette",
+      name = "CodeCompanion actions",
+      type = "static",
+    },
+  }
+end
+
 ---Build items from the chat's keymaps
 ---@param chat CodeCompanion.Chat
 ---@return table
@@ -122,6 +137,7 @@ end
 function CommandPalette.launch(chat)
   local items = {}
 
+  vim.list_extend(items, static_items())
   vim.list_extend(items, keymap_items(chat))
   vim.list_extend(items, slash_command_items(chat))
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As noted in the description below, the new chat buffer action palette prevents you from accessing the old action palette. This PR adds the ability to have static items in the chat action palette and the first of those items is the ability to access the old action palette.

## AI Usage

None

## Related Issue(s)

#3076

## Screenshots

<img width="3368" height="2240" alt="2026-04-29 22_27_51 - Ghostty@2x" src="https://github.com/user-attachments/assets/e5bd5f2d-36be-4298-974d-c1ca06d83f1e" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
