### PR TITLE
Remove gpt-4-turbo-preview from available models

### DIFF
--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -452,11 +452,6 @@ return {
           formatted_name = "GPT-4o Mini",
           opts = { has_vision = true },
         },
-        ["gpt-4-turbo-preview"] = {
-          formatted_name = "GPT-4 Turbo Preview",
-          opts = { has_vision = true },
-        },
-        "gpt-4",
         "gpt-3.5-turbo",
       },
     },


### PR DESCRIPTION

<!-- Please do not alter the structure of this PR template -->

## Description
Removed gpt-4 and gpt-4-turbo-preview from model options as they are inavailable.

Error: "The model `gpt-4-turbo-preview` does not exist or you do not have access to it." ("code": "model_not_found")

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## AI Usage

No

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
