### PR TITLE
refactor(chat): `/acp_session_options` can display models

### DIFF
--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/acp_session_options.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/acp_session_options.lua
@@ -76,7 +76,8 @@ function SlashCommand:execute()
     return utils.notify("No ACP connection available", vim.log.levels.WARN)
   end
 
-  local options = Chat.acp_connection:get_config_options({ exclude_categories = { "model" } })
+  -- local options = Chat.acp_connection:get_config_options({ exclude_categories = { "model" } })
+  local options = Chat.acp_connection:get_config_options()
   if #options == 0 then
     return utils.notify("No configuration options available", vim.log.levels.WARN)
   end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The `/acp_session_options` slash command can also display model.

## AI Usage

None

## Related Issue(s)

#3088

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
