### PR TITLE
fix(chat): handle tool responses with no role

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1449,6 +1449,15 @@ function Chat:done(output, reasoning, tools, meta, opts)
         visible = false,
         _meta = vim.tbl_extend("force", has_meta and meta or {}, token_meta),
       })
+
+      -- Ref: #3093
+      -- The Copilot adapter (when paired with Anthropic) can emit a tool call
+      -- without including the role. This results in the chat buffer not
+      -- being readied for LLM input. So, we force the role to be set
+      if self._last_role ~= config.constants.LLM_ROLE then
+        self._last_role = config.constants.LLM_ROLE
+        self:add_buf_message({ role = config.constants.LLM_ROLE })
+      end
       return self.tools:execute(self, tools)
     end
   end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Seems to have been a recent change in the Copilot adapter whereby a response that starts with a tool call will not have a role attribute. This caused the chat buffer to be unable to insert the LLM header. 

## AI Usage

None

## Related Issue(s)

#3093

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
