### PR TITLE
feat(chat): add adapter type to `codecompanion_chat_metadata` table

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -5454,7 +5454,7 @@ CodeCompanion exposes a global dictionary, `_G.codecompanion_chat_metadata`
 which users can leverage throughout their configuration. Using the chat
 buffer's buffer number as the key, the dictionary contains:
 
-- `adapter` - The `name` and `model` of the chat buffer's current adapter
+- `adapter` - The `type`, `name` and `model` of the chat buffer's current adapter
 - `context_items` - The number of context items current in the chat buffer
 - `cycles` - The number of cycles (User->LLM->User) that have taken place in the chat buffer
 - `id` - The ID of the chat buffer

--- a/doc/usage/ui.md
+++ b/doc/usage/ui.md
@@ -14,7 +14,7 @@ CodeCompanion aims to keep any changes to the user's UI to a minimum. Aesthetics
 
 CodeCompanion exposes a global dictionary, `_G.codecompanion_chat_metadata` which users can leverage throughout their configuration. Using the chat buffer's buffer number as the key, the dictionary contains:
 
-- `adapter` - The `name` and `model` of the chat buffer's current adapter
+- `adapter` - The `type`, `name` and `model` of the chat buffer's current adapter
 - `context_items` - The number of context items current in the chat buffer
 - `cycles` - The number of cycles (User->LLM->User) that have taken place in the chat buffer
 - `id` - The ID of the chat buffer

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1931,6 +1931,7 @@ function Chat:update_metadata()
 
   _G.codecompanion_chat_metadata[self.bufnr] = {
     adapter = {
+      type = self.adapter.type,
       name = self.adapter.formatted_name,
       model = model,
       model_info = (self.adapter.model and self.adapter.model.info) and self.adapter.model.info,

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1932,10 +1932,10 @@ function Chat:update_metadata()
 
   _G.codecompanion_chat_metadata[self.bufnr] = {
     adapter = {
-      type = self.adapter.type,
       name = self.adapter.formatted_name,
       model = model,
       model_info = (self.adapter.model and self.adapter.model.info) and self.adapter.model.info,
+      type = self.adapter.type,
     },
     config_options = config_options,
     context_items = #self.context_items,


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I wanted to add the adapter type to statusline, but codecompanion_chat_metadata table doesn't currently contain that info

## AI Usage

gemma4

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [X] _(optional)_ I've updated the README and/or relevant docs pages
