### PR TITLE
refactor(chat): extract tags to own file

### DIFF
--- a/.codecompanion/chat.md
+++ b/.codecompanion/chat.md
@@ -45,3 +45,32 @@ Messages in the chat buffer are lua table objects as seen. They contain the role
     content = "Yes, I am active and ready to assist you with programming tasks, code explanations, reviews, or Neovim-related questions. What would you like to do next?",
   } }
 ```
+
+## Message Tags
+
+Messages may carry a `_meta.tag` value identifying the origin or kind of the message. Tags are how downstream code (adapters, compaction, system prompt management, etc.) recognises and acts on specific message types. The full set of tags is centralised at `lua/codecompanion/interactions/shared/tags.lua` — refer to that module rather than repeating the string literals in code.
+
+| Tag | Set by | Read by |
+|---|---|---|
+| `buffer` | `shared/slash_commands/buffer.lua`, `shared/editor_context/buffer.lua`, `shared/editor_context/buffers.lua` | `adapters/acp/helpers.lua` |
+| `compact_summary` | `chat/context_management/compaction.lua` | `chat/context_management/compaction.lua` (re-run replacement) |
+| `diagnostics` | `shared/editor_context/diagnostics.lua` | — |
+| `diff` | `shared/editor_context/diff.lua` | — |
+| `editor_context` | legacy editor_context emitters | `chat/slash_commands/builtin/compact.lua` |
+| `file` | `shared/slash_commands/file.lua` | `adapters/acp/helpers.lua`, `chat/slash_commands/builtin/compact.lua` |
+| `from_custom_prompt` | `interactions/init.lua` (custom prompt library entries) | — |
+| `image` | `chat/init.lua:add_image_message` | every HTTP adapter, `adapters/acp/helpers.lua`, title generation |
+| `messages` | `shared/editor_context/messages.lua` | — |
+| `quickfix` | `shared/editor_context/quickfix.lua` | — |
+| `rules` | `shared/rules/helpers.lua` | `chat/slash_commands/builtin/compact.lua`, title generation |
+| `selection` | `shared/editor_context/selection.lua` | — |
+| `system_prompt_from_config` | `chat/init.lua:set_system_prompt` | `chat/tool_registry.lua`, title generation |
+| `terminal` | `shared/editor_context/terminal.lua` | — |
+| `tool` | `chat/tool_registry.lua` | `chat/tool_registry.lua` (group tear-down) |
+| `tool_output` | adapters (via `format_response`) | `chat/ui/init.lua` (rendering spacing) |
+| `tool_system_prompt` | `chat/tool_registry.lua:add_tool_system_prompt` | — |
+| `viewport` | `shared/editor_context/viewport.lua` | — |
+
+Inline-only tags (`system_tag`, `visual`) live entirely inside `interactions/inline/` and are not part of the shared module.
+
+String values are stable — they appear in stored chats and are read by external adapters. Adding a new tag is safe; renaming a value is a breaking change.

--- a/lua/codecompanion/adapters/acp/helpers.lua
+++ b/lua/codecompanion/adapters/acp/helpers.lua
@@ -1,4 +1,5 @@
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local M = {}
 
@@ -16,7 +17,7 @@ M.form_messages = function(self, messages, capabilities)
       return msg.role == self.roles.user and msg._meta and not msg._meta.sent
     end)
     :map(function(msg)
-      if msg._meta and msg._meta.tag == "image" and msg.context and msg.context.mimetype then
+      if msg._meta and msg._meta.tag == tags.IMAGE and msg.context and msg.context.mimetype then
         if not has.image then
           log:warn("The %s agent does not support receiving images", self.formatted_name)
         else
@@ -28,7 +29,7 @@ M.form_messages = function(self, messages, capabilities)
         end
       end
       if msg.content and msg.content ~= "" then
-        if msg._meta and (msg._meta.tag == "file" or msg._meta.tag == "buffer") then
+        if msg._meta and (msg._meta.tag == tags.FILE or msg._meta.tag == tags.BUFFER) then
           if msg.context and msg.context.path then
             return {
               type = "text",

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -1,5 +1,6 @@
 local adapter_utils = require("codecompanion.utils.adapters")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 local transform = require("codecompanion.utils.tool_transformers")
 
 ---@class CodeCompanion.HTTPAdapter.Anthropic: CodeCompanion.HTTPAdapter
@@ -193,7 +194,7 @@ return {
         local compaction = m._meta and m._meta.compaction
 
         -- 3. Account for any images
-        if m._meta and m._meta.tag == "image" and m.context and m.context.mimetype then
+        if m._meta and m._meta.tag == tags.IMAGE and m.context and m.context.mimetype then
           if self.opts and self.opts.vision then
             m.content = {
               {

--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -2,6 +2,7 @@ local adapter_utils = require("codecompanion.utils.adapters")
 local get_models = require("codecompanion.adapters.http.copilot.get_models")
 local log = require("codecompanion.utils.log")
 local stats = require("codecompanion.adapters.http.copilot.stats")
+local tags = require("codecompanion.interactions.shared.tags")
 local token = require("codecompanion.adapters.http.copilot.token")
 local tokens = require("codecompanion.utils.tokens")
 
@@ -170,7 +171,7 @@ return {
     end,
     form_messages = function(self, messages)
       for _, m in ipairs(messages) do
-        if m._meta and m._meta.tag == "image" and (m.context and m.context.mimetype) then
+        if m._meta and m._meta.tag == tags.IMAGE and (m.context and m.context.mimetype) then
           self.headers["X-Initiator"] = "user"
           self.headers["Copilot-Vision-Request"] = "true"
           break

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -2,6 +2,7 @@
 
 local adapter_utils = require("codecompanion.utils.adapters")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 local transform = require("codecompanion.utils.tool_transformers")
 
 ---Extract the first complete JSON object from a potentially concatenated string
@@ -195,7 +196,7 @@ return {
 
         -- Image -> inline_data
         -- https://ai.google.dev/gemini-api/docs/image-understanding#inline-image
-        elseif msg._meta and msg._meta.tag == "image" and msg.context and msg.context.mimetype then
+        elseif msg._meta and msg._meta.tag == tags.IMAGE and msg.context and msg.context.mimetype then
           if self.opts and self.opts.vision then
             table.insert(contents, {
               role = msg.role == self.roles.llm and self.roles.llm or self.roles.user,

--- a/lua/codecompanion/adapters/http/ollama/init.lua
+++ b/lua/codecompanion/adapters/http/ollama/init.lua
@@ -2,6 +2,7 @@ local adapter_utils = require("codecompanion.utils.adapters")
 local get_models = require("codecompanion.adapters.http.ollama.get_models")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
+local tags = require("codecompanion.interactions.shared.tags")
 
 ---@class CodeCompanion.HTTPAdapter.Ollama: CodeCompanion.HTTPAdapter
 return {
@@ -105,7 +106,7 @@ return {
           end
 
           -- Process any images
-          if m._meta and m._meta.tag == "image" and m.context and m.context.mimetype then
+          if m._meta and m._meta.tag == tags.IMAGE and m.context and m.context.mimetype then
             m.images = m.images or {}
             if self.opts and self.opts.vision then
               table.insert(m.images, m.content)

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -1,5 +1,6 @@
 local adapter_utils = require("codecompanion.utils.adapters")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local CONSTANTS = {
   STANDARD_MESSAGE_FIELDS = {
@@ -132,7 +133,7 @@ return {
           end
 
           -- Process any images
-          if m._meta and m._meta.tag == "image" and m.context and m.context.mimetype then
+          if m._meta and m._meta.tag == tags.IMAGE and m.context and m.context.mimetype then
             if self.opts and self.opts.vision then
               m.content = {
                 {

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -1,6 +1,7 @@
 local adapter_utils = require("codecompanion.utils.adapters")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
+local tags = require("codecompanion.interactions.shared.tags")
 local tool_utils = require("codecompanion.utils.tool_transformers")
 
 ---@type string|nil
@@ -164,7 +165,7 @@ return {
             end
 
             -- Check if this is an image message followed by a text message from the same user
-            if m._meta and m._meta.tag == "image" and (m.context and m.context.mimetype) then
+            if m._meta and m._meta.tag == tags.IMAGE and (m.context and m.context.mimetype) then
               if self.opts and self.opts.vision then
                 local next_msg = messages[i + 1]
                 local combined_content = {
@@ -179,7 +180,7 @@ return {
                   next_msg
                   and next_msg.role == m.role
                   and type(next_msg.content) == "string"
-                  and not (next_msg._meta and next_msg._meta.tag == "image")
+                  and not (next_msg._meta and next_msg._meta.tag == tags.IMAGE)
                 then
                   table.insert(combined_content, {
                     type = "input_text",

--- a/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
+++ b/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
@@ -1,4 +1,5 @@
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local fmt = string.format
 
@@ -8,9 +9,9 @@ local M = {}
 ---@param messages CodeCompanion.Chat.Messages
 function M.format_messages(messages)
   local exclude_tags = {
-    ["image"] = "[Image content omitted]",
-    ["rules"] = "",
-    ["system_prompt_from_config"] = "",
+    [tags.IMAGE] = "[Image content omitted]",
+    [tags.RULES] = "",
+    [tags.SYSTEM_PROMPT_FROM_CONFIG] = "",
   }
 
   local chat_messages = {}

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -66,6 +66,7 @@ local config = require("codecompanion.config")
 local helpers = require("codecompanion.interactions.chat.helpers")
 local parser = require("codecompanion.interactions.chat.parser")
 local schema = require("codecompanion.schema")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local hash = require("codecompanion.utils.hash")
 local images_utils = require("codecompanion.utils.images")
@@ -874,7 +875,7 @@ function Chat:set_system_prompt(prompt, opts)
   prompt = prompt or config.interactions.chat.opts.system_prompt
   opts = opts or { visible = false }
 
-  local _meta = { tag = "system_prompt_from_config" }
+  local _meta = { tag = tags.SYSTEM_PROMPT_FROM_CONFIG }
   if opts._meta then
     _meta = opts._meta
     opts._meta = nil
@@ -925,11 +926,11 @@ function Chat:toggle_system_prompt()
     vim.tbl_map(function(msg)
       return msg._meta and msg._meta.tag
     end, self.messages),
-    "system_prompt_from_config"
+    tags.SYSTEM_PROMPT_FROM_CONFIG
   )
 
   if has_system_prompt then
-    self:remove_tagged_message("system_prompt_from_config")
+    self:remove_tagged_message(tags.SYSTEM_PROMPT_FROM_CONFIG)
     utils.notify("Removed system prompt")
   else
     self:set_system_prompt()
@@ -1080,7 +1081,7 @@ function Chat:add_image_message(image, opts)
     content = image.base64,
   }, {
     context = { id = id, mimetype = image.mimetype, path = image.path or image.id },
-    _meta = { tag = "image" },
+    _meta = { tag = tags.IMAGE },
     visible = false,
   })
 

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/compact.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/compact.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local fmt = string.format
 
@@ -117,7 +118,7 @@ function SlashCommand:compact_messages()
   --1. Keep ALL system messages even if they come from tools
   --2. Remove ALL llm messages
   --3. Keep SOME user messages - If it has a "variable", "rules" or "file" tag
-  local ok_tags = { "editor_context", "rules", "file" }
+  local ok_tags = { tags.EDITOR_CONTEXT, tags.RULES, tags.FILE }
 
   local messages = vim.iter(self.Chat.messages):filter(function(message)
     if message.role == config.constants.SYSTEM_ROLE then

--- a/lua/codecompanion/interactions/chat/tool_registry.lua
+++ b/lua/codecompanion/interactions/chat/tool_registry.lua
@@ -14,6 +14,7 @@ Methods for handling interactions between the chat buffer and tools
 local ToolRegistry = {}
 
 local config = require("codecompanion.config")
+local tags = require("codecompanion.interactions.shared.tags")
 local utils = require("codecompanion.utils")
 
 local fmt = string.format
@@ -79,7 +80,7 @@ local function add_system_prompt(chat, tool, id)
     end
     chat:add_message(
       { role = config.constants.SYSTEM_ROLE, content = system_prompt },
-      { visible = false, _meta = { tag = "tool" }, context = { id = id } }
+      { visible = false, _meta = { tag = tags.TOOL }, context = { id = id } }
     )
   end
 end
@@ -206,7 +207,7 @@ function ToolRegistry:add_group(group, opts)
     self.chat:add_message({
       role = config.constants.SYSTEM_ROLE,
       content = system_prompt,
-    }, { _meta = { tag = "tool" }, context = { id = gid }, visible = false })
+    }, { _meta = { tag = tags.TOOL }, context = { id = gid }, visible = false })
   end
 
   if collapse_tools then
@@ -246,10 +247,10 @@ function ToolRegistry:add_tool_system_prompt()
   local index = 2 -- Add after the main system prompt if not replacing
   if opts.replace_main_system_prompt then
     index = 1
-    self.chat:remove_tagged_message("system_prompt_from_config")
+    self.chat:remove_tagged_message(tags.SYSTEM_PROMPT_FROM_CONFIG)
   end
 
-  self.chat:set_system_prompt(prompt, { visible = false, _meta = { tag = "tool_system_prompt", index = index } })
+  self.chat:set_system_prompt(prompt, { visible = false, _meta = { tag = tags.TOOL_SYSTEM_PROMPT, index = index } })
 end
 
 ---Determine if the chat buffer has any tools in use
@@ -283,7 +284,7 @@ function ToolRegistry:remove_group(name)
   self.chat.messages = vim
     .iter(self.chat.messages)
     :filter(function(msg)
-      if msg._meta and msg._meta.tag == "tool" and msg.context and to_remove[msg.context.id] then
+      if msg._meta and msg._meta.tag == tags.TOOL and msg.context and to_remove[msg.context.id] then
         return false
       end
       return true

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -7,6 +7,7 @@ local helpers = require("codecompanion.interactions.chat.helpers")
 local log = require("codecompanion.utils.log")
 local schema = require("codecompanion.schema")
 local shared_ui = require("codecompanion.interactions.shared.ui")
+local tags = require("codecompanion.interactions.shared.tags")
 local utils = require("codecompanion.utils")
 local yaml = require("codecompanion.utils.yaml")
 
@@ -351,7 +352,7 @@ function UI:render(context, messages, opts)
           self:set_header(lines, set_llm_role(self.roles.llm, self.adapter))
         end
 
-        if msg._meta and msg._meta.tag == "tool_output" then
+        if msg._meta and msg._meta.tag == tags.TOOL_OUTPUT then
           table.insert(lines, "")
         end
 

--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -3,6 +3,7 @@ local config = require("codecompanion.config")
 
 local log = require("codecompanion.utils.log")
 local rules_helpers = require("codecompanion.interactions.shared.rules.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 
 ---A user may specify an adapter for the prompt
 ---@param interaction CodeCompanion.Interactions
@@ -211,7 +212,7 @@ function Interactions:workflow()
             p.content = p.content(self.buffer_context)
           end
           if p.role == config.constants.SYSTEM_ROLE and not p.opts then
-            p.opts = { visible = false, _meta = { tag = "from_custom_prompt" } }
+            p.opts = { visible = false, _meta = { tag = tags.FROM_CUSTOM_PROMPT } }
           end
           return p
         end)
@@ -319,7 +320,7 @@ function Interactions.evaluate_prompts(prompts, buffer_context)
     :map(function(prompt)
       local content = type(prompt.content) == "function" and prompt.content(buffer_context) or prompt.content
       if prompt.role == config.constants.SYSTEM_ROLE and not prompt.opts then
-        prompt.opts = { visible = false, _meta = { tag = "from_custom_prompt" } }
+        prompt.opts = { visible = false, _meta = { tag = tags.FROM_CUSTOM_PROMPT } }
       end
       return {
         role = prompt.role or "",

--- a/lua/codecompanion/interactions/shared/editor_context/buffer.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/buffer.lua
@@ -2,6 +2,7 @@ local buf_utils = require("codecompanion.utils.buffers")
 local chat_helpers = require("codecompanion.interactions.chat.helpers")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local reserved_params = {
   "all",
@@ -94,7 +95,7 @@ function EditorContext:chat_render(selected, opts)
     role = config.constants.USER_ROLE,
     content = content,
   }, {
-    _meta = { source = "editor_context", tag = "buffer" },
+    _meta = { source = "editor_context", tag = tags.BUFFER },
     context = { id = id, path = buf_info.path },
     visible = false,
   })

--- a/lua/codecompanion/interactions/shared/editor_context/buffers.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/buffers.lua
@@ -2,6 +2,7 @@ local buf_utils = require("codecompanion.utils.buffers")
 local chat_helpers = require("codecompanion.interactions.chat.helpers")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local reserved_params = {
   "all",
@@ -77,7 +78,7 @@ function EditorContext:chat_render()
           role = config.constants.USER_ROLE,
           content = content,
         }, {
-          _meta = { source = "editor_context", tag = "buffer" },
+          _meta = { source = "editor_context", tag = tags.BUFFER },
           context = { id = id, path = buf_info.path },
           visible = false,
         })

--- a/lua/codecompanion/interactions/shared/editor_context/diagnostics.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/diagnostics.lua
@@ -1,6 +1,7 @@
 local buf_utils = require("codecompanion.utils.buffers")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 ---@class CodeCompanion.EditorContext.Diagnostics: CodeCompanion.EditorContext
 local EditorContext = {}
@@ -90,7 +91,7 @@ Code:
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = content,
-  }, { _meta = { source = "editor_context", tag = "diagnostics" }, visible = false })
+  }, { _meta = { source = "editor_context", tag = tags.DIAGNOSTICS }, visible = false })
 end
 
 ---Return inline label and context block for the CLI interaction

--- a/lua/codecompanion/interactions/shared/editor_context/diff.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/diff.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local fmt = string.format
 
@@ -56,7 +57,7 @@ function EditorContext:chat_render()
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = table.concat(content, "\n\n"),
-  }, { _meta = { source = "editor_context", tag = "diff" }, visible = false })
+  }, { _meta = { source = "editor_context", tag = tags.DIFF }, visible = false })
 end
 
 ---Return inline label and context block for the CLI interaction

--- a/lua/codecompanion/interactions/shared/editor_context/messages.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/messages.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 ---@class CodeCompanion.EditorContext.Messages: CodeCompanion.EditorContext
 local EditorContext = {}
@@ -28,7 +29,7 @@ function EditorContext:chat_render()
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = "Neovim message history (`:messages`):\n\n````\n" .. vim.trim(messages) .. "\n````",
-  }, { _meta = { source = "editor_context", tag = "messages" }, visible = false })
+  }, { _meta = { source = "editor_context", tag = tags.MESSAGES }, visible = false })
 end
 
 ---Return inline label and context block for the CLI interaction

--- a/lua/codecompanion/interactions/shared/editor_context/quickfix.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/quickfix.lua
@@ -3,6 +3,7 @@ local Path = require("plenary.path")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local symbol_helpers = require("codecompanion.interactions.chat.helpers.symbols")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local fmt = string.format
 
@@ -346,7 +347,7 @@ function EditorContext:chat_render()
         role = config.constants.USER_ROLE,
         content = description,
       }, {
-        _meta = { source = "editor_context", tag = "quickfix" },
+        _meta = { source = "editor_context", tag = tags.QUICKFIX },
         context = { id = id },
         visible = false,
       })

--- a/lua/codecompanion/interactions/shared/editor_context/selection.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/selection.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local fmt = string.format
 
@@ -43,7 +44,7 @@ function EditorContext:chat_render()
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = content,
-  }, { _meta = { source = "editor_context", tag = "selection" }, visible = false })
+  }, { _meta = { source = "editor_context", tag = tags.SELECTION }, visible = false })
 end
 
 ---Return inline label and context block for the CLI interaction

--- a/lua/codecompanion/interactions/shared/editor_context/terminal.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/terminal.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local fmt = string.format
 
@@ -47,7 +48,7 @@ function EditorContext:chat_render()
   self.Chat:add_message({
     role = config.constants.USER_ROLE,
     content = fmt("Latest output from terminal buffer %d:\n\n````\n%s\n````", bufnr, table.concat(content, "\n")),
-  }, { _meta = { source = "editor_context", tag = "terminal" }, visible = false })
+  }, { _meta = { source = "editor_context", tag = tags.TERMINAL }, visible = false })
 end
 
 ---Return inline label and context block for the CLI interaction

--- a/lua/codecompanion/interactions/shared/editor_context/viewport.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/viewport.lua
@@ -2,6 +2,7 @@ local buf_utils = require("codecompanion.utils.buffers")
 local chat_helpers = require("codecompanion.interactions.chat.helpers")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 
 ---@class CodeCompanion.EditorContext.ViewPort: CodeCompanion.EditorContext
 local EditorContext = {}
@@ -33,7 +34,7 @@ function EditorContext:chat_render()
         role = config.constants.USER_ROLE,
         content = content,
       }, {
-        _meta = { source = "editor_context", tag = "viewport" },
+        _meta = { source = "editor_context", tag = tags.VIEWPORT },
         visible = false,
       })
       count = count + 1

--- a/lua/codecompanion/interactions/shared/rules/helpers.lua
+++ b/lua/codecompanion/interactions/shared/rules/helpers.lua
@@ -1,5 +1,6 @@
 local chat_helpers = require("codecompanion.interactions.chat.helpers")
 local config = require("codecompanion.config")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local buf_utils = require("codecompanion.utils.buffers")
 local file_utils = require("codecompanion.utils.files")
@@ -149,7 +150,7 @@ function M.add_context(files, chat)
       if file.system_prompt and file.system_prompt ~= "" then
         chat:add_message(
           { role = "system", content = file.system_prompt },
-          { visible = false, context = { id = id }, _meta = { tag = "rules" } }
+          { visible = false, context = { id = id }, _meta = { tag = tags.RULES } }
         )
       end
 

--- a/lua/codecompanion/interactions/shared/slash_commands/buffer.lua
+++ b/lua/codecompanion/interactions/shared/slash_commands/buffer.lua
@@ -1,6 +1,7 @@
 local config = require("codecompanion.config")
 local helpers = require("codecompanion.interactions.chat.helpers")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 local utils = require("codecompanion.utils")
 
 local fmt = string.format
@@ -204,7 +205,7 @@ function SlashCommand:output(selected, opts)
     role = config.constants.USER_ROLE,
     content = content,
   }, {
-    _meta = { source = "slash_command", tag = "buffer" },
+    _meta = { source = "slash_command", tag = tags.BUFFER },
     context = { id = id, path = selected.path },
     visible = false,
   })

--- a/lua/codecompanion/interactions/shared/slash_commands/file.lua
+++ b/lua/codecompanion/interactions/shared/slash_commands/file.lua
@@ -3,6 +3,7 @@ local Path = require("plenary.path")
 local config = require("codecompanion.config")
 local helpers = require("codecompanion.interactions.chat.helpers")
 local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
 local utils = require("codecompanion.utils")
 
 local fmt = string.format
@@ -206,7 +207,7 @@ function SlashCommand:output(selected, opts)
   }, {
     visible = false,
     context = { id = id, path = selected.path },
-    _meta = { tag = "file" },
+    _meta = { tag = tags.FILE },
   })
 
   if opts.sync_all then

--- a/lua/codecompanion/interactions/shared/tags.lua
+++ b/lua/codecompanion/interactions/shared/tags.lua
@@ -1,0 +1,23 @@
+---@class CodeCompanion.Chat.MessageTags
+local M = {
+  BUFFER = "buffer",
+  COMPACT_SUMMARY = "compact_summary",
+  DIAGNOSTICS = "diagnostics",
+  DIFF = "diff",
+  EDITOR_CONTEXT = "editor_context",
+  FILE = "file",
+  FROM_CUSTOM_PROMPT = "from_custom_prompt",
+  IMAGE = "image",
+  MESSAGES = "messages",
+  QUICKFIX = "quickfix",
+  RULES = "rules",
+  SELECTION = "selection",
+  SYSTEM_PROMPT_FROM_CONFIG = "system_prompt_from_config",
+  TERMINAL = "terminal",
+  TOOL = "tool",
+  TOOL_OUTPUT = "tool_output",
+  TOOL_SYSTEM_PROMPT = "tool_system_prompt",
+  VIEWPORT = "viewport",
+}
+
+return M

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -94,7 +94,7 @@
 ---@field _meta.id? number Unique identifier for the message (generated via hash)
 ---@field _meta.cycle? number The chat turn cycle when this message was added
 ---@field _meta.index? number The index of the chat message in the messages stack
----@field _meta.tag? string A tag to identify special messages (e.g. "system_prompt_from_config", "tool")
+---@field _meta.tag? string A tag to identify special messages — see `codecompanion.interactions.shared.tags`
 ---@field _meta.cumulative_tokens? number Actual cumulative token count from the API when this message was generated
 ---@field _meta.estimated_tokens? number Estimated token count associated with this message
 ---@field context? { id?: string, path?: string, mimetype?: string, url?: string } Optional context object

--- a/tests/adapters/http/test_anthropic.lua
+++ b/tests/adapters/http/test_anthropic.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 local transform = require("codecompanion.utils.tool_transformers")
 local adapter
 
@@ -90,7 +91,7 @@ T["Anthropic adapter"]["form_messages"]["images"] = function()
         mimetype = "image/jpg",
       },
       _meta = {
-        tag = "image",
+        tag = tags.IMAGE,
       },
       opts = {
         visible = false,

--- a/tests/adapters/http/test_ollama.lua
+++ b/tests/adapters/http/test_ollama.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 local adapter
 
 local child = MiniTest.new_child_neovim()
@@ -154,7 +155,7 @@ T["Ollama adapter"]["Streaming"]["can form messages with images"] = function()
         mimetype = "image/jpg",
       },
       _meta = {
-        tag = "image",
+        tag = tags.IMAGE,
       },
       opts = {
         visible = false,

--- a/tests/adapters/http/test_openai.lua
+++ b/tests/adapters/http/test_openai.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 local adapter
 
 local new_set = MiniTest.new_set
@@ -39,7 +40,7 @@ T["OpenAI adapter"]["it can form messages with images"] = function()
         mimetype = "image/jpg",
       },
       _meta = {
-        tag = "image",
+        tag = tags.IMAGE,
       },
       opts = {
         visible = false,

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 local adapter
 
 local new_set = MiniTest.new_set
@@ -116,7 +117,7 @@ T["Responses"]["build_messages"]["images"] = function()
         mimetype = "image/jpg",
       },
       _meta = {
-        tag = "image",
+        tag = tags.IMAGE,
       },
     },
     {
@@ -161,21 +162,21 @@ T["Responses"]["build_messages"]["multiple consecutive images are not merged as 
       role = "user",
       opts = { visible = false },
       context = { mimetype = "image/png" },
-      _meta = { tag = "image" },
+      _meta = { tag = tags.IMAGE },
     },
     {
       content = "img2_base64",
       role = "user",
       opts = { visible = false },
       context = { mimetype = "image/png" },
-      _meta = { tag = "image" },
+      _meta = { tag = tags.IMAGE },
     },
     {
       content = "img3_base64",
       role = "user",
       opts = { visible = false },
       context = { mimetype = "image/png" },
-      _meta = { tag = "image" },
+      _meta = { tag = tags.IMAGE },
     },
     {
       content = "How many images do you see?",

--- a/tests/interactions/chat/slash_commands/test_compact.lua
+++ b/tests/interactions/chat/slash_commands/test_compact.lua
@@ -11,12 +11,13 @@ T = new_set({
 
       child.lua([[
         h = require('tests.helpers')
+        local tags = require('codecompanion.interactions.shared.tags')
         _G.chat, _ = h.setup_chat_buffer()
 
         _G.chat.messages = {
           { role = "system", content = "You are a helpful assistant." },
-          { role = "user", content = "FILE", _meta = { tag = "file" } },
-          { role = "user", content = "BUFFER", _meta = { tag = "editor_context" } },
+          { role = "user", content = "FILE", _meta = { tag = tags.FILE } },
+          { role = "user", content = "BUFFER", _meta = { tag = tags.EDITOR_CONTEXT } },
           { role = "user", content = "Hello!" },
           { role = "assistant", content = "Hi there! How can I assist you today?" },
           { role = "user", content = "Can you help me with Lua?" },

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local expect = MiniTest.expect
 local new_set = MiniTest.new_set
@@ -61,7 +62,7 @@ T["Chat"]["buffer editor context is handled"] = function()
   -- Make assertions on the retrieved values
   h.eq("foo", last_message_content)
   h.eq(false, last_message_visible)
-  h.eq("editor_context", last_message_tag)
+  h.eq(tags.EDITOR_CONTEXT, last_message_tag)
 end
 
 T["Chat"]["system prompt can be ignored"] = function()
@@ -197,7 +198,7 @@ T["Chat"]["CodeCompanion images are replaced in text and base64 encoded"] = func
     estimated_tokens = message._meta.estimated_tokens,
     index = message._meta.index,
     id = message._meta.id,
-    tag = "image",
+    tag = tags.IMAGE,
   }, message._meta)
 
   h.eq({
@@ -241,7 +242,7 @@ T["Chat"]["markdown images are replaced in text and base64 encoded"] = function(
     estimated_tokens = message._meta.estimated_tokens,
     index = message._meta.index,
     id = message._meta.id,
-    tag = "image",
+    tag = tags.IMAGE,
   }, message._meta)
 
   h.eq({

--- a/tests/interactions/chat/test_editor_context.lua
+++ b/tests/interactions/chat/test_editor_context.lua
@@ -98,7 +98,7 @@ T["Editor Context"][":parse"]["multiple buffer editor context"] = function()
     table.insert(_G.chat.messages, { role = "user", content = "Look at #{buffer:init.lua} and then #{buffer:config.lua}" })
     _G.result = _G.ec:parse(_G.chat, _G.chat.messages[#_G.chat.messages])
     _G.buffer_messages = vim.tbl_filter(function(msg)
-      return msg._meta and msg._meta.tag == "buffer"
+      return msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").BUFFER
     end, _G.chat.messages)
   ]])
 
@@ -113,7 +113,7 @@ T["Editor Context"][":parse"]["buffer editor context with params"] = function()
     table.insert(_G.chat.messages, { role = "user", content = "Look at #{buffer:init.lua}{all} Isn't it marvellous?" })
     _G.ec:parse(_G.chat, _G.chat.messages[#_G.chat.messages])
     _G.buffer_messages = vim.tbl_filter(function(msg)
-      return msg._meta and msg._meta.tag == "buffer"
+      return msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").BUFFER
     end, _G.chat.messages)
   ]])
 
@@ -128,7 +128,7 @@ T["Editor Context"][":parse"]["buffers editor context adds context items"] = fun
     table.insert(_G.chat.messages, { role = "user", content = "#{buffers} What do these files do?" })
     _G.result = _G.ec:parse(_G.chat, _G.chat.messages[#_G.chat.messages])
     _G.buffer_messages = vim.tbl_filter(function(msg)
-      return msg._meta and msg._meta.tag == "buffer"
+      return msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").BUFFER
     end, _G.chat.messages)
     _G.items_valid = true
     for _, item in ipairs(_G.chat.context_items) do

--- a/tests/interactions/chat/tools/test_tool_registry.lua
+++ b/tests/interactions/chat/tools/test_tool_registry.lua
@@ -313,7 +313,7 @@ T["ToolRegistry"][":add_group"]["ignore_system_prompt removes the default system
     -- Verify the default system prompt exists before adding the group
     _G.has_default_before = false
     for _, msg in ipairs(_G.chat.messages) do
-      if msg._meta and msg._meta.tag == "system_prompt_from_config" then
+      if msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").SYSTEM_PROMPT_FROM_CONFIG then
         _G.has_default_before = true
         break
       end
@@ -324,7 +324,7 @@ T["ToolRegistry"][":add_group"]["ignore_system_prompt removes the default system
     _G.has_default_after = false
     _G.has_group_prompt = false
     for _, msg in ipairs(_G.chat.messages) do
-      if msg._meta and msg._meta.tag == "system_prompt_from_config" then
+      if msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").SYSTEM_PROMPT_FROM_CONFIG then
         _G.has_default_after = true
       end
       if msg.content == "Custom agent system prompt" then
@@ -353,7 +353,7 @@ T["ToolRegistry"][":add_group"]["ignore_system_prompt is restored on remove_grou
 
     _G.has_default_after_add = false
     for _, msg in ipairs(_G.chat.messages) do
-      if msg._meta and msg._meta.tag == "system_prompt_from_config" then
+      if msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").SYSTEM_PROMPT_FROM_CONFIG then
         _G.has_default_after_add = true
         break
       end
@@ -368,7 +368,7 @@ T["ToolRegistry"][":add_group"]["ignore_system_prompt is restored on remove_grou
 
     _G.has_default_after_remove = false
     for _, msg in ipairs(_G.chat.messages) do
-      if msg._meta and msg._meta.tag == "system_prompt_from_config" then
+      if msg._meta and msg._meta.tag == require("codecompanion.interactions.shared.tags").SYSTEM_PROMPT_FROM_CONFIG then
         _G.has_default_after_remove = true
         break
       end

--- a/tests/interactions/inline/editor_context/bar.lua
+++ b/tests/interactions/inline/editor_context/bar.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local EditorContext = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -18,14 +20,14 @@ function EditorContext:output()
     self.Chat:add_message({
       role = "user",
       content = "bar " .. self.params,
-    }, { _meta = { tag = "editor_context" }, visible = false })
+    }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
     return
   end
 
   self.Chat:add_message({
     role = "user",
     content = "bar",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 return EditorContext

--- a/tests/interactions/inline/editor_context/baz.lua
+++ b/tests/interactions/inline/editor_context/baz.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local EditorContext = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -18,14 +20,14 @@ function EditorContext:output()
     self.Chat:add_message({
       role = "user",
       content = "bar " .. self.params,
-    }, { _meta = { tag = "editor_context" }, visible = false })
+    }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
     return
   end
 
   self.Chat:add_message({
     role = "user",
     content = "baz",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 return EditorContext

--- a/tests/interactions/shared/editor_context/bar.lua
+++ b/tests/interactions/shared/editor_context/bar.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local Bar = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -18,14 +20,14 @@ function Bar:chat_render()
     self.Chat:add_message({
       role = "user",
       content = "bar " .. self.params,
-    }, { tag = "editor_context", visible = false })
+    }, { tag = tags.EDITOR_CONTEXT, visible = false })
     return
   end
 
   self.Chat:add_message({
     role = "user",
     content = "bar",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 ---@return { inline: string, block: string }

--- a/tests/interactions/shared/editor_context/baz.lua
+++ b/tests/interactions/shared/editor_context/baz.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local Baz = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -18,14 +20,14 @@ function Baz:apply()
     self.Chat:add_message({
       role = "user",
       content = "baz " .. self.params,
-    }, { _meta = { tag = "editor_context" }, visible = false })
+    }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
     return
   end
 
   self.Chat:add_message({
     role = "user",
     content = "baz",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 return Baz

--- a/tests/interactions/shared/editor_context/foo.lua
+++ b/tests/interactions/shared/editor_context/foo.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local Foo = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -17,7 +19,7 @@ function Foo:chat_render()
   self.Chat:add_message({
     role = "user",
     content = "foo",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 ---@return { inline: string, block: string }

--- a/tests/interactions/shared/editor_context/foo_special.lua
+++ b/tests/interactions/shared/editor_context/foo_special.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local FooSpecial = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -17,7 +19,7 @@ function FooSpecial:chat_render()
   self.Chat:add_message({
     role = "user",
     content = "foo_special",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 return FooSpecial

--- a/tests/interactions/shared/editor_context/screenshot.lua
+++ b/tests/interactions/shared/editor_context/screenshot.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local Screenshot = {}
 
 ---@param args CodeCompanion.EditorContext
@@ -17,7 +19,7 @@ function Screenshot:chat_render()
   self.Chat:add_message({
     role = "user",
     content = "Resolved screenshot editor context",
-  }, { _meta = { tag = "editor_context" }, visible = false })
+  }, { _meta = { tag = tags.EDITOR_CONTEXT }, visible = false })
 end
 
 return Screenshot

--- a/tests/interactions/shared/rules/test_rules.lua
+++ b/tests/interactions/shared/rules/test_rules.lua
@@ -1,5 +1,6 @@
 local new_set = MiniTest.new_set
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 
 local child = MiniTest.new_child_neovim()
 
@@ -303,7 +304,7 @@ T["Rules:make()"]["integration: rules is added to a real chat messages stack"] =
   local last_message = messages[#messages]
 
   h.eq(#messages, 2)
-  h.eq(last_message._meta.tag, "rules")
+  h.eq(last_message._meta.tag, tags.RULES)
   h.eq(last_message.context.id, "<rules>" .. vim.fs.normalize(tmp) .. "</rules>")
 
   local relative_path = vim.fn.fnamemodify(vim.fs.normalize(tmp), ":p:.")
@@ -347,7 +348,7 @@ T["Rules:make()"]["integration: rules is added when chat is toggled"] = function
   local last_message = messages[#messages]
 
   h.eq(#messages, 2)
-  h.eq(last_message._meta.tag, "rules")
+  h.eq(last_message._meta.tag, tags.RULES)
   h.eq(last_message.context.id, "<rules>" .. vim.fs.normalize(tmp) .. "</rules>")
 
   local relative_path = vim.fn.fnamemodify(vim.fs.normalize(tmp), ":p:.")

--- a/tests/prompt_library/test_prompt_library.lua
+++ b/tests/prompt_library/test_prompt_library.lua
@@ -201,8 +201,9 @@ T["Prompt Library"]["can ignore system prompt"] = function()
       })
       codecompanion.prompt("no_sys")
       local chat = codecompanion.last_chat()
+      local tags = require("codecompanion.interactions.shared.tags")
       for _, msg in ipairs(chat.messages) do
-        if msg._meta and msg._meta.tag == "system_prompt_from_config" then
+        if msg._meta and msg._meta.tag == tags.SYSTEM_PROMPT_FROM_CONFIG then
           return true
         end
       end

--- a/tests/stubs/messages.lua
+++ b/tests/stubs/messages.lua
@@ -1,3 +1,5 @@
+local tags = require("codecompanion.interactions.shared.tags")
+
 local messages = {
   {
     content = "You are an AI programming assistant named \"CodeCompanion\". You are currently plugged into the Neovim text editor on a user's machine.\n\nYour core tasks include:\n- Answering general programming questions.\n- Explaining how the code in a Neovim buffer works.\n- Reviewing the selected code from a Neovim buffer.\n- Generating unit tests for the selected code.\n- Proposing fixes for problems in the selected code.\n- Scaffolding code for a new workspace.\n- Finding relevant code to the user's query.\n- Proposing fixes for test failures.\n- Answering questions about Neovim.\n- Running tools.\n\nYou must:\n- Follow the user's requirements carefully and to the letter.\n- Use the context and attachments the user provides.\n- Keep your answers short and impersonal, especially if the user's context is outside your core tasks.\n- Minimize additional prose unless clarification is needed.\n- Use Markdown formatting in your answers.\n- Include the programming language name at the start of each Markdown code block.\n- Do not include line numbers in code blocks.\n- Avoid wrapping the whole response in triple backticks.\n- Only return code that's directly relevant to the task at hand. You may omit code that isn’t necessary for the solution.\n- Avoid using H1, H2 or H3 headers in your responses as these are reserved for the user.\n- Use actual line breaks in your responses; only use \"\\n\" when you want a literal backslash followed by 'n'.\n- All non-code text responses must be written in the English language indicated.\n- Multiple, different tools can be called as part of the same response.\n\nWhen given a task:\n1. Think step-by-step and, unless the user requests otherwise or the task is very simple, describe your plan in detailed pseudocode.\n2. Output the final code in a single code block, ensuring that only relevant code is included.\n3. End your response with a short suggestion for the next user turn that directly supports continuing the conversation.\n4. Provide exactly one complete reply per conversation turn.\n5. If necessary, execute multiple tools in a single turn.",
@@ -8,7 +10,7 @@ local messages = {
     role = "system",
     _meta = {
       cycle = 1,
-      tag = "system_prompt_from_config",
+      tag = tags.SYSTEM_PROMPT_FROM_CONFIG,
     },
   },
   {
@@ -57,7 +59,7 @@ local messages = {
     },
     _meta = {
       cycle = 1,
-      tag = "tool_output",
+      tag = tags.TOOL_OUTPUT,
     },
   },
   {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Move message tags into their own discreet file.

## AI Usage

Opus 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
