### PR TITLE
fix(azure): enforce strict tool schemas

### DIFF
--- a/lua/codecompanion/adapters/http/azure_openai.lua
+++ b/lua/codecompanion/adapters/http/azure_openai.lua
@@ -1,4 +1,12 @@
 local openai = require("codecompanion.adapters.http.openai")
+local tool_utils = require("codecompanion.utils.tool_transformers")
+
+local function to_strict_chat_completions_schema(schema)
+  schema = tool_utils.enforce_strictness(vim.deepcopy(schema))
+  schema["function"].strict = true
+  schema["function"].parameters.strict = nil
+  return schema
+end
 
 ---@class CodeCompanion.HTTPAdapter.AzureOpenAI: CodeCompanion.HTTPAdapter
 return {
@@ -43,7 +51,21 @@ return {
       return openai.handlers.form_messages(self, messages)
     end,
     form_tools = function(self, tools)
-      return openai.handlers.form_tools(self, tools)
+      if not self.opts.tools or not tools then
+        return nil
+      end
+      if vim.tbl_count(tools) == 0 then
+        return nil
+      end
+
+      local transformed = {}
+      for _, tool in pairs(tools) do
+        for _, schema in pairs(tool) do
+          table.insert(transformed, to_strict_chat_completions_schema(schema))
+        end
+      end
+
+      return { tools = transformed }
     end,
     chat_output = function(self, data, tools)
       return openai.handlers.chat_output(self, data, tools)

--- a/tests/adapters/http/test_azure_openai.lua
+++ b/tests/adapters/http/test_azure_openai.lua
@@ -1,0 +1,42 @@
+local h = require("tests.helpers")
+local adapter
+
+local new_set = MiniTest.new_set
+T = new_set()
+
+T["Azure OpenAI adapter"] = new_set({
+  hooks = {
+    pre_case = function()
+      adapter = require("codecompanion.adapters").resolve("azure_openai")
+    end,
+  },
+})
+
+T["Azure OpenAI adapter"]["makes optional tool parameters strict"] = function()
+  local run_skill_script = {
+    type = "function",
+    ["function"] = {
+      name = "run_skill_script",
+      description = "Run a skill script",
+      parameters = {
+        type = "object",
+        properties = {
+          args = {
+            type = "object",
+          },
+        },
+      },
+    },
+  }
+  local tools = { run_skill_script = { run_skill_script } }
+  local output = adapter.handlers.form_tools(adapter, tools)
+  local parameters = output.tools[1]["function"].parameters
+
+  h.eq({ "args" }, parameters.required)
+  h.eq(false, parameters.additionalProperties)
+  h.eq(nil, parameters.strict)
+  h.eq(true, output.tools[1]["function"].strict)
+  h.eq({ "object", "null" }, parameters.properties.args.type)
+end
+
+return T

--- a/tests/adapters/http/test_openai.lua
+++ b/tests/adapters/http/test_openai.lua
@@ -324,39 +324,4 @@ T["OpenAI adapter"]["reasoning_effort enabled"] = function()
   h.eq(false, enabled_result_missing)
 end
 
-T["Azure OpenAI adapter"] = new_set({
-  hooks = {
-    pre_case = function()
-      adapter = require("codecompanion.adapters").resolve("azure_openai")
-    end,
-  },
-})
-
-T["Azure OpenAI adapter"]["makes optional tool parameters strict"] = function()
-  local run_skill_script = {
-    type = "function",
-    ["function"] = {
-      name = "run_skill_script",
-      description = "Run a skill script",
-      parameters = {
-        type = "object",
-        properties = {
-          args = {
-            type = "object",
-          },
-        },
-      },
-    },
-  }
-  local tools = { run_skill_script = { run_skill_script } }
-  local output = adapter.handlers.form_tools(adapter, tools)
-  local parameters = output.tools[1]["function"].parameters
-
-  h.eq({ "args" }, parameters.required)
-  h.eq(false, parameters.additionalProperties)
-  h.eq(nil, parameters.strict)
-  h.eq(true, output.tools[1]["function"].strict)
-  h.eq({ "object", "null" }, parameters.properties.args.type)
-end
-
 return T

--- a/tests/adapters/http/test_openai.lua
+++ b/tests/adapters/http/test_openai.lua
@@ -324,4 +324,39 @@ T["OpenAI adapter"]["reasoning_effort enabled"] = function()
   h.eq(false, enabled_result_missing)
 end
 
+T["Azure OpenAI adapter"] = new_set({
+  hooks = {
+    pre_case = function()
+      adapter = require("codecompanion.adapters").resolve("azure_openai")
+    end,
+  },
+})
+
+T["Azure OpenAI adapter"]["makes optional tool parameters strict"] = function()
+  local run_skill_script = {
+    type = "function",
+    ["function"] = {
+      name = "run_skill_script",
+      description = "Run a skill script",
+      parameters = {
+        type = "object",
+        properties = {
+          args = {
+            type = "object",
+          },
+        },
+      },
+    },
+  }
+  local tools = { run_skill_script = { run_skill_script } }
+  local output = adapter.handlers.form_tools(adapter, tools)
+  local parameters = output.tools[1]["function"].parameters
+
+  h.eq({ "args" }, parameters.required)
+  h.eq(false, parameters.additionalProperties)
+  h.eq(nil, parameters.strict)
+  h.eq(true, output.tools[1]["function"].strict)
+  h.eq({ "object", "null" }, parameters.properties.args.type)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR enforces strict tool schemas in the Azure OpenAI adapter before sending tools to chat completions.

It also ensures optional tool parameters are listed in `required` for Azure/OpenAI-compatible validation and adds a regression test for a `run_skill_script` schema with optional args.

Context: reported downstream in codecompanion-agentskills.nvim: https://github.com/cairijun/codecompanion-agentskills.nvim/issues/10

## AI Usage

Codex (GPT-5)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages

## Tests

- make test_file FILE=tests/adapters/http/test_openai.lua
- Full suite note: `make test` was run locally, but the current environment reports existing screenshot/UI failures and missing tree-sitter CLI parser compilation errors unrelated to this adapter change.
