### PR TITLE
fix(background): replace gpt-4.1

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -71,7 +71,7 @@ local defaults = {
     background = {
       adapter = {
         name = "copilot",
-        model = "claude-haiku-4.5,
+        model = "claude-haiku-4.5",
       },
       -- Callbacks within the plugin that you can attach background actions to
       chat = {

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -71,7 +71,7 @@ local defaults = {
     background = {
       adapter = {
         name = "copilot",
-        model = "gpt-4.1",
+        model = "claude-haiku-4.5,
       },
       -- Callbacks within the plugin that you can attach background actions to
       chat = {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

GPT-4.1 has been [retired](https://github.blog/changelog/2026-06-02-gpt-4-1-deprecated/) in Copilot. RIP

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
