### PR TITLE
feat(chat): add `/share` slash command

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*           For NVIM v0.11          Last change: 2026 May 16
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 June 04
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -4935,6 +4935,29 @@ The conversation history is rendered so you can continue where you left off.
 
   [!NOTE] The `/resume` command must be used before sending any messages. It is
   only available on a fresh chat buffer.
+
+/SHARE ~
+
+The `share` slash command allows you to share the conversation in the chat
+buffer as a secret GitHub Gist <https://gist.github.com>. You'll need to ensure
+that you set a token in your configuration with permission to create gists:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        chat = {
+          slash_commands = {
+            ["share"] = {
+              opts = {
+                token = os.getenv("GITHUB_GIST_TOKEN"),
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
 
 /SYMBOLS ~
 

--- a/doc/usage/chat-buffer/slash-commands.md
+++ b/doc/usage/chat-buffer/slash-commands.md
@@ -97,6 +97,26 @@ The _resume_ slash command is specific to [ACP](/configuration/adapters-acp) ada
 > [!NOTE]
 > The `/resume` command must be used before sending any messages. It is only available on a fresh chat buffer.
 
+## /share
+
+The _share_ slash command allows you to share the conversation in the chat buffer as a secret [GitHub Gist](https://gist.github.com). You'll need to ensure that you set a token in your configuration with permission to create gists:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      slash_commands = {
+        ["share"] = {
+          opts = {
+            token = os.getenv("GITHUB_GIST_TOKEN"),
+          },
+        },
+      },
+    },
+  },
+})
+```
+
 ## /symbols
 
 > [!NOTE]

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -517,6 +517,14 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
             interactions = { "chat", "cli" },
           },
         },
+        ["share"] = {
+          path = "interactions.chat.slash_commands.builtin.share",
+          description = "Share the chat in a GitHub Gist",
+          opts = {
+            contains_code = true,
+            token = nil, -- A GitHub personal access token with the `gist` scope. Required for this command to work
+          },
+        },
         ["symbols"] = {
           path = "interactions.chat.slash_commands.builtin.symbols",
           description = "Insert symbols for a selected file",

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/share.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/share.lua
@@ -1,0 +1,132 @@
+local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
+
+local fmt = string.format
+
+local CONSTANTS = {
+  GIST_API_URL = "https://api.github.com/gists",
+  NAME = "Share",
+}
+
+---Post content to the GitHub Gist API
+---@param opts { token: string, description: string, filename: string, content: string }
+---@param callback fun(err: string|nil, url: string|nil)
+local function create_gist(opts, callback)
+  local payload = vim.json.encode({
+    description = opts.description,
+    files = {
+      [opts.filename] = {
+        content = opts.content,
+      },
+    },
+    public = false,
+  })
+
+  vim.system({
+    "curl",
+    "--silent",
+    "--request",
+    "POST",
+    "--header",
+    "Accept: application/vnd.github+json",
+    "--header",
+    fmt("Authorization: Bearer %s", opts.token),
+    "--header",
+    "X-GitHub-Api-Version: 2022-11-28",
+    "--data",
+    payload,
+    CONSTANTS.GIST_API_URL,
+  }, { text = true }, function(result)
+    if result.code ~= 0 then
+      return callback(fmt("curl exited with code %d: %s", result.code, result.stderr))
+    end
+
+    local ok, response = pcall(vim.json.decode, result.stdout)
+    if not ok or not response then
+      return callback("Failed to parse GitHub API response")
+    end
+
+    if response.message then
+      return callback(fmt("GitHub API error: %s", response.message))
+    end
+
+    if not response.html_url then
+      return callback("No URL returned in GitHub API response")
+    end
+
+    callback(nil, response.html_url)
+  end)
+end
+
+---@class CodeCompanion.SlashCommand.Share: CodeCompanion.SlashCommand
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommandArgs
+function SlashCommand.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+
+  return self
+end
+
+---Execute the slash command
+---@return nil
+function SlashCommand:execute()
+  local token = self.config.opts and self.config.opts.token
+
+  if not token or #token == 0 then
+    return log:error(
+      "No GitHub token found. Set `opts.token` in your config to a personal access token with the `gist` scope"
+    )
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(self.Chat.bufnr, 0, -1, false)
+  local content = table.concat(lines, "\n")
+
+  if #vim.trim(content) == 0 then
+    return utils.notify("No visible content to share", vim.log.levels.WARN)
+  end
+
+  local default_description = self.Chat.title or "CodeCompanion Chat"
+
+  vim.ui.input({ default = default_description, prompt = " Gist Description " }, function(description)
+    if description == nil then
+      return
+    end
+
+    description = (#vim.trim(description) > 0) and description or default_description
+
+    vim.ui.input({ default = "codecompanion-chat.md", prompt = " Gist Filename " }, function(filename)
+      if filename == nil then
+        return
+      end
+
+      filename = (#vim.trim(filename) > 0) and filename or "codecompanion-chat.md"
+
+      self:output({ token = token, description = description, filename = filename, content = content })
+    end)
+  end)
+end
+
+---Create a private GitHub gist from the visible chat buffer content and copy the URL to the clipboard
+---@param opts { token: string, description: string, filename: string, content: string }
+---@return nil
+function SlashCommand:output(opts)
+  utils.notify("Sharing chat as a private GitHub gist...")
+
+  create_gist(opts, function(err, url)
+    vim.schedule(function()
+      if err then
+        return log:error("Share: %s", err)
+      end
+
+      vim.fn.setreg("+", url)
+      utils.notify(fmt("Gist created and URL copied to clipboard: %s", url))
+    end)
+  end)
+end
+
+return SlashCommand


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Adds a `/share` slash command that allows users to share their entire chat conversation as a secret GitHub Gist. Requires a token to be shared with the slash command that has the ability to create a gist.

## AI Usage

Sonnet 4.5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
