### PR TITLE
fix(adapters): copilot models and top_p hyperparameter

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -417,7 +417,8 @@ return {
         if type(model) == "function" then
           model = model()
         end
-        return not vim.startswith(model, "o1")
+        local disabled_for = { "gpt-5.4", "gpt-5.4-mini" }
+        return not vim.tbl_contains(disabled_for, model)
       end,
       desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
     },


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Latest GPT models do not support top_p. For now, disabling the parameter but in the future will likely remove it.

## AI Usage

None

## Related Issue(s)

#3139

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
