### PR TITLE
perf(chat): add ts caching and remove vim.iter calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This is a Neovim plugin written in Lua, which allows developers to code with LLM
 - **Function params:** prefer a single table argument over positional args
 - **Error handling:** `pcall` + `log:error()`, return nil on failure
 - **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise — one description line, params should be self-explanatory without inline comments
+- **Function descriptions:** exactly one line. No multi-paragraph rationale, no usage examples, no "why we cache this" essays — that belongs in commit messages or a single inline `--` comment at the relevant line. If you can't summarise the function in one line, the function is doing too much
 - **Functions:** keep under 50 lines
 - **Globals:** avoid; use module-local state
 - **Code blocks:** use four backticks with language spec

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -928,6 +928,33 @@ function Connection:get_config_options(opts)
   end, self._config_options or {})
 end
 
+---Build a lookup of value names from this connection's select options
+---@return table|nil
+function Connection:build_name_map()
+  local name_map
+  for _, opt in ipairs(self:get_config_options()) do
+    if opt.type == "select" then
+      local entries
+      for _, item in ipairs(opt.options or {}) do
+        if item.group then
+          for _, val in ipairs(item.options or {}) do
+            entries = entries or {}
+            entries[val.value] = val.name
+          end
+        else
+          entries = entries or {}
+          entries[item.value] = item.name
+        end
+      end
+      if entries then
+        name_map = name_map or {}
+        name_map[opt.id] = entries
+      end
+    end
+  end
+  return name_map
+end
+
 ---Set a config option via session/set_config_option
 ---@param config_id string The config option ID
 ---@param value string The value ID to set

--- a/lua/codecompanion/interactions/chat/context.lua
+++ b/lua/codecompanion/interactions/chat/context.lua
@@ -27,7 +27,7 @@ local context_header = "> Context:"
 local function ts_parse_buffer(chat)
   local query = query_get("markdown", "cc_context")
 
-  local tree = chat.chat_parser:parse({ chat.header_line - 1, -1 })[1]
+  local tree = chat.parsers.markdown:parse({ chat.header_line - 1, -1 })[1]
   local root = tree:root()
 
   -- Check if there are any context items already in the chat buffer
@@ -220,7 +220,7 @@ end
 local function get_range(chat)
   local query = query_get("markdown", "cc_context")
 
-  local tree = chat.chat_parser:parse()[1]
+  local tree = chat.parsers.markdown:parse()[1]
   local root = tree:root()
 
   local role = nil
@@ -352,7 +352,7 @@ end
 function Context:get_from_chat()
   local query = query_get("markdown", "cc_context")
 
-  local tree = self.Chat.chat_parser:parse()[1]
+  local tree = self.Chat.parsers.markdown:parse()[1]
   local root = tree:root()
 
   local items = {}

--- a/lua/codecompanion/interactions/chat/helpers/init.lua
+++ b/lua/codecompanion/interactions/chat/helpers/init.lua
@@ -101,12 +101,12 @@ end
 ---@param messages CodeCompanion.Chat.Messages
 ---@return boolean
 function M.has_tag(tag, messages)
-  return vim.tbl_contains(
-    vim.tbl_map(function(msg)
-      return msg._meta and msg._meta.tag
-    end, messages),
-    tag
-  )
+  for _, msg in ipairs(messages) do
+    if msg._meta and msg._meta.tag == tag then
+      return true
+    end
+  end
+  return false
 end
 
 ---Resolve which MCP servers should be added to new chat buffers

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -11,13 +11,11 @@
 ---@field bufnr number The buffer number of the chat
 ---@field builder CodeCompanion.Chat.UI.Builder The UI builder for the chat buffer
 ---@field callbacks table<string, (fun(chat: CodeCompanion.Chat, ...: any): any)[]> A table of callback functions that are executed at various points (on_created, on_before_submit, on_submitted, on_tool_output, on_ready, on_completed, on_cancelled, on_closed)
----@field chat_parser vim.treesitter.LanguageTree The Markdown Tree-sitter parser for the chat buffer
 ---@field context CodeCompanion.Chat.Context
 ---@field context_items? table<CodeCompanion.Chat.Context> Context which is sent to the LLM e.g. buffers, slash command output
 ---@field current_request table|nil The current request being executed
 ---@field current_tool table The current tool being executed
 ---@field cycle number Records the number of turn-based interactions (User -> LLM) that have taken place
----@field create_buf fun(): number The function that creates a new buffer for the chat
 ---@field editor_context? CodeCompanion.EditorContext The editor context available to the user
 ---@field from_prompt_library? boolean Whether the chat was initiated from the prompt library
 ---@field header_line number The line number of the user header that any Tree-sitter parsing should start from
@@ -27,6 +25,7 @@
 ---@field intro_message? string The welcome message that is displayed in the chat buffer
 ---@field messages? CodeCompanion.Chat.Messages The messages in the chat buffer
 ---@field opts CodeCompanion.ChatArgs Store all arguments in this table
+---@field parsers { markdown: vim.treesitter.LanguageTree, markdown_inline?: vim.treesitter.LanguageTree, yaml?: vim.treesitter.LanguageTree } Tree-sitter parsers attached to the chat buffer
 ---@field settings? table The settings that are used in the adapter of the chat buffer
 ---@field subscribers table The subscribers to the chat buffer
 ---@field title? string The title of the chat buffer
@@ -35,9 +34,10 @@
 ---@field tool_registry CodeCompanion.Chat.ToolRegistry Methods for handling interactions between the chat buffer and tools
 ---@field ui CodeCompanion.Chat.UI The UI of the chat buffer
 ---@field window_opts? table Window configuration options for the chat buffer
----@field yaml_parser vim.treesitter.LanguageTree The Yaml Tree-sitter parser for the chat buffer
+---@field _btw? string The user's "by the way" message which is queued for sending to an LLM
 ---@field _compacting? boolean Whether a compaction request is currently in flight
 ---@field _last_role string The last role that was rendered in the chat buffer
+---@field _status table Bookkeeping for the current status virtual text (extmark id + status flag)
 ---@field _tool_monitors? table A table of tool monitors that are currently running in the chat buffer
 
 ---@class CodeCompanion.ChatArgs Arguments that can be injected into the chat
@@ -118,6 +118,23 @@ local llm_role = config.interactions.chat.roles.llm
 local user_role = config.interactions.chat.roles.user
 local show_settings = config.display.chat.show_settings
 
+---Create a new buffer for the chat
+---@return number
+local function create_chat_buf()
+  local bufnr = api.nvim_create_buf(config.display.chat.window.buflisted, true)
+  api.nvim_buf_set_name(bufnr, fmt("[CodeCompanion] %d", bufnr))
+
+  vim.schedule(function()
+    pcall(vim.treesitter.start, bufnr)
+  end)
+
+  if config.interactions.chat.opts.completion_provider == "default" then
+    vim.bo[bufnr].omnifunc = "v:lua.require'codecompanion.providers.completion.default.omnifunc'.omnifunc"
+  end
+
+  return bufnr
+end
+
 --=============================================================================
 -- Private methods
 --=============================================================================
@@ -126,30 +143,23 @@ local show_settings = config.display.chat.show_settings
 ---@param chat CodeCompanion.Chat
 ---@return nil
 local function sync_all_buffer_content(chat)
-  local synced = vim
-    .iter(chat.context_items)
-    :filter(function(ctx)
-      return ctx.opts.sync_all
-    end)
-    :totable()
-
-  if vim.tbl_isempty(synced) then
-    return
-  end
-
-  -- Build a set of context IDs already present in this cycle for O(1) duplicate checks
-  local seen = {}
-  for _, msg in ipairs(chat.messages) do
-    if msg.context and msg.context.id and msg._meta and msg._meta.cycle == chat.cycle then
-      seen[msg.context.id] = true
-    end
-  end
-
-  for _, item in ipairs(synced) do
-    if not seen[item.id] then
-      require(item.source)
-        .new({ Chat = chat })
-        :output({ path = item.path, bufnr = item.bufnr, params = item.params }, { sync_all = true })
+  -- Collect IDs already present in this cycle for O(1) duplicate checks
+  local seen
+  for _, item in ipairs(chat.context_items) do
+    if item.opts.sync_all then
+      if not seen then
+        seen = {}
+        for _, msg in ipairs(chat.messages) do
+          if msg.context and msg.context.id and msg._meta and msg._meta.cycle == chat.cycle then
+            seen[msg.context.id] = true
+          end
+        end
+      end
+      if not seen[item.id] then
+        require(item.source)
+          .new({ Chat = chat })
+          :output({ path = item.path, bufnr = item.bufnr, params = item.params }, { sync_all = true })
+      end
     end
   end
 end
@@ -196,13 +206,6 @@ local function find_tool_call(id, messages)
     end
   end
   return nil
-end
-
----Make an id from a string or table
----@param val string|table
----@return number
-local function make_id(val)
-  return hash.hash(val)
 end
 
 ---Used to record the last chat buffer that was opened
@@ -285,7 +288,7 @@ local function set_autocmds(chat)
         local adapter = chat.adapter
         ---@cast adapter CodeCompanion.HTTPAdapter
 
-        local settings = parser.settings(bufnr, chat.yaml_parser, adapter)
+        local settings = parser.settings(bufnr, chat.parsers.yaml, adapter)
 
         local errors = schema.validate(adapter.schema, settings, adapter)
         local node = settings.__ts_node
@@ -352,6 +355,210 @@ Chat.MESSAGE_TYPES = {
   USER_MESSAGE = "user_message",
 }
 
+---Initiate the Tree-sitter parsers used in the chat
+---@param chat CodeCompanion.Chat
+---@return boolean
+local function init_parsers(chat)
+  chat.parsers = {}
+
+  local ok, markdown = pcall(vim.treesitter.get_parser, chat.bufnr, "markdown")
+  if not ok or not markdown then
+    log:error("[chat::init::new] Could not find the Markdown Tree-sitter parser")
+    return false
+  end
+  chat.parsers.markdown = markdown
+
+  -- markdown_inline drives image detection; cache once to avoid re-resolving per submit
+  local inline_ok, markdown_inline = pcall(vim.treesitter.get_parser, chat.bufnr, "markdown_inline")
+  if inline_ok and markdown_inline then
+    chat.parsers.markdown_inline = markdown_inline
+  end
+
+  if show_settings then
+    local yaml_ok, yaml = pcall(vim.treesitter.get_parser, chat.bufnr, "yaml", { ignore_injections = false })
+    if not yaml_ok or not yaml then
+      log:error("Could not find the Yaml Tree-sitter parser")
+      return false
+    end
+    chat.parsers.yaml = yaml
+  end
+
+  return true
+end
+
+---Initiate the adapter used in the chat
+---@param chat CodeCompanion.Chat
+---@param args CodeCompanion.ChatArgs
+---@return boolean
+local function init_adapter(chat, args)
+  if args.adapter and adapters.resolved(args.adapter) then
+    chat.adapter = args.adapter
+  else
+    chat.adapter = adapters.resolve(args.adapter or config.interactions.chat.adapter)
+  end
+  if not chat.adapter then
+    log:error("No adapter found")
+    return false
+  end
+
+  utils.fire("ChatAdapter", {
+    adapter = adapters.make_safe(chat.adapter),
+    bufnr = chat.bufnr,
+    id = chat.id,
+  })
+  utils.fire("ChatModel", {
+    adapter = adapters.make_safe(chat.adapter),
+    bufnr = chat.bufnr,
+    id = chat.id,
+    model = chat.adapter.schema and chat.adapter.schema.model.default,
+  })
+
+  if chat.adapter.type == "http" then
+    chat:apply_settings(schema.get_default(chat.adapter, args.settings))
+  elseif chat.adapter.type == "acp" then
+    -- Connection is asynchronous; available_commands_update can arrive 1-5s later
+    vim.schedule(function()
+      if args.acp_command then
+        chat.adapter.commands.selected = chat.adapter.commands[args.acp_command]
+      end
+      helpers.create_acp_connection(chat)
+    end)
+  end
+
+  return true
+end
+
+---Initialize chat sub-components
+---@param chat CodeCompanion.Chat
+---@param args CodeCompanion.ChatArgs
+---@return nil
+local function init_components(chat, args)
+  chat.builder = require("codecompanion.interactions.chat.ui.builder").new({ chat = chat })
+  chat.buffer_diffs = require("codecompanion.interactions.chat.buffer_diffs").new()
+  chat.context = require("codecompanion.interactions.chat.context").new({ chat = chat })
+  chat.editor_context = require("codecompanion.interactions.shared.editor_context").new("chat")
+  chat.subscribers = require("codecompanion.interactions.chat.subscribers").new()
+  chat.tools = require("codecompanion.interactions.chat.tools").new({
+    adapter = chat.adapter,
+    bufnr = chat.bufnr,
+    messages = chat.messages,
+  })
+  chat.tool_registry = require("codecompanion.interactions.chat.tool_registry").new({
+    chat = chat,
+    ctx = chat:make_system_prompt_context(),
+  })
+  chat.ui = require("codecompanion.interactions.chat.ui").new({
+    adapter = chat.adapter,
+    aug = chat.aug,
+    chat_id = chat.id,
+    chat_bufnr = chat.bufnr,
+    roles = { user = user_role, llm = llm_role },
+    settings = chat.settings,
+    title = chat.title,
+    window_opts = args.window_opts,
+  })
+end
+
+---Bind buffer-local keymaps for the chat plus any slash-command bindings
+---@param chat CodeCompanion.Chat
+---@return nil
+local function init_keymaps(chat)
+  if config.interactions.chat.keymaps then
+    local filtered_keymaps = {}
+    for k, v in pairs(config.interactions.chat.keymaps) do
+      if k:sub(1, 1) ~= "_" then
+        filtered_keymaps[k] = v
+      end
+    end
+    keymaps
+      .new({
+        bufnr = chat.bufnr,
+        callbacks = require("codecompanion.interactions.chat.keymaps"),
+        data = chat,
+        keymaps = filtered_keymaps,
+      })
+      :set()
+  end
+
+  local slash_command_keymaps = helpers.slash_command_keymaps(config.interactions.chat.slash_commands)
+  if vim.tbl_count(slash_command_keymaps) > 0 then
+    keymaps
+      .new({
+        bufnr = chat.bufnr,
+        callbacks = require("codecompanion.interactions.chat.slash_commands.keymaps"),
+        data = chat,
+        keymaps = slash_command_keymaps,
+      })
+      :set()
+  end
+end
+
+---Preload default tools and any tools explicitly listed in args
+---@param chat CodeCompanion.Chat
+---@param args CodeCompanion.ChatArgs
+---@return nil
+local function load_tools(chat, args)
+  if args.tools == "none" then
+    return
+  end
+  for _, tool_name in pairs(config.interactions.chat.tools.opts.default_tools or {}) do
+    chat.tool_registry:add(tool_name)
+  end
+  if args.tools then
+    for _, tool in pairs(args.tools) do
+      chat.tool_registry:add(tool)
+    end
+  end
+end
+
+---Start any MCP servers requested for this chat
+---@param chat CodeCompanion.Chat
+---@param args CodeCompanion.ChatArgs
+---@return nil
+local function start_mcp_for_chat(chat, args)
+  if chat.adapter.type == "acp" or args.mcp_servers == "none" then
+    return
+  end
+  if args.mcp_servers then
+    helpers.start_mcp_servers(chat, args.mcp_servers)
+    return
+  end
+  local servers_to_add = helpers.mcp_servers_to_add_to_chat()
+  if #servers_to_add > 0 then
+    helpers.start_mcp_servers(chat, servers_to_add)
+  end
+end
+
+---Register user-provided callbacks plus the internal subscriber lifecycle hooks
+---@param chat CodeCompanion.Chat
+---@param args CodeCompanion.ChatArgs
+---@return nil
+local function register_callbacks(chat, args)
+  if args.callbacks then
+    for event, callback_list in pairs(args.callbacks) do
+      if type(callback_list) == "function" then
+        chat:add_callback(event, callback_list)
+      elseif type(callback_list) == "table" then
+        for _, callback in ipairs(callback_list) do
+          chat:add_callback(event, callback)
+        end
+      end
+    end
+  end
+
+  chat:add_callback("on_ready", function(c)
+    c.subscribers:process(c)
+  end)
+  chat:add_callback("on_cancelled", function(c)
+    c.subscribers:stop()
+  end)
+  chat:add_callback("on_closed", function(c)
+    c.subscribers:stop()
+  end)
+
+  require("codecompanion.interactions.background.callbacks").register_chat_callbacks(chat)
+end
+
 ---@param args CodeCompanion.ChatArgs
 ---@return CodeCompanion.Chat
 function Chat.new(args)
@@ -373,55 +580,27 @@ function Chat.new(args)
     opts = args,
     status = "",
     title = args.title,
-    create_buf = function()
-      local bufnr = api.nvim_create_buf(config.display.chat.window.buflisted, true)
-      api.nvim_buf_set_name(bufnr, fmt("[CodeCompanion] %d", bufnr))
-
-      -- Safely attach treesitter
-      vim.schedule(function()
-        pcall(vim.treesitter.start, bufnr)
-      end)
-
-      -- Set up omnifunc for automatic completion when no other completion provider is active
-      local completion_provider = config.interactions.chat.opts.completion_provider
-      if completion_provider == "default" then
-        vim.bo[bufnr].omnifunc = "v:lua.require'codecompanion.providers.completion.default.omnifunc'.omnifunc"
-      end
-
-      return bufnr
-    end,
     _last_role = args.last_role or config.constants.USER_ROLE,
     _status = {},
   }, { __index = Chat })
   ---@cast self CodeCompanion.Chat
 
-  self.bufnr = self.create_buf()
-  self.aug = api.nvim_create_augroup(CONSTANTS.AUTOCMD_GROUP .. ":" .. self.bufnr, {
-    clear = false,
-  })
+  self.bufnr = create_chat_buf()
+  self.aug = api.nvim_create_augroup(CONSTANTS.AUTOCMD_GROUP .. ":" .. self.bufnr, { clear = false })
 
-  -- NOTE: Put the parser on the chat buffer for performance reasons
-  local ok, chat_parser, yaml_parser
-  ok, chat_parser = pcall(vim.treesitter.get_parser, self.bufnr, "markdown")
-  if not ok or not chat_parser then
-    return log:error("[chat::init::new] Could not find the Markdown Tree-sitter parser")
+  if not init_parsers(self) then
+    return
   end
-  self.chat_parser = chat_parser
-
-  if show_settings then
-    ok, yaml_parser = pcall(vim.treesitter.get_parser, self.bufnr, "yaml", { ignore_injections = false })
-    if not ok or not yaml_parser then
-      return log:error("Could not find the Yaml Tree-sitter parser")
-    end
-    self.yaml_parser = yaml_parser
+  if not init_adapter(self, args) then
+    return
   end
 
+  -- Register globally only after adapter resolution so a failed adapter never
+  -- leaves a half-initialized chat in any of the global tables
   table.insert(_G.codecompanion_buffers, self.bufnr)
   chats[self.bufnr] = self
-
-  local chat_name = "Chat " .. vim.tbl_count(chats)
   registry.add(self.bufnr, {
-    name = chat_name,
+    name = "Chat " .. vim.tbl_count(chats),
     description = CONSTANTS.BLANK_DESC,
     interaction = "chat",
     open = function()
@@ -433,66 +612,7 @@ function Chat.new(args)
     end,
   })
 
-  if args.adapter and adapters.resolved(args.adapter) then
-    self.adapter = args.adapter
-  else
-    self.adapter = adapters.resolve(args.adapter or config.interactions.chat.adapter)
-  end
-  if not self.adapter then
-    return log:error("No adapter found")
-  end
-  utils.fire("ChatAdapter", {
-    adapter = adapters.make_safe(self.adapter),
-    bufnr = self.bufnr,
-    id = self.id,
-  })
-  utils.fire("ChatModel", {
-    adapter = adapters.make_safe(self.adapter),
-    bufnr = self.bufnr,
-    id = self.id,
-    model = self.adapter.schema and self.adapter.schema.model.default,
-  })
-
-  if self.adapter.type == "http" then
-    self:apply_settings(schema.get_default(self.adapter, args.settings))
-  elseif self.adapter.type == "acp" then
-    -- Initialize ACP connection early to receive available_commands_update
-    -- Connection happens asynchronously; commands can arrive 1-5 seconds later, at least on claude code
-    vim.schedule(function()
-      if args.acp_command then
-        self.adapter.commands.selected = self.adapter.commands[args.acp_command]
-      end
-      helpers.create_acp_connection(self)
-    end)
-  end
-
-  -- Initialize components
-  self.builder = require("codecompanion.interactions.chat.ui.builder").new({ chat = self })
-  self.buffer_diffs = require("codecompanion.interactions.chat.buffer_diffs").new()
-  self.context = require("codecompanion.interactions.chat.context").new({ chat = self })
-  self.editor_context = require("codecompanion.interactions.shared.editor_context").new("chat")
-  self.subscribers = require("codecompanion.interactions.chat.subscribers").new()
-  self.tools = require("codecompanion.interactions.chat.tools").new({
-    adapter = self.adapter,
-    bufnr = self.bufnr,
-    messages = self.messages,
-  })
-  self.tool_registry = require("codecompanion.interactions.chat.tool_registry").new({
-    chat = self,
-    ctx = self:make_system_prompt_context(),
-  })
-
-  self.ui = require("codecompanion.interactions.chat.ui").new({
-    adapter = self.adapter,
-    aug = self.aug,
-    chat_id = self.id,
-    chat_bufnr = self.bufnr,
-    roles = { user = user_role, llm = llm_role },
-    settings = self.settings,
-    title = self.title,
-    window_opts = args.window_opts,
-  })
-
+  init_components(self, args)
   self:update_metadata()
 
   local default_servers = config.mcp.opts and config.mcp.opts.default_servers
@@ -520,9 +640,9 @@ function Chat.new(args)
     self.ui:render(self.buffer_context, self.messages, { stop_context_insertion = args.stop_context_insertion })
   end
 
-  -- Set the header line for the chat buffer
+  -- For restored chats, locate the last user header via Tree-sitter once
   if args.messages and vim.tbl_count(args.messages) > 0 then
-    local header_line = parser.headers(self, self.chat_parser)
+    local header_line = parser.headers(self)
     self.header_line = header_line and (header_line + 1) or 1
   end
 
@@ -530,38 +650,8 @@ function Chat.new(args)
     self.ui:set_intro_msg(self.intro_message)
   end
 
-  if config.interactions.chat.keymaps then
-    -- Filter out any private keymaps
-    local filtered_keymaps = {}
-    for k, v in pairs(config.interactions.chat.keymaps) do
-      if k:sub(1, 1) ~= "_" then
-        filtered_keymaps[k] = v
-      end
-    end
+  init_keymaps(self)
 
-    keymaps
-      .new({
-        bufnr = self.bufnr,
-        callbacks = require("codecompanion.interactions.chat.keymaps"),
-        data = self,
-        keymaps = filtered_keymaps,
-      })
-      :set()
-  end
-
-  local slash_command_keymaps = helpers.slash_command_keymaps(config.interactions.chat.slash_commands)
-  if vim.tbl_count(slash_command_keymaps) > 0 then
-    keymaps
-      .new({
-        bufnr = self.bufnr,
-        callbacks = require("codecompanion.interactions.chat.slash_commands.keymaps"),
-        data = self,
-        keymaps = slash_command_keymaps,
-      })
-      :set()
-  end
-
-  ---@cast self CodeCompanion.Chat
   self:set_system_prompt()
   set_autocmds(self)
 
@@ -569,61 +659,11 @@ function Chat.new(args)
     last_chat = self
   end
 
-  if args.tools ~= "none" then
-    for _, tool_name in pairs(config.interactions.chat.tools.opts.default_tools or {}) do
-      self.tool_registry:add(tool_name)
-    end
-
-    if args.tools then
-      for _, tool in pairs(args.tools) do
-        self.tool_registry:add(tool)
-      end
-    end
-  end
-
-  if self.adapter.type ~= "acp" then
-    if args.mcp_servers == "none" then
-      -- Explicitly disabled by the prompt library
-    elseif args.mcp_servers then
-      helpers.start_mcp_servers(self, args.mcp_servers)
-    else
-      local servers_to_add = helpers.mcp_servers_to_add_to_chat()
-      if #servers_to_add > 0 then
-        helpers.start_mcp_servers(self, servers_to_add)
-      end
-    end
-  end
-
-  -- Handle callbacks
-  if args.callbacks then
-    for event, callback_list in pairs(args.callbacks) do
-      if type(callback_list) == "function" then
-        -- Single callback
-        self:add_callback(event, callback_list)
-      elseif type(callback_list) == "table" then
-        -- Array of callbacks
-        for _, callback in ipairs(callback_list) do
-          self:add_callback(event, callback)
-        end
-      end
-    end
-  end
-
-  -- Set up subscriber callbacks
-  self:add_callback("on_ready", function(c)
-    c.subscribers:process(c)
-  end)
-  self:add_callback("on_cancelled", function(c)
-    c.subscribers:stop()
-  end)
-  self:add_callback("on_closed", function(c)
-    c.subscribers:stop()
-  end)
-
-  require("codecompanion.interactions.background.callbacks").register_chat_callbacks(self)
+  load_tools(self, args)
+  start_mcp_for_chat(self, args)
+  register_callbacks(self, args)
 
   self:dispatch("on_created")
-
   backfill_estimated_tokens(self.messages)
   utils.fire("ChatCreated", { bufnr = self.bufnr, from_prompt_library = self.from_prompt_library, id = self.id })
   if args.auto_submit then
@@ -909,7 +949,7 @@ function Chat:set_system_prompt(prompt, opts)
     system_prompt.opts = opts
 
     _meta.cycle = self.cycle
-    _meta.id = make_id(system_prompt)
+    _meta.id = hash.hash(system_prompt)
     _meta.index = _meta.index or 1
     _meta.estimated_tokens = tokens.calculate(prompt)
     system_prompt._meta = _meta
@@ -923,14 +963,7 @@ end
 ---Toggle the system prompt in the chat buffer
 ---@return nil
 function Chat:toggle_system_prompt()
-  local has_system_prompt = vim.tbl_contains(
-    vim.tbl_map(function(msg)
-      return msg._meta and msg._meta.tag
-    end, self.messages),
-    tags.SYSTEM_PROMPT_FROM_CONFIG
-  )
-
-  if has_system_prompt then
+  if helpers.has_tag(tags.SYSTEM_PROMPT_FROM_CONFIG, self.messages) then
     self:remove_tagged_message(tags.SYSTEM_PROMPT_FROM_CONFIG)
     utils.notify("Removed system prompt")
   else
@@ -943,15 +976,13 @@ end
 ---@param tag string
 ---@return nil
 function Chat:remove_tagged_message(tag)
-  self.messages = vim
-    .iter(self.messages)
-    :filter(function(msg)
-      if msg._meta and msg._meta.tag == tag then
-        return false
-      end
-      return true
-    end)
-    :totable()
+  local kept = {}
+  for _, msg in ipairs(self.messages) do
+    if not (msg._meta and msg._meta.tag == tag) then
+      kept[#kept + 1] = msg
+    end
+  end
+  self.messages = kept
 end
 
 ---Add a message to the message table
@@ -992,7 +1023,7 @@ function Chat:add_message(data, opts)
   end
 
   message.opts = opts
-  message._meta.id = make_id(message)
+  message._meta.id = hash.hash(message)
 
   if message._meta.index then
     table.insert(self.messages, message._meta.index, message)
@@ -1045,7 +1076,7 @@ function Chat:_complete_orphaned_tool_calls()
       output.opts = vim.tbl_extend("force", output.opts or {}, { visible = false })
       output._meta = {
         cycle = self.cycle,
-        id = make_id({ call_id = id, content = output.content, role = output.role }),
+        id = hash.hash({ call_id = id, content = output.content, role = output.role }),
       }
       table.insert(self.messages, output)
       log:debug("[chat::_complete_orphaned_tool_calls] Completed tool call result for tool call %s", id)
@@ -1144,7 +1175,7 @@ function Chat:_submit_http(payload)
   local adapter = self.adapter ---@cast adapter CodeCompanion.HTTPAdapter
 
   if show_settings then
-    local settings = parser.settings(self.bufnr, self.yaml_parser, adapter)
+    local settings = parser.settings(self.bufnr, self.parsers.yaml, adapter)
     helpers.apply_settings_and_model(self, settings)
   end
 
@@ -1361,11 +1392,11 @@ end
 ---multiple times.
 ---@return nil
 function Chat:label_sent_items()
-  vim.iter(self.messages):each(function(msg)
-    if msg.role == config.constants.USER_ROLE and (msg._meta and not msg._meta.sent) then
+  for _, msg in ipairs(self.messages) do
+    if msg.role == config.constants.USER_ROLE and msg._meta and not msg._meta.sent then
       msg._meta.sent = true
     end
-  end)
+  end
 end
 
 ---Method to call after the response from the LLM is received
@@ -1575,20 +1606,22 @@ function Chat:check_context()
   end
 
   -- Remove them from the messages table
-  self.messages = vim
-    .iter(self.messages)
-    :filter(function(msg)
-      return not (msg.context and msg.context.id and remove_set[msg.context.id])
-    end)
-    :totable()
+  local kept_messages = {}
+  for _, msg in ipairs(self.messages) do
+    if not (msg.context and msg.context.id and remove_set[msg.context.id]) then
+      kept_messages[#kept_messages + 1] = msg
+    end
+  end
+  self.messages = kept_messages
 
   -- And from the context_items table
-  self.context_items = vim
-    .iter(self.context_items)
-    :filter(function(ctx)
-      return not remove_set[ctx.id]
-    end)
-    :totable()
+  local kept_items = {}
+  for _, ctx in ipairs(self.context_items) do
+    if not remove_set[ctx.id] then
+      kept_items[#kept_items + 1] = ctx
+    end
+  end
+  self.context_items = kept_items
 
   -- Clear any tool's schemas
   local schemas_to_keep = {}
@@ -1621,12 +1654,13 @@ function Chat:refresh_context()
 
   -- Keep only context items that are still referenced by messages
   if self.context_items and not vim.tbl_isempty(self.context_items) then
-    self.context_items = vim
-      .iter(self.context_items)
-      :filter(function(ctx)
-        return ids_in_messages[ctx.id] == true
-      end)
-      :totable()
+    local kept = {}
+    for _, ctx in ipairs(self.context_items) do
+      if ids_in_messages[ctx.id] == true then
+        kept[#kept + 1] = ctx
+      end
+    end
+    self.context_items = kept
   end
 
   -- Clear currently rendered Context block and re-render
@@ -1718,8 +1752,6 @@ function Chat:close()
   if self.adapter.type == "acp" and self.acp_connection then
     self.acp_connection:disconnect()
   end
-
-  self = nil
 end
 
 ---Set a status message as virtual text in the chat buffer
@@ -1787,7 +1819,7 @@ function Chat:add_tool_output(tool, for_llm, for_user)
   end
 
   output._meta = { cycle = self.cycle }
-  output._meta.id = make_id({ role = output.role, content = output.content })
+  output._meta.id = hash.hash({ role = output.role, content = output.content })
   output.opts = vim.tbl_extend("force", output.opts or {}, {
     visible = true,
   })
@@ -1829,8 +1861,12 @@ function Chat:ready_for_input(opts)
     self.cycle = self.cycle + 1
     self:add_buf_message({ role = config.constants.USER_ROLE, content = "" })
 
-    self.header_line = api.nvim_buf_line_count(self.bufnr) - 2
-    self.ui:display_tokens(self.chat_parser, self.header_line)
+    -- The builder records the 0-based line where it inserted the new user
+    -- section's leading spacing. Tree-sitter scoping (and the context
+    -- block) anchor on the "## Me" header itself, which sits three lines
+    -- below the section start (two blank spacers + the header line).
+    self.header_line = (self.builder.state.current_section_start or 0) + 3
+    self.ui:display_tokens(self.parsers.markdown, self.header_line)
     self.context:render()
 
     self:dispatch("on_ready")

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -165,35 +165,7 @@ local function sync_all_buffer_content(chat)
   end
 end
 
----Build a lookup from an ACP connection's select options
----@param connection any
----@return table|nil
-local function build_acp_name_map(connection)
-  local name_map
-  for _, opt in ipairs(connection:get_config_options()) do
-    if opt.type == "select" then
-      local entries
-      for _, item in ipairs(opt.options or {}) do
-        if item.group then
-          for _, val in ipairs(item.options or {}) do
-            entries = entries or {}
-            entries[val.value] = val.name
-          end
-        else
-          entries = entries or {}
-          entries[item.value] = item.name
-        end
-      end
-      if entries then
-        name_map = name_map or {}
-        name_map[opt.id] = entries
-      end
-    end
-  end
-  return name_map
-end
-
----Backfill estimated_tokens on any messages that lack it (e.g. from args.messages or restored chats)
+---Some messages may not have estimated tokens calculated, so backfill them
 ---@param messages CodeCompanion.Chat.Messages
 ---@return nil
 local function backfill_estimated_tokens(messages)
@@ -1975,7 +1947,7 @@ function Chat:update_metadata()
 
     -- Cache the static name map; currentValue is read fresh below
     if self._acp_name_map_cache == nil then
-      self._acp_name_map_cache = build_acp_name_map(self.acp_connection) or false
+      self._acp_name_map_cache = self.acp_connection:build_name_map() or false
     end
     local name_map = self._acp_name_map_cache or nil
 

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -34,6 +34,7 @@
 ---@field tool_registry CodeCompanion.Chat.ToolRegistry Methods for handling interactions between the chat buffer and tools
 ---@field ui CodeCompanion.Chat.UI The UI of the chat buffer
 ---@field window_opts? table Window configuration options for the chat buffer
+---@field _acp_name_map_cache? table|false Memoised value -> display-name map for ACP select options; false means "computed, no entries"
 ---@field _btw? string The user's "by the way" message which is queued for sending to an LLM
 ---@field _compacting? boolean Whether a compaction request is currently in flight
 ---@field _last_role string The last role that was rendered in the chat buffer
@@ -162,6 +163,34 @@ local function sync_all_buffer_content(chat)
       end
     end
   end
+end
+
+---Build a lookup from an ACP connection's select options
+---@param connection any
+---@return table|nil
+local function build_acp_name_map(connection)
+  local name_map
+  for _, opt in ipairs(connection:get_config_options()) do
+    if opt.type == "select" then
+      local entries
+      for _, item in ipairs(opt.options or {}) do
+        if item.group then
+          for _, val in ipairs(item.options or {}) do
+            entries = entries or {}
+            entries[val.value] = val.name
+          end
+        else
+          entries = entries or {}
+          entries[item.value] = item.name
+        end
+      end
+      if entries then
+        name_map = name_map or {}
+        name_map[opt.id] = entries
+      end
+    end
+  end
+  return name_map
 end
 
 ---Backfill estimated_tokens on any messages that lack it (e.g. from args.messages or restored chats)
@@ -323,6 +352,7 @@ local function set_autocmds(chat)
     desc = "Update chat metadata when ACP mode changes",
     callback = function(args)
       if chat.acp_connection and args.data and args.data.session_id == chat.acp_connection.session_id then
+        chat._acp_name_map_cache = nil
         chat:update_metadata()
       end
     end,
@@ -560,7 +590,7 @@ local function register_callbacks(chat, args)
 end
 
 ---@param args CodeCompanion.ChatArgs
----@return CodeCompanion.Chat
+---@return CodeCompanion.Chat|nil
 function Chat.new(args)
   local id = math.random(10000000)
   log:trace("Chat created with ID %d", id)
@@ -769,6 +799,7 @@ function Chat:change_adapter(adapter, cb)
   end
 
   self.acp_connection = nil
+  self._acp_name_map_cache = nil
   self.adapter = new_adapter
   self.ui.adapter = self.adapter
 
@@ -1861,11 +1892,7 @@ function Chat:ready_for_input(opts)
     self.cycle = self.cycle + 1
     self:add_buf_message({ role = config.constants.USER_ROLE, content = "" })
 
-    -- The builder records the 0-based line where it inserted the new user
-    -- section's leading spacing. Tree-sitter scoping (and the context
-    -- block) anchor on the "## Me" header itself, which sits three lines
-    -- below the section start (two blank spacers + the header line).
-    self.header_line = (self.builder.state.current_section_start or 0) + 3
+    self.header_line = (self.builder.state.current_header_line or 0) + 1
     self.ui:display_tokens(self.parsers.markdown, self.header_line)
     self.context:render()
 
@@ -1946,28 +1973,21 @@ function Chat:update_metadata()
     local acp_models = self.acp_connection:get_models()
     model = acp_models and acp_models.currentModelId or "default"
 
-    -- Build a map of category -> { current, name } from all config options
-    config_options = {}
+    -- Cache the static name map; currentValue is read fresh below
+    if self._acp_name_map_cache == nil then
+      self._acp_name_map_cache = build_acp_name_map(self.acp_connection) or false
+    end
+    local name_map = self._acp_name_map_cache or nil
+
     for _, opt in ipairs(self.acp_connection:get_config_options()) do
       if opt.type == "select" and opt.currentValue then
-        local entry = { current = opt.currentValue }
-        -- Find the display name for the current value
-        for _, item in ipairs(opt.options or {}) do
-          if item.group then
-            for _, val in ipairs(item.options or {}) do
-              if val.value == opt.currentValue then
-                entry.name = val.name
-              end
-            end
-          elseif item.value == opt.currentValue then
-            entry.name = item.name
-          end
-        end
-        config_options[opt.category or opt.id] = entry
+        local names = name_map and name_map[opt.id]
+        config_options = config_options or {}
+        config_options[opt.category or opt.id] = {
+          current = opt.currentValue,
+          name = names and names[opt.currentValue],
+        }
       end
-    end
-    if vim.tbl_isempty(config_options) then
-      config_options = nil
     end
   end
 
@@ -2080,7 +2100,7 @@ end
 
 ---Toggle the chat buffer
 ---@param args? { params?: table, window_opts?: table, context?: table }
----@return nil
+---@return CodeCompanion.Chat|nil
 function Chat.toggle(args)
   args = args or {}
   local window_opts = args.window_opts

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -9,6 +9,29 @@ local yaml = require("codecompanion.utils.yaml")
 local get_node_text = vim.treesitter.get_node_text --[[@type function]]
 local get_query = vim.treesitter.query.get --[[@type function]]
 
+local cached_markdown_chat_query
+local function markdown_chat_query()
+  cached_markdown_chat_query = cached_markdown_chat_query or get_query("markdown", "chat")
+  return cached_markdown_chat_query
+end
+
+local cached_yaml_chat_query
+local function yaml_chat_query()
+  cached_yaml_chat_query = cached_yaml_chat_query or get_query("yaml", "chat")
+  return cached_yaml_chat_query
+end
+
+local cached_image_query
+local function image_query()
+  cached_image_query = cached_image_query
+    or vim.treesitter.query.parse(
+      "markdown_inline",
+      [[((image) @image)
+    ((inline_link) @link)]]
+    )
+  return cached_image_query
+end
+
 local M = {}
 
 ---Parse the chat buffer for settings
@@ -19,7 +42,7 @@ local M = {}
 function M.settings(bufnr, parser, adapter)
   local settings = {}
 
-  local query = get_query("yaml", "chat")
+  local query = yaml_chat_query()
   local root = parser:parse()[1]:root()
 
   local end_line = -1
@@ -71,9 +94,9 @@ end
 ---@param start_range number
 ---@return { content: string }|nil
 function M.messages(chat, start_range)
-  local query = get_query("markdown", "chat")
+  local query = markdown_chat_query()
 
-  local tree = chat.chat_parser:parse({ start_range - 1, -1 })[1]
+  local tree = chat.parsers.markdown:parse({ start_range - 1, -1 })[1]
   local root = tree:root()
 
   local content = {}
@@ -99,9 +122,9 @@ end
 ---@param chat CodeCompanion.Chat
 ---@return number|nil
 function M.headers(chat)
-  local query = get_query("markdown", "chat")
+  local query = markdown_chat_query()
 
-  local tree = chat.chat_parser:parse({ 0, -1 })[1]
+  local tree = chat.parsers.markdown:parse({ 0, -1 })[1]
   local root = tree:root()
 
   local last_match = nil
@@ -123,14 +146,8 @@ end
 ---@param chat CodeCompanion.Chat The chat instance.
 ---@param start_range number The 1-indexed line number from where to start parsing.
 function M.images(chat, start_range)
-  local ts_query = vim.treesitter.query.parse(
-    "markdown_inline",
-    [[
-((image) @image)
-((inline_link) @link)
-  ]]
-  )
-  local parser = vim.treesitter.get_parser(chat.bufnr, "markdown_inline")
+  local ts_query = image_query()
+  local parser = chat.parsers.markdown_inline or vim.treesitter.get_parser(chat.bufnr, "markdown_inline")
 
   local tree = parser:parse({ start_range, -1 })[1]
   local root = tree:root()
@@ -174,8 +191,8 @@ end
 ---@param cursor? table
 ---@return TSNode|nil
 function M.codeblock(chat, cursor)
-  local root = chat.chat_parser:parse()[1]:root()
-  local query = get_query("markdown", "chat")
+  local root = chat.parsers.markdown:parse()[1]:root()
+  local query = markdown_chat_query()
   if query == nil then
     return nil
   end

--- a/lua/codecompanion/interactions/chat/ui/builder.lua
+++ b/lua/codecompanion/interactions/chat/ui/builder.lua
@@ -139,7 +139,7 @@ end
 
 ---Add message using centralized state
 ---@param data { content?: string, role?: string, reasoning?: { content: string } }
----@param opts? { type?: string, force_role?: boolean, insert_at?: number, status?: string, _icon_info?: table, virt_text_pos?: string, fold_info?: table, state?: table }
+---@param opts? { type?: string, force_role?: boolean, insert_at?: number, status?: string, _icon_info?: table, virt_text_pos?: string }
 ---@return number,number|nil
 function Builder:add_message(data, opts)
   opts = opts or {}
@@ -199,9 +199,13 @@ function Builder:add_message(data, opts)
 
   local insert_line, icon_id
   if not vim.tbl_isempty(lines) then
-    opts.fold_info = fold_info
-    opts.state = state
-    insert_line, icon_id = self:_write_to_buffer(lines, opts)
+    insert_line, icon_id = self:_write_to_buffer(lines, {
+      _icon_info = opts._icon_info,
+      fold_info = fold_info,
+      insert_at = opts.insert_at,
+      state = state,
+      virt_text_pos = opts.virt_text_pos,
+    })
   end
 
   if current_type then
@@ -268,7 +272,7 @@ end
 
 ---Write lines to buffer with all the buffer management
 ---@param lines string[]
----@param opts { insert_at?: number, _icon_info?: table, virt_text_pos?: string, fold_info?: table, state: table }
+---@param opts table
 ---@return number, number|nil
 function Builder:_write_to_buffer(lines, opts)
   local state = opts.state
@@ -277,10 +281,8 @@ function Builder:_write_to_buffer(lines, opts)
   self.chat.ui:unlock_buf()
   local last_line, last_column, line_count = self.chat.ui:last()
 
-  ---@type number
-  local insert_line = last_line
+  local insert_line = opts.insert_at or last_line
   if opts.insert_at then
-    insert_line = opts.insert_at
     last_column = 0
   end
 

--- a/lua/codecompanion/interactions/chat/ui/builder.lua
+++ b/lua/codecompanion/interactions/chat/ui/builder.lua
@@ -64,7 +64,8 @@ local Builder = {}
 ---@field block_index number
 ---@field last_write_start number -- 0-based
 ---@field last_write_end number -- 0-based
----@field current_section_start? number -- 0-based
+---@field current_section_start? number -- 0-based, the leading blank that precedes the section header
+---@field current_header_line? number -- 0-based, the line that holds the rendered "## role" header
 ---@field last_section_start? number -- 0-based
 
 ---@class CodeCompanion.Chat.UI.BuilderArgs
@@ -92,6 +93,7 @@ function Builder.new(args)
       last_write_start = 0,
       last_write_end = 0,
       current_section_start = nil,
+      current_header_line = nil,
       last_section_start = nil,
     },
 
@@ -240,7 +242,7 @@ end
 ---@param state table
 ---@return boolean
 function Builder:_should_add_header(data, opts, state)
-  return (data.role and data.role ~= state.last_role) or (opts and opts.force_role)
+  return (data.role ~= nil and data.role ~= state.last_role) or (opts.force_role == true)
 end
 
 ---Add appropriate spacing before header
@@ -266,7 +268,7 @@ end
 
 ---Write lines to buffer with all the buffer management
 ---@param lines string[]
----@param opts { insert_at?: number, _icon_info?: table, virt_text_pos?: string, fold_info?: table, state?: table }
+---@param opts { insert_at?: number, _icon_info?: table, virt_text_pos?: string, fold_info?: table, state: table }
 ---@return number, number|nil
 function Builder:_write_to_buffer(lines, opts)
   local state = opts.state
@@ -275,6 +277,7 @@ function Builder:_write_to_buffer(lines, opts)
   self.chat.ui:unlock_buf()
   local last_line, last_column, line_count = self.chat.ui:last()
 
+  ---@type number
   local insert_line = last_line
   if opts.insert_at then
     insert_line = opts.insert_at
@@ -302,6 +305,8 @@ function Builder:_write_to_buffer(lines, opts)
   if state.is_new_response then
     self.state.last_section_start = self.state.current_section_start
     self.state.current_section_start = insert_line
+    -- Header text sits 2 lines below `insert_line` (two blank spacers + header)
+    self.state.current_header_line = insert_line + 2
     self.chat.ui:render_headers()
   end
 

--- a/lua/codecompanion/interactions/chat/ui/folds.lua
+++ b/lua/codecompanion/interactions/chat/ui/folds.lua
@@ -257,7 +257,7 @@ function Folds:create_reasoning_fold(chat, start_row, end_row)
   local summary_text = "  " .. config.display.chat.icons.chat_fold .. " ..."
 
   local bufnr = chat.bufnr
-  local parser = chat.chat_parser
+  local parser = chat.parsers and chat.parsers.markdown
   if not (bufnr and parser) then
     return
   end

--- a/lua/codecompanion/interactions/chat/ui/formatters/base.lua
+++ b/lua/codecompanion/interactions/chat/ui/formatters/base.lua
@@ -40,7 +40,7 @@ end
 
 ---Format the content into lines
 ---@param message table
----@param opts { type?: string, status?: string, _icon_info?: table }
+---@param opts table
 ---@param state table
 ---@return string[] lines, table? fold_info
 function BaseFormatter:format(message, opts, state)

--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -239,6 +239,9 @@ function Interactions:workflow()
     messages = messages,
     tools = get_tools(self.selected),
   })
+  if not chat then
+    return
+  end
 
   if workflow.context then
     self.add_context(workflow, chat)

--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -736,7 +736,7 @@ function Inline:place(placement)
 end
 
 ---Send a prompt to the chat if the placement is chat
----@return CodeCompanion.Chat
+---@return CodeCompanion.Chat|nil
 function Inline:to_chat()
   local prompt = self.prompts
 

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -9,102 +9,18 @@ T = new_set({
     pre_once = function()
       h.child_start(child)
       child.lua([[h = require('tests.helpers')]])
+      child.lua([[mocks_acp = require("tests.mocks.acp")]])
     end,
     pre_case = function()
       child.lua([[
-        -- Mock ACP connection for chat integration tests
-        _G.mock_acp_connection = {
-          _config_options = {},
-          connected = false,
-          session_id = nil,
-
-          connect_and_authenticate = function(self)
-            self.connected = true
-            return self
-          end,
-
-          ensure_session = function(self)
-            self.session_id = "test-session-123"
-            return true
-          end,
-
-          session_prompt = function(self, messages)
-            return {
-              messages = messages,
-              handlers = {},
-              options = {},
-
-              on_message_chunk = function(self, handler)
-                self.handlers.message_chunk = handler
-                return self
-              end,
-
-              on_thought_chunk = function(self, handler)
-                self.handlers.thought_chunk = handler
-                return self
-              end,
-
-              on_tool_call = function(self, handler)
-                self.handlers.tool_call = handler
-                return self
-              end,
-
-              on_tool_update = function(self, handler)
-                self.handlers.tool_update = handler
-                return self
-              end,
-
-              on_permission_request = function(self, handler)
-                self.handlers.permission_request = handler
-                return self
-              end,
-
-              on_complete = function(self, handler)
-                self.handlers.complete = handler
-                return self
-              end,
-
-              on_error = function(self, handler)
-                self.handlers.error = handler
-                return self
-              end,
-
-              on_cancel = function(self, handler)
-                self.handlers.cancel = handler
-                return self
-              end,
-
-              with_options = function(self, opts)
-                self.options = opts
-                return self
-              end,
-
-              send = function(self)
-                -- Store for verification, don't actually send
-                _G.last_prompt_request = self
-                return { shutdown = function() end }
-              end
-            }
-          end,
-
-          disconnect = function(self)
-            self.connected = false
-            self.session_id = nil
-          end,
-
-          get_config_options = function(self)
-            return self._config_options or {}
-          end,
-
-          get_models = function(self)
-            return nil
-          end
-        }
+        _G.last_prompt_request = nil
+        _G.last_permission_request = nil
+        _G.codecompanion_chat_metadata = {}
+        package.loaded["codecompanion.acp"] = nil
       ]])
     end,
-    post_case = function()
+    post_once = function()
       child.lua([[
-        _G.mock_acp_connection = nil
         _G.last_prompt_request = nil
         _G.last_permission_request = nil
         _G.codecompanion_chat_metadata = nil
@@ -117,8 +33,8 @@ T = new_set({
         package.loaded["codecompanion.interactions.chat"] = nil
         package.loaded["codecompanion.config"] = nil
       ]])
+      child.stop()
     end,
-    post_once = child.stop,
   },
 })
 
@@ -126,7 +42,6 @@ T["ACPHandler"] = new_set()
 
 T["ACPHandler"]["establishes connection when needed"] = function()
   local result = child.lua([[
-    -- Create chat with ACP adapter
     local chat = h.setup_chat_buffer({}, {
       name = "test_acp",
       config = {
@@ -145,28 +60,25 @@ T["ACPHandler"]["establishes connection when needed"] = function()
     local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
     local handler = ACPHandler.new(chat)
 
-    -- Mock the ACP client to return our mock connection
+    local conn = mocks_acp.new()
     package.loaded["codecompanion.acp"] = {
-      new = function(args)
-        return _G.mock_acp_connection
-      end
+      new = function() return conn end
     }
 
-    -- Submit should establish connection
-    local request = handler:submit({
+    handler:submit({
       messages = {{ type = "text", text = "Hello" }}
     })
 
     return {
       has_connection = chat.acp_connection ~= nil,
-      connection_established = chat.acp_connection.connected,
+      is_ready = chat.acp_connection:is_ready(),
       session_id = chat.acp_connection.session_id,
       request_sent = _G.last_prompt_request ~= nil
     }
   ]])
 
   h.is_true(result.has_connection)
-  h.is_true(result.connection_established)
+  h.is_true(result.is_ready)
   h.eq("test-session-123", result.session_id)
   h.is_true(result.request_sent)
 end
@@ -339,12 +251,10 @@ T["ACPHandler"]["handles connection errors"] = function()
     local handler = ACPHandler.new(chat)
 
     -- Mock connection failure
+    local conn = mocks_acp.new()
+    conn.connect_and_authenticate = function() return nil end
     package.loaded["codecompanion.acp"] = {
-      new = function(args)
-        return {
-          connect_and_authenticate = function() return nil end -- Connection fails
-        }
-      end
+      new = function() return conn end
     }
 
     local completion_called = false
@@ -380,11 +290,9 @@ T["ACPHandler"]["integrates with chat submit flow"] = function()
       }
     })
 
-    -- Mock the ACP connection
+    local conn = mocks_acp.new()
     package.loaded["codecompanion.acp"] = {
-      new = function(args)
-        return _G.mock_acp_connection
-      end
+      new = function() return conn end
     }
 
     -- Add a user message to submit
@@ -916,24 +824,6 @@ T["ACPHandler"]["Config Options"] = new_set()
 
 T["ACPHandler"]["Config Options"]["updates metadata with config options"] = function()
   local result = child.lua([[
-    local mock_connection = vim.deepcopy(_G.mock_acp_connection)
-    mock_connection._config_options = {
-      {
-        type = "select",
-        id = "mode",
-        name = "Mode",
-        category = "mode",
-        currentValue = "plan",
-        options = {
-          { value = "default", name = "Always Ask" },
-          { value = "plan", name = "Plan Mode" },
-        },
-      },
-    }
-    mock_connection.get_config_options = function(self)
-      return self._config_options
-    end
-
     local chat = h.setup_chat_buffer({}, {
       name = "test_acp",
       config = {
@@ -943,7 +833,21 @@ T["ACPHandler"]["Config Options"]["updates metadata with config options"] = func
       }
     })
 
-    chat.acp_connection = mock_connection
+    chat.acp_connection = mocks_acp.new({
+      config_options = {
+        {
+          type = "select",
+          id = "mode",
+          name = "Mode",
+          category = "mode",
+          currentValue = "plan",
+          options = {
+            { value = "default", name = "Always Ask" },
+            { value = "plan", name = "Plan Mode" },
+          },
+        },
+      },
+    })
     chat:update_metadata()
 
     local metadata = _G.codecompanion_chat_metadata[chat.bufnr]
@@ -962,12 +866,6 @@ end
 
 T["ACPHandler"]["Config Options"]["handles no config options gracefully"] = function()
   local result = child.lua([[
-    local mock_connection = vim.deepcopy(_G.mock_acp_connection)
-    mock_connection._config_options = {}
-    mock_connection.get_config_options = function(self)
-      return self._config_options
-    end
-
     local chat = h.setup_chat_buffer({}, {
       name = "test_acp",
       config = {
@@ -977,7 +875,7 @@ T["ACPHandler"]["Config Options"]["handles no config options gracefully"] = func
       }
     })
 
-    chat.acp_connection = mock_connection
+    chat.acp_connection = mocks_acp.new({ config_options = {} })
     chat:update_metadata()
 
     local metadata = _G.codecompanion_chat_metadata[chat.bufnr]
@@ -994,8 +892,14 @@ end
 
 T["ACPHandler"]["Config Options"]["reflects config option changes in metadata"] = function()
   local result = child.lua([[
-    local mock_connection = vim.deepcopy(_G.mock_acp_connection)
-    mock_connection.session_id = "test-session-123"
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
 
     local config_opts = {
       {
@@ -1010,21 +914,7 @@ T["ACPHandler"]["Config Options"]["reflects config option changes in metadata"] 
         },
       },
     }
-    mock_connection._config_options = config_opts
-    mock_connection.get_config_options = function(self)
-      return self._config_options
-    end
-
-    local chat = h.setup_chat_buffer({}, {
-      name = "test_acp",
-      config = {
-        name = "test_acp",
-        type = "acp",
-        handlers = { form_messages = function(a, m) return m end }
-      }
-    })
-
-    chat.acp_connection = mock_connection
+    chat.acp_connection = mocks_acp.new({ config_options = config_opts })
     chat:update_metadata()
 
     local metadata_before = vim.deepcopy(_G.codecompanion_chat_metadata[chat.bufnr])

--- a/tests/mocks/acp.lua
+++ b/tests/mocks/acp.lua
@@ -1,0 +1,63 @@
+local M = {}
+
+local DEFAULT_ADAPTER = {
+  name = "test_acp",
+  type = "acp",
+  handlers = {
+    form_messages = function(_, messages)
+      return messages
+    end,
+  },
+}
+
+---Create a Connection instance with transport methods stubbed for tests.
+---@param opts? { adapter?: table, config_options?: table, session_id?: string }
+---@return CodeCompanion.ACP.Connection
+function M.new(opts)
+  opts = opts or {}
+
+  local Connection = require("codecompanion.acp")
+  local PromptBuilder = require("codecompanion.acp.prompt_builder")
+
+  local adapter = opts.adapter or DEFAULT_ADAPTER
+  local session_id = opts.session_id or "test-session-123"
+
+  local conn = Connection.new({ adapter = adapter })
+  conn.adapter_modified = adapter
+  conn._config_options = opts.config_options or {}
+  conn._agent_info = { agentCapabilities = {}, authMethods = {}, protocolVersion = 1 }
+
+  conn.connect_and_authenticate = function(self)
+    self._initialized = true
+    self._authenticated = true
+    self._state.handle = self._state.handle or {}
+    return self
+  end
+
+  conn.ensure_session = function(self)
+    self.session_id = session_id
+    return true
+  end
+
+  conn.is_ready = function(self)
+    return self._initialized == true and self._authenticated == true
+  end
+
+  conn.disconnect = function(self)
+    self._state.handle = nil
+    self.session_id = nil
+  end
+
+  conn.session_prompt = function(self, messages)
+    local builder = PromptBuilder.new(self, messages)
+    builder.send = function(s)
+      _G.last_prompt_request = s
+      return { shutdown = function() end }
+    end
+    return builder
+  end
+
+  return conn
+end
+
+return M


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

For some time now, there have been numerous optimisations I've wanted to carry out on the chat class ("chat buffer"). My over enthusastic use of `vim.iter` costing ms and not enforcing caching across the tree-sitter parsers, to splitting out the `chat.new` logic into individual functions.

A good use of AI has been to critique the code that was 100% written by me over 24 months, to find improvements that will keep the chat buffer performant when working with large conversations and keep memory use down to a minimum.

## AI Usage

Opus 4.7

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
