### PR TITLE
fix(chat): context management in copilot

### DIFF
--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -11,7 +11,7 @@ function M.map_roles(adapter, messages)
   return adapter_utils.map_roles(adapter.roles, messages)
 end
 
----Resolve the context window (in tokens) for the adapter's currently selected model
+---Resolve the context window for the current model
 ---@param adapter CodeCompanion.HTTPAdapter
 ---@return number|nil
 function M.context_window(adapter)

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -1,4 +1,5 @@
 local adapter_utils = require("codecompanion.utils.adapters")
+local log = require("codecompanion.utils.log")
 
 local M = {}
 
@@ -8,6 +9,41 @@ local M = {}
 ---@return table
 function M.map_roles(adapter, messages)
   return adapter_utils.map_roles(adapter.roles, messages)
+end
+
+---Resolve the context window (in tokens) for the adapter's currently selected model
+---@param adapter CodeCompanion.HTTPAdapter
+---@return number|nil
+function M.context_window(adapter)
+  if adapter.model and adapter.model.meta and adapter.model.meta.context_window then
+    return adapter.model.meta.context_window
+  end
+
+  local model = adapter.schema and adapter.schema.model and adapter.schema.model.default
+  if type(model) == "function" then
+    local ok, resolved = pcall(model, adapter)
+    if not ok then
+      log:debug("[Context Window] Failed to resolve model name for `%s` adapter: %s", adapter.name, resolved)
+      return nil
+    end
+    model = resolved
+  end
+
+  local choices = adapter.schema and adapter.schema.model and adapter.schema.model.choices
+  if type(choices) == "function" then
+    local ok, resolved = pcall(choices, adapter, { async = true })
+    if not ok then
+      log:debug("[Context Window] Failed to resolve model choices for `%s` adapter: %s", adapter.name, resolved)
+      return nil
+    end
+    choices = resolved
+  end
+
+  if type(choices) == "table" and model and choices[model] and choices[model].meta then
+    return choices[model].meta.context_window
+  end
+
+  return nil
 end
 
 return M

--- a/lua/codecompanion/interactions/chat/helpers/init.lua
+++ b/lua/codecompanion/interactions/chat/helpers/init.lua
@@ -361,15 +361,12 @@ function M.trigger_context_management(adapter, opts)
   end
 
   if trigger < 1 then
-    local ok
-    ok, trigger = pcall(function()
-      return math.floor(trigger * adapter.schema.model.choices[adapter.schema.model.default].meta.context_window)
-    end)
-
-    if not ok then
-      log:debug("Could not evaluate the %s trigger for context management in the `%s` adapter", operation, adapter.name)
+    local context_window = require("codecompanion.adapters.shared").context_window(adapter)
+    if not context_window then
+      log:debug("[Context Window] No context window for `%s` adapter, skipping %s trigger", adapter.name, operation)
       return 0
     end
+    trigger = math.floor(trigger * context_window)
   end
 
   return trigger


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Following the addition of context management in `v19.14.0`, I noticed that with the Copilot adapter, model choices were not being expanded so the context limit could not be obtained.

## AI Usage

Opus 4.7

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
