### PR TITLE
feat(mcp): support lazy mcp server config evaluation

### DIFF
--- a/doc/configuration/mcp.md
+++ b/doc/configuration/mcp.md
@@ -43,6 +43,24 @@ require("codecompanion").setup({
 })
 ```
 
+```lua [Lazy / Deferred Config]
+require("codecompanion").setup({
+  mcp = {
+    servers = {
+      -- The function is called once, only when the server is first needed.
+      ["tavily-mcp"] = function()
+        return {
+          cmd = { "npx", "-y", "tavily-mcp@latest" },
+          env = {
+            TAVILY_API_KEY = os.getenv("TAVILY_API_KEY"),
+          },
+        }
+      end,
+    },
+  },
+})
+```
+
 :::
 
 In the environment variables example above, we're using [1Password CLI](https://developer.1password.com/docs/cli/) tool to fetch the API key. However, you can leverage CodeCompanion's built-in [environment variable](/configuration/adapters-http#environment-variables) capabilities to fetch the value from any source you like.

--- a/lua/codecompanion/mcp/init.lua
+++ b/lua/codecompanion/mcp/init.lua
@@ -11,6 +11,19 @@ local M = {}
 ---@type table<string, table> Dynamic registry for MCP tools (server_name -> { tools: table, groups: table })
 local tool_registry = {}
 
+---Resolve a server config, evaluating it if it is a function (memoized)
+---@param name string
+---@return CodeCompanion.MCP.ServerConfig|nil
+local function get_server_config(name)
+  local mcp_cfg = config.mcp
+  local server_cfg = mcp_cfg.servers[name]
+  if type(server_cfg) == "function" then
+    server_cfg = server_cfg()
+    mcp_cfg.servers[name] = server_cfg
+  end
+  return server_cfg
+end
+
 ---Check if a server is in the default_servers list
 ---@param name string
 ---@return boolean
@@ -89,7 +102,7 @@ end
 ---@field register_roots_list_changed? fun(notify: fun())
 
 ---@class CodeCompanion.MCPConfig
----@field servers? table<string, CodeCompanion.MCP.ServerConfig>
+---@field servers? table<string, CodeCompanion.MCP.ServerConfig | fun(): CodeCompanion.MCP.ServerConfig>
 
 ---@type table<string, CodeCompanion.MCP.Client>
 local clients = {}
@@ -102,9 +115,9 @@ function M.start_servers()
     return
   end
 
-  for name, cfg in pairs(mcp_cfg.servers) do
+  for name, _ in pairs(mcp_cfg.servers) do
     if is_default_server(name) and not clients[name] then
-      clients[name] = Client.new({ name = name, cfg = cfg })
+      clients[name] = Client.new({ name = name, cfg = get_server_config(name) })
     end
   end
 
@@ -145,8 +158,8 @@ end
 function M.enable_server(name, opts)
   opts = opts or {}
 
-  local mcp_cfg = config.mcp
-  local server_cfg = mcp_cfg.servers[name]
+  local server_cfg = get_server_config(name)
+
   if not server_cfg then
     log:warn("MCP server `%s` is not configured", name)
     return false, string.format("MCP server not found: %s", name)
@@ -169,8 +182,7 @@ end
 ---@param name string
 ---@return boolean, boolean|string
 function M.disable_server(name)
-  local mcp_cfg = config.mcp
-  local server_cfg = mcp_cfg.servers[name]
+  local server_cfg = get_server_config(name)
   if not server_cfg then
     return false, string.format("MCP server not found: %s", name)
   end
@@ -187,8 +199,7 @@ end
 ---@param name string
 ---@return boolean, boolean|string
 function M.toggle_server(name)
-  local mcp_cfg = config.mcp
-  local server_cfg = mcp_cfg.servers[name]
+  local server_cfg = get_server_config(name)
   if not server_cfg then
     return false, string.format("MCP server not found: %s", name)
   end
@@ -252,10 +263,12 @@ end
 function M.transform_to_acp()
   local transformed = {}
 
-  for name, cfg in pairs(config.mcp.servers) do
+  for name, _ in pairs(config.mcp.servers) do
     if not is_default_server(name) then
       goto continue
     end
+
+    local cfg = get_server_config(name)
 
     table.insert(transformed, {
       name = name,

--- a/lua/codecompanion/mcp/init.lua
+++ b/lua/codecompanion/mcp/init.lua
@@ -11,15 +11,20 @@ local M = {}
 ---@type table<string, table> Dynamic registry for MCP tools (server_name -> { tools: table, groups: table })
 local tool_registry = {}
 
+---@type table<string, CodeCompanion.MCP.ServerConfig>
+local resolved_configs = {}
+
 ---Resolve a server config, evaluating it if it is a function (memoized)
 ---@param name string
 ---@return CodeCompanion.MCP.ServerConfig|nil
 local function get_server_config(name)
-  local mcp_cfg = config.mcp
-  local server_cfg = mcp_cfg.servers[name]
+  if resolved_configs[name] then
+    return resolved_configs[name]
+  end
+  local server_cfg = config.mcp.servers[name]
   if type(server_cfg) == "function" then
     server_cfg = server_cfg()
-    mcp_cfg.servers[name] = server_cfg
+    resolved_configs[name] = server_cfg
   end
   return server_cfg
 end
@@ -142,6 +147,7 @@ function M.stop_servers()
     client:stop()
   end
   clients = {}
+  resolved_configs = {}
 end
 
 ---Restart all MCP servers


### PR DESCRIPTION
## Description

This PR adds support for lazy (deferred) evaluation of MCP server configurations. Instead of providing a static config table, users can now supply a function that returns the config. The function is called once, the first time the server is needed, and the result is memoized back into the config.

This is useful when the config depends on values that should be resolved at runtime (e.g., reading environment variables like API keys) rather than at plugin setup time.

A new `get_server_config()` helper handles the resolution and memoization. All internal call sites (`start_servers`, `enable_server`, `disable_server`, `toggle_server`, `transform_to_acp`) now go through this helper.

The `servers` type annotation has been updated to reflect the new accepted type:
```lua
table<string, CodeCompanion.MCP.ServerConfig | fun(): CodeCompanion.MCP.ServerConfig>
```

Documentation has been updated with a "Lazy / Deferred Config" example.

## AI Usage

This PR was authored with assistance from GitHub Copilot CLI.

## Related Issue(s)

Referring to discussion https://github.com/olimorris/codecompanion.nvim/discussions/3144

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages