### PR TITLE
feat(ui): improve acp tool formatting in the chat

### DIFF
--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -241,16 +241,22 @@ function ACPHandler:process_tool_call(tool_call)
   local merged = merge_tool_call(self.tools[id], tool_call)
   tool_call = merged
 
-  local ok, content = pcall(formatter.tool_message, tool_call, self.chat.adapter)
-  if not ok then
-    content = "[Error formatting tool output]"
-  end
-
   -- Cache or cleanup
   if tool_call.status == "completed" then
     self.tools[id] = nil
   else
     self.tools[id] = merged
+  end
+
+  -- Pending tool calls are awaiting approval or streaming input, so hold them
+  -- back from the buffer until the agent moves them out of the pending state
+  if tool_call.status == "pending" then
+    return
+  end
+
+  local ok, content = pcall(formatter.tool_message, tool_call, self.chat.adapter)
+  if not ok then
+    content = "[Error formatting tool output]"
   end
 
   -- If the tool call has already written output to the chat buffer, update the

--- a/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/approval_prompt.lua
@@ -67,7 +67,7 @@ function M.request(chat, opts)
   utils.fire("ToolApprovalRequested", { bufnr = bufnr, name = opts.name })
 
   local content = build_message(opts)
-  chat:add_buf_message({ content = content })
+  chat:add_buf_message({ role = config.constants.LLM_ROLE, content = content })
 
   if config.interactions.chat.tools.opts.notify_on_approval and not ui_utils.buf_is_active(bufnr) then
     utils.notify("Tool approval required")


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

(Just wanted an excuse to check out Fable 5 on a simple PR)

This PR reorders how tools are shown in the chat buffer when working with an ACP adapter. Prior to this PR, the tool call would be shown first, followed by the approval request. In this PR, that is now flipped. .

## AI Usage

Claude Fable 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
