### PR TITLE
fix(adapters): turn `top_p` off by default in openai_responses

### DIFF
--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -747,13 +747,7 @@ return {
       optional = true,
       default = 1,
       desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
-      enabled = function(self)
-        local model = adapter_utils.model(self)
-        if model == "gpt-5.4-nano" then
-          return false
-        end
-        return true
-      end,
+      enabled = false,
       validate = function(n)
         return n >= 0 and n <= 1, "Must be between 0 and 1"
       end,

--- a/lua/codecompanion/schema.lua
+++ b/lua/codecompanion/schema.lua
@@ -11,8 +11,6 @@
 
 local M = {}
 
-local islist = vim.islist or vim.tbl_islist
-
 ---Return the default values for a schema
 ---@param adapter CodeCompanion.HTTPAdapter
 ---@param defaults? table Any default values to use (will override schema defaults)
@@ -20,6 +18,9 @@ M.get_default = function(adapter, defaults)
   local schema = adapter.schema
   local ret = {}
   for k, v in pairs(schema) do
+    if v.enabled == false then
+      goto continue
+    end
     if type(v.enabled) == "function" and not v.enabled(adapter) then
       goto continue
     end
@@ -63,9 +64,9 @@ local function validate_type(schema, value, adapter)
     end
   elseif ptype == "list" then
     -- TODO validate subtype
-    return type(value) == "table" and islist(value)
+    return type(value) == "table" and vim.islist(value)
   elseif ptype == "map" then
-    local valid = type(value) == "table" and (vim.tbl_isempty(value) or not islist(value))
+    local valid = type(value) == "table" and (vim.tbl_isempty(value) or not vim.islist(value))
     -- TODO validate subtype and subtype_key
     if valid then
       -- Hack to make sure empty dicts get serialized properly


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Turn off `top_p` by default in the `openai_responses` adapter and also allow the enabled field in an adapter's schema to be a boolean (why tf wasn't it allowed before?!)

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
