### PR TITLE
fix(adapters): token reporting in copilot

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -315,13 +315,23 @@ return {
         local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
 
         if ok then
+          -- Models that use the responses endpoint have the tokens in copilot_usage
+          if json.copilot_usage and json.copilot_usage.token_details then
+            local total = 0
+            for _, detail in ipairs(json.copilot_usage.token_details) do
+              total = total + (detail.token_count or 0)
+            end
+            log:trace("Tokens: %s", total)
+            return total
+          end
+
           if json.usage then
             local total_tokens = json.usage.total_tokens or 0
             local completion_tokens = json.usage.completion_tokens or 0
             local prompt_tokens = json.usage.prompt_tokens or 0
-            local tokens = total_tokens > 0 and total_tokens or completion_tokens + prompt_tokens
-            log:trace("Tokens: %s", tokens)
-            return tokens
+            local total = total_tokens > 0 and total_tokens or completion_tokens + prompt_tokens
+            log:trace("Tokens: %s", total)
+            return total
           end
         end
       end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I noticed that with models that use the OpenAI Responses endpoint, their token output is in a different format to those that use the completions endpoint. This PR addresses that.

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
