### PR TITLE
refactor(chat): tokens stored on chat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This is a Neovim plugin written in Lua, which allows developers to code with LLM
 - **Explicit names:** `pattern` not `pat`, `should_include` not `include_ok`
 - **Readable code:** names, variables, and control flow should read like clean English. Avoid generic names like `ctx` — use domain-specific names (`permission`, `request`, `source`)
 - **Plain language:** avoid jargon shortcuts in code, comments, commit messages, and chat. Don't say "no-op" — say what the code actually does ("returns unchanged", "does nothing", "skipped because already edited")
+- **Comments earn their place:** don't restate what a readable line of code already says. If a guard like `if type(x) ~= "number" then return end` is self-evident, a comment explaining it is noise. Comment the *why* that isn't in the code (e.g. `-- NOTE: Not handling token tables yet`), not the *what*
 - **Function params:** prefer a single table argument over positional args
 - **Error handling:** `pcall` + `log:error()`, return nil on failure
 - **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise — one description line, params should be self-explanatory without inline comments

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -29,7 +29,7 @@
 ---@field settings? table The settings that are used in the adapter of the chat buffer
 ---@field subscribers table The subscribers to the chat buffer
 ---@field title? string The title of the chat buffer
----@field tokens? nil|number The number of tokens in the chat
+---@field tokens? number|table The tokens reported by the adapter
 ---@field tools CodeCompanion.Tools The tools coordinator that executes available tools
 ---@field tool_registry CodeCompanion.Chat.ToolRegistry Methods for handling interactions between the chat buffer and tools
 ---@field ui CodeCompanion.Chat.UI The UI of the chat buffer
@@ -58,7 +58,7 @@
 ---@field status? string The status of any running jobs in the chat buffe
 ---@field stop_context_insertion? boolean Stop any visual selection from being automatically inserted into the chat buffer
 ---@field title? string The title of the chat buffer
----@field tokens? table Total tokens spent in the chat buffer so far
+---@field tokens? number|table Total tokens spent in the chat buffer so far
 ---@field tools? table<string> List of tools to preload in the chat buffer
 ---@field intro_message? string The welcome message that is displayed in the chat buffer
 ---@field window_opts? table Window configuration options for the chat buffer
@@ -1100,7 +1100,7 @@ function Chat:checkpoint()
     adapter = adapters.make_safe(self.adapter),
     estimated_tokens = tokens.get_tokens(self.messages),
     messages = self.messages,
-    reported_tokens = self.ui.tokens,
+    reported_tokens = self.tokens,
   })
 end
 
@@ -1197,7 +1197,7 @@ function Chat:_submit_http(payload)
     if adapter.features.tokens then
       local token_count = adapters.call_handler(adapter, "parse_tokens", data)
       if token_count then
-        self.ui.tokens = token_count
+        self.tokens = token_count
       end
     end
 
@@ -1455,7 +1455,7 @@ function Chat:done(output, reasoning, tools, meta, opts)
       content = content,
       reasoning = reasoning_content,
     }
-    local token_meta = { cumulative_tokens = self.ui.tokens }
+    local token_meta = { cumulative_tokens = self.tokens }
     self:add_message(message, {
       _meta = vim.tbl_extend("force", has_meta and meta or {}, token_meta),
     })
@@ -1467,7 +1467,7 @@ function Chat:done(output, reasoning, tools, meta, opts)
       reasoning = reasoning_content,
     }, {
       visible = false,
-      _meta = vim.tbl_extend("force", meta, { cumulative_tokens = self.ui.tokens }),
+      _meta = vim.tbl_extend("force", meta, { cumulative_tokens = self.tokens }),
     })
     reasoning_content = nil
   end
@@ -1482,7 +1482,7 @@ function Chat:done(output, reasoning, tools, meta, opts)
   if has_tools then
     tools = adapters.call_handler(self.adapter, "format_calls", tools)
     if tools then
-      local token_meta = { cumulative_tokens = self.ui.tokens }
+      local token_meta = { cumulative_tokens = self.tokens }
       local message = {
         role = config.constants.LLM_ROLE,
         reasoning = reasoning_content,
@@ -1872,7 +1872,7 @@ function Chat:ready_for_input(opts)
     self:add_buf_message({ role = config.constants.USER_ROLE, content = "" })
 
     self.header_line = (self.builder.state.current_header_line or 0) + 1
-    self.ui:display_tokens(self.parsers.markdown, self.header_line)
+    self.ui:display_tokens({ parser = self.parsers.markdown, start_row = self.header_line, tokens = self.tokens })
     self.context:render()
 
     self:dispatch("on_ready")
@@ -1981,7 +1981,7 @@ function Chat:update_metadata()
     context_items = #self.context_items,
     cycles = self.cycle,
     id = self.id,
-    tokens = self.ui.tokens or 0,
+    tokens = self.tokens or 0,
     tools = vim.tbl_count(self.tool_registry.in_use) or 0,
   }
 

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -520,18 +520,20 @@ end
 ---@param args { parser: table, start_row: number, tokens?: number|table }
 ---@return nil
 function UI:display_tokens(args)
-  if config.display.chat.show_token_count and args.tokens then
-    local token_text = config.display.chat.token_count
-    if type(token_text) == "function" then
-      token_text = token_text(args.tokens, self.adapter)
-      require("codecompanion.utils.tokens").display({
-        bufnr = self.chat_bufnr,
-        ns_id = CONSTANTS.NS_TOKENS,
-        parser = args.parser,
-        start_row = args.start_row,
-        token_str = token_text,
-      })
-    end
+  -- NOTE: Not handling token tables yet
+  if not config.display.chat.show_token_count or type(args.tokens) ~= "number" then
+    return
+  end
+
+  local formatter = config.display.chat.token_count
+  if type(formatter) == "function" then
+    require("codecompanion.utils.tokens").display({
+      bufnr = self.chat_bufnr,
+      ns_id = CONSTANTS.NS_TOKENS,
+      parser = args.parser,
+      start_row = args.start_row,
+      token_str = formatter(args.tokens, self.adapter),
+    })
   end
 end
 

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -44,7 +44,6 @@ end
 ---@field winnr number The window number of the chat
 ---@field settings table The settings for the chat
 ---@field title string|nil The title of the chat window
----@field tokens number The current token count in the chat
 ---@field window_opts? table The window configuration options for the chat buffer
 
 ---@class CodeCompanion.Chat.UIArgs
@@ -56,7 +55,6 @@ end
 ---@field winnr number
 ---@field settings table
 ---@field title string|nil
----@field tokens number
 ---@field window_opts? table
 
 ---@class CodeCompanion.Chat.UI
@@ -76,7 +74,6 @@ function UI.new(args)
     roles = args.roles,
     settings = args.settings,
     title = args.title,
-    tokens = args.tokens,
     winnr = args.winnr,
     window_opts = args.window_opts,
   }, { __index = UI })
@@ -520,15 +517,20 @@ function UI:last()
 end
 
 ---Display the tokens in the chat buffer
----@param parser table
----@param start_row number
+---@param args { parser: table, start_row: number, tokens?: number|table }
 ---@return nil
-function UI:display_tokens(parser, start_row)
-  if config.display.chat.show_token_count and self.tokens then
-    local to_display = config.display.chat.token_count
-    if type(to_display) == "function" then
-      to_display = to_display(self.tokens, self.adapter)
-      require("codecompanion.utils.tokens").display(to_display, CONSTANTS.NS_TOKENS, parser, start_row, self.chat_bufnr)
+function UI:display_tokens(args)
+  if config.display.chat.show_token_count and args.tokens then
+    local token_text = config.display.chat.token_count
+    if type(token_text) == "function" then
+      token_text = token_text(args.tokens, self.adapter)
+      require("codecompanion.utils.tokens").display({
+        bufnr = self.chat_bufnr,
+        ns_id = CONSTANTS.NS_TOKENS,
+        parser = args.parser,
+        start_row = args.start_row,
+        token_str = token_text,
+      })
     end
   end
 end

--- a/lua/codecompanion/utils/tokens.lua
+++ b/lua/codecompanion/utils/tokens.lua
@@ -123,23 +123,19 @@ function M.get_tokens(messages, opts)
 end
 
 ---Display the number of tokens in the current buffer
----@param token_str string
----@param ns_id number
----@param parser table
----@param start_row number
----@param bufnr? number
+---@param args { bufnr?: number, ns_id: number, parser: table, start_row: number, token_str: string }
 ---@return nil
-function M.display(token_str, ns_id, parser, start_row, bufnr)
-  bufnr = bufnr or api.nvim_get_current_buf()
+function M.display(args)
+  local bufnr = args.bufnr or api.nvim_get_current_buf()
 
-  api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+  api.nvim_buf_clear_namespace(bufnr, args.ns_id, 0, -1)
 
   local query = vim.treesitter.query.get("markdown", "tokens")
-  local tree = parser:parse({ start_row - 1, -1 })[1]
+  local tree = args.parser:parse({ args.start_row - 1, -1 })[1]
   local root = tree:root()
 
   local header
-  for id, node in query:iter_captures(root, bufnr, start_row - 1, -1) do
+  for id, node in query:iter_captures(root, bufnr, args.start_row - 1, -1) do
     if query.captures[id] == "role" then
       header = node
     end
@@ -148,9 +144,9 @@ function M.display(token_str, ns_id, parser, start_row, bufnr)
   if header then
     local _, _, end_row, _ = header:range()
 
-    local virtual_text = { { token_str, "CodeCompanionChatTokens" } }
+    local virtual_text = { { args.token_str, "CodeCompanionChatTokens" } }
 
-    api.nvim_buf_set_extmark(bufnr, ns_id, end_row - 1, 0, {
+    api.nvim_buf_set_extmark(bufnr, args.ns_id, end_row - 1, 0, {
       virt_text = virtual_text,
       virt_text_pos = "eol",
       priority = 110,

--- a/tests/scripts/tool_testing/run_tests.lua
+++ b/tests/scripts/tool_testing/run_tests.lua
@@ -546,7 +546,7 @@ local function finalize_run(run)
         tool_calls = msg.tools and msg.tools.calls or nil,
       })
     end
-    result.tokens = (run.chat.ui and run.chat.ui.tokens) or 0
+    result.tokens = run.chat.tokens or 0
     pcall(function()
       run.chat:close()
     end)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When I refactored the UI about 18 months ago, I decided to have the UI display the tokens in the chat buffer. In the process, tokens ended up sitting in the UI rather than on the chat. This PR refactors that and also allows for tokens to be a table (to potentially allow input and output tokens being displayed).

## AI Usage

Opus 4.8

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
