### PR TITLE
fix(utils): update datetime formatting

### DIFF
--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/resume.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/resume.lua
@@ -40,7 +40,7 @@ local function format_session(session)
   local parts = {}
 
   if session.updatedAt then
-    local ts = utils.parse_iso8601(session.updatedAt)
+    local ts = utils.timestamp_from_iso(session.updatedAt)
     if ts then
       table.insert(parts, "(" .. utils.make_relative(ts) .. ")")
     end

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -185,26 +185,33 @@ function M.set_option(bufnr, opt, value)
   end
 end
 
----Parse an ISO 8601 timestamp to a Unix timestamp
+---Convert an ISO 8601 timestamp to a Unix timestamp
 ---@param iso string ISO 8601 timestamp (e.g. "2026-03-18T22:29:29.993Z")
 ---@return number|nil
-function M.parse_iso8601(iso)
+function M.timestamp_from_iso(iso)
   local pattern = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)"
   local year, month, day, hour, min, sec = iso:match(pattern)
   if not year then
     return nil
   end
 
+  ---@type osdateparam
   local date = {
-    year = tonumber(year), --[[@as number]]
-    month = tonumber(month), --[[@as number]]
     day = tonumber(day), --[[@as number]]
     hour = tonumber(hour), --[[@as number]]
     min = tonumber(min), --[[@as number]]
+    month = tonumber(month), --[[@as number]]
     sec = tonumber(sec), --[[@as number]]
+    year = tonumber(year), --[[@as number]]
   }
 
-  return os.time(date)
+  -- The timestamp is UTC, but os.time() reads the table as local time, so add
+  -- the local offset from UTC to recover the true instant
+  local now = os.time()
+  local utc = os.date("!*t", now) --[[@as osdateparam]]
+  local utc_offset = os.difftime(now, os.time(utc))
+
+  return os.time(date) + utc_offset
 end
 
 ---Make a timestamp relative

--- a/tests/utils/test_utils.lua
+++ b/tests/utils/test_utils.lua
@@ -305,4 +305,20 @@ T["Utils"]["resolve_nested_value()"]["handles numeric keys in path"] = function(
   h.eq(result, vim.NIL) -- Won't resolve numeric keys as strings
 end
 
+T["Utils"]["timestamp_from_iso()"] = MiniTest.new_set()
+
+T["Utils"]["timestamp_from_iso()"]["parses a UTC timestamp back to the same UTC fields"] = function()
+  -- Round-trips through os.date in UTC, so the result is correct regardless of the machine's timezone
+  local result = child.lua([[
+    local ts = utils.timestamp_from_iso("2026-03-18T22:29:29.993Z")
+    return os.date("!%Y-%m-%dT%H:%M:%S", ts)
+  ]])
+  h.eq(result, "2026-03-18T22:29:29")
+end
+
+T["Utils"]["timestamp_from_iso()"]["returns nil for an unparseable string"] = function()
+  local result = child.lua([[return utils.timestamp_from_iso("not a timestamp")]])
+  h.eq(result, vim.NIL)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As noted in the issue below, timestamps would be shown incorrectly in the `/resume` slash command as timezones were not taken into account

## AI Usage

Opus 4.8

## Related Issue(s)

#3121

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
