### PR TITLE
Add a rename slash command

### DIFF
--- a/doc/agent-client-protocol.md
+++ b/doc/agent-client-protocol.md
@@ -72,7 +72,7 @@ ACP agents can advertise their own slash commands dynamically. You can access th
 
 ### Session Resume
 
-If an agent supports the `session/list` capability, you can resume a previous session using the `/resume` slash command in a fresh chat buffer. This calls `session/list` to discover previous sessions, then `session/load` to restore the selected session's conversation history into the chat buffer. See [Slash Commands](/usage/chat-buffer/slash-commands#resume) for usage details.
+If an agent supports the `session/list` capability, you can resume a previous session using the `/resume` slash command in a fresh chat buffer. This calls `session/list` to discover previous sessions, then `session/load` to restore the selected session's conversation history into the chat buffer. Sessions can be given a custom name with `/rename` — the name is persisted to disk and shown in the picker on resume. See [Slash Commands](/usage/chat-buffer/slash-commands#resume) for usage details.
 
 ### Model Selection
 

--- a/doc/usage/chat-buffer/slash-commands.md
+++ b/doc/usage/chat-buffer/slash-commands.md
@@ -90,9 +90,13 @@ The _mode_ slash command is specific to [ACP](/configuration/adapters-acp) adapt
 
 The _now_ slash command simply inserts the current datetime stamp into the chat buffer.
 
+## /rename
+
+The _rename_ slash command lets you give the current chat buffer a custom name. It accepts an optional inline argument (`/rename My title`) or prompts via `vim.ui.input` if no argument is provided. Once renamed, auto-generated titles will no longer overwrite your choice. For ACP adapters, the custom name is sent to the agent directly. If that fails, it is persisted to disk as a fallback and restored automatically when you resume the session via `/resume`.
+
 ## /resume
 
-The _resume_ slash command is specific to [ACP](/configuration/adapters-acp) adapters that support the `session/list` capability. It allows you to resume a previous session by listing your past sessions and restoring the selected one into the chat buffer. The conversation history is rendered so you can continue where you left off.
+The _resume_ slash command is specific to [ACP](/configuration/adapters-acp) adapters that support the `session/list` capability. It allows you to resume a previous session by listing your past sessions and restoring the selected one into the chat buffer. The conversation history is rendered so you can continue where you left off. If a session was previously renamed with `/rename`, the custom name is shown in the picker and restored on resume.
 
 > [!NOTE]
 > The `/resume` command must be used before sending any messages. It is only available on a fresh chat buffer.

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -401,6 +401,22 @@ function Connection:_establish_session()
   return true
 end
 
+---Send a session_info_update request to the agent with a new title
+---@param title string
+---@return table|nil result nil on failure
+function Connection:send_session_title(title)
+  if not self.session_id then
+    return nil
+  end
+  return self:send_rpc_request(METHODS.SESSION_UPDATE, {
+    sessionId = self.session_id,
+    update = {
+      sessionUpdate = "session_info_update",
+      title = title,
+    },
+  })
+end
+
 ---Create the ACP process
 ---@return boolean success
 function Connection:start_agent_process()
@@ -632,7 +648,7 @@ local DISPATCH = {
     elseif m.params.update and m.params.update.sessionUpdate == "session_info_update" then
       -- Ref: https://agentclientprotocol.com/rfds/session-info-update
       local chat = self:get_chat(m.params.sessionId)
-      if chat and m.params.update.title and type(m.params.update.title) == "string" then
+      if chat and not chat.title_locked and m.params.update.title and type(m.params.update.title) == "string" then
         chat:set_title(m.params.update.title)
       end
     elseif m.params.update and m.params.update.sessionUpdate == "usage_update" then

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -407,6 +407,13 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
             contains_code = false,
           },
         },
+        ["rename"] = {
+          path = "interactions.chat.slash_commands.builtin.rename",
+          description = "Rename the current chat",
+          opts = {
+            contains_code = false,
+          },
+        },
         ["compact"] = {
           path = "interactions.chat.slash_commands.builtin.compact",
           description = "Clears some of the chat history, keeping a summary in context",

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -29,6 +29,7 @@
 ---@field settings? table The settings that are used in the adapter of the chat buffer
 ---@field subscribers table The subscribers to the chat buffer
 ---@field title? string The title of the chat buffer
+---@field title_locked? boolean Whether the title was set manually and should not be overwritten
 ---@field tokens? number|table The tokens reported by the adapter
 ---@field tools CodeCompanion.Tools The tools coordinator that executes available tools
 ---@field tool_registry CodeCompanion.Chat.ToolRegistry Methods for handling interactions between the chat buffer and tools

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/rename.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/rename.lua
@@ -1,0 +1,45 @@
+local session_titles = require("codecompanion.utils.session_titles")
+
+---@class CodeCompanion.SlashCommand.Rename: CodeCompanion.SlashCommand
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommandArgs
+function SlashCommand.new(args)
+  return setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+end
+
+---Execute the slash command
+---@return nil
+function SlashCommand:execute()
+  local function apply(title)
+    title = title and vim.trim(title)
+    if not title or title == "" then
+      return
+    end
+    self.Chat.title_locked = true
+    self.Chat:set_title(title)
+
+    local connection = self.Chat.acp_connection
+    if not connection or not connection.session_id then
+      return
+    end
+
+    local sent = connection:send_session_title(title)
+    if not sent then
+      -- Local file backup
+      session_titles.set(connection.session_id, title)
+    end
+  end
+
+  if self.context and self.context.args and self.context.args ~= "" then
+    return apply(self.context.args)
+  end
+
+  vim.ui.input({ prompt = "Rename chat: ", default = self.Chat.title or "" }, apply)
+end
+
+return SlashCommand

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/resume.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/resume.lua
@@ -1,3 +1,4 @@
+local session_titles = require("codecompanion.utils.session_titles")
 local utils = require("codecompanion.utils")
 
 ---@class CodeCompanion.SlashCommand.Resume: CodeCompanion.SlashCommand
@@ -35,8 +36,9 @@ end
 
 ---Format a session for display in the picker
 ---@param session table SessionInfo
+---@param custom_title? string A user-defined title that overrides the agent-generated one
 ---@return string
-local function format_session(session)
+local function format_session(session, custom_title)
   local parts = {}
 
   if session.updatedAt then
@@ -46,11 +48,7 @@ local function format_session(session)
     end
   end
 
-  if session.title then
-    table.insert(parts, session.title)
-  else
-    table.insert(parts, session.sessionId)
-  end
+  table.insert(parts, custom_title or session.title or session.sessionId)
 
   return table.concat(parts, " ")
 end
@@ -76,10 +74,11 @@ function SlashCommand:execute()
     return utils.notify("No previous sessions found", vim.log.levels.INFO)
   end
 
+  local stored_titles = session_titles.load_all()
   local choices = {}
   local session_map = {}
   for i, session in ipairs(sessions) do
-    table.insert(choices, format_session(session))
+    table.insert(choices, format_session(session, stored_titles[session.sessionId]))
     session_map[i] = session
   end
 
@@ -107,7 +106,11 @@ function SlashCommand:execute()
 
       require("codecompanion.interactions.chat.acp.render").restore_session(Chat, updates)
 
-      if selected.title then
+      local persisted_title = session_titles.get(selected.sessionId)
+      if persisted_title then
+        Chat.title_locked = true
+        Chat:set_title(persisted_title)
+      elseif selected.title then
         Chat:set_title(selected.title)
       end
 
@@ -118,7 +121,7 @@ function SlashCommand:execute()
         title = Chat.title,
       })
 
-      utils.notify("Resumed session: " .. (selected.title or selected.sessionId), vim.log.levels.INFO)
+      utils.notify("Resumed session: " .. (Chat.title or selected.sessionId), vim.log.levels.INFO)
     else
       utils.notify("Failed to load session", vim.log.levels.ERROR)
     end

--- a/lua/codecompanion/utils/session_titles.lua
+++ b/lua/codecompanion/utils/session_titles.lua
@@ -1,0 +1,72 @@
+local files = require("codecompanion.utils.files")
+local log = require("codecompanion.utils.log")
+
+local store_path = vim.fs.joinpath(vim.fn.stdpath("data"), "codecompanion", "session_titles.json")
+
+local M = {}
+
+---Load the title store from disk
+---@return table<string, string>
+local function load()
+  if not files.exists(store_path) then
+    return {}
+  end
+
+  local ok, data = pcall(files.read, store_path)
+  if not ok then
+    return {}
+  end
+
+  local decoded_ok, decoded = pcall(vim.json.decode, data, { luanil = { object = true } })
+  if not decoded_ok or type(decoded) ~= "table" then
+    return {}
+  end
+
+  return decoded
+end
+
+---Save the title store to disk
+---@param store table<string, string>
+---@return nil
+local function save(store)
+  local ok, err = pcall(files.write_to_path, store_path, vim.json.encode(store))
+  if not ok then
+    log:error("session_titles: failed to save: %s", err)
+  end
+end
+
+---Get all persisted titles
+---@return table<string, string>
+function M.load_all()
+  return load()
+end
+
+---Get the persisted title for a session
+---@param session_id string
+---@return string|nil
+function M.get(session_id)
+  return load()[session_id]
+end
+
+---Set the persisted title for a session
+---@param session_id string
+---@param title string
+---@return nil
+function M.set(session_id, title)
+  local store = load()
+  store[session_id] = title
+  save(store)
+end
+
+---Remove the persisted title for a session
+---@param session_id string
+---@return nil
+function M.remove(session_id)
+  local store = load()
+  if store[session_id] then
+    store[session_id] = nil
+    save(store)
+  end
+end
+
+return M

--- a/tests/acp/test_acp.lua
+++ b/tests/acp/test_acp.lua
@@ -785,4 +785,40 @@ T["ACP Responses"]["error response notifies active prompt"] = function()
   h.eq(result.error_message, "LLM provider error: quota exceeded")
 end
 
+T["ACP Responses"]["session_info_update applies title to chat when not locked"] = function()
+  local result = child.lua([[
+    local connection = create_test_connection()
+    connection.session_id = "s1"
+    connection.chat = { title = nil, title_locked = false, set_title = function(self, t) self.title = t end }
+
+    local notification = vim.json.encode({
+      jsonrpc = "2.0",
+      method = "session/update",
+      params = { sessionId = "s1", update = { sessionUpdate = "session_info_update", title = "My New Title" } }
+    })
+    connection:buffer_stdout_and_dispatch(notification .. "\n")
+    return connection.chat.title
+  ]])
+
+  h.eq(result, "My New Title")
+end
+
+T["ACP Responses"]["session_info_update does not overwrite title when locked"] = function()
+  local result = child.lua([[
+    local connection = create_test_connection()
+    connection.session_id = "s1"
+    connection.chat = { title = "User Title", title_locked = true, set_title = function(self, t) self.title = t end }
+
+    local notification = vim.json.encode({
+      jsonrpc = "2.0",
+      method = "session/update",
+      params = { sessionId = "s1", update = { sessionUpdate = "session_info_update", title = "Agent Title" } }
+    })
+    connection:buffer_stdout_and_dispatch(notification .. "\n")
+    return connection.chat.title
+  ]])
+
+  h.eq(result, "User Title")
+end
+
 return T

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -767,4 +767,110 @@ T["Chat"]["inject"]["is injected after tool results in auto-submit flow"] = func
   h.eq("Tool result: file contents here", result.second_last_content)
 end
 
+T["Chat"]["set_title updates the chat title"] = function()
+  local result = child.lua([[
+    _G.chat:set_title("My Renamed Chat")
+    return _G.chat.title
+  ]])
+
+  h.eq("My Renamed Chat", result)
+end
+
+T["Chat"]["/rename with inline arg sets title and locks it"] = function()
+  local result = child.lua([[
+    local SlashCommand = require("codecompanion.interactions.chat.slash_commands.builtin.rename")
+    local cmd = SlashCommand.new({
+      Chat = _G.chat,
+      config = {},
+      context = { args = "My Inline Title" },
+    })
+    cmd:execute()
+    return { title = _G.chat.title, locked = _G.chat.title_locked }
+  ]])
+
+  h.eq("My Inline Title", result.title)
+  h.eq(true, result.locked)
+end
+
+T["Chat"]["/rename trims whitespace from inline arg"] = function()
+  local result = child.lua([[
+    local SlashCommand = require("codecompanion.interactions.chat.slash_commands.builtin.rename")
+    local cmd = SlashCommand.new({
+      Chat = _G.chat,
+      config = {},
+      context = { args = "  Padded Title  " },
+    })
+    cmd:execute()
+    return _G.chat.title
+  ]])
+
+  h.eq("Padded Title", result)
+end
+
+T["Chat"]["/rename with empty arg does not change title"] = function()
+  local result = child.lua([[
+    _G.chat.title = "Original"
+    local SlashCommand = require("codecompanion.interactions.chat.slash_commands.builtin.rename")
+    local cmd = SlashCommand.new({
+      Chat = _G.chat,
+      config = {},
+      context = { args = "   " },
+    })
+    cmd:execute()
+    return _G.chat.title
+  ]])
+
+  h.eq("Original", result)
+end
+
+T["Chat"]["/rename sends title to ACP agent when connection exists"] = function()
+  local result = child.lua([[
+    local session_titles_calls = {}
+    package.loaded["codecompanion.utils.session_titles"] = {
+      set = function(_, title) table.insert(session_titles_calls, title) end,
+    }
+    local SlashCommand = require("codecompanion.interactions.chat.slash_commands.builtin.rename")
+    _G.chat.acp_connection = {
+      session_id = "test-session",
+      send_session_title = function(self, title) return { ok = true } end,
+    }
+    local cmd = SlashCommand.new({
+      Chat = _G.chat,
+      config = {},
+      context = { args = "ACP Title" },
+    })
+    cmd:execute()
+    return { title = _G.chat.title, session_titles_calls = session_titles_calls }
+  ]])
+
+  h.eq("ACP Title", result.title)
+  h.eq({}, result.session_titles_calls)
+end
+
+T["Chat"]["/rename falls back to local file when ACP request fails"] = function()
+  local result = child.lua([[
+    local session_titles_calls = {}
+    package.loaded["codecompanion.utils.session_titles"] = {
+      set = function(sid, title) table.insert(session_titles_calls, { sid = sid, title = title }) end,
+    }
+    local SlashCommand = require("codecompanion.interactions.chat.slash_commands.builtin.rename")
+    _G.chat.acp_connection = {
+      session_id = "test-session",
+      send_session_title = function(self, title) return nil end,
+    }
+    local cmd = SlashCommand.new({
+      Chat = _G.chat,
+      config = {},
+      context = { args = "Fallback Title" },
+    })
+    cmd:execute()
+    return { title = _G.chat.title, session_titles_calls = session_titles_calls }
+  ]])
+
+  h.eq("Fallback Title", result.title)
+  h.eq(1, #result.session_titles_calls)
+  h.eq("test-session", result.session_titles_calls[1].sid)
+  h.eq("Fallback Title", result.session_titles_calls[1].title)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes.

  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->
This PR adds a new slash command `/rename` which uses the ACP `session/update` request to update the title (name) of the chat. I created this because I frequently find myself having a hard time figuring out which chat I would like to resume. This allows me to rename the chat to something that's useful. 

This PR implements a fallback, in case the user's ACP doesn't support the update request, by writing titles to a JSON file. The schema is simple: `{ [session-id]: [session-title] }`. This can be removed if deemed scope creep.

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please briefly describe how you used it and the models you used.
-->
I wrote this with the assistance of Claude Code, model Sonnet 4.6.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
Refers to https://github.com/olimorris/codecompanion.nvim/discussions/3163

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->
<img width="837" height="292" alt="Screenshot 2026-06-16 at 11 22 51 AM" src="https://github.com/user-attachments/assets/8a69a952-22f9-4bbb-bc3e-0b53f25bfddc" />
<img width="801" height="210" alt="Screenshot 2026-06-16 at 11 23 12 AM" src="https://github.com/user-attachments/assets/8f330104-78d9-4d2f-a550-d5cb4e06d919" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code **
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages

** One failing test: tests/utils/test_utils.lua | Utils | timestamp_from_iso() | parses a UTC timestamp back to the same UTC fields
