### PR TITLE
Add support for reading copilot auth token from $CODECOMPANION_TOKEN_PATH/github-copilot/auth.db

### DIFF
--- a/Make.ps1
+++ b/Make.ps1
@@ -13,6 +13,7 @@ function Install-Deps
         "nvim-treesitter" = "https://github.com/nvim-treesitter/nvim-treesitter.git"
         "mini.nvim"       = "https://github.com/echasnovski/mini.nvim"
         "panvimdoc"       = "https://github.com/kdheepak/panvimdoc"
+        "sqlite.lua"      = "https://github.com/kkharji/sqlite.lua"
     }
 
     foreach ($name in $deps.Keys)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test_file: deps
 	@echo Testing File...
 	LC_ALL=C nvim --headless --noplugin -u ./scripts/minimal_init.lua -c "lua MiniTest.run_file('$(FILE)')"
 
-deps: deps/plenary.nvim deps/nvim-treesitter deps/mini.nvim deps/panvimdoc
+deps: deps/plenary.nvim deps/nvim-treesitter deps/mini.nvim deps/panvimdoc deps/sqlite.lua
 	@echo Pulling...
 
 deps/plenary.nvim:
@@ -51,3 +51,7 @@ deps/mini.nvim:
 deps/panvimdoc:
 	@mkdir -p deps
 	git clone --filter=blob:none https://github.com/kdheepak/panvimdoc $@
+
+deps/sqlite.lua:
+	@mkdir -p deps
+	git clone --filter=blob:none https://github.com/kkharji/sqlite.lua $@

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Update your config and turn debug logging on:
   dependencies = {
     "nvim-lua/plenary.nvim",
     "nvim-treesitter/nvim-treesitter",
+    "kkharji/sqlite.lua",
   },
   opts = {
     -- NOTE: The log_level is in `opts.opts`

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,5 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 June 04
+*codecompanion.txt*
+                                   For NVIM v0.11    Last change: 2026 June 18
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -880,7 +881,7 @@ CURRENT LIMITATIONS                    *codecompanion-acp-current-limitations*
     `terminal/output`, `terminal/release`, etc.) are not implemented. CodeCompanion
     doesn't advertise terminal capabilities to agents.
 - **Agent Plan Rendering**: Plan
-    <https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
+<https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
     received and logged, but they're not currently rendered in the chat buffer UI.
 - **Audio Content**: Audio can't be sent or received
 
@@ -2306,9 +2307,9 @@ conversation.
           opts = {
             context_management = {
               editing = {
-                trigger = 0.65,
-                keep_cycles = 3,                -- preserve tool results from the last N cycles
-                exclude_tools = { "memory" },   -- tool names whose results are never edited
+                trigger = 0.65, -- Context editing is triggered when X% of the context window is reached
+                exclude_tools = { "memory" }, -- Output from these tools is never edited
+                keep_cycles = 3, -- Keep the last N cycles of tool results
               },
             },
           },
@@ -2332,14 +2333,14 @@ whether a failure should silently fall back to the chat adapter.
           opts = {
             context_management = {
               compaction = {
-                trigger = 0.85,
+                trigger = 0.85, -- Compaction is triggered when X% of the context window is reached
+                min_token_savings = 10000, -- Only compact when at least this amount of tokens will be saved
     
-                -- Adapter used to generate the summary. Defaults to the chat adapter.
-                -- Accepts a string (adapter name) or a table `{ name = "...", model = "..." }`
+                ---The adapter to use for compaction. Defaults to the current chat adapter
+                ---@type nil|string|{ name: string, model:string }
                 adapter = nil,
     
-                -- If the override adapter fails, silently retry with the chat adapter
-                fallback_to_chat_adapter = false,
+                fallback_to_chat_adapter = false, -- on failure, retry with the chat adapter?
               },
             },
           },

--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -65,6 +65,65 @@ local function find_config_path()
   end
 end
 
+---Run a sqlite query and return the first row
+---@param db table
+---@param file_path string
+---@param query string
+---@return table|nil
+local function query_sqlite_row(db, file_path, query)
+  local ok, rows = pcall(db.eval, db, query)
+  if not ok then
+    log:error("Copilot Adapter: Could not read token from %s: %s", file_path, rows)
+    return nil
+  end
+
+  if type(rows) ~= "table" or not rows[1] then
+    return nil
+  end
+
+  return rows[1]
+end
+
+---Read an OAuth token from a Copilot sqlite database
+---@param file_path string
+---@return string|nil
+local function get_oauth_token_from_sqlite(file_path)
+  local ok, sqlite_db = pcall(require, "sqlite.db")
+  if not ok then
+    log:error("Copilot Adapter: Could not read token from %s: sqlite.lua is not available", file_path)
+    return nil
+  end
+
+  local db_ok, db = pcall(function()
+    return sqlite_db:open(file_path, { open_mode = "ro" })
+  end)
+  if not db_ok then
+    log:error("Copilot Adapter: Could not open token database %s: %s", file_path, db)
+    return nil
+  end
+
+  local table_name_row = query_sqlite_row(
+    db,
+    file_path,
+    "SELECT DISTINCT m.name AS name FROM sqlite_master AS m "
+      .. "JOIN pragma_table_info(m.name) AS p "
+      .. "WHERE m.type = 'table' AND p.name = 'token_ciphertext' LIMIT 1;"
+  )
+  if not table_name_row then
+    db:close()
+    return nil
+  end
+
+  local token_row = query_sqlite_row(
+    db,
+    file_path,
+    string.format('SELECT token_ciphertext FROM "%s" LIMIT 1;', table_name_row.name:gsub('"', '""'))
+  )
+  db:close()
+
+  return token_row and token_row.token_ciphertext or nil
+end
+
 ---The function first attempts to load the token from the environment variables,
 ---specifically for GitHub Codespaces. If not found, it then attempts to load
 ---the token from configuration files located in the user's configuration path.
@@ -109,6 +168,11 @@ local function get_oauth_token()
         end
       end
     end
+  end
+
+  local db_path = config_path .. "/github-copilot/apps.db"
+  if vim.uv.fs_stat(db_path) then
+    return get_oauth_token_from_sqlite(db_path)
   end
 
   return nil

--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -170,7 +170,7 @@ local function get_oauth_token()
     end
   end
 
-  local db_path = config_path .. "/github-copilot/apps.db"
+  local db_path = config_path .. "/github-copilot/auth.db"
   if vim.uv.fs_stat(db_path) then
     return get_oauth_token_from_sqlite(db_path)
   end

--- a/lua/codecompanion/adapters/http/copilot/token.lua
+++ b/lua/codecompanion/adapters/http/copilot/token.lua
@@ -117,10 +117,16 @@ local function get_oauth_token_from_sqlite(file_path)
   local token_row = query_sqlite_row(
     db,
     file_path,
-    string.format('SELECT token_ciphertext FROM "%s" LIMIT 1;', table_name_row.name:gsub('"', '""'))
+    string.format(
+      'SELECT CAST(token_ciphertext AS TEXT) AS token_ciphertext FROM "%s" LIMIT 1;',
+      table_name_row.name:gsub('"', '""')
+    )
   )
   db:close()
-
+  log:info("Copilot Adapter: Loaded OAuth token from sqlite database %s", file_path)
+  for key, value in pairs(token_row) do
+    log:info(" - %s: %s", key, value)
+  end
   return token_row and token_row.token_ciphertext or nil
 end
 

--- a/minimal.lua
+++ b/minimal.lua
@@ -5,6 +5,7 @@ NOTE: Set the config path to enable the copilot adapter to work.
 It will search the following paths for a token:
   - "$CODECOMPANION_TOKEN_PATH/github-copilot/hosts.json"
   - "$CODECOMPANION_TOKEN_PATH/github-copilot/apps.json"
+  - "$CODECOMPANION_TOKEN_PATH/github-copilot/apps.db"
 --]]
 vim.env["CODECOMPANION_TOKEN_PATH"] = vim.fn.expand("~/.config")
 

--- a/minimal.lua
+++ b/minimal.lua
@@ -5,7 +5,7 @@ NOTE: Set the config path to enable the copilot adapter to work.
 It will search the following paths for a token:
   - "$CODECOMPANION_TOKEN_PATH/github-copilot/hosts.json"
   - "$CODECOMPANION_TOKEN_PATH/github-copilot/apps.json"
-  - "$CODECOMPANION_TOKEN_PATH/github-copilot/apps.db"
+  - "$CODECOMPANION_TOKEN_PATH/github-copilot/auth.db"
 --]]
 vim.env["CODECOMPANION_TOKEN_PATH"] = vim.fn.expand("~/.config")
 
@@ -25,6 +25,7 @@ local plugins = {
         lazy = false,
         build = ":TSUpdate",
       },
+      { "kkharji/sqlite.lua" },
 
       -- Test with blink.cmp
       {

--- a/tests/adapters/http/copilot/test_copilot.lua
+++ b/tests/adapters/http/copilot/test_copilot.lua
@@ -534,6 +534,77 @@ T["Token initialization"]["forces token init for synchronous model fetching"] = 
   h.eq(token_child.lua_get("_G.init_called"), true)
 end
 
+T["Token initialization"]["loads oauth token from apps.db"] = function()
+  token_child.lua([[
+    local config_dir = vim.fn.tempname()
+    local copilot_dir = config_dir .. "/github-copilot"
+    local db_path = copilot_dir .. "/apps.db"
+
+    vim.fn.mkdir(copilot_dir, "p")
+    vim.fn.writefile({ "" }, db_path)
+
+    vim.env.CODECOMPANION_TOKEN_PATH = config_dir
+
+    package.loaded["codecompanion.config"] = require("tests.config")
+    package.loaded["plenary.curl"] = {
+      get = function()
+        return {
+          body = vim.json.encode({
+            token = "test_copilot_token",
+            expires_at = os.time() + 3600,
+            endpoints = { api = "https://api.githubcopilot.com" },
+          }),
+        }
+      end,
+    }
+
+    package.loaded["sqlite.db"] = nil
+    package.preload["sqlite.db"] = function()
+      return {
+        open = function(_, opened_path, opts)
+          _G.sqlite_opened_path = opened_path
+          _G.sqlite_open_mode = opts.open_mode
+          _G.sqlite_expected_path = db_path
+
+          return {
+            eval = function(_, query)
+              if query:find("sqlite_master", 1, true) then
+                return { { name = "github_users" } }
+              end
+
+              if query:find("SELECT token_ciphertext", 1, true) then
+                return { { token_ciphertext = "db_oauth_token" } }
+              end
+
+              return {}
+            end,
+            close = function() end,
+          }
+        end,
+      }
+    end
+
+    package.loaded["codecompanion.adapters.http.copilot.token"] = nil
+
+    local token = require("codecompanion.adapters.http.copilot.token")
+    token._oauth_token = nil
+    token._copilot_token = nil
+
+    local fetched = token.fetch({ force = true })
+    _G.oauth_token_from_apps_db = fetched.oauth_token
+    _G.copilot_token_from_apps_db = fetched.copilot_token
+
+    package.preload["sqlite.db"] = nil
+    vim.fn.delete(config_dir, "rf")
+    vim.env.CODECOMPANION_TOKEN_PATH = nil
+  ]])
+
+  h.eq(token_child.lua_get("_G.sqlite_opened_path"), token_child.lua_get("_G.sqlite_expected_path"))
+  h.eq(token_child.lua_get("_G.sqlite_open_mode"), "ro")
+  h.eq(token_child.lua_get("_G.oauth_token_from_apps_db"), "db_oauth_token")
+  h.eq(token_child.lua_get("_G.copilot_token_from_apps_db"), "test_copilot_token")
+end
+
 T["test model selection dialog works with copilot adapter"] = function()
   local child = MiniTest.new_child_neovim()
   child.restart({ "-u", "scripts/minimal_init.lua" })

--- a/tests/adapters/http/copilot/test_copilot.lua
+++ b/tests/adapters/http/copilot/test_copilot.lua
@@ -534,11 +534,11 @@ T["Token initialization"]["forces token init for synchronous model fetching"] = 
   h.eq(token_child.lua_get("_G.init_called"), true)
 end
 
-T["Token initialization"]["loads oauth token from apps.db"] = function()
+T["Token initialization"]["loads oauth token from auth.db"] = function()
   token_child.lua([[
     local config_dir = vim.fn.tempname()
     local copilot_dir = config_dir .. "/github-copilot"
-    local db_path = copilot_dir .. "/apps.db"
+    local db_path = copilot_dir .. "/auth.db"
 
     vim.fn.mkdir(copilot_dir, "p")
     vim.fn.writefile({ "" }, db_path)
@@ -572,7 +572,8 @@ T["Token initialization"]["loads oauth token from apps.db"] = function()
                 return { { name = "github_users" } }
               end
 
-              if query:find("SELECT token_ciphertext", 1, true) then
+              if query:find("token_ciphertext", 1, true) then
+                _G.sqlite_token_query = query
                 return { { token_ciphertext = "db_oauth_token" } }
               end
 
@@ -591,8 +592,8 @@ T["Token initialization"]["loads oauth token from apps.db"] = function()
     token._copilot_token = nil
 
     local fetched = token.fetch({ force = true })
-    _G.oauth_token_from_apps_db = fetched.oauth_token
-    _G.copilot_token_from_apps_db = fetched.copilot_token
+    _G.oauth_token_from_auth_db = fetched.oauth_token
+    _G.copilot_token_from_auth_db = fetched.copilot_token
 
     package.preload["sqlite.db"] = nil
     vim.fn.delete(config_dir, "rf")
@@ -601,8 +602,11 @@ T["Token initialization"]["loads oauth token from apps.db"] = function()
 
   h.eq(token_child.lua_get("_G.sqlite_opened_path"), token_child.lua_get("_G.sqlite_expected_path"))
   h.eq(token_child.lua_get("_G.sqlite_open_mode"), "ro")
-  h.eq(token_child.lua_get("_G.oauth_token_from_apps_db"), "db_oauth_token")
-  h.eq(token_child.lua_get("_G.copilot_token_from_apps_db"), "test_copilot_token")
+  h.expect_truthy(
+    token_child.lua_get('_G.sqlite_token_query:find("CAST(token_ciphertext AS TEXT)", 1, true)')
+  )
+  h.eq(token_child.lua_get("_G.oauth_token_from_auth_db"), "db_oauth_token")
+  h.eq(token_child.lua_get("_G.copilot_token_from_auth_db"), "test_copilot_token")
 end
 
 T["test model selection dialog works with copilot adapter"] = function()

--- a/tests/adapters/http/copilot/test_copilot.lua
+++ b/tests/adapters/http/copilot/test_copilot.lua
@@ -602,9 +602,7 @@ T["Token initialization"]["loads oauth token from auth.db"] = function()
 
   h.eq(token_child.lua_get("_G.sqlite_opened_path"), token_child.lua_get("_G.sqlite_expected_path"))
   h.eq(token_child.lua_get("_G.sqlite_open_mode"), "ro")
-  h.expect_truthy(
-    token_child.lua_get('_G.sqlite_token_query:find("CAST(token_ciphertext AS TEXT)", 1, true)')
-  )
+  h.expect_truthy(token_child.lua_get('_G.sqlite_token_query:find("CAST(token_ciphertext AS TEXT)", 1, true)'))
   h.eq(token_child.lua_get("_G.oauth_token_from_auth_db"), "db_oauth_token")
   h.eq(token_child.lua_get("_G.copilot_token_from_auth_db"), "test_copilot_token")
 end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Per https://github.com/github/copilot.vim/issues/284, it seems that the Github Copilot's authentication token fetched by copilot.vim now is stored in an sqlite3 file located at $CODECOMPANION_TOKEN_PATH/github-copilot/auth.db (although admittedly it isn't clear to me from a cursory search through the latest copilot.vim source how this is done). This PR adds support for reading the token from the above sqlite3 file. The PR relies upon https://github.com/kkharji/sqlite.lua for sqlite3 support. I did not remove support for loading from $CODECOMPANION_TOKEN_PATH/github-copilot/apps.json, as that file still seems to be referenced in the copilot.vim source code.

Some tests don't pass on my system, but the ones associated with the changes in this PR all seem to pass.

## Supporting Documentation

None.

## AI Usage

This PR was mostly developed using Github Copilot.

## Related Issue(s)

https://github.com/github/copilot.vim/issues/284

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
