### PR TITLE
feat(chat): allow `session_id` to be edited in the debug window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ This is a Neovim plugin written in Lua, which allows developers to code with LLM
 - **Readable code:** names, variables, and control flow should read like clean English. Avoid generic names like `ctx` — use domain-specific names (`permission`, `request`, `source`)
 - **Plain language:** avoid jargon shortcuts in code, comments, commit messages, and chat. Don't say "no-op" — say what the code actually does ("returns unchanged", "does nothing", "skipped because already edited")
 - **Comments earn their place:** don't restate what a readable line of code already says. If a guard like `if type(x) ~= "number" then return end` is self-evident, a comment explaining it is noise. Comment the *why* that isn't in the code (e.g. `-- NOTE: Not handling token tables yet`), not the *what*
+- **Don't narrate every change:** the maintainer is an expert who knows this codebase. Do NOT add a comment to explain routine code (`-- Clear the modified flag`, `-- Loop over the messages`, `-- Return early`). Default to no comment. Reserve comments for genuinely non-obvious *why* — a subtle API quirk, a workaround, an ordering constraint — the kind of thing that would trip up even a reader who knows the codebase
 - **Function params:** prefer a single table argument over positional args
 - **Error handling:** `pcall` + `log:error()`, return nil on failure
 - **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise — one description line, params should be self-explanatory without inline comments

--- a/lua/codecompanion/interactions/chat/debug.lua
+++ b/lua/codecompanion/interactions/chat/debug.lua
@@ -50,7 +50,9 @@ local function get_buffer_content(lines)
 
   local env = {}
   local chunk, err = load(
-    "local settings, messages; " .. content .. " return {settings=settings, messages=messages}",
+    "local settings, messages, session_id; "
+      .. content
+      .. " return {settings=settings, messages=messages, session_id=session_id}",
     "buffer",
     "t",
     env
@@ -60,13 +62,14 @@ local function get_buffer_content(lines)
   end
 
   local result = chunk()
-  return result.settings, result.messages
+  return result.settings, result.messages, result.session_id
 end
 
 ---@class CodeCompanion.Chat.Debug
 ---@field chat CodeCompanion.Chat
 ---@field settings table
 ---@field aug number
+---@field winnr? number
 local Debug = {}
 
 function Debug.new(args)
@@ -164,6 +167,10 @@ function Debug:render()
       table.insert(lines, string.format("-- %s%s (tools: %d)", is_ready, server, status.tool_count))
     end
   end
+
+  -- Add session ID
+  table.insert(lines, "")
+  table.insert(lines, "local session_id = " .. string.format("%q", self.chat.session_id))
 
   -- Add settings
   if not config.display.chat.show_settings and adapter.type ~= "acp" then
@@ -271,7 +278,11 @@ function Debug:render()
 
   self.bufnr = api.nvim_create_buf(false, true)
 
+  -- Prevent buffers appearing as listed after saving/closing
   api.nvim_buf_set_name(self.bufnr, "CodeCompanion_debug")
+  vim.bo[self.bufnr].buftype = "acwrite"
+  vim.bo[self.bufnr].bufhidden = "wipe"
+
   -- Set the keymaps as per the user's chat buffer config
   local maps = {}
   local config_maps = vim.deepcopy(config.interactions.chat.keymaps)
@@ -300,14 +311,16 @@ function Debug:render()
     })
     :set()
 
-  ui_utils.create_float(
+  local _, winnr = ui_utils.create_float(
     lines,
     vim.tbl_extend("force", config.display.chat.floating_window, {
       bufnr = self.bufnr,
       ft = "lua",
       title = "Debug Chat",
+      winbar = "%= :w Save | q Close %=",
     })
   )
+  self.winnr = winnr
 
   self:setup_window()
 
@@ -347,7 +360,7 @@ function Debug:setup_window()
     end,
   })
 
-  api.nvim_create_autocmd("BufWrite", {
+  api.nvim_create_autocmd("BufWriteCmd", {
     group = self.aug,
     buffer = self.bufnr,
     desc = "Save the contents of the debug window to the chat buffer",
@@ -369,9 +382,9 @@ end
 ---Save the contents of the debug window to the chat buffer
 function Debug:save()
   local contents = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
-  local settings, messages = get_buffer_content(contents)
+  local settings, messages, session_id = get_buffer_content(contents)
 
-  if not settings and not messages then
+  if not settings and not messages and not session_id then
     return
   end
 
@@ -381,17 +394,31 @@ function Debug:save()
   if messages then
     self.chat.messages = messages
   end
+  if session_id then
+    self.chat.session_id = session_id
+  end
 
-  utils.notify("Updated the settings and messages")
+  if api.nvim_buf_is_valid(self.bufnr) then
+    vim.bo[self.bufnr].modified = false
+  end
+
+  utils.notify("Updated the chat buffer")
 end
 
 ---Function to run when the debug chat is closed
 ---@return nil
 function Debug:close()
+  -- Clear autocmds first so closing the window doesn't re-enter via WinClosed
   if self.aug then
     api.nvim_clear_autocmds({ group = self.aug })
+    self.aug = nil
   end
-  api.nvim_buf_delete(self.bufnr, { force = true })
+  if self.winnr and api.nvim_win_is_valid(self.winnr) then
+    api.nvim_win_close(self.winnr, true)
+  end
+  if api.nvim_buf_is_valid(self.bufnr) then
+    api.nvim_buf_delete(self.bufnr, { force = true })
+  end
 end
 
 return Debug

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -19,6 +19,7 @@ local M = {}
 ---@field title? string Title of the floating window
 ---@field width? number Default width if not specified in window
 ---@field height? number Default height if not specified in window
+---@field winbar? string Winbar text to display at the top of the window
 
 ---Open a floating window with the provided lines
 ---@param lines table
@@ -88,6 +89,10 @@ M.create_float = function(lines, opts)
   if opts.lock then
     vim.bo[bufnr].modified = false
     vim.bo[bufnr].modifiable = false
+  end
+
+  if opts.winbar then
+    vim.wo[winnr].winbar = opts.winbar
   end
 
   if opts.opts then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Following on from #3179, allow users to edit the `session_id` for their chat buffer. This PR also adds a winbar to the debug window and allows users to do `:w` to persist their changes.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code and Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
