### PR TITLE
feat(adapters): allow static `session_id` in OpenRouter

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -2003,6 +2003,18 @@ section below. However, you can also customise it on a per-chat basis, using
 `gd` to open the |codecompanion-usage-chat-buffer--debug-window|.
 
 
+The adapter also supports sticky sessions
+<https://openrouter.ai/docs/guides/best-practices/prompt-caching#using-session_id-for-sticky-sessions>
+via the use of a `session_id`. When a chat buffer is created, the plugin will
+automatically generate a unique session ID and pass it to the adapter. This ID
+can be renamed in the debug window of the chat to make it more relevant to the
+session you are working on. You can also statically set this on the adapter:
+
+`lua {6} require("codecompanion").setup({ adapters = { http = {
+openrouter_title_generation = function() return
+require("codecompanion.adapters").extend("openrouter", { opts = { session_id =
+"title_generation" }, }) end, }, }, })`
+
 
 COMMUNITY ADAPTERS ~
 

--- a/doc/configuration/adapters-http.md
+++ b/doc/configuration/adapters-http.md
@@ -507,7 +507,21 @@ require("codecompanion").setup({
 
 :::
 
-The adapter also supports [sticky sessions](https://openrouter.ai/docs/guides/best-practices/prompt-caching#using-session_id-for-sticky-sessions) via the use of a `session_id`. When a chat buffer is created, the plugin will automatically generate a unique session ID and pass it to the adapter. This ID can be renamed in the debug window of the chat to make it more relevant to the session you are working on.
+The adapter also supports [sticky sessions](https://openrouter.ai/docs/guides/best-practices/prompt-caching#using-session_id-for-sticky-sessions) via the use of a `session_id`. When a chat buffer is created, the plugin will automatically generate a unique session ID and pass it to the adapter. This ID can be renamed in the debug window of the chat to make it more relevant to the session you are working on. You can also statically set this on the adapter:
+
+```lua {6}
+require("codecompanion").setup({
+  adapters = {
+    http = {
+      openrouter_title_generation = function()
+        return require("codecompanion.adapters").extend("openrouter", {
+          opts = { session_id = "title_generation" },
+        })
+      end,
+    },
+  },
+})
+```
 
 ## Community Adapters
 

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -201,6 +201,12 @@ return {
     ---@param data table The request payload built by the chat buffer
     ---@return table|nil
     set_body = function(self, data)
+      -- A user's session ID takes priority...
+      if self.opts and self.opts.session_id then
+        return { session_id = self.opts.session_id }
+      end
+
+      -- ...over one from the chat buffer
       if data and data.session_id then
         return { session_id = data.session_id }
       end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Users may wish to have a static `session_id` on their OpenRouter adapter.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
