### PR TITLE
feat(interactions): add one-time yaml treesitter parser check

### DIFF
--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -71,9 +71,19 @@ function Interactions.new(args)
   }, { __index = Interactions })
 end
 
----@param interaction string
 function Interactions:start(interaction)
-  return self[interaction](self)
+  interaction = interaction or self.selected.interaction or self.selected.strategy or "chat"
+
+  local handler = self[interaction]
+  if type(handler) ~= "function" then
+    return log:warn(
+      "[Prompt Library] Unknown interaction `%s` for `%s`",
+      tostring(interaction),
+      tostring(self.selected.name)
+    )
+  end
+
+  return handler(self)
 end
 
 ---Add context to the chat buffer

--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -71,16 +71,11 @@ function Interactions.new(args)
   }, { __index = Interactions })
 end
 
+---@param interaction string
 function Interactions:start(interaction)
-  interaction = interaction or self.selected.interaction or self.selected.strategy or "chat"
-
   local handler = self[interaction]
   if type(handler) ~= "function" then
-    return log:warn(
-      "[Prompt Library] Unknown interaction `%s` for `%s`",
-      tostring(interaction),
-      tostring(self.selected.name)
-    )
+    return log:warn("[Prompt Library] Unknown interaction `%s` for `%s`", interaction, self.selected.name)
   end
 
   return handler(self)

--- a/lua/codecompanion/prompt_library/markdown.lua
+++ b/lua/codecompanion/prompt_library/markdown.lua
@@ -11,30 +11,12 @@ local allowed_roles = {
   config.constants.USER_ROLE,
 }
 
-local _yaml_parser_warned = false
-
----Check if YAML treesitter parser is available and warn if missing
-local function check_yaml_parser()
-  if _yaml_parser_warned then
-    return
-  end
-
-  _yaml_parser_warned = true
-
-  local ok = pcall(vim.treesitter.get_string_parser, "name: test", "yaml")
-  if not ok then
-    log:warn("[Prompt Library] Install with :TSInstall yaml to properly parse prompt frontmatter")
-  end
-end
-
 ---Load all markdown prompts from a directory
 ---@param dir string
 ---@param context CodeCompanion.BufferContext
 ---@return table
 function M.load_from_dir(dir, context)
   local prompts = {}
-
-  check_yaml_parser()
 
   dir = vim.fs.normalize(dir)
 
@@ -69,7 +51,7 @@ function M.parse_file(path, context)
 
   local frontmatter = M.parse_frontmatter(content)
 
-  if not frontmatter or not (frontmatter.interaction or frontmatter.strategy) or not frontmatter.name then
+  if not frontmatter or not frontmatter.interaction or not frontmatter.name then
     log:warn("[Prompt Library] Missing frontmatter, name or interaction in `%s`", path)
     return nil
   end
@@ -101,7 +83,7 @@ function M.parse_frontmatter(content)
 
   local ok, parser = pcall(vim.treesitter.get_string_parser, content, "yaml")
   if not ok then
-    return
+    return log:warn("[Prompt Library] Install the `yaml` treesitter parser to parse frontmatter")
   end
 
   local query = vim.treesitter.query.get("yaml", "prompt_library")
@@ -118,7 +100,6 @@ function M.parse_frontmatter(content)
 
   for id, node in query:iter_captures(root, content, 0, -1) do
     local capture_name = query.captures[id]
-
     if capture_name == "cc_top_key" then
       pending_key = vim.treesitter.get_node_text(node, content)
     elseif capture_name == "cc_top_value" then

--- a/lua/codecompanion/prompt_library/markdown.lua
+++ b/lua/codecompanion/prompt_library/markdown.lua
@@ -11,12 +11,30 @@ local allowed_roles = {
   config.constants.USER_ROLE,
 }
 
+local _yaml_parser_warned = false
+
+---Check if YAML treesitter parser is available and warn if missing
+local function check_yaml_parser()
+  if _yaml_parser_warned then
+    return
+  end
+
+  _yaml_parser_warned = true
+
+  local ok = pcall(vim.treesitter.get_string_parser, "name: test", "yaml")
+  if not ok then
+    log:warn("[Prompt Library] Install with :TSInstall yaml to properly parse prompt frontmatter")
+  end
+end
+
 ---Load all markdown prompts from a directory
 ---@param dir string
 ---@param context CodeCompanion.BufferContext
 ---@return table
 function M.load_from_dir(dir, context)
   local prompts = {}
+
+  check_yaml_parser()
 
   dir = vim.fs.normalize(dir)
 
@@ -32,7 +50,6 @@ function M.load_from_dir(dir, context)
     local ok, prompt = pcall(M.parse_file, path, context)
 
     if ok and prompt then
-      prompt.name = prompt.name or vim.fn.fnamemodify(path, ":t:r")
       table.insert(prompts, prompt)
     end
   end
@@ -52,7 +69,6 @@ function M.parse_file(path, context)
 
   local frontmatter = M.parse_frontmatter(content)
 
-  --TODO: Remove frontmatter.strategy conditional in v19.0.0
   if not frontmatter or not (frontmatter.interaction or frontmatter.strategy) or not frontmatter.name then
     log:warn("[Prompt Library] Missing frontmatter, name or interaction in `%s`", path)
     return nil


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

- Add check_yaml_parser() that warns once per session if YAML parser is missing
- Surfaces root cause (missing parser) instead of masking with lenient parsing
- Require name and (interaction OR strategy) fields in prompt frontmatter
- Clear user-facing warning: "Install with :TSInstall yaml to properly parse prompt frontmatter"

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

Used codecompanion with claude Haiku to format commit message.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
