### PR TITLE
refactor: http client

### DIFF
--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -1,9 +1,9 @@
 local Curl = require("plenary.curl")
-local Path = require("plenary.path")
 
 local adapter_utils = require("codecompanion.adapters.utils")
 local adapters = require("codecompanion.adapters")
 local config = require("codecompanion.config")
+local files = require("codecompanion.utils.files")
 local log = require("codecompanion.utils.log")
 local utils = require("codecompanion.utils")
 
@@ -25,17 +25,33 @@ Client.static.methods = {
   schedule_wrap = { default = vim.schedule_wrap },
 }
 
----Write HTTP headers to a temp file on disk
 ---@param headers table
----@return table
+---@return string
 local function write_headers_file(headers)
   local lines = {}
   for k, v in pairs(headers) do
     table.insert(lines, k .. ": " .. tostring(v))
   end
-  local file = Path.new(vim.fn.tempname() .. ".headers")
-  file:write(table.concat(lines, "\n"), "w")
-  return file
+
+  local path = vim.fn.tempname() .. ".headers"
+  files.write_to_path(path, table.concat(lines, "\n"))
+
+  return path
+end
+
+---@param paths { body: string, headers: string }
+---@param status? string
+---@return nil
+local function delete_temp_files(paths, status)
+  -- Don't remove any files if there was an error, so the user can debug
+  if status == "error" then
+    return
+  end
+
+  if vim.tbl_contains({ "ERROR", "INFO" }, config.opts.log_level) then
+    files.delete(paths.body)
+    files.delete(paths.headers)
+  end
 end
 
 ---Allow for easier testing/mocking of the static methods
@@ -51,6 +67,77 @@ local function transform_static_methods(opts)
     end
   end
   return ret
+end
+
+---@param self CodeCompanion.HTTPClient
+---@return CodeCompanion.HTTPAdapter|nil
+local function prepare_adapter(self)
+  local adapter = vim.deepcopy(self.adapter)
+  if adapters.call_handler(adapter, "setup") == false then
+    return nil
+  end
+
+  return adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
+end
+
+---Encode the JSON request body from the adapter's build handlers
+---@param self CodeCompanion.HTTPClient
+---@param adapter CodeCompanion.HTTPAdapter
+---@param payload { messages: table, tools?: table }
+---@return string
+local function encode_body(self, adapter, payload)
+  return self.methods.encode(
+    vim.tbl_extend(
+      "keep",
+      adapters.call_handler(
+        adapter,
+        "build_parameters",
+        adapter_utils.set_env_vars(adapter, adapter.parameters),
+        payload.messages
+      ) or {},
+      adapters.call_handler(adapter, "build_messages", payload.messages) or {},
+      adapters.call_handler(adapter, "build_tools", payload.tools) or {},
+      adapter.body and adapter.body or {},
+      adapters.call_handler(adapter, "build_body", payload) or {}
+    )
+  )
+end
+
+---@return table
+local function curl_args()
+  return {
+    "--retry",
+    "3",
+    "--retry-delay",
+    "1",
+    "--keepalive-time",
+    "60",
+    "--connect-timeout",
+    "10",
+  }
+end
+
+---@param adapter CodeCompanion.HTTPAdapter
+---@return string
+local function resolve_method(adapter)
+  if adapter.opts and adapter.opts.method then
+    return adapter.opts.method:lower()
+  end
+
+  return "post"
+end
+
+---Adapter metadata fired with request events
+---@param adapter CodeCompanion.HTTPAdapter
+---@return table
+local function adapter_event_data(adapter)
+  local model = adapter.schema.model.default
+
+  return {
+    name = adapter.name,
+    formatted_name = adapter.formatted_name,
+    model = (type(model) == "function" and model(adapter)) or model or "",
+  }
 end
 
 ---@class CodeCompanion.HTTPClientArgs
@@ -73,6 +160,7 @@ end
 
 ---@class CodeCompanion.HTTPClient.Request
 ---@field id string
+---@field adapter? CodeCompanion.HTTPAdapter
 
 ---@class CodeCompanion.HTTPClient.RequestHandle
 ---@field id string
@@ -80,16 +168,16 @@ end
 ---@field cancel fun(): boolean
 ---@field status fun(): "pending"|"streaming"|"success"|"error"|"cancelled"
 
----Async request API
+---Send a payload and receive the response over time via callbacks, returning a cancelable handle
 ---@param payload { messages: table, tools?: table }
 ---@param opts { stream?: boolean,
 ---             on_chunk?: fun(chunk: table, meta: CodeCompanion.HTTPClient.Request),
 ---             on_done?: fun(response: table|nil, meta: CodeCompanion.HTTPClient.Request),
 ---             on_error?: fun(err: table, meta: CodeCompanion.HTTPClient.Request),
----             timeout?: number,
----             silent?: boolean }|nil
+---             silent?: boolean,
+---             timeout?: number}|nil
 ---@return CodeCompanion.HTTPClient.RequestHandle
-function Client:send(payload, opts)
+function Client:stream(payload, opts)
   opts = opts or {}
   local handle_state = "pending"
   local meta = { id = tostring(math.random(10000000)) }
@@ -102,8 +190,11 @@ function Client:send(payload, opts)
 
   local request_opts = vim.tbl_extend("force", opts or {}, { id = meta.id })
 
-  local job = self:request(payload, {
-    callback = function(err, data)
+  local job = self:_dispatch(payload, {
+    callback = function(err, data, adapter)
+      if adapter then
+        meta.adapter = adapter
+      end
       if err then
         had_error = true
         set_state("error")
@@ -115,7 +206,6 @@ function Client:send(payload, opts)
 
       local is_streaming = self.adapter and self.adapter.opts and self.adapter.opts.stream
 
-      -- Streaming chunks (no final response table is delivered here on success)
       if is_streaming then
         if data and data ~= "" then
           set_state("streaming")
@@ -176,94 +266,46 @@ function Client:send(payload, opts)
   return handle
 end
 
----Synchronous request API
+---Send a payload and block until the single response returns
 ---@param payload { messages: table, tools?: table }
 ---@param opts { stream?: false, timeout?: number, silent?: boolean }|nil
 ---@return table|nil, table|nil  -- response, err
-function Client:send_sync(payload, opts)
+function Client:fetch(payload, opts)
   opts = opts or {}
-  -- We do not support stream in sync mode
-  -- if self.adapter and self.adapter.opts and self.adapter.opts.stream then
-  --   return nil, { message = "send_sync does not support streaming adapters", stderr = "stream=true" }
-  -- end
 
-  local adapter = vim.deepcopy(self.adapter)
-
-  local ok = adapters.call_handler(adapter, "setup")
-  if ok == false then
+  local adapter = prepare_adapter(self)
+  if not adapter then
     return nil, { message = "Failed to setup adapter", stderr = "setup=false" }
   end
 
-  adapter = adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
+  local body = encode_body(self, adapter, payload)
 
-  local body = self.methods.encode(
-    vim.tbl_extend(
-      "keep",
-      adapters.call_handler(
-        adapter,
-        "build_parameters",
-        adapter_utils.set_env_vars(adapter, adapter.parameters),
-        payload.messages
-      ) or {},
-      adapters.call_handler(adapter, "build_messages", payload.messages) or {},
-      adapters.call_handler(adapter, "build_tools", payload.tools) or {},
-      adapter.body and adapter.body or {},
-      adapters.call_handler(adapter, "build_body", payload) or {}
-    )
-  )
+  local body_file = vim.fn.tempname() .. ".json"
+  files.write_to_path(body_file, body)
 
-  local body_file = Path.new(vim.fn.tempname() .. ".json")
-  body_file:write(vim.split(body, "\n"), "w")
-
-  local raw = {
-    "--retry",
-    "3",
-    "--retry-delay",
-    "1",
-    "--keepalive-time",
-    "60",
-    "--connect-timeout",
-    "10",
-  }
+  local raw = curl_args()
 
   if adapter.raw then
     vim.list_extend(raw, adapter_utils.set_env_vars(adapter, adapter.raw))
   end
 
   local headers_file = write_headers_file(adapter_utils.set_env_vars(adapter, adapter.headers))
-  vim.list_extend(raw, { "--header", "@" .. headers_file.filename })
-
-  local function cleanup_file()
-    if vim.tbl_contains({ "ERROR", "INFO" }, config.opts.log_level) then
-      body_file:rm()
-      headers_file:rm()
-    end
-  end
+  vim.list_extend(raw, { "--header", "@" .. headers_file })
 
   local request_opts = {
-    url = adapter_utils.set_env_vars(adapter, adapter.url),
+    body = body_file or "",
     insecure = config.adapters.http.opts.allow_insecure,
     proxy = config.adapters.http.opts.proxy,
     raw = raw,
-    body = body_file.filename or "",
     timeout = opts.timeout,
+    url = adapter_utils.set_env_vars(adapter, adapter.url),
   }
 
-  local method = "post"
-  if adapter.opts and adapter.opts.method then
-    method = adapter.opts.method:lower()
-  end
+  local method = resolve_method(adapter)
 
-  -- Emit start event (optional)
   local event_opts = {
+    adapter = adapter_event_data(adapter),
     id = tostring(math.random(10000000)),
-    adapter = {
-      name = adapter.name,
-      formatted_name = adapter.formatted_name,
-      model = type(adapter.schema.model.default) == "function" and adapter.schema.model.default(adapter)
-        or adapter.schema.model.default
-        or "",
-    },
   }
   if not opts.silent then
     utils.fire("RequestStarted", event_opts)
@@ -288,20 +330,20 @@ function Client:send_sync(payload, opts)
     utils.fire("RequestFinished", event_opts)
   end
 
-  cleanup_file()
+  delete_temp_files({ body = body_file, headers = headers_file })
   return response, err
 end
 
 ---@class CodeCompanion.HTTPAdapter.RequestActions
----@field callback fun(err: nil|table, chunk: nil|table) Callback function, executed when the request has finished or is called multiple times if the request is streaming
+---@field callback fun(err: nil|table, chunk: nil|table, adapter?: CodeCompanion.HTTPAdapter) Callback function, executed when the request has finished or is called multiple times if the request is streaming
 ---@field done? fun() Function to run when the request is complete
 
----Send a HTTP request (legacy interface). Kept for backwards compatibility.
----@param payload { messages: table, tools: table|nil } The payload to be sent to the endpoint
+---Build the request, initiate curl and stream
+---@param payload { messages: table, tools: table|nil }
 ---@param actions CodeCompanion.HTTPAdapter.RequestActions
----@param opts? table Options that can be passed to the request
+---@param opts? table
 ---@return table|nil The Plenary job
-function Client:request(payload, actions, opts)
+function Client:_dispatch(payload, actions, opts)
   -- Check if the adapter has a custom request function and use it instead
   if
     self.adapter
@@ -315,47 +357,19 @@ function Client:request(payload, actions, opts)
   opts = opts or {}
   local cb = log:wrap_cb(actions.callback, "Response error: %s") --[[@type function]]
 
-  -- Make a copy of the adapter to ensure that we replace variables in every request
-  local adapter = vim.deepcopy(self.adapter)
-
-  local ok = adapters.call_handler(adapter, "setup")
-  if ok == false then
+  local adapter = prepare_adapter(self)
+  if not adapter then
     return log:error("Failed to setup adapter")
   end
 
-  adapter = adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
+  local body = encode_body(self, adapter, payload)
 
-  local body = self.methods.encode(
-    vim.tbl_extend(
-      "keep",
-      adapters.call_handler(
-        adapter,
-        "build_parameters",
-        adapter_utils.set_env_vars(adapter, adapter.parameters),
-        payload.messages
-      ) or {},
-      adapters.call_handler(adapter, "build_messages", payload.messages) or {},
-      adapters.call_handler(adapter, "build_tools", payload.tools) or {},
-      adapter.body and adapter.body or {},
-      adapters.call_handler(adapter, "build_body", payload) or {}
-    )
-  )
+  local body_file = vim.fn.tempname() .. ".json"
+  files.write_to_path(body_file, body)
 
-  local body_file = Path.new(vim.fn.tempname() .. ".json")
-  body_file:write(vim.split(body, "\n"), "w")
+  log:info("Request body file: %s", body_file)
 
-  log:info("Request body file: %s", body_file.filename)
-
-  local raw = {
-    "--retry",
-    "3",
-    "--retry-delay",
-    "1",
-    "--keepalive-time",
-    "60",
-    "--connect-timeout",
-    "10",
-  }
+  local raw = curl_args()
 
   if adapter.opts and adapter.opts.stream then
     table.insert(raw, "--tcp-nodelay")
@@ -367,14 +381,7 @@ function Client:request(payload, actions, opts)
   end
 
   local headers_file = write_headers_file(adapter_utils.set_env_vars(adapter, adapter.headers))
-  vim.list_extend(raw, { "--header", "@" .. headers_file.filename })
-
-  local function cleanup(status)
-    if vim.tbl_contains({ "ERROR", "INFO" }, config.opts.log_level) and status ~= "error" then
-      body_file:rm()
-      headers_file:rm()
-    end
-  end
+  vim.list_extend(raw, { "--header", "@" .. headers_file })
 
   -- Capture streaming errors for use in final callback
   local stream_error_body = nil
@@ -384,7 +391,7 @@ function Client:request(payload, actions, opts)
     insecure = config.adapters.http.opts.allow_insecure,
     proxy = config.adapters.http.opts.proxy,
     raw = raw,
-    body = body_file.filename or "",
+    body = body_file or "",
     -- Final callback invoked when HTTP request is complete
     callback = function(data)
       self.methods.schedule(function()
@@ -412,7 +419,7 @@ function Client:request(payload, actions, opts)
         if not opts.silent then
           utils.fire("RequestFinished", opts)
         end
-        cleanup(opts.status)
+        delete_temp_files({ body = body_file, headers = headers_file }, opts.status)
         if self.user_args.event then
           if not opts.silent then
             utils.fire(self.user_args.event, opts)
@@ -440,7 +447,6 @@ function Client:request(payload, actions, opts)
     request_opts["stream"] = self.methods.schedule_wrap(function(_, data)
       if data and data ~= "" then
         log:debug("Output data:\n%s", data)
-        -- Capture error responses that come through the stream (various API formats)
         if data:match('^%s*{"error"') or data:match('^%s*{"type"%s*:%s*"error"') then
           stream_error_body = data
           return -- Don't pass error to cb, handle in final callback
@@ -456,22 +462,10 @@ function Client:request(payload, actions, opts)
     end)
   end
 
-  local request_method = "post"
-  if adapter.opts and adapter.opts.method then
-    request_method = adapter.opts.method:lower()
-  end
+  local job = self.methods[resolve_method(adapter)](request_opts)
 
-  local job = self.methods[request_method](request_opts)
-
-  -- Data to be sent via the request
   opts.id = opts.id or math.random(10000000)
-  opts.adapter = {
-    name = adapter.name,
-    formatted_name = adapter.formatted_name,
-    model = type(adapter.schema.model.default) == "function" and adapter.schema.model.default(adapter)
-      or adapter.schema.model.default
-      or "",
-  }
+  opts.adapter = adapter_event_data(adapter)
 
   if not opts.silent then
     utils.fire("RequestStarted", opts)
@@ -486,7 +480,6 @@ function Client:request(payload, actions, opts)
     end
   end
 
-  -- Unify the API across the plugin
   job.cancel = function()
     job:shutdown()
   end

--- a/lua/codecompanion/interactions/background/init.lua
+++ b/lua/codecompanion/interactions/background/init.lua
@@ -88,7 +88,7 @@ local function ask_sync(background, messages, opts)
   }
 
   log:debug("[background::init] Ask Sync Payload:\n%s", payload)
-  local response, err = client:send_sync(payload, { silent = opts.silent })
+  local response, err = client:fetch(payload, { silent = opts.silent })
 
   if err then
     log:debug("[background::init] ask_sync failed: %s", err.stderr or err.message)
@@ -133,7 +133,7 @@ local function ask_async(background, messages, opts)
   end
 
   log:trace("[background::init] Ask Async Payload:\n%s", payload)
-  return client:send(payload, opts)
+  return client:stream(payload, opts)
 end
 
 ---Ask the LLM for a specific response

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1248,7 +1248,7 @@ function Chat:_submit_http(payload)
     end
   end
 
-  local handle = get_client(adapter).new({ adapter = mapped_settings }):send(payload, {
+  local handle = get_client(adapter).new({ adapter = mapped_settings }):stream(payload, {
     on_chunk = function(data)
       process_chunk(data)
     end,

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/fetch.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/fetch.lua
@@ -320,44 +320,44 @@ local function fetch(chat, adapter, url, opts)
     .new({
       adapter = adapter,
     })
-    :request({ url = url }, {
-      callback = function(err, data)
-        if err then
-          return log:error("Failed to fetch the URL, with error %s", err)
+    :stream({ url = url }, {
+      on_error = function(err)
+        return log:error("Failed to fetch the URL, with error %s", err)
+      end,
+      on_done = function(data)
+        if not data then
+          return
+        end
+        local body = adapter.methods.slash_commands.fetch.callback(adapter, data)
+
+        if body.status == "error" then
+          return log:error("Error fetching URL: %s", body.content)
         end
 
-        if data then
-          local body = adapter.methods.slash_commands.fetch.callback(adapter, data)
+        output(chat, {
+          content = body.content,
+          url = url,
+        }, opts)
 
-          if body.status == "error" then
-            return log:error("Error fetching URL: %s", body.content)
+        -- Cache the response
+        -- TODO: Get an LLM to create summary
+        vim.ui.select({ "Yes", "No" }, {
+          prompt = "Do you want to cache this URL?",
+          kind = "codecompanion.nvim",
+        }, function(selected)
+          if selected == "Yes" then
+            local hash = hash_utils.hash(url)
+            write_cache(
+              hash,
+              vim.json.encode({
+                url = url,
+                hash = hash,
+                timestamp = os.time(),
+                data = body.content,
+              })
+            )
           end
-
-          output(chat, {
-            content = body.content,
-            url = url,
-          }, opts)
-
-          -- Cache the response
-          -- TODO: Get an LLM to create summary
-          vim.ui.select({ "Yes", "No" }, {
-            prompt = "Do you want to cache this URL?",
-            kind = "codecompanion.nvim",
-          }, function(selected)
-            if selected == "Yes" then
-              local hash = hash_utils.hash(url)
-              write_cache(
-                hash,
-                vim.json.encode({
-                  url = url,
-                  hash = hash,
-                  timestamp = os.time(),
-                  data = body.content,
-                })
-              )
-            end
-          end)
-        end
+        end)
       end,
     })
 end

--- a/lua/codecompanion/interactions/chat/tools/builtin/fetch_webpage.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/fetch_webpage.lua
@@ -45,22 +45,22 @@ return {
         .new({
           adapter = adapter,
         })
-        :request({ messages = {}, tools = nil }, {
-          callback = function(err, data)
-            if err then
-              log:error("[Fetch Webpage Tool] Error fetching `%s`: %s", url, err)
-              return cb({ status = "error", data = fmt("Error fetching `%s`\n%s", url, err) })
+        :stream({ messages = {}, tools = nil }, {
+          on_error = function(err)
+            log:error("[Fetch Webpage Tool] Error fetching `%s`: %s", url, err)
+            return cb({ status = "error", data = fmt("Error fetching `%s`\n%s", url, err) })
+          end,
+          on_done = function(data)
+            if not data then
+              return
+            end
+            local output = adapter.methods.tools.fetch_webpage.callback(adapter, data)
+            if output.status == "error" then
+              log:error("[Fetch Webpage Tool] Error processing data for `%s`: %s", url, output.content)
+              return cb({ status = "error", data = fmt("Error processing `%s`\n%s", url, output.content) })
             end
 
-            if data then
-              local output = adapter.methods.tools.fetch_webpage.callback(adapter, data)
-              if output.status == "error" then
-                log:error("[Fetch Webpage Tool] Error processing data for `%s`: %s", url, output.content)
-                return cb({ status = "error", data = fmt("Error processing `%s`\n%s", url, output.content) })
-              end
-
-              return cb({ status = "success", data = output.content })
-            end
+            return cb({ status = "success", data = output.content })
           end,
         })
     end,

--- a/lua/codecompanion/interactions/chat/tools/builtin/web_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/web_search.lua
@@ -39,24 +39,27 @@ return {
 
       local query = args.query
 
+      local function resolve(data)
+        if not data then
+          return
+        end
+        local output = adapter.methods.tools.web_search.callback(adapter, data)
+        if output.status == "error" then
+          log:error([[[Web Search Tool] Error searching for "%s"]], query)
+          return cb({ status = "error", data = fmt([[Error searching for "%s" %s]], query, output.content) })
+        end
+
+        return cb({ status = "success", data = output.content })
+      end
+
       client
         .new({
           adapter = adapter,
         })
-        :request({ query = query, domains = args.domains }, {
-          callback = function(err, data)
-            local error_message = [[Error searching for "%s"]]
-            local error_message_expanded = error_message .. " %s"
-
-            if data then
-              local output = adapter.methods.tools.web_search.callback(adapter, data)
-              if output.status == "error" then
-                log:error("[Web Search Tool] " .. error_message, query)
-                return cb({ status = "error", data = fmt(error_message_expanded, query, output.content) })
-              end
-
-              return cb({ status = "success", data = output.content })
-            end
+        :stream({ query = query, domains = args.domains }, {
+          on_done = resolve,
+          on_error = function(err)
+            resolve(err and err.stderr)
           end,
         })
     end,

--- a/lua/codecompanion/interactions/cmd.lua
+++ b/lua/codecompanion/interactions/cmd.lua
@@ -53,30 +53,28 @@ function Cmd:start()
     table.insert(messages, p)
   end)
 
+  -- The command is parsed from a single response, so we don't stream it back
+  self.adapter.opts.stream = false
+
   client
     .new({ adapter = self.adapter:map_schema_to_params() })
-    :request({ messages = self.adapter:map_roles(messages) }, {
-      ---@param err string
-      ---@param data table
-      ---@param adapter CodeCompanion.HTTPAdapter The modified adapter from the http client
-      callback = function(err, data, adapter)
-        if err then
-          return log:error(err)
-        end
-
-        if data then
-          local result = adapters.call_handler(adapter, "parse_chat", data)
-          if result and result.output and result.output.content then
-            local content = result.output.content
-            content:gsub("^%s*(.-)%s*$", "%1")
-            vim.api.nvim_feedkeys(content, "n", false)
-          end
-        end
-      end,
-      done = function() end,
-    }, {
+    :stream({ messages = self.adapter:map_roles(messages) }, {
       bufnr = self.buffer_context.bufnr,
       interaction = "cmd",
+      on_error = function(err)
+        return log:error(err)
+      end,
+      on_done = function(data, meta)
+        if not data then
+          return
+        end
+        local result = adapters.call_handler(meta.adapter, "parse_chat", data)
+        if result and result.output and result.output.content then
+          local content = result.output.content
+          content:gsub("^%s*(.-)%s*$", "%1")
+          vim.api.nvim_feedkeys(content, "n", false)
+        end
+      end,
     })
 end
 

--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -427,33 +427,25 @@ function Inline:submit(prompt)
 
   self.current_request = client
     .new({ adapter = self.adapter:map_schema_to_params(), user_args = { event = "InlineStarted" } })
-    :request({ messages = self.adapter:map_roles(prompt) }, {
-      ---@param err string
-      ---@param data table
-      ---@param adapter CodeCompanion.HTTPAdapter The modified adapter from the http client
-      callback = function(err, data, adapter)
-        local function error(msg)
-          log:error("[Inline] Request failed with error %s", msg)
-        end
-
-        if err then
-          local msg = type(err) == "table" and err.message or err
-          return error(msg)
-        end
-
-        if data then
-          data = adapters.call_handler(adapter, "parse_inline", data, self.buffer_context)
-          if data and data.status == CONSTANTS.STATUS_SUCCESS then
-            return self:done(data.output)
-          elseif data then
-            return error(data.output)
-          end
-        end
-      end,
-    }, {
+    :stream({ messages = self.adapter:map_roles(prompt) }, {
       bufnr = self.bufnr,
       buffer_context = self.buffer_context or {},
       interaction = "inline",
+      on_error = function(err)
+        local msg = type(err) == "table" and err.message or err
+        log:error("[Inline] Request failed with error %s", msg)
+      end,
+      on_done = function(data, meta)
+        if not data then
+          return
+        end
+        data = adapters.call_handler(meta.adapter, "parse_inline", data, self.buffer_context)
+        if data and data.status == CONSTANTS.STATUS_SUCCESS then
+          return self:done(data.output)
+        elseif data then
+          return log:error("[Inline] Request failed with error %s", data.output)
+        end
+      end,
     })
 end
 

--- a/tests/interactions/chat/tools/builtin/test_fetch_webpage.lua
+++ b/tests/interactions/chat/tools/builtin/test_fetch_webpage.lua
@@ -37,9 +37,9 @@ local T = new_set({
         package.loaded["codecompanion.http"] = {
           new = function()
             return {
-              request = function(_, __, handlers)
+              stream = function(_, __, opts)
                 vim.schedule(function()
-                  handlers.callback(nil, { html = "Hello World content" })
+                  opts.on_done({ html = "Hello World content" })
                 end)
               end
             }

--- a/tests/interactions/chat/tools/builtin/test_web_search.lua
+++ b/tests/interactions/chat/tools/builtin/test_web_search.lua
@@ -37,9 +37,9 @@ local T = new_set({
         package.loaded["codecompanion.http"] = {
           new = function()
             return {
-              request = function(_, __, handlers)
+              stream = function(_, __, opts)
                 vim.schedule(function()
-                  handlers.callback(nil, {
+                  opts.on_done({
                     results = {
                       {
                         url = "https://example.com/result1",

--- a/tests/mocks/http.lua
+++ b/tests/mocks/http.lua
@@ -41,7 +41,7 @@ function MockHTTPClient.new(args)
   }, { __index = MockHTTPClient })
 end
 
----Queue a response to be returned on the next send/send_sync call
+---Queue a response to be returned on the next stream/fetch call
 ---@param response table The mock response
 ---@return nil
 function MockHTTPClient:queue_response(response)
@@ -58,28 +58,29 @@ end
 ---@param payload table
 ---@param opts table
 ---@return CodeCompanion.HTTPClient.RequestHandle
-function MockHTTPClient:send(payload, opts)
+function MockHTTPClient:stream(payload, opts)
   opts = opts or {}
   table.insert(self.requests, { type = "async", payload = payload, opts = opts })
 
   local response = self:dequeue_response()
   local handle_state = "pending"
+  local meta = { id = "mock", adapter = self.adapter }
 
   vim.schedule(function()
     if response then
       if opts.on_chunk and response.stream then
         for _, chunk in ipairs(response.stream) do
-          opts.on_chunk(chunk, { id = "mock" })
+          opts.on_chunk(chunk, meta)
         end
       end
       handle_state = "success"
       if opts.on_done then
-        opts.on_done(response, { id = "mock" })
+        opts.on_done(response, meta)
       end
     else
       handle_state = "error"
       if opts.on_error then
-        opts.on_error({ message = "No queued response" }, { id = "mock" })
+        opts.on_error({ message = "No queued response" }, meta)
       end
     end
   end)
@@ -101,7 +102,7 @@ end
 ---@param payload table
 ---@param opts table
 ---@return table|nil, table|nil
-function MockHTTPClient:send_sync(payload, opts)
+function MockHTTPClient:fetch(payload, opts)
   opts = opts or {}
   table.insert(self.requests, { type = "sync", payload = payload, opts = opts })
 

--- a/tests/test_http.lua
+++ b/tests/test_http.lua
@@ -80,7 +80,7 @@ T["can call POST API endpoint"] = function()
   child.lua([[
     local adapter = __make_adapter()
     local cb = function() end
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
   ]])
 
   h.eq(child.lua_get([[_G.__calls.post]]), 1)
@@ -90,7 +90,7 @@ T["substitutes variables in url, headers, and raw"] = function()
   child.lua([[
     local adapter = __make_adapter()
     local cb = function() end
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
   ]])
 
   h.eq(child.lua_get([[ _G.__last_request_opts.url ]]), "https://api.openai.com/v1/chat/completions")
@@ -113,7 +113,7 @@ T["writes headers to a temp file with one header per line"] = function()
   child.lua([[
     local adapter = __make_adapter()
     local cb = function() end
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
   ]])
 
   -- Headers must not appear as process args
@@ -138,7 +138,7 @@ T["adds streaming flags and stream handler when stream=true"] = function()
   child.lua([[
     local adapter = __make_adapter({ opts = { method = "POST", stream = true, compress = false } })
     local cb = function() end
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
   ]])
 
   h.eq(child.lua_get([[ type(_G.__last_request_opts.stream) ]]), "function")
@@ -154,7 +154,7 @@ T["dispatches GET when method is GET"] = function()
   child.lua([[
     local adapter = __make_adapter({ opts = { method = "GET", stream = false } })
     local cb = function() end
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
   ]])
 
   h.eq(child.lua_get([[_G.__calls.get]]), 1)
@@ -176,7 +176,7 @@ T["invokes on_error callback with error"] = function()
     local cb = function(err, _)
       err_received = err and err.message or nil
     end
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
 
     return { err_received = err_received }
   ]])
@@ -204,7 +204,7 @@ T["calls done then emits error callback for HTTP status >= 400"] = function()
     local done_called = false
     local done = function() done_called = true end
 
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb, done = done }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb, done = done }, {})
 
     return { callback_calls = callback_calls, done_called = done_called, err_received = err_received }
   ]])
@@ -214,7 +214,7 @@ T["calls done then emits error callback for HTTP status >= 400"] = function()
   h.eq(result.err_received, "500 error: ")
 end
 
-T["send_sync returns response on success"] = function()
+T["fetch returns response on success"] = function()
   local result = child.lua([[
     -- Override POST to return a synchronous success response
     _G.Client.static.methods.post = {
@@ -225,7 +225,7 @@ T["send_sync returns response on success"] = function()
     }
 
     local adapter = __make_adapter({ opts = { method = "POST", stream = false } })
-    local resp, err = Client.new({ adapter = adapter }):send_sync({ messages = {}, tools = {} }, { stream = false, silent = true, timeout = 100 })
+    local resp, err = Client.new({ adapter = adapter }):fetch({ messages = {}, tools = {} }, { stream = false, silent = true, timeout = 100 })
 
     return {
       body = resp and resp.body or nil,
@@ -241,7 +241,7 @@ T["send_sync returns response on success"] = function()
   h.eq(result.err_is_nil, true)
 end
 
-T["send_sync returns error on HTTP status >= 400"] = function()
+T["fetch returns error on HTTP status >= 400"] = function()
   local result = child.lua([[
     -- Override POST to return a synchronous 500 response
     _G.Client.static.methods.post = {
@@ -252,7 +252,7 @@ T["send_sync returns error on HTTP status >= 400"] = function()
     }
 
     local adapter = __make_adapter({ opts = { method = "POST", stream = false } })
-    local resp, err = Client.new({ adapter = adapter }):send_sync({ messages = {}, tools = {} }, { stream = false, silent = true, timeout = 100 })
+    local resp, err = Client.new({ adapter = adapter }):fetch({ messages = {}, tools = {} }, { stream = false, silent = true, timeout = 100 })
 
     return {
       err_message = err and err.message or nil,
@@ -266,7 +266,7 @@ T["send_sync returns error on HTTP status >= 400"] = function()
   h.eq(result.err_message, "500 error: ")
 end
 
-T["send_sync returns error when curl call fails"] = function()
+T["fetch returns error when curl call fails"] = function()
   local result = child.lua([[
     -- Override POST to simulate a thrown error in curl
     _G.Client.static.methods.post = {
@@ -277,7 +277,7 @@ T["send_sync returns error when curl call fails"] = function()
     }
 
     local adapter = __make_adapter({ opts = { method = "POST", stream = false } })
-    local resp, err = Client.new({ adapter = adapter }):send_sync({ messages = {}, tools = {} }, { stream = false, silent = true, timeout = 100 })
+    local resp, err = Client.new({ adapter = adapter }):fetch({ messages = {}, tools = {} }, { stream = false, silent = true, timeout = 100 })
 
     return {
       err_message = err and err.message or nil,
@@ -309,7 +309,7 @@ T["handles nil data with captured stream error"] = function()
       if err then err_received = err.message end
     end
 
-    Client.new({ adapter = adapter }):request({ messages = {}, tools = {} }, { callback = cb }, {})
+    Client.new({ adapter = adapter }):_dispatch({ messages = {}, tools = {} }, { callback = cb }, {})
 
     return { err_received = err_received }
   ]])


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Refactor the http client (`http.lua`), renaming the three methods that comprise it and extracting some fuctions along the way. Also took the opportunity to fix some issues with the cmd interaction and the `web_search` tool if no API key is present.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 4.8 and Claude Code

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
