### PR TITLE
fix(chat): handle model override for ACP adapters

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,5 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 June 23
+*codecompanion.txt*
+                                   For NVIM v0.11    Last change: 2026 June 28
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -881,7 +882,7 @@ CURRENT LIMITATIONS                    *codecompanion-acp-current-limitations*
     `terminal/output`, `terminal/release`, etc.) are not implemented. CodeCompanion
     doesn't advertise terminal capabilities to agents.
 - **Agent Plan Rendering**: Plan
-    <https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
+<https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
     received and logged, but they're not currently rendered in the chat buffer UI.
 - **Audio Content**: Audio can't be sent or received
 

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -130,7 +130,12 @@ CodeCompanion.chat = function(args)
     adapter = config.adapters.http[adapter_name] or config.adapters.acp[adapter_name]
     adapter = require("codecompanion.adapters").resolve(adapter)
     if args.params.model then
-      adapter.schema.model.default = args.params.model
+      if adapter.schema and adapter.schema.model then
+        adapter.schema.model.default = args.params.model
+      elseif adapter.type == "acp" then
+        adapter.defaults = adapter.defaults or {}
+        adapter.defaults.model = args.params.model
+      end
     end
     if adapter.type == "acp" and args.params.command then
       acp_command = args.params.command

--- a/tests/test_cmds.lua
+++ b/tests/test_cmds.lua
@@ -477,4 +477,48 @@ T["cmds_pertab"]["closing a tab leaves its chat in the hidden pool, available to
   h.eq(true, child.lua_get("require('codecompanion.interactions.shared.registry').get(_G.tab2_bufnr) ~= nil"))
 end
 
+T["cmds_acp"] = new_set({
+  hooks = {
+    pre_once = function()
+      h.child_start(child)
+      child.lua([[
+        h = require('tests.helpers')
+        config = require('codecompanion.config')
+        config.adapters = config.adapters or {}
+        config.adapters.acp = config.adapters.acp or {}
+        config.adapters.acp.test_acp = {
+          name = "test_acp",
+          type = "acp",
+          command = { "node", "test-agent.js" },
+          roles = { user = "user", assistant = "assistant" },
+        }
+        config.rules.opts.chat.enabled = false
+        h.setup_plugin(config)
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["cmds_acp"]["chat with model param on ACP adapter"] = function()
+  child.lua([[
+    local CC = require('codecompanion')
+
+    local ok, err = pcall(CC.chat, { params = { adapter = "test_acp", model = "sonnet" } })
+
+    _G.test_acp_ok = ok
+    if not ok then
+      _G.test_acp_err = tostring(err)
+    end
+
+    local chat = CC.last_chat()
+    if chat and chat.adapter then
+      _G.acp_adapter_model = chat.adapter.defaults and chat.adapter.defaults.model
+    end
+  ]])
+
+  h.expect_truthy(child.lua_get("_G.test_acp_ok"))
+  h.eq("sonnet", child.lua_get("_G.acp_adapter_model"))
+end
+
 return T


### PR DESCRIPTION

<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

When trying to start a chat with ACP adapter and specify the model:
```
:CodeCompanionChat adapter=opencode model=opencode/big-pickle
```

codecompanion crashes with error:

```lua
  Lua :command callback: ...k/core/opt/codecompanion.nvim/lua/codecompanion/init.lua:133: attempt to index field 'schema' (a nil value)
  stack traceback:
    ...k/core/opt/codecompanion.nvim/lua/codecompanion/init.lua:133: in function 'chat'
    ...t/codecompanion.nvim/lua/codecompanion/commands/init.lua:164: in function <...t/codecompanion.nvim/lua/codecompanion/commands/init.lua:139>
```

ACP adapters (opencode for example) lack a schema property, so adapter.schema.model.default assignment crashes with attempt to index field schema (a nil value).

Fix: check for schema presence first, fall back to adapter.defaults.model for ACP adapters.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

opencode's big pickle

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
