### PR TITLE
feat(adapters): display reasoning effort for `openrouter` models

### DIFF
--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -18,7 +18,6 @@ local _cache_expires
 local _cache_file = vim.fn.tempname()
 local _cached_models
 
----Get a list of available models
 ---@params self CodeCompanion.HTTPAdapter
 ---@params opts? table
 ---@return table
@@ -66,8 +65,10 @@ local function get_models()
       supported_parameters = supported,
       can_use_tools = supported.tools or false,
       can_reason = supported.reasoning or false,
-      reasoning_efforts = model.reasoning and model.reasoning.supported_efforts or nil,
-      reasoning_default_effort = model.reasoning and model.reasoning.default_effort or nil,
+      reasoning = model.reasoning and {
+        default = model.reasoning.default_effort,
+        supported = model.reasoning.supported_efforts,
+      } or nil,
     }
     if model.architecture and model.architecture.input_modalities then
       choice_opts.has_vision = vim.tbl_contains(model.architecture.input_modalities, "image")
@@ -86,7 +87,14 @@ local function get_models()
   return models
 end
 
----Check whether the currently selected model supports the given parameter
+---@param self CodeCompanion.HTTPAdapter
+---@return table|nil
+local function model_choices(self)
+  local cached_models = get_models()
+  local model = cached_models[self.schema.model.default]
+  return model and model.opts or nil
+end
+
 ---@param self CodeCompanion.HTTPAdapter
 ---@param parameter string
 ---@return boolean
@@ -98,15 +106,6 @@ local function model_supports(self, parameter)
   end
 
   return model.opts.supported_parameters[parameter] or false
-end
-
----Get the opts table for the currently selected model
----@param self CodeCompanion.HTTPAdapter
----@return table|nil
-local function current_model_opts(self)
-  local cached_models = get_models()
-  local model = cached_models[self.schema.model.default]
-  return model and model.opts or nil
 end
 
 ---@class CodeCompanion.HTTPAdapter.OpenRouter: CodeCompanion.HTTPAdapter
@@ -185,12 +184,11 @@ return {
       end
 
       -- Some models only support a subset of reasoning efforts, or, none at all
-      local reasoning_opts = model_opts and model_opts.opts
-      if reasoning_opts and reasoning_opts.reasoning_efforts and self.parameters.reasoning then
+      local reasoning = model_opts and model_opts.opts and model_opts.opts.reasoning
+      if reasoning and reasoning.supported and self.parameters.reasoning then
         local effort = self.parameters.reasoning.effort
-        if not vim.tbl_contains(reasoning_opts.reasoning_efforts, effort) then
-          self.parameters.reasoning.effort = reasoning_opts.reasoning_default_effort
-            or reasoning_opts.reasoning_efforts[1]
+        if not vim.tbl_contains(reasoning.supported, effort) then
+          self.parameters.reasoning.effort = reasoning.default or reasoning.supported[1]
         end
       end
 
@@ -402,8 +400,8 @@ return {
       ---@param self CodeCompanion.HTTPAdapter
       ---@return string
       default = function(self)
-        local model_opts = current_model_opts(self)
-        return (model_opts and model_opts.reasoning_default_effort) or "medium"
+        local choices = model_choices(self)
+        return (choices and choices.reasoning and choices.reasoning.default) or "medium"
       end,
       enabled = function(self)
         return model_supports(self, "reasoning")
@@ -412,18 +410,11 @@ return {
       ---@param self CodeCompanion.HTTPAdapter
       ---@return string[]
       choices = function(self)
-        local model_opts = current_model_opts(self)
-        if model_opts and model_opts.reasoning_efforts then
-          return model_opts.reasoning_efforts
+        local choices = model_choices(self)
+        if choices and choices.reasoning and choices.reasoning.supported then
+          return choices.reasoning.supported
         end
-        return {
-          "xhigh",
-          "high",
-          "medium",
-          "low",
-          "minimal",
-          "none",
-        }
+        return { "xhigh", "high", "medium", "low", "minimal", "none" }
       end,
     },
     temperature = {

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -66,6 +66,8 @@ local function get_models()
       supported_parameters = supported,
       can_use_tools = supported.tools or false,
       can_reason = supported.reasoning or false,
+      reasoning_efforts = model.reasoning and model.reasoning.supported_efforts or nil,
+      reasoning_default_effort = model.reasoning and model.reasoning.default_effort or nil,
     }
     if model.architecture and model.architecture.input_modalities then
       choice_opts.has_vision = vim.tbl_contains(model.architecture.input_modalities, "image")
@@ -96,6 +98,15 @@ local function model_supports(self, parameter)
   end
 
   return model.opts.supported_parameters[parameter] or false
+end
+
+---Get the opts table for the currently selected model
+---@param self CodeCompanion.HTTPAdapter
+---@return table|nil
+local function current_model_opts(self)
+  local cached_models = get_models()
+  local model = cached_models[self.schema.model.default]
+  return model and model.opts or nil
 end
 
 ---@class CodeCompanion.HTTPAdapter.OpenRouter: CodeCompanion.HTTPAdapter
@@ -171,6 +182,16 @@ return {
       end
       if (self.opts and self.opts.vision) and (model_opts and model_opts.opts and not model_opts.opts.has_vision) then
         self.opts.vision = false
+      end
+
+      -- Some models only support a subset of reasoning efforts, or, none at all
+      local reasoning_opts = model_opts and model_opts.opts
+      if reasoning_opts and reasoning_opts.reasoning_efforts and self.parameters.reasoning then
+        local effort = self.parameters.reasoning.effort
+        if not vim.tbl_contains(reasoning_opts.reasoning_efforts, effort) then
+          self.parameters.reasoning.effort = reasoning_opts.reasoning_default_effort
+            or reasoning_opts.reasoning_efforts[1]
+        end
       end
 
       return true
@@ -378,19 +399,32 @@ return {
       mapping = "parameters",
       type = "string",
       optional = true,
-      default = "medium",
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return string
+      default = function(self)
+        local model_opts = current_model_opts(self)
+        return (model_opts and model_opts.reasoning_default_effort) or "medium"
+      end,
       enabled = function(self)
         return model_supports(self, "reasoning")
       end,
-      desc = "Constrains effort on reasoning for reasoning models. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.",
-      choices = {
-        "xhigh",
-        "high",
-        "medium",
-        "low",
-        "minimal",
-        "none",
-      },
+      desc = "Constrains effort on reasoning for reasoning models. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response. Not all efforts are supported by every model.",
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return string[]
+      choices = function(self)
+        local model_opts = current_model_opts(self)
+        if model_opts and model_opts.reasoning_efforts then
+          return model_opts.reasoning_efforts
+        end
+        return {
+          "xhigh",
+          "high",
+          "medium",
+          "low",
+          "minimal",
+          "none",
+        }
+      end,
     },
     temperature = {
       order = 3,

--- a/lua/codecompanion/interactions/chat/debug.lua
+++ b/lua/codecompanion/interactions/chat/debug.lua
@@ -215,6 +215,10 @@ function Debug:render()
           formatted_key = '["' .. key .. '"]'
         end
 
+        if type(val) == "function" then
+          val = val(self.adapter)
+        end
+
         if key == "model" then
           local other_models = " -- "
 
@@ -227,21 +231,35 @@ function Debug:render()
             end
           end)
 
-          if type(val) == "function" then
-            val = val(self.adapter)
-          end
           if vim.tbl_count(models) > 1 then
             table.insert(lines, "  " .. formatted_key .. ' = "' .. val .. '", ' .. other_models)
           else
             table.insert(lines, "  " .. formatted_key .. ' = "' .. val .. '",')
           end
+        elseif type(val) == "string" and adapter.schema[key] and adapter.schema[key].choices then
+          local choices = adapter.schema[key].choices
+          if type(choices) == "function" then
+            choices = choices(self.adapter)
+          end
+
+          local other_choices = vim
+            .iter(choices)
+            :map(function(choice, choice_name)
+              return type(choice) == "number" and choice_name or choice
+            end)
+            :filter(function(choice)
+              return choice ~= val
+            end)
+            :totable()
+
+          local line = "  " .. formatted_key .. ' = "' .. val .. '",'
+          if #other_choices > 0 then
+            line = line .. ' -- "' .. table.concat(other_choices, '", "') .. '"'
+          end
+          table.insert(lines, line)
         elseif is_nil and current_settings[key] == nil then
           table.insert(lines, "  " .. formatted_key .. " = nil,")
         else
-          if type(val) == "function" then
-            val = val(self.adapter)
-          end
-
           if type(val) == "number" or type(val) == "boolean" then
             table.insert(lines, "  " .. formatted_key .. " = " .. tostring(val) .. ",")
           elseif type(val) == "string" then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Allow openrouter models' reasoning effort to be displayed to users in the debug window. Ensure that each model's supported efforts are reflected.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Sonnet 4.6

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
