### PR TITLE
feat(adapters): cleaner way to customise adapters

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 June 23
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 June 30
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1147,38 +1147,19 @@ This section contains configuration which is specific to Agent Client Protocol
 recommended you read the two pages together.
 
 
-ADAPTER SETTINGS ~
+CUSTOMISING AN ADAPTER ~
 
-To change any of the default settings for an ACP adapter, you can extend it in
-your CodeCompanion setup. For example, to change the timeout and authentication
-method for the Gemini CLI adapter, you can do the following:
+There are two ways to customise a preset adapter, and you'll see both
+throughout this page:
 
->lua
-    require("codecompanion").setup({
-      adapters = {
-        acp = {
-          gemini_cli = function()
-            return require("codecompanion.adapters").extend("gemini_cli", {
-              commands = {
-                default = {
-                  "some-other-gemini"
-                  "--experimental-acp",
-                },
-              },
-              defaults = {
-                auth_method = "gemini-api-key",
-                timeout = 20000, -- 20 seconds
-              },
-              env = {
-                GEMINI_API_KEY = "GEMINI_API_KEY",
-              },
-            })
-          end,
-        },
-      },
-    })
-<
+- **Function** - Use this for full or computed setups. Custom `commands`, `defaults`, or values resolved at call time
+- **extend table** - Use this for static overrides like credentials or setting a default value
 
+
+
+  [!IMPORTANT] The `extend` key is the adapter's name in the config
+  <https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua>,
+  not the resolved adapter name.
 
 SETTING A DEFAULT ADAPTER ~
 
@@ -1638,7 +1619,7 @@ HTTP ADAPTERS                      *codecompanion-configuration-http-adapters*
   <https://github.com/olimorris/codecompanion.nvim/discussions>
 An adapter is what connects Neovim to an LLM provider and model. It's the
 interface that allows data to be sent, received and processed. There are a
-multitude of ways to customize them.
+multitude of ways to customise them.
 
 There are two "types" of adapter in CodeCompanion; **http** adapters which
 connect you to an LLM and |codecompanion-configuration-adapters-acp| adapters
@@ -1681,6 +1662,20 @@ A core part of working with CodeCompanion is being able to easily switch
 between adapters and LLMs. Below are two examples of how this can be achieved.
 
 
+
+CUSTOMISING AN ADAPTER ~
+
+There are two ways to customise a preset adapter, and you'll see both
+throughout this page:
+
+- **Function** - Use this for full or computed setups. Custom `url`, `headers`, `schema`, or values resolved at call time
+- **extend table** - Use this for static overrides like credentials or setting a default value
+
+
+
+  [!IMPORTANT] The `extend` key is the adapter's name in the config
+  <https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua>,
+  not the resolved adapter name.
 
 CHANGING ADAPTER PARAMETERS (SCHEMA) ~
 

--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -6,35 +6,55 @@ description: "Configure Agent Client Protocol (ACP) adapters in CodeCompanion to
 
 This section contains configuration which is specific to Agent Client Protocol (ACP) adapters only. There is a lot of shared functionality between ACP and [http](/configuration/adapters-http) adapters. Therefore it's recommended you read the two pages together.
 
-## Configuring Adapter Settings
+## Customising an Adapter
 
-To change any of the default settings for an ACP adapter, you can extend it in your CodeCompanion setup. For example, to change the timeout and authentication method for the Gemini CLI adapter, you can do the following:
+There are two ways to customise a preset adapter, and you'll see both throughout this page:
 
-```lua
+- **Function** - Use this for full or computed setups. Custom `commands`, `defaults`, or values resolved at call time
+- **`extend` table** - Use this for static overrides like credentials or setting a default value
+
+::: code-group
+
+```lua [Function]
 require("codecompanion").setup({
   adapters = {
     acp = {
       gemini_cli = function()
         return require("codecompanion.adapters").extend("gemini_cli", {
           commands = {
-            default = {
-              "some-other-gemini"
-              "--experimental-acp",
-            },
+            default = { "some-other-gemini", "--experimental-acp" },
           },
           defaults = {
             auth_method = "gemini-api-key",
             timeout = 20000, -- 20 seconds
           },
-          env = {
-            GEMINI_API_KEY = "GEMINI_API_KEY",
-          },
+          env = { GEMINI_API_KEY = "cmd:op read op://personal/Gemini/credential --no-newline" },
         })
       end,
     },
   },
 })
 ```
+
+```lua [Extend Table]
+require("codecompanion").setup({
+  adapters = {
+    acp = {
+      extend = {
+        gemini_cli = {
+          defaults = { auth_method = "gemini-api-key" },
+          env = { GEMINI_API_KEY = "cmd:op read op://personal/Gemini/credential --no-newline" },
+        },
+      },
+    },
+  },
+})
+```
+
+:::
+
+> [!IMPORTANT]
+> The `extend` key is the adapter's name in the [config](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua), not the resolved adapter name.
 
 ## Setting a Default Adapter
 

--- a/doc/configuration/adapters-http.md
+++ b/doc/configuration/adapters-http.md
@@ -8,7 +8,7 @@ description: "Configure CodeCompanion's HTTP adapters to connect Neovim to OpenA
 > Want to connect to an LLM that isn't supported out of the box? Check out
 > [these](#community-adapters) user contributed adapters, [create](/extending/adapters) your own or post in the [discussions](https://github.com/olimorris/codecompanion.nvim/discussions)
 
-An adapter is what connects Neovim to an LLM provider and model. It's the interface that allows data to be sent, received and processed. There are a multitude of ways to customize them.
+An adapter is what connects Neovim to an LLM provider and model. It's the interface that allows data to be sent, received and processed. There are a multitude of ways to customise them.
 
 There are two "types" of adapter in CodeCompanion; **http** adapters which connect you to an LLM and [ACP](/configuration/adapters-acp) adapters which leverage the [Agent Client Protocol](https://agentclientprotocol.com) to connect you to an agent.
 
@@ -72,6 +72,46 @@ require("codecompanion").setup({
 ```
 
 :::
+
+## Customising an Adapter
+
+There are two ways to customise a preset adapter, and you'll see both throughout this page:
+
+- **Function** - Use this for full or computed setups. Custom `url`, `headers`, `schema`, or values resolved at call time
+- **`extend` table** - Use this for static overrides like credentials or setting a default value
+
+::: code-group
+
+```lua [Function]
+require("codecompanion").setup({
+  adapters = {
+    http = {
+      anthropic = function()
+        return require("codecompanion.adapters").extend("anthropic", {
+          env = { api_key = "cmd:op read op://personal/Anthropic/credential --no-newline" },
+        })
+      end,
+    },
+  },
+})
+```
+
+```lua [Extend Table]
+require("codecompanion").setup({
+  adapters = {
+    http = {
+      extend = {
+        anthropic = { env = { api_key = "cmd:op read op://personal/Anthropic/credential --no-newline" } },
+      },
+    },
+  },
+})
+```
+
+:::
+
+> [!IMPORTANT]
+> The `extend` key is the adapter's name in the [config](https://github.com/olimorris/codecompanion.nvim/blob/main/lua/codecompanion/config.lua), not the resolved adapter name.
 
 ## Changing Adapter Parameters (Schema)
 

--- a/lua/codecompanion/adapters/acp/init.lua
+++ b/lua/codecompanion/adapters/acp/init.lua
@@ -79,6 +79,8 @@ function Adapter.resolve(adapter, opts)
   adapter = adapter or config.interactions.chat.adapter
   opts = opts or {}
 
+  local config_key = type(adapter) == "string" and adapter or nil
+
   if type(adapter) == "table" then
     -- Handle { name = "claude_code", model = "opus" } style config first
     if adapter.name and adapter.model and not adapter.type then
@@ -130,6 +132,8 @@ function Adapter.resolve(adapter, opts)
   elseif type(adapter) == "function" then
     adapter = adapter()
   end
+
+  shared.apply_extend(adapter, { extend = config.adapters.acp.extend, config_key = config_key })
 
   if adapter.commands and adapter.commands.default then
     adapter.commands.selected = adapter.commands.default

--- a/lua/codecompanion/adapters/acp/init.lua
+++ b/lua/codecompanion/adapters/acp/init.lua
@@ -79,7 +79,7 @@ function Adapter.resolve(adapter, opts)
   adapter = adapter or config.interactions.chat.adapter
   opts = opts or {}
 
-  local config_key = type(adapter) == "string" and adapter or nil
+  local key = type(adapter) == "string" and adapter or nil
 
   if type(adapter) == "table" then
     -- Handle { name = "claude_code", model = "opus" } style config first
@@ -133,7 +133,7 @@ function Adapter.resolve(adapter, opts)
     adapter = adapter()
   end
 
-  shared.apply_extend(adapter, { extend = config.adapters.acp.extend, config_key = config_key })
+  shared.apply_extend(adapter, { extend = config.adapters.acp.extend, key = key })
 
   if adapter.commands and adapter.commands.default then
     adapter.commands.selected = adapter.commands.default

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -309,7 +309,7 @@ function Adapter.resolve(adapter, opts)
   adapter = adapter or config.interactions.chat.adapter
   opts = opts or {}
 
-  local config_key = type(adapter) == "string" and adapter or nil
+  local key = type(adapter) == "string" and adapter or nil
 
   if type(adapter) == "table" then
     if adapter.name and adapter.schema and Adapter.resolved(adapter) then
@@ -350,7 +350,7 @@ function Adapter.resolve(adapter, opts)
     adapter.handlers.resolve(adapter)
   end
 
-  shared.apply_extend(adapter, { extend = config.adapters.http.extend, config_key = config_key })
+  shared.apply_extend(adapter, { extend = config.adapters.http.extend, key = key })
 
   return Adapter.set_model({ adapter = adapter })
 end

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -309,6 +309,8 @@ function Adapter.resolve(adapter, opts)
   adapter = adapter or config.interactions.chat.adapter
   opts = opts or {}
 
+  local config_key = type(adapter) == "string" and adapter or nil
+
   if type(adapter) == "table" then
     if adapter.name and adapter.schema and Adapter.resolved(adapter) then
       log:trace("[adapters:http:resolve] Returning existing resolved adapter: %s", adapter.name)
@@ -347,6 +349,8 @@ function Adapter.resolve(adapter, opts)
   if adapter.handlers and adapter.handlers.resolve then
     adapter.handlers.resolve(adapter)
   end
+
+  shared.apply_extend(adapter, { extend = config.adapters.http.extend, config_key = config_key })
 
   return Adapter.set_model({ adapter = adapter })
 end

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -13,12 +13,12 @@ end
 
 ---Deep-merge a user's extend table onto a resolved adapter
 ---@param adapter table
----@param opts { extend?: table, config_key?: string }
+---@param opts { extend?: table, key?: string }
 ---@return table
 function M.apply_extend(adapter, opts)
   opts = opts or {}
 
-  local patch = opts.config_key and opts.extend and opts.extend[opts.config_key]
+  local patch = opts.key and opts.extend and opts.extend[opts.key]
   if type(patch) ~= "table" then
     return adapter
   end

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -11,6 +11,29 @@ function M.map_roles(adapter, messages)
   return adapter_utils.map_roles(adapter.roles, messages)
 end
 
+---Deep-merge a user's extend table onto a resolved adapter
+---@param adapter table
+---@param opts { extend?: table, config_key?: string }
+---@return table
+function M.apply_extend(adapter, opts)
+  opts = opts or {}
+
+  local patch = opts.config_key and opts.extend and opts.extend[opts.config_key]
+  if type(patch) ~= "table" then
+    return adapter
+  end
+
+  for key, value in pairs(patch) do
+    if type(value) == "table" and type(adapter[key]) == "table" then
+      adapter[key] = vim.tbl_deep_extend("force", adapter[key], value)
+    else
+      adapter[key] = value
+    end
+  end
+
+  return adapter
+end
+
 ---Resolve the context window for the current model
 ---@param adapter CodeCompanion.HTTPAdapter
 ---@return number|nil

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -61,7 +61,8 @@ end
 ---@return nil
 function M.extend(base_tbl, new_tbl)
   for name, adapter in pairs(new_tbl) do
-    if base_tbl[name] then
+    -- NOTE: `opts` and `extend` are adapter-table metadata, not adapters, so leave them be
+    if name ~= "opts" and name ~= "extend" and base_tbl[name] then
       if type(adapter) == "table" then
         base_tbl[name] = adapter
         if adapter.schema then

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -61,8 +61,7 @@ end
 ---@return nil
 function M.extend(base_tbl, new_tbl)
   for name, adapter in pairs(new_tbl) do
-    -- NOTE: `opts` and `extend` are adapter-table metadata, not adapters, so leave them be
-    if name ~= "opts" and name ~= "extend" and base_tbl[name] then
+    if name ~= "extend" and name ~= "opts" and base_tbl[name] then
       if type(adapter) == "table" then
         base_tbl[name] = adapter
         if adapter.schema then

--- a/lua/codecompanion/commands/init.lua
+++ b/lua/codecompanion/commands/init.lua
@@ -29,7 +29,7 @@ local function get_adapters(type)
     _cached_adapters[type] = vim
       .iter(config_adapters)
       :filter(function(k, _)
-        return k ~= "acp" and k ~= "http" and k ~= "opts" and k ~= "extend"
+        return k ~= "acp" and k ~= "http" and k ~= "extend" and k ~= "opts"
       end)
       :map(function(k, _)
         return k

--- a/lua/codecompanion/commands/init.lua
+++ b/lua/codecompanion/commands/init.lua
@@ -29,7 +29,7 @@ local function get_adapters(type)
     _cached_adapters[type] = vim
       .iter(config_adapters)
       :filter(function(k, _)
-        return k ~= "acp" and k ~= "http" and k ~= "opts"
+        return k ~= "acp" and k ~= "http" and k ~= "opts" and k ~= "extend"
       end)
       :map(function(k, _)
         return k

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -28,6 +28,7 @@ local defaults = {
       xai = "xai",
       jina = "jina",
       tavily = "tavily",
+      extend = nil, -- Per-adapter overrides keyed by config key e.g. { openai = { env = { api_key = "ABC-123" } } }
       opts = {
         allow_insecure = false, -- Allow insecure connections?
         cache_models_for = 1800, -- Cache adapter models for this long (seconds)
@@ -50,6 +51,7 @@ local defaults = {
       kiro = "kiro",
       mistral_vibe = "mistral_vibe",
       opencode = "opencode",
+      extend = nil, -- Per-adapter overrides keyed by config key e.g. { codex = { env = { OPENAI_API_KEY = "ABC-123" } } }
       opts = {
         show_presets = true,
       },

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -32,7 +32,11 @@ function M.get_adapters_list(current_adapter)
     .iter(adapters)
     :filter(function(adapter)
       -- Clear out the acp and http keys
-      return adapter ~= "opts" and adapter ~= "acp" and adapter ~= "http" and adapter ~= current_adapter
+      return adapter ~= "opts"
+        and adapter ~= "extend"
+        and adapter ~= "acp"
+        and adapter ~= "http"
+        and adapter ~= current_adapter
     end)
     :map(function(adapter, _)
       return adapter

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -32,10 +32,10 @@ function M.get_adapters_list(current_adapter)
     .iter(adapters)
     :filter(function(adapter)
       -- Clear out the acp and http keys
-      return adapter ~= "opts"
-        and adapter ~= "extend"
-        and adapter ~= "acp"
+      return adapter ~= "acp"
         and adapter ~= "http"
+        and adapter ~= "extend"
+        and adapter ~= "opts"
         and adapter ~= current_adapter
     end)
     :map(function(adapter, _)

--- a/tests/adapters/test_adapters.lua
+++ b/tests/adapters/test_adapters.lua
@@ -375,11 +375,82 @@ T["HTTP Adapter"]["can extend an adapter"] = function()
   h.eq("test_api_key", result)
 end
 
+T["HTTP Adapter"]["extend patches by config key, not resolved name"] = function()
+  local result = child.lua([[
+    require("codecompanion").setup({
+      adapters = { http = {
+        -- A second config key resolving to the same preset
+        openai_variant = function()
+          return require("codecompanion.adapters").extend("openai")
+        end,
+        extend = {
+          openai = { env = { api_key = "key_for_openai" } },
+          openai_variant = { env = { api_key = "key_for_variant" } },
+        },
+      } },
+    })
+    local adapters = require("codecompanion.adapters")
+    return {
+      openai = adapters.resolve("openai").env.api_key,
+      variant = adapters.resolve("openai_variant").env.api_key,
+    }
+  ]])
+
+  h.eq("key_for_openai", result.openai)
+  h.eq("key_for_variant", result.variant)
+end
+
+T["HTTP Adapter"]["extend doesn't overwrite opts defaults"] = function()
+  local result = child.lua([[
+    require("codecompanion").setup({
+      adapters = { http = { extend = { openai = { env = { api_key = "abc" } } } } },
+    })
+    local change_adapter = require("codecompanion.interactions.chat.keymaps.change_adapter")
+    local models = change_adapter.list_http_models(require("codecompanion.adapters").resolve("openai"))
+    return {
+      show_model_choices = require("codecompanion.config").adapters.http.opts.show_model_choices,
+      models_listed = models and #models or 0,
+    }
+  ]])
+
+  h.eq(true, result.show_model_choices)
+  h.expect_truthy(result.models_listed > 1)
+end
+
 --=============================================================================
 -- ACP Adapter Tests
 --=============================================================================
 
 T["ACP Adapter"] = new_set()
+
+T["ACP Adapter"]["extend deep-merges defaults and env onto the adapter"] = function()
+  local result = child.lua([[
+    require("codecompanion").setup({
+      adapters = { acp = {
+        test_acp = function()
+          return require("codecompanion.adapters").extend(_G.test_acp_adapter)
+        end,
+        extend = {
+          test_acp = {
+            defaults = { auth_method = "gemini-api-key" },
+            env = { GEMINI_API_KEY = "cmd:echo key" },
+          },
+        },
+      } },
+    })
+    local adapter = require("codecompanion.adapters").resolve("test_acp")
+    return {
+      auth_method = adapter.defaults.auth_method,
+      api_key = adapter.env.GEMINI_API_KEY,
+      -- A sibling default from the preset must survive the merge
+      timeout = adapter.defaults.timeout,
+    }
+  ]])
+
+  h.eq("gemini-api-key", result.auth_method)
+  h.eq("cmd:echo key", result.api_key)
+  h.eq(10000, result.timeout)
+end
 
 T["ACP Adapter"]["can extend an adapter"] = function()
   local result = child.lua([[


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Previously, my CodeCompanion adapter config was:

```lua
require("codecompanion").setup({
  adapters = {
    http = {
      anthropic = function()
        return require("codecompanion.adapters").extend("anthropic", {
          env = {
            api_key = "cmd:op read op://personal/Anthropic_API/credential --no-newline",
          },
        })
      end,
      deepseek = function()
        return require("codecompanion.adapters").extend("deepseek", {
          env = {
            api_key = "cmd:op read op://personal/DeepSeek_API/credential --no-newline",
          },
        })
      end,
      gemini = function()
        return require("codecompanion.adapters").extend("gemini", {
          env = {
            api_key = "cmd:op read op://personal/Gemini_API/credential --no-newline",
          },
        })
      end,
      mistral = function()
        return require("codecompanion.adapters").extend("mistral", {
          env = {
            api_key = "cmd:op read op://personal/Mistral_API/credential --no-newline",
          },
        })
      end,
      openrouter = function()
        return require("codecompanion.adapters").extend("openrouter", {
          env = {
            api_key = "cmd:op read op://personal/OpenRouter_API/credential --no-newline",
          },
        })
      end,
      -- and many more
    },
  },
})
```

and with this PR, it can now become:

```lua
require("codecompanion").setup({
  adapters = {
    http = {
      extend = {
        anthropic = { env = { api_key = "cmd:op read op://personal/Anthropic_API/credential --no-newline" } },
        deepseek = { env = { api_key = "cmd:op read op://personal/DeepSeek_API/credential --no-newline" } },
        gemini = { env = { api_key = "cmd:op read op://personal/Gemini_API/credential --no-newline" } },
        mistral = { env = { api_key = "cmd:op read op://personal/Mistral_API/credential --no-newline" } },
        openrouter = { env = { api_key = "cmd:op read op://personal/OpenRouter_API/credential --no-newline" } },
      }
    }
  }
})
```

Also available for ACP adapters too.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code and Opus 4.8 to identify how the `extend` table mechanism can be used across HTTP and ACP adapters.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
