### PR TITLE
fix(types): add missing code field annotation to BufferContext

### DIFF
--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -210,6 +210,7 @@
 ---@class CodeCompanion.BufferContext
 ---@field bufnr number The buffer number
 ---@field buftype string The buffer type
+---@field code string|false The lines of the selection
 ---@field cursor_pos number[] The cursor position as [line, col]
 ---@field end_col number The end column of the selection
 ---@field end_line number The end line of the selection


### PR DESCRIPTION
## Description

Add the missing `code` field type annotation to the `CodeCompanion.BufferContext` class in `lua/codecompanion/types.lua`. This field is populated in `lua/codecompanion/utils/context.lua` (`get()` function) but was missing its LuaCATS annotation.

## Supporting Documentation

N/A — LuaCATS type annotations are standard practice in this codebase (see existing annotations in the same file).

## AI Usage

AI assistance used for codebase research and PR creation only. The fix itself is a one-line LuaCATS annotation addition.

## Related Issue(s)

None.

## Screenshots

N/A — annotation-only change with no visual impact.

## Checklist

- [x] I have read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I have run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I have added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I have updated the README and/or relevant docs pages