### PR TITLE
feat(adapters): load models dynamically for `anthropic` and `mistral`

### DIFF
--- a/.codecompanion/adapters/adapters.md
+++ b/.codecompanion/adapters/adapters.md
@@ -196,3 +196,7 @@ Sharing an example HTTP adapter for OpenAI. Note: This adapter currently uses th
 @.codecompanion/adapters/plenary_curl.md
 
 The http.lua module implements a provider-agnostic HTTP client for CodeCompanion that centralizes request construction, streaming, scheduling, and testability. It uses `adapters.call_handler()` to invoke adapter handlers in a backwards-compatible way, working seamlessly with both old and new handler formats.
+
+## Models
+
+@.codecompanion/adapters/models_list.md

--- a/.codecompanion/adapters/models_list.md
+++ b/.codecompanion/adapters/models_list.md
@@ -1,0 +1,32 @@
+# Models List
+
+CodeCompanion allows some adapters to dynamically fetch the list of models that they support.
+
+@./lua/codecompanion/adapters/http/openrouter.lua
+@./lua/codecompanion/adapters/http/copilot/get_models.lua
+
+This can be seen in the OpenRouter and Copilot adapters.
+
+## Anthropic
+
+Anthropic's `https://api.anthropic.com/v1/models` endpoint (with `x-api-key` and `anthropic-version` headers) outputs:
+
+@./tests/adapters/http/stubs/model_list/anthropic.json
+
+## Copilot
+
+Copilot's endpoint outputs:
+
+@./tests/adapters/http/stubs/model_list/copilot.json
+
+## Ollama
+
+Ollama's endpoint `http://localhost:11434/api/tags`:
+
+@./tests/adapters/http/stubs/model_list/ollama.json
+
+## OpenRouter
+
+OpenRouter's `https://openrouter.ai/api/v1/models` endpoint outputs:
+
+@./tests/adapters/http/stubs/model_list/openrouter.json

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -1,7 +1,20 @@
 local adapter_utils = require("codecompanion.adapters.utils")
+local config = require("codecompanion.config")
+local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
-local transform = require("codecompanion.adapters.utils.tool_transformers")
+local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
+
+local models = fetch_models.sync({
+  name = "Anthropic",
+  url = "https://api.anthropic.com/v1/models",
+  ---@param adapter CodeCompanion.HTTPAdapter
+  ---@return table
+  headers = function(adapter)
+    adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
+    return adapter_utils.set_env_vars(adapter, adapter.headers)
+  end,
+})
 
 ---@class CodeCompanion.HTTPAdapter.Anthropic: CodeCompanion.HTTPAdapter
 return {
@@ -426,7 +439,7 @@ return {
               self.available_tools[schema.name].callback(self, { tools = transformed })
             end
           else
-            table.insert(transformed, transform.to_anthropic(schema))
+            table.insert(transformed, tool_transformer.to_anthropic(schema))
           end
         end
       end
@@ -666,61 +679,11 @@ return {
       type = "enum",
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
       default = "claude-sonnet-5",
-      choices = {
-        -- Current models
-        ["claude-sonnet-5"] = {
-          formatted_name = "Claude Sonnet 5",
-          meta = { context_window = 1000000, max_tokens = 128000 },
-          opts = { can_reason = true, can_manage_context = true, has_vision = true },
-        },
-        ["claude-fable-5"] = {
-          formatted_name = "Claude Fable 5",
-          meta = { context_window = 1000000, max_tokens = 128000 },
-          opts = { can_form_structured_outputs = true, can_manage_context = true, has_vision = true },
-        },
-        ["claude-opus-4-8"] = {
-          formatted_name = "Claude Opus 4.8",
-          meta = { context_window = 1000000, max_tokens = 128000 },
-          opts = { can_form_structured_outputs = true, can_manage_context = true, has_vision = true },
-        },
-        ["claude-haiku-4-5"] = {
-          formatted_name = "Claude Haiku 4.5",
-          meta = { context_window = 200000, max_tokens = 64000 },
-          opts = { can_form_structured_outputs = true, can_reason = false, has_vision = true },
-        },
-
-        -- Legacy models
-        ["claude-opus-4-7"] = {
-          formatted_name = "Claude Opus 4.7",
-          meta = { context_window = 1000000, max_tokens = 128000 },
-          opts = { can_form_structured_outputs = true, can_manage_context = true, has_vision = true },
-        },
-        ["claude-opus-4-6"] = {
-          formatted_name = "Claude Opus 4.6",
-          meta = { context_window = 1000000, max_tokens = 128000 },
-          opts = { can_form_structured_outputs = true, can_manage_context = true, can_reason = true, has_vision = true },
-        },
-        ["claude-opus-4-5"] = {
-          formatted_name = "Claude Opus 4.5",
-          meta = { context_window = 200000, max_tokens = 64000 },
-          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true, legacy_reasoning = true },
-        },
-        ["claude-sonnet-4-6"] = {
-          formatted_name = "Claude Sonnet 4.6",
-          meta = { context_window = 1000000, max_tokens = 128000 },
-          opts = { can_reason = true, can_manage_context = true, has_vision = true },
-        },
-        ["claude-sonnet-4-5"] = {
-          formatted_name = "Claude Sonnet 4.5",
-          meta = { context_window = 100000, max_tokens = 64000 },
-          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true, legacy_reasoning = true },
-        },
-        ["claude-opus-4-1"] = {
-          formatted_name = "Claude Opus 4.1",
-          meta = { context_window = 200000, max_tokens = 32000 },
-          opts = { can_reason = true, has_vision = true, legacy_reasoning = true },
-        },
-      },
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return table<string, CodeCompanion.Adapter.ModelChoice>
+      choices = function(self)
+        return models(self)
+      end,
     },
     ---@type CodeCompanion.Schema
     extended_output = {

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -2,6 +2,7 @@ local Curl = require("plenary.curl")
 
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local model_transformers = require("codecompanion.adapters.utils.models.transform")
 local token = require("codecompanion.adapters.http.copilot.token")
 
 local CONSTANTS = {
@@ -104,74 +105,12 @@ local function fetch_async(adapter, opts)
 
         local models = {}
         for _, model in ipairs(json.data) do
-          -- Copilot models can use the "completions" or "responses" endpoint
-          local internal_endpoint = "completions"
-          if model.supported_endpoints then
-            for _, endpoint in ipairs(model.supported_endpoints) do
-              if endpoint == "/responses" then
-                internal_endpoint = "responses"
-                break
-              end
-            end
+          local id, entry = model_transformers.from_copilot(model)
+          if id then
+            models[id] = entry
+          else
+            log:debug("Copilot Adapter: Skipping model '%s'", model.id)
           end
-
-          if model.model_picker_enabled then
-            local choice_opts = {}
-            local limits = {}
-            local billing = {}
-
-            if model.capabilities then
-              if type(model.capabilities.type) == "string" and model.capabilities.type ~= "chat" then
-                log:debug("Copilot Adapter: Skipping non-chat model '%s'", model.id)
-                goto continue
-              end
-              if type(model.capabilities.type) == "table" and not vim.tbl_contains(model.capabilities.type, "chat") then
-                log:debug("Copilot Adapter: Skipping non-chat model '%s'", model.id)
-                goto continue
-              end
-
-              if model.capabilities.supports then
-                if model.capabilities.supports.streaming then
-                  choice_opts.can_stream = true
-                end
-                if model.capabilities.supports.structured_outputs then
-                  choice_opts.can_form_structured_outputs = true
-                end
-                if model.capabilities.supports.tool_calls then
-                  choice_opts.can_use_tools = true
-                end
-                if model.capabilities.supports.vision then
-                  choice_opts.has_vision = true
-                end
-              end
-
-              if model.capabilities.limits then
-                limits.max_output_tokens = model.capabilities.limits.max_output_tokens
-                limits.max_prompt_tokens = model.capabilities.limits.max_prompt_tokens
-                limits.context_window = model.capabilities.limits.max_context_window_tokens
-              end
-            end
-
-            if model.billing then
-              billing.is_premium = model.billing.is_premium
-              billing.multiplier = model.billing.multiplier
-            end
-
-            local description = model.name .. (billing.multiplier and (" (" .. billing.multiplier .. "x)") or "")
-
-            models[model.id] = {
-              billing = billing,
-              description = description,
-              endpoint = internal_endpoint,
-              formatted_name = model.name,
-              limits = limits,
-              meta = limits.context_window and { context_window = limits.context_window } or nil,
-              opts = choice_opts,
-              vendor = model.vendor,
-            }
-          end
-
-          ::continue::
         end
 
         _cached_models = models

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -3,7 +3,7 @@
 local adapter_utils = require("codecompanion.adapters.utils")
 local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
-local transform = require("codecompanion.adapters.utils.tool_transformers")
+local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
 
 ---Extract the first complete JSON object from a potentially concatenated string
 ---Workaround for Gemini bug where multiple JSON objects get concatenated
@@ -273,7 +273,7 @@ return {
       local declarations = {}
       for _, tool in pairs(tools) do
         for _, schema in pairs(tool) do
-          table.insert(declarations, transform.to_gemini(schema))
+          table.insert(declarations, tool_transformer.to_gemini(schema))
         end
       end
 

--- a/lua/codecompanion/adapters/http/mistral.lua
+++ b/lua/codecompanion/adapters/http/mistral.lua
@@ -1,6 +1,19 @@
 local adapter_utils = require("codecompanion.adapters.utils")
+local config = require("codecompanion.config")
+local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
+
+local models = fetch_models.sync({
+  name = "Mistral",
+  url = "https://api.mistral.ai/v1/models",
+  ---@param adapter CodeCompanion.HTTPAdapter
+  ---@return table
+  headers = function(adapter)
+    adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
+    return adapter_utils.set_env_vars(adapter, adapter.headers)
+  end,
+})
 
 ---@class CodeCompanion.HTTPAdapter.Mistral: CodeCompanion.HTTPAdapter
 return {
@@ -35,14 +48,13 @@ return {
         self.parameters.stream = true
       end
 
-      local model = self.schema.model.default
-      local model_opts = self.schema.model.choices[model]
+      local model_opts = adapter_utils.model_choice(self)
       if model_opts and model_opts.opts then
         self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
         if not model_opts.opts.has_vision then
           self.opts.vision = false
         end
-        if model_opts.opts.has_function_calling ~= nil and not model_opts.opts.has_function_calling then
+        if not model_opts.opts.can_use_tools then
           self.opts.tools = false
         end
       end
@@ -200,24 +212,11 @@ return {
       type = "enum",
       desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
       default = "mistral-small-latest",
-      choices = {
-        -- Premier models
-        ["mistral-large-latest"] = { opts = { can_form_structured_outputs = true } },
-        ["pixtral-large-latest"] = { opts = { has_vision = true, can_form_structured_outputs = true } },
-        ["magistral-medium-latest"] = { opts = { can_reason = true, can_form_structured_outputs = true } },
-        ["magistral-small-latest"] = { opts = { can_reason = true, can_form_structured_outputs = true } },
-        ["mistral-medium-latest"] = { opts = { has_vision = true, can_form_structured_outputs = true } },
-        ["mistral-saba-latest"] = { opts = { has_function_calling = false } },
-        ["codestral-latest"] = { opts = { can_form_structured_outputs = true } },
-        ["ministral-8b-latest"] = { opts = { can_form_structured_outputs = true } },
-        ["ministral-3b-latest"] = { opts = { can_form_structured_outputs = true } },
-        -- Free models, latest
-        ["mistral-small-latest"] = { opts = { has_vision = true, can_form_structured_outputs = true } },
-        ["pixtral-12b-2409"] = { opts = { has_vision = true } },
-        -- Free models, research
-        "open-mistral-nemo",
-        "open-codestral-mamba",
-      },
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return table<string, CodeCompanion.Adapter.ModelChoice>
+      choices = function(self)
+        return models(self)
+      end,
     },
     temperature = {
       order = 2,

--- a/lua/codecompanion/adapters/http/ollama/get_models.lua
+++ b/lua/codecompanion/adapters/http/ollama/get_models.lua
@@ -2,6 +2,7 @@ local Curl = require("plenary.curl")
 local adapter_utils = require("codecompanion.adapters.utils")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local model_transformers = require("codecompanion.adapters.utils.models.transform")
 
 local CONSTANTS = {
   TIMEOUT = 3000, -- 3 seconds
@@ -12,7 +13,7 @@ local _running = {}
 
 local M = {}
 
----@type table<string, table<string, { formatted_name: string?, meta: { context_window: number }?, opts: {can_reason: boolean, has_vision: boolean, can_use_tools: boolean} }>>
+---@type table<string, table<string, CodeCompanion.Adapter.ModelChoice>>
 local _cached_models = {}
 
 ---@alias OllamaGetModelsOpts {last?: boolean, async?: boolean}
@@ -45,34 +46,21 @@ local function build_headers(adapter)
   return headers
 end
 
----Parse capabilities and metadata from a model info response
----@param output table The curl response
----@return { can_reason: boolean, can_use_tools: boolean, has_vision: boolean }, { context_window: number }?
-local function parse_model_info(output)
-  local opts = {}
+---Parse a model info response into a model entry
+---@param name string The model's name, as returned by `/api/tags`
+---@param output table The curl response from `/api/show`
+---@return CodeCompanion.Adapter.ModelChoice entry
+local function parse_model_info(name, output)
   if output.status ~= 200 then
-    return opts
+    return model_transformers.from_ollama(name)
   end
 
   local ok, json = pcall(vim.json.decode, output.body, { array = true, object = true })
   if not ok then
-    return opts
+    return model_transformers.from_ollama(name)
   end
 
-  local capabilities = json.capabilities or {}
-  opts.can_reason = vim.list_contains(capabilities, "thinking")
-  opts.can_use_tools = vim.list_contains(capabilities, "tools")
-  opts.has_vision = vim.list_contains(capabilities, "vision")
-
-  local meta
-  if json.model_info and json.details and json.details.family then
-    local context_length = json.model_info[json.details.family .. ".context_length"]
-    if context_length then
-      meta = { context_window = context_length }
-    end
-  end
-
-  return opts, meta
+  return model_transformers.from_ollama(name, json)
 end
 
 ---Fetch model list and model info.
@@ -118,12 +106,7 @@ local function fetch_models(adapter)
             proxy = config.adapters.http.opts.proxy,
             timeout = CONSTANTS.TIMEOUT,
             callback = function(output)
-              local opts, meta = parse_model_info(output)
-              _cached_models[url][model_obj.name] = {
-                formatted_name = model_obj.name,
-                meta = meta,
-                opts = opts,
-              }
+              _cached_models[url][model_obj.name] = parse_model_info(model_obj.name, output)
               pending[model_obj.name] = nil
               if vim.tbl_isempty(pending) then
                 _running[url] = false

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -2,7 +2,7 @@ local adapter_utils = require("codecompanion.adapters.utils")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 local tags = require("codecompanion.interactions.shared.tags")
-local tool_utils = require("codecompanion.adapters.utils.tool_transformers")
+local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
 
 ---@type string|nil
 local response_id
@@ -270,7 +270,7 @@ return {
             else
               table.insert(
                 transformed,
-                tool_utils.transform_schema_if_needed(schema, {
+                tool_transformer.transform_schema_if_needed(schema, {
                   strict_mode = true,
                 })
               )

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -1,97 +1,16 @@
-local Curl = require("plenary.curl")
-local adapter_utils = require("codecompanion.adapters.utils")
-local config = require("codecompanion.config")
+local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
----@class OpenRouterModels
----@field archirecture { input_modalities: string[], output_modalities: string[] } e.g. { input_modalities = { "text", "image" }, output_modalities = { "text" } }
----@field context_length number e.g. 1000000
----@field created number e.g. 1759161676
----@field default_parameters table e.g. { temperature = 1, top_p = 1, top_k = null }
----@field description string
----@field id string e.g. anthropic/claude-sonnet-4.5
----@field name string e.g. Anthropic: Claude Sonnet 4.5
----@field pricing table
-
-local _cache_expires
-local _cache_file = vim.fn.tempname()
-local _cached_models
-
----@params self CodeCompanion.HTTPAdapter
----@params opts? table
----@return table
-local function get_models()
-  if _cached_models and _cache_expires and _cache_expires > os.time() then
-    return _cached_models
-  end
-
-  local url = "https://openrouter.ai/api/v1/models"
-
-  local ok
-  local response ---@type OpenRouterModels
-
-  ok, response = pcall(function()
-    return Curl.get(url, {
-      headers = {
-        Authorization = "Bearer ${api_key}",
-      },
-      insecure = config.adapters.http.opts.allow_insecure,
-      proxy = config.adapters.http.opts.proxy,
-      sync = true,
-    })
-  end)
-  if not ok then
-    log:error("Could not get the OpenRouter models from " .. url .. "\nError: %s", response)
-    return {}
-  end
-
-  local ok, json = pcall(vim.json.decode, response.body)
-  if not ok then
-    log:error("Error parsing the response from " .. url .. "\nError: %s", response.body)
-    return {}
-  end
-
-  local models = {}
-  for _, model in ipairs(json.data) do
-    -- Turn the model's `supported_parameters` array into a lookup set so the
-    -- schema fields can check, per model, which parameters the API accepts
-    local supported = {}
-    for _, parameter in ipairs(model.supported_parameters or {}) do
-      supported[parameter] = true
-    end
-
-    local choice_opts = {
-      supported_parameters = supported,
-      can_form_structured_outputs = supported.structured_outputs or false,
-      can_use_tools = supported.tools or false,
-      can_reason = supported.reasoning or false,
-      reasoning = model.reasoning and {
-        default = model.reasoning.default_effort,
-        supported = model.reasoning.supported_efforts,
-      } or nil,
-    }
-    if model.architecture and model.architecture.input_modalities then
-      choice_opts.has_vision = vim.tbl_contains(model.architecture.input_modalities, "image")
-    end
-
-    models[model.id] = {
-      formatted_name = model.name,
-      meta = model.context_length and { context_window = model.context_length } or nil,
-      opts = choice_opts,
-    }
-  end
-
-  _cached_models = models
-  _cache_expires = adapter_utils.refresh_cache(_cache_file, config.adapters.http.opts.cache_models_for)
-
-  return models
-end
+local models = fetch_models.sync({
+  name = "OpenRouter",
+  url = "https://openrouter.ai/api/v1/models",
+})
 
 ---@param self CodeCompanion.HTTPAdapter
 ---@return table|nil
 local function model_choices(self)
-  local cached_models = get_models()
+  local cached_models = models(self)
   local model = cached_models[self.schema.model.default]
   return model and model.opts or nil
 end
@@ -100,7 +19,7 @@ end
 ---@param parameter string
 ---@return boolean
 local function model_supports(self, parameter)
-  local cached_models = get_models()
+  local cached_models = models(self)
   local model = cached_models[self.schema.model.default]
   if not model then
     return false
@@ -409,7 +328,7 @@ return {
       default = "openai/gpt-5.4-mini",
       ---@return table
       choices = function(self)
-        return get_models()
+        return models(self)
       end,
     },
     ["reasoning.effort"] = {

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -422,6 +422,9 @@ end
 ---@return table?
 function M.model_choice(adapter)
   local choices = adapter.schema.model.choices
+  if type(choices) == "function" then
+    choices = choices(adapter)
+  end
   if type(choices) ~= "table" then
     return nil
   end

--- a/lua/codecompanion/adapters/utils/models/fetch.lua
+++ b/lua/codecompanion/adapters/utils/models/fetch.lua
@@ -1,0 +1,62 @@
+local Curl = require("plenary.curl")
+local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
+local transform = require("codecompanion.adapters.utils.models.transform")
+local utils = require("codecompanion.adapters.utils")
+
+local M = {}
+
+---@class CodeCompanion.Adapter.ModelFetcher.Opts
+---@field name string The adapter's name. Used in log messages and to find its `transform.from_<name>` function
+---@field url string
+---@field headers? fun(adapter: CodeCompanion.HTTPAdapter): table
+
+---Synchronously fetch models from an endpoint
+---@param opts CodeCompanion.Adapter.ModelFetcher.Opts
+---@return fun(adapter: CodeCompanion.HTTPAdapter): table<string, CodeCompanion.Adapter.ModelChoice>
+function M.sync(opts)
+  local from_vendor = transform["from_" .. opts.name:lower()]
+  assert(from_vendor, "No model transformer found for adapter: " .. opts.name)
+
+  local cache_expires
+  local cache_file = vim.fn.tempname()
+  local cached_models
+
+  return function(adapter)
+    if cached_models and cache_expires and cache_expires > os.time() then
+      return cached_models
+    end
+
+    local ok, response = pcall(function()
+      return Curl.get(opts.url, {
+        headers = opts.headers and opts.headers(adapter) or nil,
+        insecure = config.adapters.http.opts.allow_insecure,
+        proxy = config.adapters.http.opts.proxy,
+        sync = true,
+      })
+    end)
+    if not ok then
+      log:error("Could not get the %s models from " .. opts.url .. "\nError: %s", opts.name, response)
+      return {}
+    end
+
+    local decode_ok, json = pcall(vim.json.decode, response.body)
+    if not decode_ok or not json.data then
+      log:error("Error parsing the %s response from " .. opts.url .. "\nError: %s", opts.name, response.body)
+      return {}
+    end
+
+    local models = {}
+    for _, model in ipairs(json.data) do
+      local id, entry = from_vendor(model)
+      models[id] = entry
+    end
+
+    cached_models = models
+    cache_expires = utils.refresh_cache(cache_file, config.adapters.http.opts.cache_models_for)
+
+    return cached_models
+  end
+end
+
+return M

--- a/lua/codecompanion/adapters/utils/models/transform.lua
+++ b/lua/codecompanion/adapters/utils/models/transform.lua
@@ -140,6 +140,27 @@ function M.from_ollama(name, model_info)
   }
 end
 
+---Ref: https://docs.mistral.ai/api/#tag/models/operation/list_models_v1_models_get
+---@param model table
+---@return string id, CodeCompanion.Adapter.ModelChoice entry
+function M.from_mistral(model)
+  local capabilities = model.capabilities or {}
+
+  local opts = {
+    can_form_structured_outputs = capabilities.function_calling or false,
+    can_reason = capabilities.reasoning or false,
+    can_use_tools = capabilities.function_calling or false,
+    has_vision = capabilities.vision or false,
+  }
+
+  return model.id,
+    {
+      formatted_name = model.name,
+      meta = model.max_context_length and { context_window = model.max_context_length } or nil,
+      opts = opts,
+    }
+end
+
 ---Ref: https://openrouter.ai/docs/api-reference/list-available-models
 ---@param model table
 ---@return string id, CodeCompanion.Adapter.ModelChoice entry

--- a/lua/codecompanion/adapters/utils/models/transform.lua
+++ b/lua/codecompanion/adapters/utils/models/transform.lua
@@ -1,0 +1,174 @@
+local M = {}
+
+---@class CodeCompanion.Adapter.ModelChoice
+---@field formatted_name string
+---@field meta? { context_window?: number, max_tokens?: number }
+---@field opts table
+
+---Ref: https://platform.claude.com/docs/en/api/models-list
+---@param model table
+---@return string id, CodeCompanion.Adapter.ModelChoice entry
+function M.from_anthropic(model)
+  local capabilities = model.capabilities or {}
+  local thinking = capabilities.thinking or {}
+  local thinking_types = thinking.types or {}
+
+  local context_management = capabilities.context_management or {}
+
+  local opts = {
+    can_form_structured_outputs = (capabilities.structured_outputs or {}).supported or false,
+    can_manage_context = (context_management.compact_20260112 or {}).supported or false,
+    can_reason = thinking.supported or false,
+    has_vision = (capabilities.image_input or {}).supported or false,
+  }
+
+  -- Models that only support the legacy "enabled" thinking type (no adaptive effort) still
+  -- need the old `thinking = { type = "enabled" }` request shape rather than `effort`
+  if
+    thinking.supported
+    and (thinking_types.enabled or {}).supported
+    and not (thinking_types.adaptive or {}).supported
+  then
+    opts.legacy_reasoning = true
+  end
+
+  local effort = capabilities.effort
+  if effort and effort.supported then
+    local supported_efforts = {}
+    for _, level in ipairs({ "low", "medium", "high", "xhigh", "max" }) do
+      if effort[level] and effort[level].supported then
+        table.insert(supported_efforts, level)
+      end
+    end
+    opts.reasoning = { supported = supported_efforts }
+  end
+
+  return model.id,
+    {
+      formatted_name = model.display_name,
+      meta = { context_window = model.max_input_tokens, max_tokens = model.max_tokens },
+      opts = opts,
+    }
+end
+
+---@param model table
+---@return string|nil id, CodeCompanion.Adapter.ModelChoice|nil entry
+function M.from_copilot(model)
+  if not model.model_picker_enabled then
+    return nil
+  end
+
+  local capabilities = model.capabilities or {}
+  local model_type = capabilities.type
+  if type(model_type) == "string" and model_type ~= "chat" then
+    return nil
+  end
+  if type(model_type) == "table" and not vim.tbl_contains(model_type, "chat") then
+    return nil
+  end
+
+  local endpoint = "completions"
+  for _, supported_endpoint in ipairs(model.supported_endpoints or {}) do
+    if supported_endpoint == "/responses" then
+      endpoint = "responses"
+      break
+    end
+  end
+
+  local opts = {}
+  local limits = {}
+  local billing = {}
+
+  local supports = capabilities.supports or {}
+  opts.can_stream = supports.streaming or nil
+  opts.can_form_structured_outputs = supports.structured_outputs or nil
+  opts.can_use_tools = supports.tool_calls or nil
+  opts.has_vision = supports.vision or nil
+
+  local capability_limits = capabilities.limits
+  if capability_limits then
+    limits.max_output_tokens = capability_limits.max_output_tokens
+    limits.max_prompt_tokens = capability_limits.max_prompt_tokens
+    limits.context_window = capability_limits.max_context_window_tokens
+  end
+
+  if model.billing then
+    billing.is_premium = model.billing.is_premium
+    billing.multiplier = model.billing.multiplier
+  end
+
+  local description = model.name .. (billing.multiplier and (" (" .. billing.multiplier .. "x)") or "")
+
+  return model.id,
+    {
+      billing = billing,
+      description = description,
+      endpoint = endpoint,
+      formatted_name = model.name,
+      limits = limits,
+      meta = limits.context_window and { context_window = limits.context_window } or nil,
+      opts = opts,
+      vendor = model.vendor,
+    }
+end
+
+---@param name string The model's name, as returned by `/api/tags`
+---@param model_info table|nil The decoded body of the `/api/show` response
+---@return CodeCompanion.Adapter.ModelChoice entry
+function M.from_ollama(name, model_info)
+  model_info = model_info or {}
+
+  local capabilities = model_info.capabilities or {}
+  local opts = {
+    can_reason = vim.list_contains(capabilities, "thinking"),
+    can_use_tools = vim.list_contains(capabilities, "tools"),
+    has_vision = vim.list_contains(capabilities, "vision"),
+  }
+
+  local meta
+  if model_info.model_info and model_info.details and model_info.details.family then
+    local context_length = model_info.model_info[model_info.details.family .. ".context_length"]
+    if context_length then
+      meta = { context_window = context_length }
+    end
+  end
+
+  return {
+    formatted_name = name,
+    meta = meta,
+    opts = opts,
+  }
+end
+
+---Ref: https://openrouter.ai/docs/api-reference/list-available-models
+---@param model table
+---@return string id, CodeCompanion.Adapter.ModelChoice entry
+function M.from_openrouter(model)
+  local supported = {}
+  for _, parameter in ipairs(model.supported_parameters or {}) do
+    supported[parameter] = true
+  end
+
+  local opts = {
+    supported_parameters = supported,
+    can_form_structured_outputs = supported.structured_outputs or false,
+    can_use_tools = supported.tools or false,
+    can_reason = supported.reasoning or false,
+    reasoning = model.reasoning and {
+      default = model.reasoning.default_effort,
+      supported = model.reasoning.supported_efforts,
+    } or nil,
+  }
+  if model.architecture and model.architecture.input_modalities then
+    opts.has_vision = vim.tbl_contains(model.architecture.input_modalities, "image")
+  end
+
+  return model.id,
+    {
+      formatted_name = model.name,
+      meta = model.context_length and { context_window = model.context_length } or nil,
+      opts = opts,
+    }
+end
+
+return M

--- a/tests/adapters/http/stubs/model_list/anthropic.json
+++ b/tests/adapters/http/stubs/model_list/anthropic.json
@@ -1,0 +1,214 @@
+{
+  "data": [
+    {
+      "type": "model",
+      "id": "claude-sonnet-5",
+      "display_name": "Claude Sonnet 5",
+      "created_at": "2026-06-29T00:00:00Z",
+      "max_input_tokens": 1000000,
+      "max_tokens": 128000,
+      "capabilities": {
+        "batch": {
+          "supported": true
+        },
+        "citations": {
+          "supported": true
+        },
+        "code_execution": {
+          "supported": true
+        },
+        "context_management": {
+          "supported": true,
+          "clear_tool_uses_20250919": {
+            "supported": true
+          },
+          "clear_thinking_20251015": {
+            "supported": true
+          },
+          "compact_20260112": {
+            "supported": true
+          }
+        },
+        "effort": {
+          "supported": true,
+          "low": {
+            "supported": true
+          },
+          "medium": {
+            "supported": true
+          },
+          "high": {
+            "supported": true
+          },
+          "xhigh": {
+            "supported": true
+          },
+          "max": {
+            "supported": true
+          }
+        },
+        "image_input": {
+          "supported": true
+        },
+        "pdf_input": {
+          "supported": true
+        },
+        "structured_outputs": {
+          "supported": true
+        },
+        "thinking": {
+          "supported": true,
+          "types": {
+            "enabled": {
+              "supported": false
+            },
+            "adaptive": {
+              "supported": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "model",
+      "id": "claude-opus-4-8",
+      "display_name": "Claude Opus 4.8",
+      "created_at": "2026-05-28T00:00:00Z",
+      "max_input_tokens": 1000000,
+      "max_tokens": 128000,
+      "capabilities": {
+        "batch": {
+          "supported": true
+        },
+        "citations": {
+          "supported": true
+        },
+        "code_execution": {
+          "supported": true
+        },
+        "context_management": {
+          "supported": true,
+          "clear_tool_uses_20250919": {
+            "supported": true
+          },
+          "clear_thinking_20251015": {
+            "supported": true
+          },
+          "compact_20260112": {
+            "supported": true
+          }
+        },
+        "effort": {
+          "supported": true,
+          "low": {
+            "supported": true
+          },
+          "medium": {
+            "supported": true
+          },
+          "high": {
+            "supported": true
+          },
+          "xhigh": {
+            "supported": true
+          },
+          "max": {
+            "supported": true
+          }
+        },
+        "image_input": {
+          "supported": true
+        },
+        "pdf_input": {
+          "supported": true
+        },
+        "structured_outputs": {
+          "supported": true
+        },
+        "thinking": {
+          "supported": true,
+          "types": {
+            "enabled": {
+              "supported": false
+            },
+            "adaptive": {
+              "supported": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "model",
+      "id": "claude-haiku-4-5-20251001",
+      "display_name": "Claude Haiku 4.5",
+      "created_at": "2025-10-15T00:00:00Z",
+      "max_input_tokens": 200000,
+      "max_tokens": 64000,
+      "capabilities": {
+        "batch": {
+          "supported": true
+        },
+        "citations": {
+          "supported": true
+        },
+        "code_execution": {
+          "supported": false
+        },
+        "context_management": {
+          "supported": true,
+          "clear_tool_uses_20250919": {
+            "supported": true
+          },
+          "clear_thinking_20251015": {
+            "supported": true
+          },
+          "compact_20260112": {
+            "supported": false
+          }
+        },
+        "effort": {
+          "supported": false,
+          "low": {
+            "supported": false
+          },
+          "medium": {
+            "supported": false
+          },
+          "high": {
+            "supported": false
+          },
+          "xhigh": {
+            "supported": false
+          },
+          "max": {
+            "supported": false
+          }
+        },
+        "image_input": {
+          "supported": true
+        },
+        "pdf_input": {
+          "supported": true
+        },
+        "structured_outputs": {
+          "supported": true
+        },
+        "thinking": {
+          "supported": true,
+          "types": {
+            "enabled": {
+              "supported": true
+            },
+            "adaptive": {
+              "supported": false
+            }
+          }
+        }
+      }
+    }
+  ],
+  "has_more": false,
+  "first_id": "claude-sonnet-5",
+  "last_id": "claude-opus-4-1-20250805"
+}

--- a/tests/adapters/http/stubs/model_list/copilot.json
+++ b/tests/adapters/http/stubs/model_list/copilot.json
@@ -1,0 +1,242 @@
+{
+  "data": [
+    {
+      "billing": {
+        "is_premium": true,
+        "multiplier": 1,
+        "restricted_to": ["pro_plus", "business", "enterprise", "max"]
+      },
+      "capabilities": {
+        "family": "claude-opus-4.7",
+        "limits": {
+          "max_context_window_tokens": 264000,
+          "max_non_streaming_output_tokens": 16000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 200000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "adaptive_thinking": true,
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 1024,
+          "parallel_tool_calls": true,
+          "reasoning_effort": ["low", "medium", "high", "xhigh", "max"],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "claude-opus-4.7",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": false,
+      "name": "Claude Opus 4.7",
+      "object": "model",
+      "policy": {
+        "state": "disabled",
+        "terms": "Enable access to the latest Claude Opus 4.7 model from Anthropic. [Learn more about how GitHub Copilot serves Claude Opus 4.7](https://gh.io/copilot-claude-opus)."
+      },
+      "preview": false,
+      "supported_endpoints": ["/v1/messages", "/chat/completions"],
+      "vendor": "Anthropic",
+      "version": "claude-opus-4.7"
+    },
+    {
+      "billing": {
+        "is_premium": true,
+        "multiplier": 1,
+        "restricted_to": [
+          "edu",
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ]
+      },
+      "capabilities": {
+        "family": "gemini-3.1-pro-preview",
+        "limits": {
+          "max_context_window_tokens": 264000,
+          "max_output_tokens": 64000,
+          "max_prompt_tokens": 200000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 10,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/heic",
+              "image/heif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "max_thinking_budget": 32000,
+          "min_thinking_budget": 256,
+          "parallel_tool_calls": true,
+          "reasoning_effort": ["low", "medium", "high"],
+          "streaming": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gemini-3.1-pro-preview",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "name": "Gemini 3.1 Pro",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest Gemini 3 Pro model from Google. [Learn more about how GitHub Copilot serves Gemini 3 Pro](https://docs.github.com/en/copilot/reference/ai-models/model-hosting#google-models)."
+      },
+      "preview": true,
+      "supported_endpoints": ["/chat/completions"],
+      "vendor": "Google",
+      "version": "gemini-3.1-pro-preview"
+    },
+    {
+      "billing": {
+        "is_premium": true,
+        "multiplier": 1,
+        "restricted_to": [
+          "pro",
+          "edu",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ]
+      },
+      "capabilities": {
+        "family": "gpt-5.3-codex",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": ["low", "medium", "high", "xhigh"],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.3-codex",
+      "is_chat_default": false,
+      "is_chat_fallback": true,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "name": "GPT-5.3-Codex",
+      "object": "model",
+      "preview": false,
+      "supported_endpoints": ["/responses", "ws:/responses"],
+      "vendor": "OpenAI",
+      "version": "gpt-5.3-codex"
+    },
+    {
+      "billing": {
+        "is_premium": true,
+        "multiplier": 1,
+        "restricted_to": [
+          "pro",
+          "pro_plus",
+          "individual_trial",
+          "business",
+          "enterprise",
+          "max"
+        ]
+      },
+      "capabilities": {
+        "family": "gpt-5.4",
+        "limits": {
+          "max_context_window_tokens": 400000,
+          "max_output_tokens": 128000,
+          "max_prompt_tokens": 272000,
+          "vision": {
+            "max_prompt_image_size": 3145728,
+            "max_prompt_images": 1,
+            "supported_media_types": [
+              "image/jpeg",
+              "image/png",
+              "image/webp",
+              "image/gif",
+              "application/pdf"
+            ]
+          }
+        },
+        "object": "model_capabilities",
+        "supports": {
+          "parallel_tool_calls": true,
+          "reasoning_effort": ["none", "low", "medium", "high", "xhigh"],
+          "streaming": true,
+          "structured_outputs": true,
+          "tool_calls": true,
+          "vision": true
+        },
+        "tokenizer": "o200k_base",
+        "type": "chat"
+      },
+      "id": "gpt-5.4",
+      "is_chat_default": false,
+      "is_chat_fallback": false,
+      "model_picker_category": "powerful",
+      "model_picker_enabled": true,
+      "name": "GPT-5.4",
+      "object": "model",
+      "policy": {
+        "state": "enabled",
+        "terms": "Enable access to the latest GPT-5.4 model from OpenAI. [Learn more about how GitHub Copilot serves GPT-5.4](https://gh.io/copilot-openai)."
+      },
+      "preview": false,
+      "supported_endpoints": [
+        "/responses",
+        "/chat/completions",
+        "ws:/responses"
+      ],
+      "vendor": "OpenAI",
+      "version": "gpt-5.4"
+    }
+  ],
+  "object": "list"
+}

--- a/tests/adapters/http/stubs/model_list/mistral.json
+++ b/tests/adapters/http/stubs/model_list/mistral.json
@@ -1,0 +1,162 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "mistral-medium-2505",
+      "object": "model",
+      "created": 1782930794,
+      "owned_by": "mistralai",
+      "capabilities": {
+        "completion_chat": true,
+        "function_calling": true,
+        "reasoning": false,
+        "completion_fim": false,
+        "fine_tuning": true,
+        "vision": true,
+        "ocr": false,
+        "classification": false,
+        "moderation": false,
+        "audio": false,
+        "audio_transcription": false,
+        "audio_transcription_realtime": false,
+        "audio_speech": false
+      },
+      "name": "mistral-medium-2505",
+      "description": "Our frontier-class multimodal model released May 2025.",
+      "max_context_length": 131072,
+      "aliases": [],
+      "deprecation": null,
+      "deprecation_replacement_model": null,
+      "default_model_temperature": 0.3,
+      "type": "base"
+    },
+    {
+      "id": "open-mistral-nemo",
+      "object": "model",
+      "created": 1782930794,
+      "owned_by": "mistralai",
+      "capabilities": {
+        "completion_chat": true,
+        "function_calling": true,
+        "reasoning": false,
+        "completion_fim": false,
+        "fine_tuning": true,
+        "vision": false,
+        "ocr": false,
+        "classification": false,
+        "moderation": false,
+        "audio": false,
+        "audio_transcription": false,
+        "audio_transcription_realtime": false,
+        "audio_speech": false
+      },
+      "name": "open-mistral-nemo",
+      "description": "Our best multilingual open source model released July 2024.",
+      "max_context_length": 131072,
+      "aliases": [
+        "open-mistral-nemo-2407",
+        "mistral-tiny-2407",
+        "mistral-tiny-latest"
+      ],
+      "deprecation": null,
+      "deprecation_replacement_model": null,
+      "default_model_temperature": 0.3,
+      "type": "base"
+    },
+    {
+      "id": "codestral-latest",
+      "object": "model",
+      "created": 1782930794,
+      "owned_by": "mistralai",
+      "capabilities": {
+        "completion_chat": true,
+        "function_calling": true,
+        "reasoning": false,
+        "completion_fim": true,
+        "fine_tuning": false,
+        "vision": false,
+        "ocr": false,
+        "classification": false,
+        "moderation": false,
+        "audio": false,
+        "audio_transcription": false,
+        "audio_transcription_realtime": false,
+        "audio_speech": false
+      },
+      "name": "codestral-2508",
+      "description": "Our cutting-edge language model for coding released August 2025.",
+      "max_context_length": 256000,
+      "aliases": [
+        "codestral-2508",
+        "mistral-code-latest",
+        "mistral-code-fim-latest"
+      ],
+      "deprecation": null,
+      "deprecation_replacement_model": null,
+      "default_model_temperature": 0.3,
+      "type": "base"
+    },
+    {
+      "id": "mistral-code-latest",
+      "object": "model",
+      "created": 1782930794,
+      "owned_by": "mistralai",
+      "capabilities": {
+        "completion_chat": true,
+        "function_calling": true,
+        "reasoning": false,
+        "completion_fim": true,
+        "fine_tuning": false,
+        "vision": false,
+        "ocr": false,
+        "classification": false,
+        "moderation": false,
+        "audio": false,
+        "audio_transcription": false,
+        "audio_transcription_realtime": false,
+        "audio_speech": false
+      },
+      "name": "codestral-2508",
+      "description": "Our cutting-edge language model for coding released August 2025.",
+      "max_context_length": 256000,
+      "aliases": [
+        "codestral-2508",
+        "codestral-latest",
+        "mistral-code-fim-latest"
+      ],
+      "deprecation": null,
+      "deprecation_replacement_model": null,
+      "default_model_temperature": 0.3,
+      "type": "base"
+    },
+    {
+      "id": "voxtral-mini-latest",
+      "object": "model",
+      "created": 1782930794,
+      "owned_by": "mistralai",
+      "capabilities": {
+        "completion_chat": false,
+        "function_calling": false,
+        "reasoning": false,
+        "completion_fim": false,
+        "fine_tuning": false,
+        "vision": false,
+        "ocr": false,
+        "classification": false,
+        "moderation": false,
+        "audio": false,
+        "audio_transcription": true,
+        "audio_transcription_realtime": false,
+        "audio_speech": false
+      },
+      "name": "voxtral-mini-2602",
+      "description": "Official voxtral-mini-2602 Mistral AI model",
+      "max_context_length": 16384,
+      "aliases": ["voxtral-mini-2602"],
+      "deprecation": null,
+      "deprecation_replacement_model": null,
+      "default_model_temperature": 0.0,
+      "type": "base"
+    }
+  ]
+}

--- a/tests/adapters/http/stubs/model_list/mistral.json
+++ b/tests/adapters/http/stubs/model_list/mistral.json
@@ -34,7 +34,7 @@
       "id": "open-mistral-nemo",
       "object": "model",
       "created": 1782930794,
-      "owned_by": "mistralai",
+      "owned_by": "mistralai",
       "capabilities": {
         "completion_chat": true,
         "function_calling": true,

--- a/tests/adapters/http/stubs/model_list/ollama.json
+++ b/tests/adapters/http/stubs/model_list/ollama.json
@@ -1,0 +1,64 @@
+{
+  "models": [
+    {
+      "name": "vatistasdim/Cipher:latest",
+      "model": "vatistasdim/Cipher:latest",
+      "modified_at": "2026-06-23T08:44:40.673864576+01:00",
+      "size": 2019376500,
+      "digest": "c71a0954f1d8596cd60227b577ef77b12625514297e65a3655ad4102a733633c",
+      "details": {
+        "parent_model": "",
+        "format": "gguf",
+        "family": "llama",
+        "families": ["llama"],
+        "parameter_size": "3.2B",
+        "quantization_level": "Q4_K_M"
+      }
+    },
+    {
+      "name": "phi4:latest",
+      "model": "phi4:latest",
+      "modified_at": "2026-06-23T08:40:53.626443834+01:00",
+      "size": 9053116391,
+      "digest": "ac896e5b8b34a1f4efa7b14d7520725140d5512484457fab45d2a4ea14c69dba",
+      "details": {
+        "parent_model": "",
+        "format": "gguf",
+        "family": "phi3",
+        "families": ["phi3"],
+        "parameter_size": "14.7B",
+        "quantization_level": "Q4_K_M"
+      }
+    },
+    {
+      "name": "gemma:latest",
+      "model": "gemma:latest",
+      "modified_at": "2026-04-04T11:21:40.71189545+01:00",
+      "size": 5011853225,
+      "digest": "a72c7f4d0a15522df81486d13ce432c79e191bda2558d024fbad4362c4f7cbf8",
+      "details": {
+        "parent_model": "",
+        "format": "gguf",
+        "family": "gemma",
+        "families": ["gemma"],
+        "parameter_size": "9B",
+        "quantization_level": "Q4_0"
+      }
+    },
+    {
+      "name": "llama3:latest",
+      "model": "llama3:latest",
+      "modified_at": "2026-01-11T18:55:35.681497009Z",
+      "size": 4661224676,
+      "digest": "365c0bd3c000a25d28ddbf732fe1c6add414de7275464c4e4d1c3b5fcb5d8ad1",
+      "details": {
+        "parent_model": "",
+        "format": "gguf",
+        "family": "llama",
+        "families": ["llama"],
+        "parameter_size": "8.0B",
+        "quantization_level": "Q4_0"
+      }
+    }
+  ]
+}

--- a/tests/adapters/http/stubs/model_list/openrouter.json
+++ b/tests/adapters/http/stubs/model_list/openrouter.json
@@ -1,0 +1,168 @@
+{
+  "data": [
+    {
+      "id": "anthropic/claude-sonnet-5",
+      "canonical_slug": "anthropic/claude-sonnet-5-20260630",
+      "hugging_face_id": null,
+      "name": "Anthropic: Claude Sonnet 5",
+      "created": 1782843083,
+      "description": "Sonnet 5 is Anthropic's most capable Sonnet-class model, with frontier performance across coding, agents, and professional work. It supports adaptive thinking with selectable reasoning effort levels (low, medium, high, max,...",
+      "context_length": 1000000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": ["text", "image", "file"],
+        "output_modalities": ["text"],
+        "tokenizer": "Claude",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000002",
+        "completion": "0.00001",
+        "web_search": "0.01",
+        "input_cache_read": "0.0000002",
+        "input_cache_write": "0.0000025",
+        "input_cache_write_1h": "0.000004"
+      },
+      "top_provider": {
+        "context_length": 1000000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "per_request_limits": null,
+      "supported_parameters": [
+        "include_reasoning",
+        "max_completion_tokens",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "stop",
+        "structured_outputs",
+        "tool_choice",
+        "tools",
+        "verbosity"
+      ],
+      "default_parameters": {
+        "temperature": null,
+        "top_p": null,
+        "top_k": null,
+        "frequency_penalty": null,
+        "presence_penalty": null,
+        "repetition_penalty": null
+      },
+      "supported_voices": null,
+      "knowledge_cutoff": null,
+      "expiration_date": null,
+      "links": {
+        "details": "/api/v1/models/anthropic/claude-sonnet-5-20260630/endpoints"
+      },
+      "benchmarks": {
+        "design_arena": [],
+        "artificial_analysis": {
+          "intelligence_index": 53.4,
+          "coding_index": 71.5,
+          "agentic_index": 46.7
+        }
+      },
+      "reasoning": {
+        "mandatory": false,
+        "supported_efforts": ["max", "xhigh", "high", "medium", "low"],
+        "default_effort": "medium"
+      }
+    },
+    {
+      "id": "microsoft/phi-4",
+      "canonical_slug": "microsoft/phi-4",
+      "hugging_face_id": "microsoft/phi-4",
+      "name": "Microsoft: Phi 4",
+      "created": 1736489872,
+      "description": "[Microsoft Research](/microsoft) Phi-4 is designed to perform well in complex reasoning tasks and can operate efficiently in situations with limited memory or where quick responses are needed. At 14 billion...",
+      "context_length": 16384,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000007",
+        "completion": "0.00000014"
+      },
+      "top_provider": {
+        "context_length": 16384,
+        "max_completion_tokens": 16384,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "supported_parameters": [
+        "frequency_penalty",
+        "logit_bias",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "top_k",
+        "top_p"
+      ],
+      "default_parameters": {},
+      "supported_voices": null,
+      "knowledge_cutoff": "2024-06-30",
+      "expiration_date": null,
+      "links": {
+        "details": "/api/v1/models/microsoft/phi-4/endpoints"
+      }
+    },
+    {
+      "id": "sao10k/l3.1-70b-hanami-x1",
+      "canonical_slug": "sao10k/l3.1-70b-hanami-x1",
+      "hugging_face_id": "Sao10K/L3.1-70B-Hanami-x1",
+      "name": "Sao10K: Llama 3.1 70B Hanami x1",
+      "created": 1736302854,
+      "description": "This is [Sao10K](/sao10k)'s experiment over [Euryale v2.2](/sao10k/l3.1-euryale-70b).",
+      "context_length": 16000,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "tokenizer": "Llama3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000003",
+        "completion": "0.000003"
+      },
+      "top_provider": {
+        "context_length": 16000,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "per_request_limits": null,
+      "supported_parameters": [
+        "frequency_penalty",
+        "logit_bias",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "top_k",
+        "top_p"
+      ],
+      "default_parameters": {},
+      "supported_voices": null,
+      "knowledge_cutoff": "2023-12-31",
+      "expiration_date": null,
+      "links": {
+        "details": "/api/v1/models/sao10k/l3.1-70b-hanami-x1/endpoints"
+      }
+    }
+  ]
+}

--- a/tests/adapters/http/test_anthropic.lua
+++ b/tests/adapters/http/test_anthropic.lua
@@ -1,6 +1,6 @@
 local h = require("tests.helpers")
 local tags = require("codecompanion.interactions.shared.tags")
-local transform = require("codecompanion.adapters.utils.tool_transformers")
+local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
 local adapter
 
 local new_set = MiniTest.new_set
@@ -667,7 +667,7 @@ T["Anthropic adapter"]["form_tools"] = function()
   local weather = require("tests.interactions.chat.tools.builtin.stubs.weather").schema
   local tools = { weather = { weather } }
 
-  h.eq({ tools = { transform.to_anthropic(weather) } }, adapter.handlers.form_tools(adapter, tools))
+  h.eq({ tools = { tool_transformer.to_anthropic(weather) } }, adapter.handlers.form_tools(adapter, tools))
 end
 
 T["Anthropic adapter"]["Non-Reasoning models have less tokens"] = function()
@@ -675,6 +675,13 @@ T["Anthropic adapter"]["Non-Reasoning models have less tokens"] = function()
     schema = {
       model = {
         default = "claude-3-5-sonnet-20241022",
+        choices = {
+          ["claude-3-5-sonnet-20241022"] = {
+            formatted_name = "Claude 3.5 Sonnet",
+            meta = { max_tokens = 4096 },
+            opts = {},
+          },
+        },
       },
     },
   })
@@ -687,6 +694,13 @@ T["Anthropic adapter"]["Reasoning models have more tokens"] = function()
     schema = {
       model = {
         default = "claude-opus-4-6",
+        choices = {
+          ["claude-opus-4-6"] = {
+            formatted_name = "Claude Opus 4.6",
+            meta = { max_tokens = 128000 },
+            opts = { can_reason = true },
+          },
+        },
       },
     },
   })
@@ -886,6 +900,35 @@ T["Anthropic adapter"]["No Streaming"]["can output for the inline assistant with
     [[<response>\n  <code>hello world</code>\n  <language>lua</language>\n  <placement>add</placement>\n</response>]],
     adapter.handlers.inline_output(adapter, json).output
   )
+end
+
+T["Anthropic model_transformers"] = new_set()
+
+T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model list"] = function()
+  local model_transformers = require("codecompanion.adapters.utils.models.transform")
+
+  local body = table.concat(vim.fn.readfile("tests/adapters/http/stubs/model_list/anthropic.json"), "\n")
+  local json = vim.json.decode(body)
+
+  local result = {}
+  for _, model in ipairs(json.data) do
+    local id, entry = model_transformers.from_anthropic(model)
+    result[id] = entry
+  end
+
+  h.eq("Claude Sonnet 5", result["claude-sonnet-5"].formatted_name)
+  h.eq({ context_window = 1000000, max_tokens = 128000 }, result["claude-sonnet-5"].meta)
+  h.eq(true, result["claude-sonnet-5"].opts.can_reason)
+  h.eq(true, result["claude-sonnet-5"].opts.has_vision)
+
+  -- Supports context_management as a whole, including compact_20260112
+  h.eq(true, result["claude-sonnet-5"].opts.can_manage_context)
+
+  -- Only supports the legacy "enabled" thinking type, not adaptive effort
+  h.eq(true, result["claude-haiku-4-5-20251001"].opts.legacy_reasoning)
+
+  -- Supports context_management (clear_tool_uses/clear_thinking) but not compact_20260112
+  h.eq(false, result["claude-haiku-4-5-20251001"].opts.can_manage_context)
 end
 
 return T

--- a/tests/adapters/http/test_mistral.lua
+++ b/tests/adapters/http/test_mistral.lua
@@ -267,4 +267,28 @@ T["Mistral adapter"]["No Streaming"]["can output for the inline assistant"] = fu
   h.eq("Dynamic Language", adapter.handlers.inline_output(adapter, json).output)
 end
 
+T["Mistral model_transformers"] = new_set()
+
+T["Mistral model_transformers"]["from_mistral() transforms the stubbed model list"] = function()
+  local model_transformers = require("codecompanion.adapters.utils.models.transform")
+
+  local body = table.concat(vim.fn.readfile("tests/adapters/http/stubs/model_list/mistral.json"), "\n")
+  local json = vim.json.decode(body)
+
+  local result = {}
+  for _, model in ipairs(json.data) do
+    local id, entry = model_transformers.from_mistral(model)
+    result[id] = entry
+  end
+
+  h.eq("mistral-medium-2505", result["mistral-medium-2505"].formatted_name)
+  h.eq({ context_window = 131072 }, result["mistral-medium-2505"].meta)
+  h.eq(true, result["mistral-medium-2505"].opts.has_vision)
+  h.eq(true, result["mistral-medium-2505"].opts.can_use_tools)
+  h.eq(false, result["mistral-medium-2505"].opts.can_reason)
+
+  h.eq(false, result["voxtral-mini-latest"].opts.can_use_tools)
+  h.eq(false, result["voxtral-mini-latest"].opts.can_form_structured_outputs)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

There are a number of providers that allow for their models to be dynamically retrieved via an API, such as Anthropic, Copilot, Mistral and OpenRouter. These endpoints also output model capabilities making it easy for CodeCompanion to know if they support function call, reasoning and vision.

Having their respective adapters load their models dynamically ensures that CodeCompanion does not need to be updated to add any new models as was the case with Fable 5 and Sonnet 5 with Anthropic. Caching the results for 30 mins also ensures that the operation remains cheap. This also ensures that users do not need to restart Neovim to use the latest models.

This has been in the plugin for a while with Copilot, Ollama and OpenRouter but this PR expands it to Anthropic and Mistral. Unfortunately other adapters do not have a robust endpoint for us to reach.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Sonnet-5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
