### PR TITLE
fix(acp): fall back to modes/models when agent lacks configOptions

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -376,7 +376,7 @@ function Connection:_establish_session()
   end
 
   local function apply_session_metadata(session_data, source)
-    if session_data.configOptions then
+    if session_data.configOptions and #session_data.configOptions > 0 then
       self:_apply_config_options(session_data.configOptions)
       log:debug("[acp::_establish_session] %s config options applied", source)
     else

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -32,6 +32,13 @@ local TIMEOUTS = {
   RESPONSE_POLL = 10, -- 10ms
 }
 
+-- Synthetic config option ids used for agents that only implement the
+-- older, separate `modes`/`models` session/new fields and the
+-- `session/set_mode` / `session/set_model` methods, rather than the unified
+-- `configOptions` / `session/set_config_option` extension.
+local LEGACY_MODE_CONFIG_ID = "__legacy_mode"
+local LEGACY_MODEL_CONFIG_ID = "__legacy_model"
+
 local api = vim.api
 local uv = vim.uv
 
@@ -372,6 +379,12 @@ function Connection:_establish_session()
     if session_data.configOptions then
       self:_apply_config_options(session_data.configOptions)
       log:debug("[acp::_establish_session] %s config options applied", source)
+    else
+      local legacy_options = Connection._legacy_config_options_from_session(session_data)
+      if #legacy_options > 0 then
+        self:_apply_config_options(legacy_options)
+        log:debug("[acp::_establish_session] %s legacy mode/model options applied", source)
+      end
     end
   end
 
@@ -793,6 +806,49 @@ function Connection:handle_available_commands_update(session_id, commands)
   acp_commands.register_commands(session_id, commands)
 end
 
+---Build synthetic SessionConfigOption entries from the older, separate
+---`modes`/`models` fields returned by `session/new` and `session/load`, for
+---agents that don't implement the `configOptions` extension.
+---@param session_data table
+---@return table[]
+function Connection._legacy_config_options_from_session(session_data)
+  local options = {}
+
+  local modes = session_data.modes
+  if modes and modes.availableModes and #modes.availableModes > 0 then
+    table.insert(options, {
+      id = LEGACY_MODE_CONFIG_ID,
+      name = "Mode",
+      description = "Session permission mode",
+      category = "mode",
+      type = "select",
+      currentValue = modes.currentModeId,
+      legacy_method = "mode",
+      options = vim.tbl_map(function(m)
+        return { value = m.id, name = m.name, description = m.description }
+      end, modes.availableModes),
+    })
+  end
+
+  local models = session_data.models
+  if models and models.availableModels and #models.availableModels > 0 then
+    table.insert(options, {
+      id = LEGACY_MODEL_CONFIG_ID,
+      name = "Model",
+      description = "AI model to use",
+      category = "model",
+      type = "select",
+      currentValue = models.currentModelId,
+      legacy_method = "model",
+      options = vim.tbl_map(function(m)
+        return { value = m.modelId, name = m.name, description = m.description }
+      end, models.availableModels),
+    })
+  end
+
+  return options
+end
+
 ---Store raw configOptions from the agent
 ---@param config_options table[] Array of SessionConfigOption
 function Connection:_apply_config_options(config_options)
@@ -952,6 +1008,36 @@ function Connection:build_name_map()
   return name_map
 end
 
+---Set a mode/model via the legacy `session/set_mode` / `session/set_model`
+---methods, for agents that only expose the separate `modes`/`models` fields
+---rather than the unified `configOptions` extension.
+---@param option table The synthetic config option (see `_legacy_config_options_from_session`)
+---@param config_id string The config option ID
+---@param value string The value ID to set
+---@return boolean success
+function Connection:_set_legacy_config_option(option, config_id, value)
+  local method, param_key
+  if option.legacy_method == "mode" then
+    method, param_key = METHODS.SESSION_SET_MODE, "modeId"
+  else
+    method, param_key = METHODS.SESSION_SET_MODEL, "modelId"
+  end
+
+  local result = self:send_rpc_request(method, {
+    sessionId = self.session_id,
+    [param_key] = value,
+  })
+
+  if not result then
+    log:error("[acp::set_config_option] Failed to set %s to %s", config_id, value)
+    return false
+  end
+
+  option.currentValue = value
+  log:debug("[acp::set_config_option] Changed %s to %s (legacy)", config_id, value)
+  return true
+end
+
 ---Set a config option via session/set_config_option
 ---@param config_id string The config option ID
 ---@param value string The value ID to set
@@ -960,6 +1046,12 @@ function Connection:set_config_option(config_id, value)
   if not self.session_id then
     log:error("[acp::set_config_option] Connection not established")
     return false
+  end
+
+  for _, opt in ipairs(self._config_options or {}) do
+    if opt.id == config_id and opt.legacy_method then
+      return self:_set_legacy_config_option(opt, config_id, value)
+    end
   end
 
   -- Ref: https://agentclientprotocol.com/protocol/session-config-options#from-the-client

--- a/lua/codecompanion/acp/methods.lua
+++ b/lua/codecompanion/acp/methods.lua
@@ -8,6 +8,8 @@ return {
   SESSION_PROMPT = "session/prompt",
   SESSION_REQUEST_PERMISSION = "session/request_permission",
   SESSION_SET_CONFIG_OPTION = "session/set_config_option",
+  SESSION_SET_MODE = "session/set_mode",
+  SESSION_SET_MODEL = "session/set_model",
   SESSION_UPDATE = "session/update",
   FS_READ_TEXT_FILE = "fs/read_text_file",
   FS_WRITE_TEXT_FILE = "fs/write_text_file",

--- a/tests/acp/test_acp.lua
+++ b/tests/acp/test_acp.lua
@@ -314,6 +314,39 @@ T["ACP Connection"]["session/new synthesizes config options from legacy models/m
   h.eq(result.models.currentModelId, "glm-5.1")
 end
 
+T["ACP Connection"]["falls back to legacy models/modes when configOptions is an empty array"] = function()
+  local result = child.lua([[
+    local connection = create_init_connection()
+    function connection:send_rpc_request(method, params)
+      if method == "initialize" then
+        return { protocolVersion = 1, authMethods = {}, agentCapabilities = { loadSession = false } }
+      elseif method == "session/new" then
+        return {
+          sessionId = "new-session",
+          configOptions = {},
+          models = {
+            currentModelId = "glm-5.1",
+            availableModels = { { modelId = "glm-5.1", name = "GLM-5.1" } },
+          },
+          modes = {
+            currentModeId = "default",
+            availableModes = { { id = "default", name = "Default" } },
+          },
+        }
+      end
+    end
+
+    local ok = connection:connect_and_initialize()
+    return {
+      ok = ok ~= nil,
+      config_options_count = #connection:get_config_options(),
+    }
+  ]])
+
+  h.eq(result.ok, true)
+  h.eq(result.config_options_count, 2)
+end
+
 T["ACP Connection"]["set_config_option routes legacy mode/model options through session/set_mode and session/set_model"] = function()
   local result = child.lua([[
     local connection = create_init_connection()

--- a/tests/acp/test_acp.lua
+++ b/tests/acp/test_acp.lua
@@ -271,6 +271,108 @@ T["ACP Connection"]["session/new stores config options metadata"] = function()
   h.eq(result.models.availableModels[1].modelId, "claude-opus")
 end
 
+T["ACP Connection"]["session/new synthesizes config options from legacy models/modes"] = function()
+  local result = child.lua([[
+    local connection = create_init_connection()
+    function connection:send_rpc_request(method, params)
+      if method == "initialize" then
+        return { protocolVersion = 1, authMethods = {}, agentCapabilities = { loadSession = false } }
+      elseif method == "session/new" then
+        return {
+          sessionId = "new-session",
+          models = {
+            currentModelId = "glm-5.1",
+            availableModels = {
+              { modelId = "glm-5.1", name = "GLM-5.1", description = "Latest GLM reasoning model" },
+              { modelId = "glm-4.7", name = "GLM-4.7", description = "200K-context reasoning model" },
+            },
+          },
+          modes = {
+            currentModeId = "default",
+            availableModes = {
+              { id = "default", name = "Ask for permission", description = "Prompt before edits and commands." },
+              { id = "bypassPermissions", name = "Bypass all permissions", description = "Edits and commands run without prompting." },
+            },
+          },
+        }
+      end
+    end
+
+    local ok = connection:connect_and_initialize()
+    local options = connection:get_config_options()
+    return {
+      ok = ok ~= nil,
+      config_options_count = #options,
+      models = connection:get_models(),
+    }
+  ]])
+
+  h.eq(result.ok, true)
+  h.eq(result.config_options_count, 2)
+  h.eq(#result.models.availableModels, 2)
+  h.eq(result.models.availableModels[1].modelId, "glm-5.1")
+  h.eq(result.models.currentModelId, "glm-5.1")
+end
+
+T["ACP Connection"]["set_config_option routes legacy mode/model options through session/set_mode and session/set_model"] = function()
+  local result = child.lua([[
+    local connection = create_init_connection()
+    local calls = {}
+    function connection:send_rpc_request(method, params)
+      table.insert(calls, { method = method, params = params })
+      if method == "initialize" then
+        return { protocolVersion = 1, authMethods = {}, agentCapabilities = { loadSession = false } }
+      elseif method == "session/new" then
+        return {
+          sessionId = "new-session",
+          models = {
+            currentModelId = "glm-5.1",
+            availableModels = { { modelId = "glm-5.1", name = "GLM-5.1" }, { modelId = "glm-4.7", name = "GLM-4.7" } },
+          },
+          modes = {
+            currentModeId = "default",
+            availableModes = { { id = "default", name = "Default" }, { id = "bypassPermissions", name = "Bypass" } },
+          },
+        }
+      elseif method == "session/set_mode" or method == "session/set_model" then
+        return {}
+      end
+    end
+
+    connection:connect_and_initialize()
+
+    local model_opt, mode_opt
+    for _, opt in ipairs(connection:get_config_options()) do
+      if opt.category == "model" then model_opt = opt end
+      if opt.category == "mode" then mode_opt = opt end
+    end
+
+    local model_ok = connection:set_config_option(model_opt.id, "glm-4.7")
+    local mode_ok = connection:set_config_option(mode_opt.id, "bypassPermissions")
+
+    return {
+      model_ok = model_ok,
+      mode_ok = mode_ok,
+      calls = calls,
+      model_current_value = model_opt.currentValue,
+      mode_current_value = mode_opt.currentValue,
+    }
+  ]])
+
+  h.eq(result.model_ok, true)
+  h.eq(result.mode_ok, true)
+  h.eq(result.model_current_value, "glm-4.7")
+  h.eq(result.mode_current_value, "bypassPermissions")
+
+  local methods_called = {}
+  for _, c in ipairs(result.calls) do
+    table.insert(methods_called, c.method)
+  end
+  h.eq(true, vim.tbl_contains(methods_called, "session/set_mode"))
+  h.eq(true, vim.tbl_contains(methods_called, "session/set_model"))
+  h.eq(false, vim.tbl_contains(methods_called, "session/set_config_option"))
+end
+
 T["ACP Connection"]["falls back to session/new if session/load fails"] = function()
   local result = child.lua([[
     local calls = {}


### PR DESCRIPTION
Some ACP agents (e.g. glm-acp-agent) only implement the standard, separate `modes`/`models` session/new fields and the `session/set_mode` / `session/set_model` methods, without the newer unified `configOptions` / `session/set_config_option` extension. Previously this left `_config_options` empty, so `/acp_session_options` always reported "No configuration options available" for those agents.

Synthesize configOptions-shaped entries from `modes`/`models` when the agent doesn't send `configOptions`, and route `set_config_option` calls for those entries through `session/set_mode`/`session/set_model`.

<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

- `lua/codecompanion/acp/methods.lua`: added `SESSION_SET_MODE`/`SESSION_SET_MODEL` method constants.
- `lua/codecompanion/acp/init.lua`:
  - `Connection._legacy_config_options_from_session()` synthesizes `configOptions`-shaped entries from `session_data.modes`/`session_data.models` when the agent doesn't send `configOptions`.
  - `_establish_session` now falls back to this synthesis.
  - `set_config_option()` detects these synthetic entries (tagged `legacy_method`) and routes them through `session/set_mode` / `session/set_model` instead of `session/set_config_option`, updating `currentValue` locally since those methods don't echo back state.
- Added two tests in `tests/acp/test_acp.lua` reproducing the exact glm-acp-agent payload shape; all 26 ACP tests and the full suite (0 fails) pass.
- Verified live against your actual running `glm-acp-agent` process: `get_config_options()` now returns Mode (3 values) and Model (5 values), matching your log, and `set_config_option` correctly flips the model via `session/set_model`.

`/acp_session_options` should now work for the `glm_acp` adapter — and as a bonus, model switching via `<leader>ca` for that adapter is also fixed, since it used the same `_config_options` machinery.

some relevant glm-acp-agent json-rpc messages sent:

```
{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentInfo":{"name":"glm-acp-agent","version":"1.0.0"},"authMethods":[{"id":"z-ai-api-key","name":"Z.AI API key","description":"Set Z_AI_API_KEY in the environment, or run `glm-acp-agent --setup` once to store the key on disk. Generate one at https://z.ai/manage-apikey/apikey-list"},{"type":"env_var","id":"z_ai_api_key","name":"Z.AI API key","description":"API key for the Z.AI / Zhipu AI service. Generate one at https://z.ai/manage-apikey/apikey-list","link":"https://z.ai/manage-apikey/apikey-list","vars":[{"name":"Z_AI_API_KEY","label":"Z.AI API key","secret":true,"optional":false}]}],"agentCapabilities":{"loadSession":true,"mcpCapabilities":{"http":true},"promptCapabilities":{"embeddedContext":true,"image":true},"sessionCapabilities":{"close":{},"list":{},"fork":{},"resume":{}}}}}
{"jsonrpc":"2.0","id":2,"result":{"sessionId":"a742afe8-3d31-4af9-b19a-7f22fc4f9426","models":{"availableModels":[{"modelId":"glm-5.1","name":"GLM-5.1","description":"Latest GLM reasoning model with thinking mode"},{"modelId":"glm-5-turbo","name":"GLM-5 Turbo","description":"Faster Coding Plan reasoning model"},{"modelId":"glm-5v-turbo","name":"GLM-5V Turbo","description":"Multimodal Coding Plan model with native vision"},{"modelId":"glm-4.7","name":"GLM-4.7","description":"200K-context reasoning model"},{"modelId":"glm-4.5-air","name":"GLM-4.5 Air","description":"Lightweight, lower-latency model"}],"currentModelId":"glm-5.1"},"modes":{"availableModes":[{"id":"default","name":"Ask for permission","description":"Prompt before edits and commands."},{"id":"accept_edits","name":"Auto-approve edits","description":"Edits run without prompting. Commands still prompt."},{"id":"bypass_permissions","name":"Bypass all permissions","description":"Edits and commands run without prompting."}],"currentModeId":"default"}}}
```

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->
claude

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->
<img width="1920" height="1200" alt="20260704_0719_1920x1200_1783142392" src="https://github.com/user-attachments/assets/7beafbf7-5203-49bb-87bc-9a3403a4cd11" />
<img width="1920" height="1200" alt="20260704_0719_1920x1200_1783142382" src="https://github.com/user-attachments/assets/3b646c34-a4a0-41d1-8936-ab3fd8dad347" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
