### PR TITLE
fix(codex): filter ACP auth env by auth method

### DIFF
--- a/lua/codecompanion/adapters/acp/codex.lua
+++ b/lua/codecompanion/adapters/acp/codex.lua
@@ -1,5 +1,14 @@
 local helpers = require("codecompanion.adapters.acp.helpers")
 
+local AUTH_ENV_BY_METHOD = {
+  ["openai-api-key"] = {
+    OPENAI_API_KEY = true,
+  },
+  ["codex-api-key"] = {
+    CODEX_API_KEY = true,
+  },
+}
+
 ---@class CodeCompanion.ACPAdapter.Codex: CodeCompanion.ACPAdapter
 return {
   name = "codex",
@@ -24,6 +33,7 @@ return {
   },
   env = {
     OPENAI_API_KEY = "OPENAI_API_KEY",
+    CODEX_API_KEY = "CODEX_API_KEY",
   },
   parameters = {
     protocolVersion = 1,
@@ -39,6 +49,16 @@ return {
     ---@param self CodeCompanion.ACPAdapter
     ---@return boolean
     setup = function(self)
+      local allowed_env = AUTH_ENV_BY_METHOD[self.defaults.auth_method] or {}
+      local filtered_env = {}
+
+      for env_name, env_value in pairs(self.env_replaced or {}) do
+        if allowed_env[env_name] then
+          filtered_env[env_name] = env_value
+        end
+      end
+
+      self.env_replaced = filtered_env
       return true
     end,
 

--- a/tests/acp/test_acp.lua
+++ b/tests/acp/test_acp.lua
@@ -297,6 +297,43 @@ T["ACP Connection"]["falls back to session/new if session/load fails"] = functio
   h.eq(result.session_id, "new-session")
 end
 
+T["ACP Connection"]["start_agent_process passes filtered codex env vars"] = function()
+  local result = child.lua([[
+    local codex_adapter = require("codecompanion.adapters.acp.codex")
+    local captured_env
+
+    local connection = create_test_connection({
+      job = function(command, options)
+        captured_env = options.env
+        return { write = function() end }
+      end,
+    })
+
+    function connection:prepare_adapter()
+      return {
+        command = { "codex-acp" },
+        defaults = { auth_method = "chatgpt" },
+        parameters = test_adapter.parameters,
+        env_replaced = {
+          OPENAI_API_KEY = "openai-test-key",
+          CODEX_API_KEY = "codex-test-key",
+        },
+        handlers = codex_adapter.handlers,
+      }
+    end
+
+    local started = connection:start_agent_process()
+
+    return {
+      started = started,
+      env = captured_env,
+    }
+  ]])
+
+  h.eq(true, result.started)
+  h.eq({}, result.env)
+end
+
 T["ACP Responses"] = new_set()
 
 T["ACP Responses"]["handles partial JSON messages correctly"] = function()

--- a/tests/adapters/acp/test_acp.lua
+++ b/tests/adapters/acp/test_acp.lua
@@ -107,4 +107,73 @@ T["ACP Adapter"]["extends adapters correctly"] = function()
   h.eq({ max_tokens = 1000 }, result.parameters)
 end
 
+T["ACP Adapter"]["codex chatgpt auth does not pass API key env vars"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.adapters.utils")
+    local adapter = require("codecompanion.adapters.acp").extend("codex", {
+      env = {
+        OPENAI_API_KEY = "openai-test-key",
+        CODEX_API_KEY = "codex-test-key",
+      },
+      defaults = {
+        auth_method = "chatgpt",
+      },
+    })
+
+    adapter = utils.get_env_vars(adapter)
+    adapter.defaults.auth_method = utils.set_env_vars(adapter, adapter.defaults.auth_method)
+    adapter.handlers.setup(adapter)
+
+    return adapter.env_replaced
+  ]])
+
+  h.eq({}, result)
+end
+
+T["ACP Adapter"]["codex openai-api-key auth keeps OPENAI_API_KEY only"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.adapters.utils")
+    local adapter = require("codecompanion.adapters.acp").extend("codex", {
+      env = {
+        OPENAI_API_KEY = "openai-test-key",
+        CODEX_API_KEY = "codex-test-key",
+      },
+      defaults = {
+        auth_method = "openai-api-key",
+      },
+    })
+
+    adapter = utils.get_env_vars(adapter)
+    adapter.defaults.auth_method = utils.set_env_vars(adapter, adapter.defaults.auth_method)
+    adapter.handlers.setup(adapter)
+
+    return adapter.env_replaced
+  ]])
+
+  h.eq({ OPENAI_API_KEY = "openai-test-key" }, result)
+end
+
+T["ACP Adapter"]["codex codex-api-key auth keeps CODEX_API_KEY only"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.adapters.utils")
+    local adapter = require("codecompanion.adapters.acp").extend("codex", {
+      env = {
+        OPENAI_API_KEY = "openai-test-key",
+        CODEX_API_KEY = "codex-test-key",
+      },
+      defaults = {
+        auth_method = "codex-api-key",
+      },
+    })
+
+    adapter = utils.get_env_vars(adapter)
+    adapter.defaults.auth_method = utils.set_env_vars(adapter, adapter.defaults.auth_method)
+    adapter.handlers.setup(adapter)
+
+    return adapter.env_replaced
+  ]])
+
+  h.eq({ CODEX_API_KEY = "codex-test-key" }, result)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR updates the Codex ACP adapter so `codex-acp` only receives API-key environment variables when the selected `auth_method` actually requires them.

In `chatgpt` mode, the adapter now launches without `OPENAI_API_KEY` or `CODEX_API_KEY`, which avoids upstream `codex-acp` API-key detection overriding ChatGPT auth.

This behavior change is specifically needed for the newer `agentclientprotocol/codex-acp` project:
https://github.com/agentclientprotocol/codex-acp

The older `zed-industries/codex-acp` project does not exhibit this problem and behaves correctly already:
https://github.com/zed-industries/codex-acp

This PR also preserves key-based behavior by passing only the relevant key for `openai-api-key` and `codex-api-key`, and adds regression coverage for adapter setup plus ACP process launch.

## AI Usage

Codex (GPT-5)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages

## Tests

- `make test_file FILE=tests/adapters/acp/test_acp.lua`
- `make test_file FILE=tests/acp/test_acp.lua`
- Full suite note: `make test` was run in this environment, but it reports existing screenshot/UI failures unrelated to this change and missing `tree-sitter` CLI parser compilation.
- Formatting note: `make format` could not be completed in this environment because `stylua` is not installed.
