### PR TITLE
fix(inline): orphaned keymaps after request

### DIFF
--- a/lua/codecompanion/diff/ui.lua
+++ b/lua/codecompanion/diff/ui.lua
@@ -195,8 +195,9 @@ function DiffUI:setup_keymaps(opts)
     self:_set_keymap("n", shared_keymaps.previous_hunk.modes.n, keymaps.previous_hunk)
   end
 
-  -- Always add 'q' to close
-  self:_set_keymap("n", "q", keymaps.close_window)
+  if not self.inline then
+    self:_set_keymap("n", "q", keymaps.close_window)
+  end
 end
 
 ---Apply diff highlighting to merged lines in a buffer

--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -432,6 +432,8 @@ function Inline:submit(prompt)
       ---@param data table
       ---@param adapter CodeCompanion.HTTPAdapter The modified adapter from the http client
       callback = function(err, data, adapter)
+        require("codecompanion.interactions.inline.keymaps").clear_map(config.interactions.inline.keymaps, self.bufnr)
+
         local function error(msg)
           log:error("[Inline] Request failed with error %s", msg)
         end

--- a/lua/codecompanion/interactions/inline/keymaps.lua
+++ b/lua/codecompanion/interactions/inline/keymaps.lua
@@ -6,7 +6,7 @@ local M = {}
 ---Clear a keymap from a specific buffer
 ---@param keymaps table
 ---@param bufnr? number
-local function clear_map(keymaps, bufnr)
+function M.clear_map(keymaps, bufnr)
   bufnr = bufnr or 0
 
   for _, map in pairs(keymaps) do
@@ -19,7 +19,7 @@ end
 M.stop = {
   callback = function(inline)
     inline:stop()
-    clear_map(config.interactions.inline.keymaps, inline.bufnr)
+    M.clear_map(config.interactions.inline.keymaps, inline.bufnr)
     log:trace("[Inline] Cancelling the request")
   end,
 }

--- a/tests/interactions/inline/test_inline.lua
+++ b/tests/interactions/inline/test_inline.lua
@@ -221,6 +221,27 @@ T["Inline"]["integration"] = function()
   h.eq("<prompt>can you print hello world?</prompt>", submitted_prompts[3].content)
 end
 
+T["Inline"]["removes the stop keymap once the request finishes"] = function()
+  child.lua([[inline:set_keymaps(inline.buffer_context.bufnr, { keymaps = { "stop" } })]])
+
+  local has_stop_keymap = function()
+    return child.lua([[
+      for _, map in ipairs(vim.api.nvim_buf_get_keymap(0, "n")) do
+        if map.lhs == "q" then
+          return true
+        end
+      end
+      return false
+    ]])
+  end
+
+  h.eq(true, has_stop_keymap())
+
+  child.lua([[inline:reset()]])
+
+  h.eq(false, has_stop_keymap())
+end
+
 T["Inline"]["can parse adapter syntax"] = function()
   child.lua([[
     _G.submitted_prompts = {}

--- a/tests/interactions/inline/test_inline.lua
+++ b/tests/interactions/inline/test_inline.lua
@@ -221,25 +221,33 @@ T["Inline"]["integration"] = function()
   h.eq("<prompt>can you print hello world?</prompt>", submitted_prompts[3].content)
 end
 
-T["Inline"]["removes the stop keymap once the request finishes"] = function()
-  child.lua([[inline:set_keymaps(inline.buffer_context.bufnr, { keymaps = { "stop" } })]])
+T["Inline"]["clears the stop keymap as soon as the request completes"] = function()
+  child.lua([[
+    local http = require("codecompanion.http")
+    _G.original_http_new = http.new
+    http.new = function()
+      return {
+        request = function(_, _, actions)
+          actions.callback("network error")
+        end,
+      }
+    end
 
-  local has_stop_keymap = function()
-    return child.lua([[
-      for _, map in ipairs(vim.api.nvim_buf_get_keymap(0, "n")) do
-        if map.lhs == "q" then
-          return true
-        end
+    inline:submit({ { role = "user", content = "test prompt" } })
+  ]])
+
+  local has_stop_keymap = child.lua([[
+    for _, map in ipairs(vim.api.nvim_buf_get_keymap(0, "n")) do
+      if map.lhs == "q" then
+        return true
       end
-      return false
-    ]])
-  end
+    end
+    return false
+  ]])
 
-  h.eq(true, has_stop_keymap())
+  h.eq(false, has_stop_keymap)
 
-  child.lua([[inline:reset()]])
-
-  h.eq(false, has_stop_keymap())
+  child.lua([[require("codecompanion.http").new = _G.original_http_new]])
 end
 
 T["Inline"]["can parse adapter syntax"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As per the issue below, an orphaned `q` keymap would be left behind after an inline request which would scupper anyone's attempts at using macros in the buffer.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Sonnet-5

## Related Issue(s)

#3205

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
