### PR TITLE
feat(adapters): fetch models async

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Core: `lua/codecompanion/`
 - When the user asks to fix tests, fix the tests — not the source code — unless explicitly asked otherwise.
 - If you're working with directories or files, utilise the functions in `codecompanion/utils/files.lua` ensuring you join paths with `vim.fs.joinpath`
 
+### Testing
+
+- When running `make test_file` tests, do not append `| tail -12` or similar to filter the output. This prevents the user's rules governing what can be auto-accepted, from applying
+
 ## Important instructions
 
 - Do what has been asked; nothing more, nothing less.

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -5,7 +5,7 @@ local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
 local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
 
-local models = fetch_models.sync({
+local model_source = {
   name = "Anthropic",
   url = "https://api.anthropic.com/v1/models",
   ---@param adapter CodeCompanion.HTTPAdapter
@@ -14,7 +14,7 @@ local models = fetch_models.sync({
     adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
     return adapter_utils.set_env_vars(adapter, adapter.headers)
   end,
-})
+}
 
 ---@class CodeCompanion.HTTPAdapter.Anthropic: CodeCompanion.HTTPAdapter
 return {
@@ -680,9 +680,10 @@ return {
       desc = "The model that will complete your prompt. See https://docs.anthropic.com/claude/docs/models-overview for additional details and options.",
       default = "claude-sonnet-5",
       ---@param self CodeCompanion.HTTPAdapter
+      ---@param opts? { async?: boolean }
       ---@return table<string, CodeCompanion.Adapter.ModelChoice>
-      choices = function(self)
-        return models(self)
+      choices = function(self, opts)
+        return fetch_models.get(model_source, self, opts)
       end,
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -5,7 +5,7 @@ local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
 local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
 
-local model_source = {
+local models_source = {
   name = "Anthropic",
   url = "https://api.anthropic.com/v1/models",
   ---@param adapter CodeCompanion.HTTPAdapter
@@ -683,7 +683,7 @@ return {
       ---@param opts? { async?: boolean }
       ---@return table<string, CodeCompanion.Adapter.ModelChoice>
       choices = function(self, opts)
-        return fetch_models.get(model_source, self, opts)
+        return fetch_models.get(models_source, self, opts)
       end,
     },
     ---@type CodeCompanion.Schema

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -1,14 +1,5 @@
-local Curl = require("plenary.curl")
-
-local config = require("codecompanion.config")
-local log = require("codecompanion.utils.log")
-local model_transformers = require("codecompanion.adapters.utils.models.transform")
+local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local token = require("codecompanion.adapters.http.copilot.token")
-
-local CONSTANTS = {
-  TIMEOUT = 3000, -- 3 seconds
-  POLL_INTERVAL = 10,
-}
 
 local M = {}
 
@@ -17,152 +8,57 @@ local M = {}
 ---@field vendor string
 ---@field opts { can_stream: boolean, can_use_tools: boolean, has_vision: boolean }
 
--- Cache / state
-local _cached_models
-local _cached_adapter
-local _cache_expires
-local _fetch_in_progress = false
-
----Reset the cache
----@return nil
-function M.reset_cache()
-  _cached_adapter = nil
+---Resolve the Copilot token to authenticate the models request with
+---@param request_opts? { token?: table, async?: boolean }
+---@return table|nil
+local function resolve_token(request_opts)
+  if request_opts and request_opts.token then
+    return request_opts.token
+  end
+  local force = request_opts and request_opts.async == false
+  return token.fetch({ force = force })
 end
 
----Refresh the cache expiry timestamp
----@param seconds number|nil Number of seconds until the cache expires. Default: 1800
----@return number
-local function set_cache_expiry(seconds)
-  seconds = seconds or 1800
-  _cache_expires = os.time() + seconds
-  return _cache_expires
-end
+local model_source = {
+  name = "Copilot",
+  ---@param _ CodeCompanion.HTTPAdapter
+  ---@param request_opts? { token?: table, async?: boolean }
+  ---@return string
+  url = function(_, request_opts)
+    local fresh_token = resolve_token(request_opts)
+    local base_url = (fresh_token and fresh_token.endpoints and fresh_token.endpoints.api)
+      or "https://api.githubcopilot.com"
+    return base_url .. "/models"
+  end,
+  ---@param adapter CodeCompanion.HTTPAdapter
+  ---@param request_opts? { token?: table, async?: boolean }
+  ---@return table|nil
+  headers = function(adapter, request_opts)
+    local fresh_token = resolve_token(request_opts)
+    if not fresh_token or not fresh_token.copilot_token then
+      return nil
+    end
 
----Return cached models if the cache is still valid.
----@return CopilotModels|nil
-local function get_cached_models()
-  if _cached_models and _cache_expires and _cache_expires > os.time() then
-    log:trace("Copilot Adapter: Using cached Copilot models")
-    return _cached_models
-  end
-  return nil
-end
-
----Asynchronously fetch the list of available Copilot
----@param adapter table
----@param opts? { token: table, force: boolean } Whether to force token initialization if not available
----@return boolean
-local function fetch_async(adapter, opts)
-  _cached_models = get_cached_models()
-  if _cached_models then
-    return true
-  end
-  if _fetch_in_progress then
-    return true
-  end
-  _fetch_in_progress = true
-
-  opts = opts or {}
-
-  if not _cached_adapter then
-    _cached_adapter = adapter
-  end
-
-  local fresh_token = opts.token or token.fetch({ force = opts.force })
-
-  if not fresh_token or not fresh_token.copilot_token then
-    log:trace("Copilot Adapter: No copilot token available, skipping async models fetch")
-    _fetch_in_progress = false
-    return false
-  end
-
-  local base_url = (fresh_token.endpoints and fresh_token.endpoints.api) or "https://api.githubcopilot.com"
-  local url = base_url .. "/models"
-
-  local headers = vim.deepcopy(_cached_adapter.headers or {})
-  headers["Authorization"] = "Bearer " .. fresh_token.copilot_token
-  headers["X-Github-Api-Version"] = "2025-10-01"
-
-  -- Async request via plenary.curl with a callback
-  local ok, err = pcall(function()
-    Curl.get(url, {
-      headers = headers,
-      insecure = config.adapters.http.opts.allow_insecure,
-      proxy = config.adapters.http.opts.proxy,
-      callback = vim.schedule_wrap(function(response)
-        _fetch_in_progress = false
-
-        if not response or not response.body then
-          log:error("Could not get the Copilot models from " .. url .. ". Empty response")
-          return
-        end
-
-        local ok_json, json = pcall(vim.json.decode, response.body)
-        if not ok_json or type(json) ~= "table" or not json.data then
-          log:error("Error parsing the response from " .. url .. ".\nError: %s", response.body)
-          return
-        end
-
-        local models = {}
-        for _, model in ipairs(json.data) do
-          local id, entry = model_transformers.from_copilot(model)
-          if id then
-            models[id] = entry
-          else
-            log:debug("Copilot Adapter: Skipping model '%s'", model.id)
-          end
-        end
-
-        _cached_models = models
-        set_cache_expiry(config.adapters.http.opts.cache_models_for)
-      end),
-    })
-  end)
-
-  if not ok then
-    _fetch_in_progress = false
-    log:error("Could not start async request for Copilot models: %s", err)
-    return false
-  end
-
-  return true
-end
-
----Fetch the list of available Copilot models synchronously.
----@param adapter table
----@param opts { token: table, async: boolean }
----@return CopilotModels|nil
-local function fetch(adapter, opts)
-  local _ = fetch_async(adapter, { token = opts.token, force = true })
-
-  -- Block until models are cached or timeout
-  local ok = vim.wait(CONSTANTS.TIMEOUT, function()
-    return get_cached_models() ~= nil
-  end, CONSTANTS.POLL_INTERVAL)
-
-  if not ok then
-    return log:error("Copilot Adapter: Timeout waiting for models")
-  end
-
-  return _cached_models
-end
+    local headers = vim.deepcopy(adapter.headers or {})
+    headers["Authorization"] = "Bearer " .. fresh_token.copilot_token
+    headers["X-Github-Api-Version"] = "2025-10-01"
+    return headers
+  end,
+}
 
 ---Canonical interface used by adapter.schema.model.choices implementations.
 ---@param adapter table
 ---@param opts? { token: table, async: boolean }
 ---@return CopilotModels|nil
 function M.choices(adapter, opts)
-  opts = opts or {}
-  opts.async = opts.async ~= false -- Default to true unless explicitly false
+  local result = fetch_models.get(model_source, adapter, opts)
 
-  if opts.async == false then
-    return fetch(adapter, opts)
+  if opts and opts.async == false then
+    return result
   end
 
-  -- Non-blocking: start async fetching (if possible) and return whatever is cached
-  -- Don't force token initialization for async requests
-  fetch_async(adapter, { token = opts.token, force = false })
-  return get_cached_models()
+  -- Non-blocking lookups return nil until the background fetch has populated the cache
+  return (result and not vim.tbl_isempty(result)) and result or nil
 end
 
 return M

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -19,7 +19,7 @@ local function resolve_token(request_opts)
   return token.fetch({ force = force })
 end
 
-local model_source = {
+local models_source = {
   name = "Copilot",
   ---@param _ CodeCompanion.HTTPAdapter
   ---@param request_opts? { token?: table, async?: boolean }
@@ -51,7 +51,7 @@ local model_source = {
 ---@param opts? { token: table, async: boolean }
 ---@return CopilotModels|nil
 function M.choices(adapter, opts)
-  local result = fetch_models.get(model_source, adapter, opts)
+  local result = fetch_models.get(models_source, adapter, opts)
 
   if opts and opts.async == false then
     return result

--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -383,7 +383,6 @@ return {
       return handlers(self).inline_output(self, data, context)
     end,
     on_exit = function(self, data)
-      get_models.reset_cache()
       return handlers(self).on_exit(self, data)
     end,
   },

--- a/lua/codecompanion/adapters/http/mistral.lua
+++ b/lua/codecompanion/adapters/http/mistral.lua
@@ -4,7 +4,7 @@ local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
-local models = fetch_models.sync({
+local model_source = {
   name = "Mistral",
   url = "https://api.mistral.ai/v1/models",
   ---@param adapter CodeCompanion.HTTPAdapter
@@ -13,7 +13,7 @@ local models = fetch_models.sync({
     adapter_utils.get_env_vars(adapter, { timeout = config.adapters.opts.cmd_timeout })
     return adapter_utils.set_env_vars(adapter, adapter.headers)
   end,
-})
+}
 
 ---@class CodeCompanion.HTTPAdapter.Mistral: CodeCompanion.HTTPAdapter
 return {
@@ -213,9 +213,10 @@ return {
       desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
       default = "mistral-small-latest",
       ---@param self CodeCompanion.HTTPAdapter
+      ---@param opts? { async?: boolean }
       ---@return table<string, CodeCompanion.Adapter.ModelChoice>
-      choices = function(self)
-        return models(self)
+      choices = function(self, opts)
+        return fetch_models.get(model_source, self, opts)
       end,
     },
     temperature = {

--- a/lua/codecompanion/adapters/http/mistral.lua
+++ b/lua/codecompanion/adapters/http/mistral.lua
@@ -4,7 +4,7 @@ local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
-local model_source = {
+local models_source = {
   name = "Mistral",
   url = "https://api.mistral.ai/v1/models",
   ---@param adapter CodeCompanion.HTTPAdapter
@@ -216,7 +216,7 @@ return {
       ---@param opts? { async?: boolean }
       ---@return table<string, CodeCompanion.Adapter.ModelChoice>
       choices = function(self, opts)
-        return fetch_models.get(model_source, self, opts)
+        return fetch_models.get(models_source, self, opts)
       end,
     },
     temperature = {

--- a/lua/codecompanion/adapters/http/novita.lua
+++ b/lua/codecompanion/adapters/http/novita.lua
@@ -5,7 +5,6 @@ local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
 local _cache_expires
-local _cache_file = vim.fn.tempname()
 local _cached_models
 
 ---Get a list of available models
@@ -51,7 +50,7 @@ local function get_models(self, opts)
   end
 
   _cached_models = models
-  _cache_expires = adapter_utils.refresh_cache(_cache_file, config.adapters.http.opts.cache_models_for)
+  _cache_expires = adapter_utils.cache_expiry(config.adapters.http.opts.cache_models_for)
 
   return models
 end

--- a/lua/codecompanion/adapters/http/openai_compatible.lua
+++ b/lua/codecompanion/adapters/http/openai_compatible.lua
@@ -11,7 +11,6 @@ local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
 local _cache_expires
-local _cache_file = vim.fn.tempname()
 local _cached_models
 
 ---Return the cached models
@@ -70,7 +69,7 @@ local function get_models(self, opts)
     table.insert(_cached_models, model.id)
   end
 
-  _cache_expires = adapter_utils.refresh_cache(_cache_file, config.adapters.http.opts.cache_models_for)
+  _cache_expires = adapter_utils.cache_expiry(config.adapters.http.opts.cache_models_for)
 
   return models(opts)
 end

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -2,7 +2,7 @@ local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
-local model_source = {
+local models_source = {
   name = "OpenRouter",
   url = "https://openrouter.ai/api/v1/models",
 }
@@ -10,7 +10,7 @@ local model_source = {
 ---@param self CodeCompanion.HTTPAdapter
 ---@return table|nil
 local function model_choices(self)
-  local cached_models = fetch_models.get(model_source, self)
+  local cached_models = fetch_models.get(models_source, self)
   local model = cached_models[self.schema.model.default]
   return model and model.opts or nil
 end
@@ -19,7 +19,7 @@ end
 ---@param parameter string
 ---@return boolean
 local function model_supports(self, parameter)
-  local cached_models = fetch_models.get(model_source, self)
+  local cached_models = fetch_models.get(models_source, self)
   local model = cached_models[self.schema.model.default]
   if not model then
     return false
@@ -329,7 +329,7 @@ return {
       ---@param opts? { async?: boolean }
       ---@return table
       choices = function(self, opts)
-        return fetch_models.get(model_source, self, opts)
+        return fetch_models.get(models_source, self, opts)
       end,
     },
     ["reasoning.effort"] = {

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -2,15 +2,15 @@ local fetch_models = require("codecompanion.adapters.utils.models.fetch")
 local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
-local models = fetch_models.sync({
+local model_source = {
   name = "OpenRouter",
   url = "https://openrouter.ai/api/v1/models",
-})
+}
 
 ---@param self CodeCompanion.HTTPAdapter
 ---@return table|nil
 local function model_choices(self)
-  local cached_models = models(self)
+  local cached_models = fetch_models.get(model_source, self)
   local model = cached_models[self.schema.model.default]
   return model and model.opts or nil
 end
@@ -19,7 +19,7 @@ end
 ---@param parameter string
 ---@return boolean
 local function model_supports(self, parameter)
-  local cached_models = models(self)
+  local cached_models = fetch_models.get(model_source, self)
   local model = cached_models[self.schema.model.default]
   if not model then
     return false
@@ -326,9 +326,10 @@ return {
       desc = "ID of the model to use. See the model endpoint compatibility table for details on which models work with the Chat API.",
       ---@type string|fun(): string
       default = "openai/gpt-5.4-mini",
+      ---@param opts? { async?: boolean }
       ---@return table
-      choices = function(self)
-        return models(self)
+      choices = function(self, opts)
+        return fetch_models.get(model_source, self, opts)
       end,
     },
     ["reasoning.effort"] = {

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -1,4 +1,3 @@
-local Path = require("plenary.path")
 local log = require("codecompanion.utils.log")
 
 local M = {}
@@ -21,38 +20,11 @@ function M.filter_out_messages(params)
   return filtered_message
 end
 
----Refresh when we should next check the model cache
----@param file string
----@param cache_for number
+---Return the time at which the model cache should next be refreshed
+---@param cache_for? number Seconds to cache for; defaults to 30 minutes
 ---@return number
-function M.refresh_cache(file, cache_for)
-  cache_for = cache_for or 1800
-  local time = os.time() + cache_for
-  Path.new(file):write(time, "w")
-  return time
-end
-
----Return when the model cache expires
----@param file string
----@return number
-function M.cache_expires(file, cache_for)
-  cache_for = cache_for or 1800
-  local ok, expires = pcall(function()
-    return Path.new(file):read()
-  end)
-  if not ok then
-    expires = M.refresh_cache(file, cache_for)
-  end
-  expires = tonumber(expires)
-  assert(expires, "Could not get the cache expiry time")
-  return expires
-end
-
----Check if the cache has expired
----@param file string
----@return boolean
-function M.cache_expired(file)
-  return os.time() > M.cache_expires(file)
+function M.cache_expiry(cache_for)
+  return os.time() + (cache_for or 1800)
 end
 
 ---Extend a default adapter

--- a/lua/codecompanion/adapters/utils/models/fetch.lua
+++ b/lua/codecompanion/adapters/utils/models/fetch.lua
@@ -4,59 +4,149 @@ local log = require("codecompanion.utils.log")
 local transform = require("codecompanion.adapters.utils.models.transform")
 local utils = require("codecompanion.adapters.utils")
 
+local TIMEOUT = 3000
+local POLL_INTERVAL = 10
+
+---@alias CodeCompanion.Adapter.ModelFetcher.RequestOpts { async?: boolean }
+
+---@class CodeCompanion.Adapter.ModelFetcher.Spec
+---@field name string
+---@field url string|fun(adapter: CodeCompanion.HTTPAdapter, request_opts?: CodeCompanion.Adapter.ModelFetcher.RequestOpts): string
+---@field headers? fun(adapter: CodeCompanion.HTTPAdapter, request_opts?: CodeCompanion.Adapter.ModelFetcher.RequestOpts): table|nil
+
 local M = {}
 
----@class CodeCompanion.Adapter.ModelFetcher.Opts
----@field name string The adapter's name. Used in log messages and to find its `transform.from_<name>` function
----@field url string
----@field headers? fun(adapter: CodeCompanion.HTTPAdapter): table
+-- Per-adapter model cache, keyed by adapter name
+local caches = {}
 
----Synchronously fetch models from an endpoint
----@param opts CodeCompanion.Adapter.ModelFetcher.Opts
----@return fun(adapter: CodeCompanion.HTTPAdapter): table<string, CodeCompanion.Adapter.ModelChoice>
-function M.sync(opts)
-  local from_vendor = transform["from_" .. opts.name:lower()]
-  assert(from_vendor, "No model transformer found for adapter: " .. opts.name)
-
-  local cache_expires
-  local cache_file = vim.fn.tempname()
-  local cached_models
-
-  return function(adapter)
-    if cached_models and cache_expires and cache_expires > os.time() then
-      return cached_models
-    end
-
-    local ok, response = pcall(function()
-      return Curl.get(opts.url, {
-        headers = opts.headers and opts.headers(adapter) or nil,
-        insecure = config.adapters.http.opts.allow_insecure,
-        proxy = config.adapters.http.opts.proxy,
-        sync = true,
-      })
-    end)
-    if not ok then
-      log:error("Could not get the %s models from " .. opts.url .. "\nError: %s", opts.name, response)
-      return {}
-    end
-
-    local decode_ok, json = pcall(vim.json.decode, response.body)
-    if not decode_ok or not json.data then
-      log:error("Error parsing the %s response from " .. opts.url .. "\nError: %s", opts.name, response.body)
-      return {}
-    end
-
-    local models = {}
-    for _, model in ipairs(json.data) do
-      local id, entry = from_vendor(model)
-      models[id] = entry
-    end
-
-    cached_models = models
-    cache_expires = utils.refresh_cache(cache_file, config.adapters.http.opts.cache_models_for)
-
-    return cached_models
+---Return the cache record for an adapter, creating it on first use
+---@param spec CodeCompanion.Adapter.ModelFetcher.Spec
+---@return { file: string, in_progress: boolean, transform: function, models?: table, expires?: number }
+local function cache_for(spec)
+  if not caches[spec.name] then
+    local transformer = transform["from_" .. spec.name:lower()]
+    assert(transformer, "No model transformer found for adapter: " .. spec.name)
+    caches[spec.name] = { file = vim.fn.tempname(), in_progress = false, transform = transformer }
   end
+  return caches[spec.name]
+end
+
+---Return the cached models, or nil when the cache is empty or has expired
+---@param cache table
+---@return table<string, CodeCompanion.Adapter.ModelChoice>|nil
+local function fresh(cache)
+  if cache.models and cache.expires and cache.expires > os.time() then
+    return cache.models
+  end
+end
+
+---Parse the API response into model choices and cache them
+---@param cache table
+---@param json table
+---@return nil
+local function store(cache, json)
+  local models = {}
+  for _, model in ipairs(json.data) do
+    local id, choice = cache.transform(model)
+    if id then
+      models[id] = choice
+    end
+  end
+
+  cache.models = models
+  cache.expires = utils.refresh_cache(cache.file, config.adapters.http.opts.cache_models_for)
+end
+
+---Kick off a non-blocking request for the model list, unless one is already running
+---@param spec CodeCompanion.Adapter.ModelFetcher.Spec
+---@param adapter CodeCompanion.HTTPAdapter
+---@param request_opts? CodeCompanion.Adapter.ModelFetcher.RequestOpts
+---@return nil
+local function request(spec, adapter, request_opts)
+  local cache = cache_for(spec)
+  if fresh(cache) or cache.in_progress then
+    return
+  end
+
+  local headers = spec.headers and spec.headers(adapter, request_opts)
+  if spec.headers and not headers then
+    -- Not ready to fetch yet (e.g. no auth token available)
+    return
+  end
+
+  cache.in_progress = true
+  local url = type(spec.url) == "function" and spec.url(adapter, request_opts) or spec.url
+
+  local ok, err = pcall(function()
+    Curl.get(url, {
+      headers = headers,
+      insecure = config.adapters.http.opts.allow_insecure,
+      proxy = config.adapters.http.opts.proxy,
+      callback = vim.schedule_wrap(function(response)
+        cache.in_progress = false
+
+        local decode_ok, json = pcall(vim.json.decode, response and response.body)
+        if not decode_ok or type(json) ~= "table" or not json.data then
+          log:error(
+            "Error parsing the %s response from " .. url .. "\nError: %s",
+            spec.name,
+            response and response.body
+          )
+          return
+        end
+
+        store(cache, json)
+      end),
+    })
+  end)
+
+  if not ok then
+    cache.in_progress = false
+    log:error("Could not start async request for %s models: %s", spec.name, err)
+  end
+end
+
+---Block until the model list is available, or the request times out
+---@param spec CodeCompanion.Adapter.ModelFetcher.Spec
+---@param adapter CodeCompanion.HTTPAdapter
+---@param request_opts? CodeCompanion.Adapter.ModelFetcher.RequestOpts
+---@return table<string, CodeCompanion.Adapter.ModelChoice>
+local function wait(spec, adapter, request_opts)
+  local cache = cache_for(spec)
+  local models = fresh(cache)
+  if models then
+    return models
+  end
+
+  request(spec, adapter, request_opts)
+
+  local ok = vim.wait(TIMEOUT, function()
+    return fresh(cache) ~= nil
+  end, POLL_INTERVAL)
+
+  if not ok then
+    log:error("Timeout waiting for %s models", spec.name)
+    return {}
+  end
+
+  return cache.models
+end
+
+---Return an adapter's models, blocking for the result when `async == false`
+---@param spec CodeCompanion.Adapter.ModelFetcher.Spec
+---@param adapter CodeCompanion.HTTPAdapter
+---@param request_opts? CodeCompanion.Adapter.ModelFetcher.RequestOpts
+---@return table<string, CodeCompanion.Adapter.ModelChoice>
+function M.get(spec, adapter, request_opts)
+  local cache = cache_for(spec)
+
+  if request_opts and request_opts.async == false then
+    return wait(spec, adapter, request_opts)
+  end
+
+  -- Non-blocking: start the background fetch (if needed) and return whatever's cached
+  request(spec, adapter, request_opts)
+  return fresh(cache) or {}
 end
 
 return M

--- a/lua/codecompanion/adapters/utils/models/fetch.lua
+++ b/lua/codecompanion/adapters/utils/models/fetch.lua
@@ -4,8 +4,10 @@ local log = require("codecompanion.utils.log")
 local transform = require("codecompanion.adapters.utils.models.transform")
 local utils = require("codecompanion.adapters.utils")
 
-local TIMEOUT = 3000
-local POLL_INTERVAL = 10
+local CONSTANTS = {
+  TIMEOUT = 3000,
+  POLL_INTERVAL = 10,
+}
 
 ---@alias CodeCompanion.Adapter.ModelFetcher.RequestOpts { async?: boolean }
 
@@ -21,12 +23,12 @@ local caches = {}
 
 ---Return the cache record for an adapter, creating it on first use
 ---@param spec CodeCompanion.Adapter.ModelFetcher.Spec
----@return { file: string, in_progress: boolean, transform: function, models?: table, expires?: number }
+---@return { in_progress: boolean, transform: function, models?: table, expires?: number }
 local function cache_for(spec)
   if not caches[spec.name] then
     local transformer = transform["from_" .. spec.name:lower()]
     assert(transformer, "No model transformer found for adapter: " .. spec.name)
-    caches[spec.name] = { file = vim.fn.tempname(), in_progress = false, transform = transformer }
+    caches[spec.name] = { in_progress = false, transform = transformer }
   end
   return caches[spec.name]
 end
@@ -54,7 +56,7 @@ local function store(cache, json)
   end
 
   cache.models = models
-  cache.expires = utils.refresh_cache(cache.file, config.adapters.http.opts.cache_models_for)
+  cache.expires = utils.cache_expiry(config.adapters.http.opts.cache_models_for)
 end
 
 ---Kick off a non-blocking request for the model list, unless one is already running
@@ -120,9 +122,9 @@ local function wait(spec, adapter, request_opts)
 
   request(spec, adapter, request_opts)
 
-  local ok = vim.wait(TIMEOUT, function()
+  local ok = vim.wait(CONSTANTS.TIMEOUT, function()
     return fresh(cache) ~= nil
-  end, POLL_INTERVAL)
+  end, CONSTANTS.POLL_INTERVAL)
 
   if not ok then
     log:error("Timeout waiting for %s models", spec.name)
@@ -132,7 +134,7 @@ local function wait(spec, adapter, request_opts)
   return cache.models
 end
 
----Return an adapter's models, blocking for the result when `async == false`
+---Return an adapter's models
 ---@param spec CodeCompanion.Adapter.ModelFetcher.Spec
 ---@param adapter CodeCompanion.HTTPAdapter
 ---@param request_opts? CodeCompanion.Adapter.ModelFetcher.RequestOpts
@@ -140,11 +142,12 @@ end
 function M.get(spec, adapter, request_opts)
   local cache = cache_for(spec)
 
+  -- Blocking
   if request_opts and request_opts.async == false then
     return wait(spec, adapter, request_opts)
   end
 
-  -- Non-blocking: start the background fetch (if needed) and return whatever's cached
+  -- Async
   request(spec, adapter, request_opts)
   return fresh(cache) or {}
 end

--- a/lua/codecompanion/schema.lua
+++ b/lua/codecompanion/schema.lua
@@ -4,7 +4,7 @@
 ---@field mapping? string Where to map the item to the request
 ---@field order nil|integer The order to display the item when the full schema is shown
 ---@field optional nil|boolean
----@field choices nil|table|fun(self: CodeCompanion.HTTPAdapter): table<string>
+---@field choices nil|table|fun(self: CodeCompanion.HTTPAdapter, opts?: { async?: boolean }): table<string>
 ---@field desc string The description of the schema item
 ---@field enabled? nil|fun(self: CodeCompanion.HTTPAdapter): boolean
 ---@field validate? fun(value: any): boolean, nil|string

--- a/tests/adapters/http/copilot/test_models.lua
+++ b/tests/adapters/http/copilot/test_models.lua
@@ -34,12 +34,6 @@ T["copilot.models"]["choices() synchronous returns expected models"] = function(
       }
     end
 
-    -- Avoid filesystem side effects
-    local adapters_utils = require("codecompanion.adapters.utils")
-    adapters_utils.refresh_cache = function()
-      return os.time() + 100
-    end
-
     -- Mock Curl.get to trigger the scheduled callback with a stub response
     local curl = require("plenary.curl")
     local body = vim.json.encode({
@@ -127,12 +121,6 @@ T["copilot.models"]["choices() async populates cache and returns later"] = funct
         copilot_token = "test-token",
         endpoints = { api = "https://api.githubcopilot.com" },
       }
-    end
-
-    -- Avoid filesystem side effects
-    local adapters_utils = require("codecompanion.adapters.utils")
-    adapters_utils.refresh_cache = function()
-      return os.time() + 100
     end
 
     -- Mock Curl.get to trigger the scheduled callback with a stub response


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

#3201 added the abilty for some adapters to fetch models dynamically from their providers endpoint. However, this was done synchonrously. This PR enables the adapters to accomplish using async which prevents the user's UI from being blocked.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 4.8

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
