### PR TITLE
fix(adapters): gpt-5.6-luna does not support top_p

### DIFF
--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -449,7 +449,7 @@ return {
         if type(model) == "function" then
           model = model()
         end
-        local disabled_for = { "gpt-5.4", "gpt-5.4-mini" }
+        local disabled_for = { "gpt-5.4", "gpt-5.4-mini", "gpt-5.6-luna" }
         return not vim.tbl_contains(disabled_for, model)
       end,
       desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",


### PR DESCRIPTION
## Description

This PR fixes the error from the copilot by disabling top_p parameter for gpt-5.6-luna. I don't have access to Terra and Sol models so I don't know if they support this or not.

The error:
```
Error: {"error":{"message":"Unsupported parameter: 'top_p' is not supported with this model.","code":"invalid_request_body"}}
```

NOTE: I ran `make all`  and 2 of the tests are not passing - but it seems it's unrelated:

```
FAIL in tests/utils/test_files.lua | Files utils | get_mimetype | can invoke `file`:
  Failed expectation for equality
  Cause: different types
  Left:  { "file", "--mime-type", "some_file.txt" }
  Right: nil
  Traceback:
    tests/utils/test_files.lua:179

FAIL in tests/utils/test_files.lua | Files utils | get_mimetype | works without `file`:
  Failed expectation for equality
  Cause: different types
  Left:  { "file", "--mime-type", "some_file.png" }
  Right: nil
  Traceback:
    tests/utils/test_files.lua:201
```


## Supporting Documentation

None

## AI Usage

I did not use AI for this change.

## Related Issue(s)

None

## Screenshots

<img width="2558" height="1438" alt="image" src="https://github.com/user-attachments/assets/bbbdf1f5-efba-441b-9b5b-0f22aac00c7e" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
