### PR TITLE
refactor: streamline logging

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -54,6 +54,7 @@ local uv = vim.uv
 ---@field _on_session_update function|nil
 ---@field _config_options table[] Raw configOptions from the agent
 ---@field _pending_callbacks table<number, function> Async callbacks keyed by request ID
+---@field _rpc_log? { path: string, write: fun(data: string) } Per-connection log capturing raw JSON-RPC traffic
 ---@field methods table
 local Connection = {}
 
@@ -131,8 +132,6 @@ function Connection:connect_and_authenticate()
       return log:error("[acp::connect_and_authenticate] Failed to initialize")
     end
     self._agent_info = initialized
-
-    log:debug("[acp::connect_and_authenticate] Agent info: %s", initialized)
 
     if
       initialized.protocolVersion and initialized.protocolVersion ~= self.adapter_modified.parameters.protocolVersion
@@ -416,6 +415,9 @@ function Connection:start_agent_process()
 
   self._state.line_buffer:reset()
 
+  self._rpc_log = log.new_response_file()
+  log:info("[acp] RPC log: %s", self._rpc_log.path)
+
   local ok, sysobj = pcall(
     self.methods.job,
     self.adapter_modified.command,
@@ -557,6 +559,10 @@ function Connection:handle_rpc_message(line)
     return
   end
 
+  if self._rpc_log then
+    self._rpc_log.write("Received:\n" .. line)
+  end
+
   local ok, message = jsonrpc.decode(line, self.methods.decode)
   if not ok then
     return log:error("[acp::handle_rpc_message] Invalid JSON:\n%s", line)
@@ -690,6 +696,10 @@ function Connection:write_message(data)
     return false
   end
 
+  if self._rpc_log then
+    self._rpc_log.write("Sent:\n" .. vim.trim(data))
+  end
+
   local ok, err = pcall(function()
     self._state.handle:write(data)
   end)
@@ -797,7 +807,6 @@ end
 ---@param config_options table[] Array of SessionConfigOption
 function Connection:_apply_config_options(config_options)
   self._config_options = config_options
-  log:debug("[acp] Config options: %s", config_options)
 end
 
 ---Find a config option by category

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -108,8 +108,6 @@ local function fetch_async(adapter, opts)
           local id, entry = model_transformers.from_copilot(model)
           if id then
             models[id] = entry
-          else
-            log:debug("Copilot Adapter: Skipping model '%s'", model.id)
           end
         end
 

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -398,6 +398,9 @@ function Client:request(payload, actions, opts)
   local body_file = write_body_file(encode_body(self, adapter, payload))
   log:info("Request body file: %s", body_file)
 
+  local response = log.new_response_file()
+  log:info("Response output file: %s", response.path)
+
   local raw, headers_file = Client.build_curl_args(adapter, { stream = adapter.opts and adapter.opts.stream })
 
   -- Capture streaming errors for use in final callback
@@ -413,7 +416,7 @@ function Client:request(payload, actions, opts)
     callback = function(data)
       self.methods.schedule(function()
         if (not adapter.opts.stream) and data and data ~= "" then
-          log:debug("Output data:\n%s", data)
+          response.write(data)
           cb(nil, data, adapter)
         end
 
@@ -436,7 +439,7 @@ function Client:request(payload, actions, opts)
         if not opts.silent then
           utils.fire("RequestFinished", opts)
         end
-        delete_temp_files({ body_file, headers_file }, opts.status)
+        delete_temp_files({ body_file, headers_file, response.path }, opts.status)
         if self.user_args.event then
           if not opts.silent then
             utils.fire(self.user_args.event, opts)
@@ -463,7 +466,7 @@ function Client:request(payload, actions, opts)
     -- This will be called multiple times until the stream is finished
     request_opts["stream"] = self.methods.schedule_wrap(function(_, data)
       if data and data ~= "" then
-        log:debug("Output data:\n%s", data)
+        response.write(data)
         if data:match('^%s*{"error"') or data:match('^%s*{"type"%s*:%s*"error"') then
           stream_error_body = data
           return

--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -238,8 +238,6 @@ end
 function ACPHandler:process_tool_call(tool_call)
   local id = tool_call.toolCallId
 
-  log:debug("[ACP::Handler] Processing tool call %s", utils.truncate(tool_call))
-
   local merged = merge_tool_call(self.tools[id], tool_call)
   tool_call = merged
 
@@ -332,16 +330,6 @@ function ACPHandler:_process_next_permission()
       request.tool_call = merge_tool_call(cached, tool_call)
     end
   end
-
-  log:debug(
-    "[ACP::Handler] Permission Request\n  id: %s\n  kind: %s\n  %s\n  options: %s",
-    tool_call and tool_call.toolCallId or "unknown",
-    tool_call and tool_call.kind or "unknown",
-    tool_call and tool_call.title or "No title",
-    vim.inspect(vim.tbl_map(function(o)
-      return o.kind
-    end, request.options or {}))
-  )
 
   -- The original respond function is stored so that if the user cancels the request, we can respond as per the spec
   self._permission.respond = request.respond

--- a/lua/codecompanion/interactions/chat/acp/request_permission.lua
+++ b/lua/codecompanion/interactions/chat/acp/request_permission.lua
@@ -129,7 +129,6 @@ local function setup_diff_keymaps(opts)
           return
         end
         opts.diff_ui.resolved = true
-        log:debug("[acp::request_permission] User selected option: %s (%s)", kind, option_id)
         opts.on_done(label)
         opts.request.respond(option_id, false)
         opts.diff_ui:close()
@@ -214,7 +213,6 @@ local function build_choices(permission, has_diff)
         keymap = key,
         label = (ACP_OPTIONS[opt.kind] and ACP_OPTIONS[opt.kind].label) or opt.name,
         callback = function()
-          log:debug("[acp::request_permission] User selected option %s", opt.optionId)
           permission.request.respond(opt.optionId, false)
         end,
       })
@@ -225,7 +223,6 @@ local function build_choices(permission, has_diff)
     keymap = keys.cancel,
     label = labels.cancel,
     callback = function()
-      log:debug("[acp::request_permission] User cancelled")
       permission.request.respond(nil, true)
     end,
   })

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -697,6 +697,23 @@ function Chat:add_callback(event, callback)
   return self
 end
 
+---Remove a previously registered callback for an event
+---@param event string The event name
+---@param callback fun(chat: CodeCompanion.Chat) The exact callback function that was registered
+---@return CodeCompanion.Chat
+function Chat:remove_callback(event, callback)
+  local callbacks = self.callbacks[event]
+  if not callbacks then
+    return self
+  end
+  for i = #callbacks, 1, -1 do
+    if callbacks[i] == callback then
+      table.remove(callbacks, i)
+    end
+  end
+  return self
+end
+
 ---Dispatch callbacks for a specific event
 ---@param event string The event name
 ---@param ... any Additional arguments to pass to callbacks
@@ -707,7 +724,8 @@ function Chat:dispatch(event, ...)
     return self
   end
 
-  for _, callback in ipairs(callbacks) do
+  -- Iterate a snapshot so a callback that deregisters itself doesn't shift the loop
+  for _, callback in ipairs(vim.list_slice(callbacks, 1, #callbacks)) do
     local ok, err = pcall(callback, self, ...)
     if not ok then
       log:error("Callback error for %s: %s", event, err, { silent = true })

--- a/lua/codecompanion/utils/log.lua
+++ b/lua/codecompanion/utils/log.lua
@@ -10,6 +10,15 @@ for k, v in pairs(vim.log.levels) do
   levels_reverse[v] = k
 end
 
+local TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S"
+
+---A timestamp in the log format, with millisecond precision appended
+---@return string
+local function timestamp()
+  local seconds, microseconds = vim.uv.gettimeofday()
+  return os.date(TIMESTAMP_FMT, seconds) .. string.format(".%03d", math.floor(microseconds / 1000))
+end
+
 function LogHandler.new(opts)
   vim.validate("type", opts.type, "string")
   vim.validate("handle", opts.handle, "function")
@@ -43,23 +52,17 @@ local function default_formatter(level, msg, ...)
   local ok, text = pcall(string.format, msg, vim.F.unpack_len(args))
   if ok then
     local str_level = levels_reverse[level]
-    return string.format("[%s] %s\n%s", str_level, os.date("%Y-%m-%d %H:%M:%S"), text)
+    return string.format("[%s] %s\n%s", str_level, os.date(TIMESTAMP_FMT), text)
   else
     return string.format("[ERROR] error formatting log line: '%s' args %s", msg, vim.inspect(args))
   end
 end
 
----@param opts table
----@return CodeCompanion.LogHandler
-local function create_file_handler(opts)
+---Create a non-blocking writer that queues text and flushes it to a file in batches
+---@param path string
+---@return fun(text: string) write
+local function async_writer(path)
   local a = require("plenary.async")
-  vim.validate("filename", opts.filename, "string")
-  local ok, stdpath = pcall(vim.fn.stdpath, "log")
-  if not ok then
-    stdpath = vim.fn.stdpath("cache")
-  end
-  local path = vim.fs.joinpath(stdpath, opts.filename)
-  --
   local write_queue = {}
   local is_writing = false
 
@@ -75,7 +78,7 @@ local function create_file_handler(opts)
     a.run(function()
       local err, fd = a.uv.fs_open(path, "a", 438)
       if err then
-        vim.notify(string.format("Failed to open log file: %s", err), vim.log.levels.ERROR, { title = "CodeCompanion" })
+        vim.notify(string.format("Failed to open %s: %s", path, err), vim.log.levels.ERROR, { title = "CodeCompanion" })
         is_writing = false
         return
       end
@@ -83,7 +86,7 @@ local function create_file_handler(opts)
       err, _ = a.uv.fs_write(fd, text)
       if err then
         vim.notify(
-          string.format("Failed to write to log file: %s", err),
+          string.format("Failed to write to %s: %s", path, err),
           vim.log.levels.ERROR,
           { title = "CodeCompanion" }
         )
@@ -92,7 +95,7 @@ local function create_file_handler(opts)
       err = a.uv.fs_close(fd)
       if err then
         vim.notify(
-          string.format("Failed to close log file: %s", err),
+          string.format("Failed to close %s: %s", path, err),
           vim.log.levels.ERROR,
           { title = "CodeCompanion" }
         )
@@ -103,9 +106,25 @@ local function create_file_handler(opts)
     end)
   end
 
-  opts.handle = function(_level, text)
-    table.insert(write_queue, text .. "\n")
+  return function(text)
+    table.insert(write_queue, text)
     vim.schedule(process_queue)
+  end
+end
+
+---@param opts table
+---@return CodeCompanion.LogHandler
+local function create_file_handler(opts)
+  vim.validate("filename", opts.filename, "string")
+  local ok, stdpath = pcall(vim.fn.stdpath, "log")
+  if not ok then
+    stdpath = vim.fn.stdpath("cache")
+  end
+  local path = vim.fs.joinpath(stdpath, opts.filename)
+
+  local write = async_writer(path)
+  opts.handle = function(_level, text)
+    write(text .. "\n")
   end
 
   return LogHandler.new(opts)
@@ -303,6 +322,20 @@ M.get_logfile = function()
   end
 
   return vim.fs.joinpath(stdpath, "codecompanion.log")
+end
+
+---Create a temp file that captures a request's streamed response, one timestamped entry per chunk
+---@return { path: string, write: fun(data: string|table) }
+M.new_response_file = function()
+  local path = vim.fn.tempname() .. ".log"
+  local write = async_writer(path)
+  return {
+    path = path,
+    write = function(data)
+      local content = type(data) == "table" and vim.inspect(data) or data
+      write(timestamp() .. "\n" .. content .. "\n")
+    end,
+  }
 end
 
 ---@param logger CodeCompanion.Logger


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Logging in CodeCompanion has not been touched in circa 2 years. As a result, streaming text from http and acp adapters leads to huge logs that can store private data until the log is deleted.

This PR refactors the logging to ensure that any http and acp streams go into the OS' temp folder and are cleaned up on Neovim exit. This makes it much easier for users to share request specific data too.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 4.8

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
