### PR TITLE
feat(background): can deregister commands

### DIFF
--- a/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
+++ b/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
@@ -77,8 +77,12 @@ end
 ---Make the request to generate a title for the chat
 ---@param background CodeCompanion.Background
 ---@param chat CodeCompanion.Chat
-function M.request(background, chat)
+---@param opts? { deregister: fun() }
+function M.request(background, chat, opts)
   if chat.title and chat.title ~= "" then
+    if opts and opts.deregister then
+      opts.deregister()
+    end
     return
   end
 
@@ -99,7 +103,9 @@ function M.request(background, chat)
       local title = M.on_done(result)
       if title then
         chat:set_title(title)
-        -- TODO: Remove the callback from the chat buffer
+        if opts and opts.deregister then
+          opts.deregister()
+        end
         log:debug("[Background] Chat title generated: %s", title)
       end
     end,

--- a/lua/codecompanion/interactions/background/callbacks.lua
+++ b/lua/codecompanion/interactions/background/callbacks.lua
@@ -32,8 +32,9 @@ end
 ---Execute an action
 ---@param path string The path to the module
 ---@param chat CodeCompanion.Chat The chat instance
+---@param opts? { deregister: fun() }
 ---@return nil
-local function execute_action(path, chat)
+local function execute_action(path, chat, opts)
   local action = resolve(path)
   if not action then
     return log:error("[background::callbacks] File `%s` could not be found", path)
@@ -55,11 +56,9 @@ local function execute_action(path, chat)
 
   -- Don't block the main thread
   vim.schedule(function()
-    local ok, result = pcall(action.request, background, chat)
+    local ok, result = pcall(action.request, background, chat, { deregister = opts and opts.deregister })
     if not ok then
       log:debug("[background::callbacks] Error executing action %s: %s", path, result)
-    else
-      log:debug("[background::callbacks] Action %s completed successfully", path)
     end
   end)
 end
@@ -74,16 +73,20 @@ function M.register_chat_callbacks(chat)
     return
   end
 
-  -- Register callbacks for each configured event
+  -- Register each action as its own callback so it can deregister itself once done
   for event, event_config in pairs(background_config.callbacks) do
     if event_config.enabled and event_config.actions then
-      chat:add_callback(event, function(c)
-        log:debug("[background::callbacks] Executing %d actions for event: %s", #event_config.actions, event)
-
-        for _, path in ipairs(event_config.actions) do
-          execute_action(path, c)
+      for _, path in ipairs(event_config.actions) do
+        local callback
+        callback = function(c)
+          execute_action(path, c, {
+            deregister = function()
+              c:remove_callback(event, callback)
+            end,
+          })
         end
-      end)
+        chat:add_callback(event, callback)
+      end
 
       log:debug("[background::callbacks] Registered %d actions for chat event: %s", #event_config.actions, event)
     end

--- a/tests/interactions/background/test_callbacks.lua
+++ b/tests/interactions/background/test_callbacks.lua
@@ -30,7 +30,7 @@ T["callbacks"]["can register chat callbacks"] = function()
       callbacks = {
         test_event = {
           enabled = true,
-          actions = {}
+          actions = { "some.background.action" }
         }
       }
     }


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Background callbacks can be deregistered. The make chat title callback was executing on every `n` request where `n > 2`. This can now be prevented with this PR.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 4.8

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
