### PR TITLE
feat(adapters): add pdf file support for `http` adapters

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 June 30
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 12
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -5045,6 +5045,18 @@ The `file` slash command allows you to add the contents of a file in the
 current working directory to the chat buffer. The command has native,
 `Telescope`, `mini.pick`, `fzf.lua` and `snacks.nvim` providers available.
 Also, multiple files can be selected and added to the chat buffer.
+
+#3218 <https://github.com/olimorris/codecompanion.nvim/pull/3218> added support
+for PDFs for the following http adapters:
+
+- Anthropic
+- Copilot (currently only supports OpenAI models)
+- OpenAI
+- OpenAI Responses
+- OpenRouter
+
+Simply use the `/file` slash command and select a PDF file. The plugin will
+`base64` encode the PDF and send it to the LLM.
 
 This slash command is also available in the
 |codecompanion-usage-cli-slash-commands|, where it inserts `@path` references

--- a/doc/usage/chat-buffer/slash-commands.md
+++ b/doc/usage/chat-buffer/slash-commands.md
@@ -55,6 +55,16 @@ The _fetch_ slash command allows you to add the contents of a URL to the chat bu
 
 The _file_ slash command allows you to add the contents of a file in the current working directory to the chat buffer. The command has native, _Telescope_, _mini.pick_, _fzf.lua_ and _snacks.nvim_ providers available. Also, multiple files can be selected and added to the chat buffer.
 
+[#3218](https://github.com/olimorris/codecompanion.nvim/pull/3218) added support for PDFs for the following http adapters:
+
+- Anthropic
+- Copilot (currently only supports OpenAI models)
+- OpenAI
+- OpenAI Responses
+- OpenRouter
+
+Simply use the `/file` slash command and select a PDF file. The plugin will `base64` encode the PDF and send it to the LLM.
+
 This slash command is also available in the [CLI prompt input](/usage/cli#slash-commands), where it inserts `@path` references instead of file contents.
 
 - Select a single file: `⏎ enter`

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -30,6 +30,7 @@ return {
   },
   opts = {
     compaction = true,
+    documents = true,
     stream = true,
     tools = true,
     vision = true,
@@ -222,6 +223,29 @@ return {
           else
             -- Remove the message if vision is not supported
             return nil
+          end
+        end
+
+        -- 3b. Account for any documents
+        -- NOTE: Only support PDFs for now
+        if
+          m._meta
+          and m._meta.tag == tags.DOCUMENT
+          and m._meta.filetype == "pdf"
+          and m.context
+          and m.context.mimetype
+        then
+          if self.opts and self.opts.documents then
+            m.content = {
+              {
+                type = "document",
+                source = {
+                  type = "base64",
+                  media_type = m.context.mimetype,
+                  data = m.content,
+                },
+              },
+            }
           end
         end
 

--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -92,6 +92,7 @@ return {
     user = "user",
   },
   opts = {
+    documents = true,
     stream = true,
     tools = true,
     vision = true,
@@ -164,6 +165,17 @@ return {
       if (self.opts and self.opts.vision) and (model_opts and model_opts.opts and not model_opts.opts.has_vision) then
         self.opts.vision = false
       end
+
+      -- NOTE: Does NOT seem possible to be able to send documents through the
+      -- /chat/completions endpoint. Copilot has a translation layer that
+      -- returns a 400 error asking for `image_url` or `text` block
+      if self.opts and self.opts.documents then
+        local vendor = model_opts and model_opts.vendor
+        if not (vendor and vendor:find("OpenAI", 1, true)) then
+          self.opts.documents = false
+        end
+      end
+
       self.opts.can_form_structured_outputs = (
         model_opts
         and model_opts.opts

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -168,6 +168,11 @@ return {
                   },
                 },
               }
+            else
+              return log:warn(
+                "The `%s` model does not support documents so has been removed from the request",
+                self.formatted_name
+              )
             end
           end
 

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -42,6 +42,7 @@ return {
     tool = "tool",
   },
   opts = {
+    documents = true,
     stream = true,
     tools = true,
     vision = true,
@@ -145,6 +146,28 @@ return {
             else
               -- Remove the message if vision is not supported
               return nil
+            end
+          end
+
+          -- Process any documents
+          -- NOTE: Only support PDFs for now
+          if
+            m._meta
+            and m._meta.tag == tags.DOCUMENT
+            and m._meta.filetype == "pdf"
+            and m.context
+            and m.context.mimetype
+          then
+            if self.opts and self.opts.documents then
+              m.content = {
+                {
+                  type = "file",
+                  file = {
+                    filename = vim.fn.fnamemodify(m.context.path, ":t"),
+                    file_data = string.format("data:%s;base64,%s", m.context.mimetype, m.content),
+                  },
+                },
+              }
             end
           end
 

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -23,6 +23,7 @@ return {
   },
   opts = {
     compaction = true,
+    documents = true,
     stream = true,
     tools = true,
     vision = true,
@@ -181,6 +182,43 @@ return {
                   and next_msg.role == m.role
                   and type(next_msg.content) == "string"
                   and not (next_msg._meta and next_msg._meta.tag == tags.IMAGE)
+                then
+                  table.insert(combined_content, {
+                    type = "input_text",
+                    text = next_msg.content,
+                  })
+                  i = i + 1 -- Skip the next message since we've combined it
+                end
+
+                table.insert(input, {
+                  role = m.role,
+                  content = combined_content,
+                })
+              end
+            elseif
+              -- NOTE: Only support PDFs for now
+              m._meta
+              and m._meta.tag == tags.DOCUMENT
+              and m._meta.filetype == "pdf"
+              and (m.context and m.context.mimetype)
+            then
+              -- Check if this is a document message followed by a text message from the same user
+              if self.opts and self.opts.documents then
+                local next_msg = messages[i + 1]
+                local combined_content = {
+                  {
+                    type = "input_file",
+                    filename = vim.fn.fnamemodify(m.context.path, ":t"),
+                    file_data = string.format("data:%s;base64,%s", m.context.mimetype, m.content),
+                  },
+                }
+
+                -- If next message is also from user with text content, combine them
+                if
+                  next_msg
+                  and next_msg.role == m.role
+                  and type(next_msg.content) == "string"
+                  and not (next_msg._meta and next_msg._meta.tag == tags.DOCUMENT)
                 then
                   table.insert(combined_content, {
                     type = "input_text",

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -231,6 +231,11 @@ return {
                   role = m.role,
                   content = combined_content,
                 })
+              else
+                return log:warn(
+                  "The `%s` model does not support documents so has been removed from the request",
+                  self.formatted_name
+                )
               end
             elseif m.role == "tool" then
               table.insert(input, {

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -37,6 +37,7 @@ return {
     user = "user",
   },
   opts = {
+    documents = true,
     stream = true,
     tools = true,
     vision = true,

--- a/lua/codecompanion/interactions/shared/slash_commands/file.lua
+++ b/lua/codecompanion/interactions/shared/slash_commands/file.lua
@@ -1,6 +1,7 @@
 local Path = require("plenary.path")
 
 local config = require("codecompanion.config")
+local files_utils = require("codecompanion.utils.files")
 local helpers = require("codecompanion.interactions.chat.helpers")
 local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
@@ -185,6 +186,53 @@ function SlashCommand:read(selected)
   return content, ft, id, selected.path
 end
 
+---Base64 encode a document and add it to the chat buffer for adapters that support documents
+---@param selected { path: string }
+---@param opts { filetype: string, mimetype: string, silent: boolean, sync_all: boolean }
+---@return nil
+function SlashCommand:output_doc(selected, opts)
+  local adapter = self.Chat.adapter
+  if not (adapter.opts and adapter.opts.documents) then
+    return log:warn(
+      "The `%s` adapter does not support documents. `%s` was not added to the chat",
+      adapter.formatted_name,
+      vim.fn.fnamemodify(selected.path, ":t")
+    )
+  end
+
+  local base64, err = files_utils.base64_encode_file(selected.path)
+  if err then
+    return log:error(err)
+  end
+
+  local id = "<file>" .. vim.fn.fnamemodify(selected.path, ":.") .. "</file>"
+
+  self.Chat:add_message({
+    role = config.constants.USER_ROLE,
+    content = base64,
+  }, {
+    visible = false,
+    context = { id = id, mimetype = opts.mimetype, path = selected.path },
+    _meta = { tag = tags.DOCUMENT, filetype = opts.filetype },
+  })
+
+  if opts.sync_all then
+    return
+  end
+
+  self.Chat.context:add({
+    id = id,
+    path = selected.path,
+    source = "codecompanion.interactions.shared.slash_commands.file",
+  })
+
+  if opts.silent then
+    return
+  end
+
+  utils.notify(fmt("Added the `%s` document to the chat", vim.fn.fnamemodify(selected.path, ":t")))
+end
+
 ---Output from the slash command in the chat buffer
 ---@param selected { path: string, relative_path?: string, description?: string }
 ---@param opts? { message?:string, description?: string, silent: boolean, sync_all: boolean }
@@ -194,6 +242,12 @@ function SlashCommand:output(selected, opts)
     return log:warn("Sending of code has been disabled")
   end
   opts = opts or {}
+
+  local mimetype = files_utils.get_mimetype(selected.path)
+  if mimetype == "application/pdf" then
+    opts = vim.tbl_extend("force", opts, { filetype = "pdf", mimetype = mimetype })
+    return self:output_doc(selected, opts)
+  end
 
   if selected.description then
     opts.message = selected.description

--- a/lua/codecompanion/interactions/shared/tags.lua
+++ b/lua/codecompanion/interactions/shared/tags.lua
@@ -4,6 +4,7 @@ local M = {
   COMPACT_SUMMARY = "compact_summary",
   DIAGNOSTICS = "diagnostics",
   DIFF = "diff",
+  DOCUMENT = "document",
   EDITOR_CONTEXT = "editor_context",
   FILE = "file",
   FROM_CUSTOM_PROMPT = "from_custom_prompt",

--- a/lua/codecompanion/utils/files.lua
+++ b/lua/codecompanion/utils/files.lua
@@ -218,9 +218,9 @@ function M.get_mimetype(path)
     gif = "image/gif",
     jpg = "image/jpeg",
     jpeg = "image/jpeg",
+    pdf = "application/pdf",
     png = "image/png",
     webp = "image/webp",
-    pdf = "application/pdf",
   }
 
   local extension = vim.fn.fnamemodify(path, ":e")

--- a/tests/adapters/http/copilot/test_copilot.lua
+++ b/tests/adapters/http/copilot/test_copilot.lua
@@ -241,44 +241,6 @@ T["Copilot adapter"]["forms reasoning output"] = function()
   h.eq("gj5HGhYVIOT", form_reasoning.opaque)
 end
 
-T["Copilot adapter"]["drops the PDF instead of sending raw base64 once setup disables documents for the model"] = function()
-  local anthropic_adapter = require("codecompanion.adapters").extend("copilot", {
-    schema = { model = { default = "claude-sonnet-4" } },
-  })
-
-  anthropic_adapter.handlers.setup(anthropic_adapter)
-
-  local messages = {
-    {
-      content = "somefakebase64encoding",
-      role = "user",
-      context = {
-        id = "<file>report.pdf</file>",
-        mimetype = "application/pdf",
-        path = "report.pdf",
-      },
-      _meta = {
-        tag = tags.DOCUMENT,
-        filetype = "pdf",
-      },
-    },
-    {
-      content = "What does this PDF say?",
-      role = "user",
-    },
-  }
-
-  local result = anthropic_adapter.handlers.form_messages(anthropic_adapter, messages)
-
-  h.eq({
-    {
-      role = "user",
-      content = "What does this PDF say?",
-      copilot_cache_control = { type = "ephemeral" },
-    },
-  }, result.messages)
-end
-
 T["Copilot adapter"]["Streaming"] = new_set()
 
 T["Copilot adapter"]["Streaming"]["can output streamed data into the chat buffer"] = function()

--- a/tests/adapters/http/copilot/test_copilot.lua
+++ b/tests/adapters/http/copilot/test_copilot.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 local adapter
 
 local new_set = MiniTest.new_set
@@ -238,6 +239,44 @@ T["Copilot adapter"]["forms reasoning output"] = function()
 
   h.eq("Content 1\nContent 2\nContent 3\n", form_reasoning.content)
   h.eq("gj5HGhYVIOT", form_reasoning.opaque)
+end
+
+T["Copilot adapter"]["drops the PDF instead of sending raw base64 once setup disables documents for the model"] = function()
+  local anthropic_adapter = require("codecompanion.adapters").extend("copilot", {
+    schema = { model = { default = "claude-sonnet-4" } },
+  })
+
+  anthropic_adapter.handlers.setup(anthropic_adapter)
+
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  local result = anthropic_adapter.handlers.form_messages(anthropic_adapter, messages)
+
+  h.eq({
+    {
+      role = "user",
+      content = "What does this PDF say?",
+      copilot_cache_control = { type = "ephemeral" },
+    },
+  }, result.messages)
 end
 
 T["Copilot adapter"]["Streaming"] = new_set()

--- a/tests/adapters/http/test_anthropic.lua
+++ b/tests/adapters/http/test_anthropic.lua
@@ -144,6 +144,76 @@ T["Anthropic adapter"]["form_messages"]["images"] = function()
   h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
 end
 
+T["Anthropic adapter"]["form_messages"]["documents"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+      opts = {
+        visible = false,
+      },
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  local expected = {
+    {
+      content = {
+        {
+          type = "document",
+          source = {
+            type = "base64",
+            media_type = "application/pdf",
+            data = "somefakebase64encoding",
+          },
+        },
+        {
+          type = "text",
+          text = "What does this PDF say?",
+        },
+      },
+      role = "user",
+    },
+  }
+
+  h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
+end
+
+T["Anthropic adapter"]["form_messages"]["only PDFs are converted into document blocks"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.docx</file>",
+        mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "docx",
+      },
+      opts = {
+        visible = false,
+      },
+    },
+  }
+
+  local output = adapter.handlers.form_messages(adapter, messages).messages
+
+  h.eq("somefakebase64encoding", output[1].content[1].text)
+end
+
 T["Anthropic adapter"]["form_messages"]["with tools and consecutive tool results"] = function()
   local input = {
     {

--- a/tests/adapters/http/test_openai.lua
+++ b/tests/adapters/http/test_openai.lua
@@ -81,6 +81,106 @@ T["OpenAI adapter"]["it can form messages with images"] = function()
   h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
 end
 
+T["OpenAI adapter"]["it can form messages with documents"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+      opts = {
+        visible = false,
+      },
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  local expected = {
+    {
+      content = {
+        {
+          type = "file",
+          file = {
+            filename = "report.pdf",
+            file_data = "data:application/pdf;base64,somefakebase64encoding",
+          },
+        },
+      },
+      role = "user",
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  h.eq(expected, adapter.handlers.form_messages(adapter, messages).messages)
+end
+
+T["OpenAI adapter"]["only PDFs are converted into document blocks"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.docx</file>",
+        mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        path = "report.docx",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "docx",
+      },
+      opts = {
+        visible = false,
+      },
+    },
+  }
+
+  local output = adapter.handlers.form_messages(adapter, messages).messages
+
+  h.eq("somefakebase64encoding", output[1].content)
+end
+
+T["OpenAI adapter"]["leaves document messages untouched for adapters that do not support documents"] = function()
+  local no_documents_adapter = require("codecompanion.adapters").extend("openai", {
+    opts = { documents = false },
+  })
+
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+      opts = {
+        visible = false,
+      },
+    },
+  }
+
+  local output = no_documents_adapter.handlers.form_messages(no_documents_adapter, messages).messages
+
+  h.eq("somefakebase64encoding", output[1].content)
+end
+
 T["OpenAI adapter"]["it can form messages with tools"] = function()
   local messages = {
     {

--- a/tests/adapters/http/test_openai.lua
+++ b/tests/adapters/http/test_openai.lua
@@ -152,35 +152,6 @@ T["OpenAI adapter"]["only PDFs are converted into document blocks"] = function()
   h.eq("somefakebase64encoding", output[1].content)
 end
 
-T["OpenAI adapter"]["leaves document messages untouched for adapters that do not support documents"] = function()
-  local no_documents_adapter = require("codecompanion.adapters").extend("openai", {
-    opts = { documents = false },
-  })
-
-  local messages = {
-    {
-      content = "somefakebase64encoding",
-      role = "user",
-      context = {
-        id = "<file>report.pdf</file>",
-        mimetype = "application/pdf",
-        path = "report.pdf",
-      },
-      _meta = {
-        tag = tags.DOCUMENT,
-        filetype = "pdf",
-      },
-      opts = {
-        visible = false,
-      },
-    },
-  }
-
-  local output = no_documents_adapter.handlers.form_messages(no_documents_adapter, messages).messages
-
-  h.eq("somefakebase64encoding", output[1].content)
-end
-
 T["OpenAI adapter"]["it can form messages with tools"] = function()
   local messages = {
     {

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -294,46 +294,6 @@ T["Responses"]["build_messages"]["only PDFs are converted into document blocks"]
   h.eq("somefakebase64encoding", result.input[1].content)
 end
 
-T["Responses"]["build_messages"]["skips document messages for adapters that do not support documents"] = function()
-  local no_documents_adapter = require("codecompanion.adapters").extend("openai_responses", {
-    opts = { documents = false },
-  })
-
-  local messages = {
-    {
-      content = "somefakebase64encoding",
-      role = "user",
-      opts = {
-        visible = false,
-      },
-      context = {
-        id = "<file>report.pdf</file>",
-        mimetype = "application/pdf",
-        path = "report.pdf",
-      },
-      _meta = {
-        tag = tags.DOCUMENT,
-        filetype = "pdf",
-      },
-    },
-    {
-      content = "What does this PDF say?",
-      role = "user",
-    },
-  }
-
-  local result = no_documents_adapter.handlers.request.build_messages(no_documents_adapter, messages)
-
-  h.eq({
-    input = {
-      {
-        content = "What does this PDF say?",
-        role = "user",
-      },
-    },
-  }, result)
-end
-
 T["Responses"]["build_messages"]["format tool calls"] = function()
   local messages = {
     {

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -223,6 +223,117 @@ T["Responses"]["build_messages"]["multiple consecutive images are not merged as 
   h.eq(expected, adapter.handlers.request.build_messages(adapter, messages))
 end
 
+T["Responses"]["build_messages"]["documents"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      opts = {
+        visible = false,
+      },
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  local expected = {
+    input = {
+      {
+        content = {
+          {
+            type = "input_file",
+            filename = "report.pdf",
+            file_data = "data:application/pdf;base64,somefakebase64encoding",
+          },
+          {
+            type = "input_text",
+            text = "What does this PDF say?",
+          },
+        },
+        role = "user",
+      },
+    },
+  }
+
+  h.eq(expected, adapter.handlers.request.build_messages(adapter, messages))
+end
+
+T["Responses"]["build_messages"]["only PDFs are converted into document blocks"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      opts = {
+        visible = false,
+      },
+      context = {
+        id = "<file>report.docx</file>",
+        mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        path = "report.docx",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "docx",
+      },
+    },
+  }
+
+  local result = adapter.handlers.request.build_messages(adapter, messages)
+
+  h.eq("somefakebase64encoding", result.input[1].content)
+end
+
+T["Responses"]["build_messages"]["skips document messages for adapters that do not support documents"] = function()
+  local no_documents_adapter = require("codecompanion.adapters").extend("openai_responses", {
+    opts = { documents = false },
+  })
+
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      opts = {
+        visible = false,
+      },
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  local result = no_documents_adapter.handlers.request.build_messages(no_documents_adapter, messages)
+
+  h.eq({
+    input = {
+      {
+        content = "What does this PDF say?",
+        role = "user",
+      },
+    },
+  }, result)
+end
+
 T["Responses"]["build_messages"]["format tool calls"] = function()
   local messages = {
     {

--- a/tests/adapters/http/test_openrouter.lua
+++ b/tests/adapters/http/test_openrouter.lua
@@ -1,4 +1,5 @@
 local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
 local adapter
 
 local new_set = MiniTest.new_set
@@ -156,6 +157,101 @@ T["OpenRouter adapter"]["strips image messages for models that do not support vi
   h.eq({
     { role = "user", content = "Describe this image" },
   }, result.messages)
+end
+
+T["OpenRouter adapter"]["forms documents into file content blocks"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+    },
+    {
+      content = "What does this PDF say?",
+      role = "user",
+    },
+  }
+
+  local result = adapter.handlers.form_messages(adapter, messages)
+
+  h.eq({
+    {
+      role = "user",
+      content = {
+        {
+          type = "file",
+          file = {
+            filename = "report.pdf",
+            file_data = "data:application/pdf;base64,somefakebase64encoding",
+          },
+        },
+      },
+      tool_calls = nil,
+      tool_call_id = nil,
+    },
+    {
+      role = "user",
+      content = "What does this PDF say?",
+      tool_calls = nil,
+      tool_call_id = nil,
+    },
+  }, result.messages)
+end
+
+T["OpenRouter adapter"]["only PDFs are converted into document blocks"] = function()
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.docx</file>",
+        mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        path = "report.docx",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "docx",
+      },
+    },
+  }
+
+  local result = adapter.handlers.form_messages(adapter, messages)
+
+  h.eq("somefakebase64encoding", result.messages[1].content)
+end
+
+T["OpenRouter adapter"]["leaves document messages untouched for adapters that do not support documents"] = function()
+  local no_documents_adapter = require("codecompanion.adapters").extend("openrouter", {
+    opts = { documents = false },
+  })
+
+  local messages = {
+    {
+      content = "somefakebase64encoding",
+      role = "user",
+      context = {
+        id = "<file>report.pdf</file>",
+        mimetype = "application/pdf",
+        path = "report.pdf",
+      },
+      _meta = {
+        tag = tags.DOCUMENT,
+        filetype = "pdf",
+      },
+    },
+  }
+
+  local result = no_documents_adapter.handlers.form_messages(no_documents_adapter, messages)
+
+  h.eq("somefakebase64encoding", result.messages[1].content)
 end
 
 T["OpenRouter adapter"]["can output tool call"] = function()

--- a/tests/adapters/http/test_openrouter.lua
+++ b/tests/adapters/http/test_openrouter.lua
@@ -1,5 +1,4 @@
 local h = require("tests.helpers")
-local tags = require("codecompanion.interactions.shared.tags")
 local adapter
 
 local new_set = MiniTest.new_set
@@ -157,101 +156,6 @@ T["OpenRouter adapter"]["strips image messages for models that do not support vi
   h.eq({
     { role = "user", content = "Describe this image" },
   }, result.messages)
-end
-
-T["OpenRouter adapter"]["forms documents into file content blocks"] = function()
-  local messages = {
-    {
-      content = "somefakebase64encoding",
-      role = "user",
-      context = {
-        id = "<file>report.pdf</file>",
-        mimetype = "application/pdf",
-        path = "report.pdf",
-      },
-      _meta = {
-        tag = tags.DOCUMENT,
-        filetype = "pdf",
-      },
-    },
-    {
-      content = "What does this PDF say?",
-      role = "user",
-    },
-  }
-
-  local result = adapter.handlers.form_messages(adapter, messages)
-
-  h.eq({
-    {
-      role = "user",
-      content = {
-        {
-          type = "file",
-          file = {
-            filename = "report.pdf",
-            file_data = "data:application/pdf;base64,somefakebase64encoding",
-          },
-        },
-      },
-      tool_calls = nil,
-      tool_call_id = nil,
-    },
-    {
-      role = "user",
-      content = "What does this PDF say?",
-      tool_calls = nil,
-      tool_call_id = nil,
-    },
-  }, result.messages)
-end
-
-T["OpenRouter adapter"]["only PDFs are converted into document blocks"] = function()
-  local messages = {
-    {
-      content = "somefakebase64encoding",
-      role = "user",
-      context = {
-        id = "<file>report.docx</file>",
-        mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        path = "report.docx",
-      },
-      _meta = {
-        tag = tags.DOCUMENT,
-        filetype = "docx",
-      },
-    },
-  }
-
-  local result = adapter.handlers.form_messages(adapter, messages)
-
-  h.eq("somefakebase64encoding", result.messages[1].content)
-end
-
-T["OpenRouter adapter"]["leaves document messages untouched for adapters that do not support documents"] = function()
-  local no_documents_adapter = require("codecompanion.adapters").extend("openrouter", {
-    opts = { documents = false },
-  })
-
-  local messages = {
-    {
-      content = "somefakebase64encoding",
-      role = "user",
-      context = {
-        id = "<file>report.pdf</file>",
-        mimetype = "application/pdf",
-        path = "report.pdf",
-      },
-      _meta = {
-        tag = tags.DOCUMENT,
-        filetype = "pdf",
-      },
-    },
-  }
-
-  local result = no_documents_adapter.handlers.form_messages(no_documents_adapter, messages)
-
-  h.eq("somefakebase64encoding", result.messages[1].content)
 end
 
 T["OpenRouter adapter"]["can output tool call"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR will add support for the sending of PDFs to various http adapters.

- ✅️ Anthropic
- ✅️ Copilot (OpenAI models only)
- ✅️ OpenAI
- ✅️ OpenAI Responses
- ✅️ OpenRouter

Initially this is scoped for just PDFs but happy to accept PRs that will allow other document types.

Gemini support will follow later once I've migrated the adapter to their new interactions endpoint. I also couldn't quite work out Mistral's docs so will be happy to accept that via a user contributed PR.

## Supporting Documentation

- [Anthropic](https://platform.claude.com/docs/en/build-with-claude/pdf-support#option-2-base64-encoded-pdf-document)
- [OpenAI Responses](https://developers.openai.com/api/docs/guides/file-inputs#base64-encoded-files)
- [OpenRouter](https://openrouter.ai/docs/guides/overview/multimodal/pdfs#using-base64-encoded-pdfs)

## AI Usage

Claude Sonnet 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
