### PR TITLE
feat(adapters): env vars can be in files

### DIFF
--- a/.codecompanion/adapters/adapters.md
+++ b/.codecompanion/adapters/adapters.md
@@ -200,3 +200,8 @@ The http.lua module implements a provider-agnostic HTTP client for CodeCompanion
 ## Models
 
 @.codecompanion/adapters/models_list.md
+
+## Tests
+
+@./tests/adapters/test_adapters.lua
+@./tests/adapters/http/test_openai.lua

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1751,7 +1751,11 @@ be executed via the shell. Example: `"cmd:op read
 op://personal/Gemini/credential --no-newline"`. - **Function**: you can provide
 a Lua function which returns a string and will be called with the adapter as
 its sole argument. - **Schema reference (dot notation)**: you can reference
-values from the adapter table (for example `"schema.model.default"`).
+values from the adapter table (for example `"schema.model.default"`). - **File
+(string prefixed with file:)**: any value that starts with `file:` will be read
+from disk, e.g. `"file:.api_key"` (relative to the cwd) or
+`"file:~/.dotfiles/.api_key"`. The file is read fresh on every request rather
+than being cached, so updating the file takes effect immediately.
 
 
 DISABLING COMPACTION ~

--- a/doc/configuration/adapters-http.md
+++ b/doc/configuration/adapters-http.md
@@ -277,6 +277,22 @@ require("codecompanion").setup({
 })
 ```
 
+```lua{7} [File]
+require("codecompanion").setup({
+  adapters = {
+    http = {
+      anthropic = function()
+        return require("codecompanion.adapters").extend("anthropic", {
+          env = {
+            api_key = "file:~/.dotfiles/.anthropic_api_key",
+          },
+        })
+      end,
+    },
+  },
+})
+```
+
 :::
 
 > [!NOTE]
@@ -287,6 +303,7 @@ Supported `env` value types:
 - **Command (string prefixed with `cmd:`)**: any value that starts with `cmd:` will be executed via the shell. Example: `"cmd:op read op://personal/Gemini/credential --no-newline"`.
 - **Function**: you can provide a Lua function which returns a string and will be called with the adapter as its sole argument.
 - **Schema reference (dot notation)**: you can reference values from the adapter table (for example `"schema.model.default"`).
+- **File (string prefixed with `file:`)**: any value that starts with `file:` will be read from disk, e.g. `"file:.api_key"` (relative to the cwd) or `"file:~/.dotfiles/.api_key"`. The file is read fresh on every request rather than being cached, so updating the file takes effect immediately.
 
 ## Disabling Compaction
 

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -174,6 +174,34 @@ local function is_cmd(var)
   return var:match("^cmd:")
 end
 
+---Check if a variable starts with "file:"
+---@param var string
+---@return boolean
+local function is_file(var)
+  return var:match("^file:")
+end
+
+---Read the contents of the file in the environment variable, relative to the cwd if not absolute
+---@param var string
+---@return string|nil
+local function read_file(var)
+  log:trace("[Adapters] Detected file in environment variable")
+
+  local path = vim.fs.normalize(var:sub(6))
+  local files = require("codecompanion.utils.files")
+
+  if not files.exists(path) then
+    return log:error("[Adapters] Could not find file: %s", path)
+  end
+
+  local ok, content = pcall(files.read, path)
+  if not ok then
+    return log:error("[Adapters] Could not read file: %s", path)
+  end
+
+  return (content:gsub("%s+$", ""))
+end
+
 ---Check if the variable is an environment variable
 ---@param var string
 ---@return boolean
@@ -288,6 +316,8 @@ function M.get_env_vars(adapter, args)
     if type(v) == "string" and is_cmd(v) then
       local timeout = (args and args.timeout) or 5000
       adapter.env_replaced[k] = run_cmd(v, timeout)
+    elseif type(v) == "string" and is_file(v) then
+      adapter.env_replaced[k] = read_file(v)
     elseif type(v) == "string" and is_env_var(v) then
       adapter.env_replaced[k] = get_env_var(v)
     elseif type(v) == "function" then

--- a/tests/adapters/test_adapters.lua
+++ b/tests/adapters/test_adapters.lua
@@ -265,6 +265,60 @@ T["HTTP Adapter"]["environment variables can be functions"] = function()
   h.eq("test_api_key", result)
 end
 
+T["HTTP Adapter"]["environment variables can be read from a file (absolute path)"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.adapters.utils")
+    local path = vim.fn.tempname()
+    vim.fn.writefile({ "sk-test-123" }, path)
+
+    local adapter = require("codecompanion.adapters").extend("openai", {
+      env = {
+        api_key = "file:" .. path,
+      }
+    })
+    local api_key = utils.get_env_vars(adapter).env_replaced.api_key
+
+    vim.fn.delete(path)
+    return api_key
+  ]])
+
+  h.eq("sk-test-123", result)
+end
+
+T["HTTP Adapter"]["environment variables can be read from a file (relative path)"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.adapters.utils")
+    local filename = ".codecompanion_test_api_key"
+    vim.fn.writefile({ "relative-key" }, filename)
+
+    local adapter = require("codecompanion.adapters").extend("openai", {
+      env = {
+        api_key = "file:" .. filename,
+      }
+    })
+    local api_key = utils.get_env_vars(adapter).env_replaced.api_key
+
+    vim.fn.delete(filename)
+    return api_key
+  ]])
+
+  h.eq("relative-key", result)
+end
+
+T["HTTP Adapter"]["returns nil when the file for an environment variable doesn't exist"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.adapters.utils")
+    local adapter = require("codecompanion.adapters").extend("openai", {
+      env = {
+        api_key = "file:/tmp/codecompanion_test_file_that_does_not_exist",
+      }
+    })
+    return utils.get_env_vars(adapter).env_replaced.api_key
+  ]])
+
+  h.eq(vim.NIL, result)
+end
+
 T["HTTP Adapter"]["can update a model on the adapter"] = function()
   local result = child.lua([[
     local adapter = require("codecompanion.adapters").extend(test_adapter)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I have [per-project configs](https://codecompanion.olimorris.dev/configuration/others#per-project-configuration) for a number of my other projects. I'll often overwrite my default adapter config with a `.codecompanion.lua` file at the root of the project. I don't want to use 1Password for the API keys because it's a pain to authenticate so regularly, but at the same time, I don't want to risk uploading an API key into the version history.

So...introducing the ability to pass in a file:

```lua
return {
  adapters = {
    http = {
      extend = {
        openrouter = {
          env = {
            api_key = "file:.api_key",
          },
        },
      },
    },
  },
}
```

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Sonnet-5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
