### PR TITLE
feat(rules): opt-in autoload of default rules for prompt-library prompts

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3334,7 +3334,7 @@ To have prompts leverage autoload groups when they don't name their own rules:
 rules = { opts = { chat = { autoload = "default", autoload_prompt_library =
 true, }, }, }, })`
 
-With this enabled, a prompt that explictly names no rules, will have the
+With this enabled, a prompt that explicitly names no rules, will have the
 autoload groups loaded in the chat buffer. However, a prompt that names its own
 rules will use those instead.
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -881,7 +881,7 @@ CURRENT LIMITATIONS                    *codecompanion-acp-current-limitations*
     `terminal/output`, `terminal/release`, etc.) are not implemented. CodeCompanion
     doesn't advertise terminal capabilities to agents.
 - **Agent Plan Rendering**: Plan
-    <https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
+<https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
     received and logged, but they're not currently rendered in the chat buffer UI.
 - **Audio Content**: Audio can't be sent or received
 
@@ -3323,6 +3323,25 @@ available.
 
 
 
+AUTOLOADING RULES FOR PROMPT LIBRARY PROMPTS
+
+By default, |codecompanion-configuration-prompt-library| prompts that don't
+name any `rules` of their own load **no** rules. This differs from a plain chat
+buffer, which autoloads the `autoload` groups.
+
+To make prompt-library prompts also autoload the `autoload` groups, opt in with
+`autoload_prompt_library`:
+
+`lua{6} [Autoload for prompts] require("codecompanion").setup({ rules = { opts
+= { chat = { autoload = "default", autoload_prompt_library = true, }, }, }, })`
+
+With this enabled, a prompt that names no rules behaves like a plain chat and
+loads the `autoload` groups. A prompt can still opt out explicitly with `rules
+= "none"` (see |codecompanion-configuration-prompt-library-rules| in the prompt
+library docs), and a prompt that names its own rules always loads those
+instead.
+
+
 PARSERS ~
 
 Parsers allow CodeCompanion to transform rules, affecting how they are shared
@@ -3406,6 +3425,145 @@ BASIC STRUCTURE
 At their core, prompts define a series of messages sent to an LLM. Let's start
 with a simple example:
 
+
+
+PICKERS
+
+Pickers allow you to create dynamic prompt menus based on runtime data.
+
+**Lua only:**
+
+>lua
+    ["My picker menu ..."] = {
+      name = "A list of items",
+      interaction = " ",
+      description = "My current items",
+      picker = {
+        prompt = "Select an item",
+        columns = { "name", "description" },
+        items = {
+          {
+            name = "Item 1",
+            description = "This is item 1",
+            callback = function()
+              print("You selected item 1")
+            end,
+          },
+          {
+            name = "Item 2",
+            description = "This is item 2",
+            callback = function()
+              print("You selected item 2")
+            end,
+          },
+        },
+      },
+    },
+<
+
+
+PRE-HOOKS
+
+Pre-hooks allow you to run custom logic before a prompt is executed. This is
+particularly useful for creating new buffers or setting up the environment:
+
+**Lua only:**
+
+>lua
+    ["Boilerplate HTML"] = {
+      interaction = "inline",
+      description = "Generate some boilerplate HTML",
+      opts = {
+        ---@return number
+        pre_hook = function()
+          local bufnr = vim.api.nvim_create_buf(true, false)
+          vim.api.nvim_set_current_buf(bufnr)
+          vim.api.nvim_set_option_value("filetype", "html", { buf = bufnr })
+          return bufnr
+        end,
+      },
+      prompts = {
+        {
+          role = "system",
+          content = "You are an expert HTML programmer",
+        },
+        {
+          role = "user",
+          content = "Please generate some HTML boilerplate for me. Return the code only and no markdown codeblocks",
+        },
+      },
+    }
+<
+
+For the inline interaction, the plugin will detect a number being returned from
+the `pre_hook` and assume that is the buffer number you wish any code to be
+streamed into.
+
+
+RULES
+
+You can also specify rules to be loaded with your prompt:
+
+
+
+  [!INFO] By default, a prompt that names no `rules` loads **no** rules, unlike a
+  plain chat buffer which autoloads its
+  |codecompanion-configuration-rules-autoload| groups. To make prompts without a
+  `rules` field autoload those groups too, set
+  |codecompanion-configuration-rules-autoloading-rules-for-prompt-library-prompts|.
+  A prompt can always opt out with `rules = "none"`, regardless of that setting.
+
+TOOLS
+
+You can also specify tools to be loaded with your prompt. These can be
+individual tools as well as tool groups:
+
+
+::: tip Disabling all tools Setting `tools` to `none` will prevent any tools
+from being loaded in the chat, including any
+|codecompanion-configuration-chat-buffer-default-tools|:
+
+
+:::
+
+
+WORKFLOWS
+
+Workflows allow you to chain multiple prompts together in a sequence. That is,
+the first prompt is sent to the LLM, the LLM responds, then the next prompt in
+the workflow is sent, etc. This can be useful for implementing multi-step
+processes such as chain-of-thought reasoning or iterative code refinement.
+
+**Note:** Markdown prompts do not support
+|codecompanion-extending-agentic-workflows|.
+
+
+You can also modify the options for the entire workflow at an individual prompt
+level. This can be useful if you wish to automatically submit certain prompts
+or change the adapter/model mid-workflow. Simply use a yaml code block with
+`opts` as a meta field:
+
+
+
+OTHERS ~
+
+
+HIDING BUILT-IN PROMPTS
+
+You can hide the built-in prompts from the Action Palette by setting the
+following configuration option:
+
+>lua
+    require("codecompanion").setup({
+      display = {
+        action_palette = {
+          opts = {
+            show_preset_prompts = false,
+          }
+        },
+      },
+    })
+<
 
 
 SYSTEM PROMPTS                    *codecompanion-configuration-system-prompts*

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -881,7 +881,7 @@ CURRENT LIMITATIONS                    *codecompanion-acp-current-limitations*
     `terminal/output`, `terminal/release`, etc.) are not implemented. CodeCompanion
     doesn't advertise terminal capabilities to agents.
 - **Agent Plan Rendering**: Plan
-<https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
+    <https://agentclientprotocol.com/protocol/agent-plan> updates from agents are
     received and logged, but they're not currently rendered in the chat buffer UI.
 - **Audio Content**: Audio can't be sent or received
 
@@ -3323,23 +3323,21 @@ available.
 
 
 
-AUTOLOADING RULES FOR PROMPT LIBRARY PROMPTS
+RULES IN PROMPT LIBRARY PROMPTS
 
-By default, |codecompanion-configuration-prompt-library| prompts that don't
-name any `rules` of their own load **no** rules. This differs from a plain chat
-buffer, which autoloads the `autoload` groups.
+By default, prompt library prompts will never autoload rule groups. A prompt
+only gets rules if it names them itself, via its own rules field.
 
-To make prompt-library prompts also autoload the `autoload` groups, opt in with
-`autoload_prompt_library`:
+To have prompts fall back to the autoload groups when they don't name their own
+rules, enable autoload_for_prompt_library:
 
-`lua{6} [Autoload for prompts] require("codecompanion").setup({ rules = { opts
-= { chat = { autoload = "default", autoload_prompt_library = true, }, }, }, })`
+`lua{6} [Autoload for prompt library prompts] require("codecompanion").setup({
+rules = { opts = { chat = { autoload = "default", autoload_prompt_library =
+true, }, }, }, })`
 
-With this enabled, a prompt that names no rules behaves like a plain chat and
-loads the `autoload` groups. A prompt can still opt out explicitly with `rules
-= "none"` (see |codecompanion-configuration-prompt-library-rules| in the prompt
-library docs), and a prompt that names its own rules always loads those
-instead.
+With this enabled, a prompt that explictly names no rules, will have the
+autoload groups loaded in the chat buffer. However, a prompt that names its own
+rules will use those instead.
 
 
 PARSERS ~
@@ -3506,12 +3504,9 @@ You can also specify rules to be loaded with your prompt:
 
 
 
-  [!INFO] By default, a prompt that names no `rules` loads **no** rules, unlike a
-  plain chat buffer which autoloads its
-  |codecompanion-configuration-rules-autoload| groups. To make prompts without a
-  `rules` field autoload those groups too, set
-  |codecompanion-configuration-rules-autoloading-rules-for-prompt-library-prompts|.
-  A prompt can always opt out with `rules = "none"`, regardless of that setting.
+  [!INFO] A prompt that names no rules loads none by default. Enable
+  `rules.opts.chat.autoload_prompt_library` to have your prompts autoload rule
+  groups that you've specified in `rules.opts.chat.autoload`
 
 TOOLS
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3328,8 +3328,7 @@ RULES IN PROMPT LIBRARY PROMPTS
 By default, prompt library prompts will never autoload rule groups. A prompt
 only gets rules if it names them itself, via its own rules field.
 
-To have prompts fall back to the autoload groups when they don't name their own
-rules, enable autoload_for_prompt_library:
+To have prompts leverage autoload groups when they don't name their own rules:
 
 `lua{6} [Autoload for prompt library prompts] require("codecompanion").setup({
 rules = { opts = { chat = { autoload = "default", autoload_prompt_library =

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 13
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 15
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -3328,15 +3328,15 @@ RULES IN PROMPT LIBRARY PROMPTS
 By default, prompt library prompts will never autoload rule groups. A prompt
 only gets rules if it names them itself, via its own rules field.
 
-To have prompts leverage autoload groups when they don't name their own rules:
+To have prompts leverage the autoload groups when they don't name any rules:
 
 `lua{6} [Autoload for prompt library prompts] require("codecompanion").setup({
-rules = { opts = { chat = { autoload = "default", autoload_prompt_library =
-true, }, }, }, })`
+rules = { opts = { chat = { autoload = "default",
+autoload_groups_in_prompt_library = true, }, }, }, })`
 
-With this enabled, a prompt that explicitly names no rules, will have the
-autoload groups loaded in the chat buffer. However, a prompt that names its own
-rules will use those instead.
+With this enabled, a prompt that names no rules will have the autoload groups
+(`rules.opts.chat.autoload`) loaded in the chat buffer. However, a prompt that
+names its own rules will use those instead.
 
 
 PARSERS ~
@@ -3504,8 +3504,8 @@ You can also specify rules to be loaded with your prompt:
 
 
   [!INFO] A prompt that names no rules loads none by default. Enable
-  `rules.opts.chat.autoload_prompt_library` to have your prompts autoload rule
-  groups that you've specified in `rules.opts.chat.autoload`
+  `rules.opts.chat.autoload_groups_in_prompt_library` to have your prompts
+  autoload rule groups that you've specified in `rules.opts.chat.autoload`
 
 TOOLS
 

--- a/doc/configuration/prompt-library.md
+++ b/doc/configuration/prompt-library.md
@@ -709,7 +709,7 @@ rules:
 :::
 
 > [!INFO]
-> A prompt that names no rules loads none by default. Enable `rules.opts.chat.autoload_prompt_library` to have your prompts autoload rule groups that you've specified in `rules.opts.chat.autoload`
+> A prompt that names no rules loads none by default. Enable `rules.opts.chat.autoload_groups_in_prompt_library` to have your prompts autoload rule groups that you've specified in `rules.opts.chat.autoload`
 
 #### Tools
 

--- a/doc/configuration/prompt-library.md
+++ b/doc/configuration/prompt-library.md
@@ -608,6 +608,8 @@ mcp_servers: none
 
 :::
 
+:::
+
 #### Pickers
 
 Pickers allow you to create dynamic prompt menus based on runtime data.
@@ -706,6 +708,11 @@ rules:
 
 :::
 
+> [!INFO]
+> By default, a prompt that names no `rules` loads **no** rules, unlike a plain chat buffer which autoloads its [`autoload`](/configuration/rules#autoload) groups.
+> To make prompts without a `rules` field autoload those groups too, set [`rules.opts.chat.autoload_prompt_library = true`](/configuration/rules#autoloading-rules-for-prompt-library-prompts).
+> A prompt can always opt out with `rules = "none"`, regardless of that setting.
+
 #### Tools
 
 You can also specify tools to be loaded with your prompt. These can be individual tools as well as tool groups:
@@ -757,6 +764,8 @@ tools: none
   tools = "none",
 },
 ```
+
+:::
 
 :::
 

--- a/doc/configuration/prompt-library.md
+++ b/doc/configuration/prompt-library.md
@@ -709,9 +709,7 @@ rules:
 :::
 
 > [!INFO]
-> By default, a prompt that names no `rules` loads **no** rules, unlike a plain chat buffer which autoloads its [`autoload`](/configuration/rules#autoload) groups.
-> To make prompts without a `rules` field autoload those groups too, set [`rules.opts.chat.autoload_prompt_library = true`](/configuration/rules#autoloading-rules-for-prompt-library-prompts).
-> A prompt can always opt out with `rules = "none"`, regardless of that setting.
+> A prompt that names no rules loads none by default. Enable `rules.opts.chat.autoload_prompt_library` to have your prompts autoload rule groups that you've specified in `rules.opts.chat.autoload`
 
 #### Tools
 

--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -250,13 +250,13 @@ require("codecompanion").setup({
 
 :::
 
-#### Autoloading Rules for Prompt Library Prompts
+#### Rules in Prompt Library Prompts
 
-By default, [prompt library](/configuration/prompt-library) prompts that don't name any `rules` of their own load **no** rules. This differs from a plain chat buffer, which autoloads the `autoload` groups.
+By default, prompt library prompts will never autoload rule groups. A prompt only gets rules if it names them itself, via its own rules field.
 
-To make prompt-library prompts also autoload the `autoload` groups, opt in with `autoload_prompt_library`:
+To have prompts fall back to the autoload groups when they don't name their own rules, enable autoload_for_prompt_library:
 
-```lua{6} [Autoload for prompts]
+```lua{6} [Autoload for prompt library prompts]
 require("codecompanion").setup({
   rules = {
     opts = {
@@ -269,7 +269,7 @@ require("codecompanion").setup({
 })
 ```
 
-With this enabled, a prompt that names no rules behaves like a plain chat and loads the `autoload` groups. A prompt can still opt out explicitly with `rules = "none"` (see [Rules](/configuration/prompt-library#rules) in the prompt library docs), and a prompt that names its own rules always loads those instead.
+With this enabled, a prompt that explictly names no rules, will have the autoload groups loaded in the chat buffer. However, a prompt that names its own rules will use those instead.
 
 ## Parsers
 

--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -250,6 +250,27 @@ require("codecompanion").setup({
 
 :::
 
+#### Autoloading Rules for Prompt Library Prompts
+
+By default, [prompt library](/configuration/prompt-library) prompts that don't name any `rules` of their own load **no** rules. This differs from a plain chat buffer, which autoloads the `autoload` groups.
+
+To make prompt-library prompts also autoload the `autoload` groups, opt in with `autoload_prompt_library`:
+
+```lua{6} [Autoload for prompts]
+require("codecompanion").setup({
+  rules = {
+    opts = {
+      chat = {
+        autoload = "default",
+        autoload_prompt_library = true,
+      },
+    },
+  },
+})
+```
+
+With this enabled, a prompt that names no rules behaves like a plain chat and loads the `autoload` groups. A prompt can still opt out explicitly with `rules = "none"` (see [Rules](/configuration/prompt-library#rules) in the prompt library docs), and a prompt that names its own rules always loads those instead.
+
 ## Parsers
 
 Parsers allow CodeCompanion to transform rules, affecting how they are shared in the chat buffer. This is particularly useful if you reference files in your rules. Currently, the plugin has two in-built parsers:

--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -254,7 +254,7 @@ require("codecompanion").setup({
 
 By default, prompt library prompts will never autoload rule groups. A prompt only gets rules if it names them itself, via its own rules field.
 
-To have prompts leverage autoload groups when they don't name their own rules:
+To have prompts leverage the autoload groups when they don't name any rules:
 
 ```lua{6} [Autoload for prompt library prompts]
 require("codecompanion").setup({
@@ -262,14 +262,14 @@ require("codecompanion").setup({
     opts = {
       chat = {
         autoload = "default",
-        autoload_prompt_library = true,
+        autoload_groups_in_prompt_library  = true,
       },
     },
   },
 })
 ```
 
-With this enabled, a prompt that explicitly names no rules, will have the autoload groups loaded in the chat buffer. However, a prompt that names its own rules will use those instead.
+With this enabled, a prompt that names no rules will have the autoload groups (`rules.opts.chat.autoload`) loaded in the chat buffer. However, a prompt that names its own rules will use those instead.
 
 ## Parsers
 

--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -269,7 +269,7 @@ require("codecompanion").setup({
 })
 ```
 
-With this enabled, a prompt that explictly names no rules, will have the autoload groups loaded in the chat buffer. However, a prompt that names its own rules will use those instead.
+With this enabled, a prompt that explicitly names no rules, will have the autoload groups loaded in the chat buffer. However, a prompt that names its own rules will use those instead.
 
 ## Parsers
 

--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -254,7 +254,7 @@ require("codecompanion").setup({
 
 By default, prompt library prompts will never autoload rule groups. A prompt only gets rules if it names them itself, via its own rules field.
 
-To have prompts fall back to the autoload groups when they don't name their own rules, enable autoload_for_prompt_library:
+To have prompts leverage autoload groups when they don't name their own rules:
 
 ```lua{6} [Autoload for prompt library prompts]
 require("codecompanion").setup({

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1081,6 +1081,11 @@ The user is working on a %s machine. Please respond with system specific command
         ---@type string|fun(): string
         autoload = "default",
 
+        ---Also autoload the `autoload` rule groups for prompt-library prompts
+        ---that name no rules of their own? Prompts can still opt out with `rules = "none"`.
+        ---@type boolean
+        autoload_prompt_library = false,
+
         ---@type boolean | fun(chat: CodeCompanion.Chat): boolean
         enabled = true,
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1081,10 +1081,7 @@ The user is working on a %s machine. Please respond with system specific command
         ---@type string|fun(): string
         autoload = "default",
 
-        ---Also autoload the `autoload` rule groups for prompt-library prompts
-        ---that name no rules of their own? Prompts can still opt out with `rules = "none"`.
-        ---@type boolean
-        autoload_prompt_library = false,
+        autoload_groups_in_prompt_library = false, -- Load the autoload rule groups into a prompt library by default?
 
         ---@type boolean | fun(chat: CodeCompanion.Chat): boolean
         enabled = true,

--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -42,16 +42,12 @@ local function get_callbacks(selected)
   --TODO: Remove opts.rules fallback in v20.0.0
   local rules = selected.rules or opts.rules
   if rules == "none" then
-    -- Explicit opt-out: this prompt loads no rules at all.
     return callbacks
   end
 
-  -- When the prompt names rules explicitly, load those. When it names none
-  -- (`rules == nil`), only fall back to the global `rules.opts.chat.autoload`
-  -- default if the user opted in via `autoload_prompt_library`; otherwise a
-  -- prompt-library prompt loads no rules, preserving the historic behaviour.
+  -- Load a prompt library's explicit rules, or the autoload rules groups, if enabled
   local chat_rules = config.rules and config.rules.opts and config.rules.opts.chat
-  if not rules and not (chat_rules and chat_rules.autoload_prompt_library) then
+  if not rules and not (chat_rules and chat_rules.autoload_groups_in_prompt_library) then
     return callbacks
   end
 

--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -39,15 +39,27 @@ end
 local function get_callbacks(selected)
   local opts = selected.opts or {}
   local callbacks = opts.callbacks or {}
-
   --TODO: Remove opts.rules fallback in v20.0.0
   local rules = selected.rules or opts.rules
-  if rules and rules ~= "none" then
-    local rules_cb = rules_helpers.add_callbacks(callbacks, rules)
-    if rules_cb then
-      callbacks = rules_cb
-    end
+  if rules == "none" then
+    -- Explicit opt-out: this prompt loads no rules at all.
+    return callbacks
   end
+
+  -- When the prompt names rules explicitly, load those. When it names none
+  -- (`rules == nil`), only fall back to the global `rules.opts.chat.autoload`
+  -- default if the user opted in via `autoload_prompt_library`; otherwise a
+  -- prompt-library prompt loads no rules, preserving the historic behaviour.
+  local chat_rules = config.rules and config.rules.opts and config.rules.opts.chat
+  if not rules and not (chat_rules and chat_rules.autoload_prompt_library) then
+    return callbacks
+  end
+
+  local rules_cb = rules_helpers.add_callbacks(callbacks, rules)
+  if rules_cb then
+    callbacks = rules_cb
+  end
+
   return callbacks
 end
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Prompt-library prompts that name no `rules` currently bypass rule loading entirely: `get_callbacks` only invokes `add_callbacks` when the prompt declares a `rules` field, so the global `rules.opts.chat.autoload` default (e.g.
`"default"`) never applies to them. A plain chat, by contrast, autoloads the default rules.

This PR makes that autoload behaviour available to prompt-library prompts, but **as an opt-in** so it doesn't change existing behaviour on upgrade:

- Adds a new `rules.opts.chat.autoload_prompt_library` option, defaulting to `false`.
- When enabled, `get_callbacks` falls back to the global `autoload` default for a prompt that names no rules of its own — matching a plain chat.
- When disabled (the default), a prompt without a `rules` field loads no rules, preserving the historic behaviour.
- A prompt can still opt out explicitly with `rules = "none"`, regardless of the setting.

Why opt-in: silently loading default rules into every library prompt is a behavioural change that shouldn't go live with a release without the user asking for it. Gating it behind a config flag lets users adopt it deliberately.

Also updates the docs: the option is documented on the Rules and Prompt Library configuration pages, the vimdoc is regenerated, and two pre-existing unclosed `::: tip` divs in `prompt-library.md` are fixed (they were causing `panvimdoc` to emit an "unclosed Div" warning and swallow the new callout out of the
generated vimdoc).

### Examples

#### Default Opt-in

When `rules.opts.chat.autoload_prompt_library = true`:

```mdx
---
name: "Rules: load default"
description: "Start a chat that loads the default rules group"
interaction: chat
opts:
  is_slash_cmd: true
  alias: "rules-default"
  auto_submit: false
---

## system

This chat explicitly loads the `default` rules group. The rules files
configured under that group (for example `AGENTS.md` and `CLAUDE.md`) are
attached to the chat buffer so you carry the project's persistent instructions
and context.

## user

I've loaded the default rules for this project. Confirm which rules files you
can see, then wait for my next instruction.
```

#### Opt-out

```mdx
---
name: "Rules: opt out"
description: "Start a chat that loads no rules, overriding the autoload default"
interaction: chat
rules: none
opts:
  is_slash_cmd: true
  alias: "rules-none"
  auto_submit: false
---

## system

This chat explicitly opts out of rules with `rules: none`. No rules files are
attached, including any group set via the global `rules.opts.chat.autoload`
default. Use this when you want a clean chat without the project's persistent
instructions.

## user

I've started this chat with rules disabled. Confirm that no rules files are
attached, then wait for my next instruction.
```

## Supporting Documentation

N/A — this is an internal configuration/behaviour change with no external protocol or LLM documentation to reference.

## AI Usage

The implementation, docs, and this PR description were drafted with AI assistance (CodeCompanion) and reviewed/edited by me. The AI helped locate the relevant `get_callbacks` logic, add the config flag, write the doc prose, regenerate the vimdoc, and diagnose/fix the unclosed-div issue.

## Related Issue(s)

<!-- Fixes #<issue_number> -->

## Screenshots

N/A — no UI changes.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above) <!-- see AI Usage above -->
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code <!-- make docs run and the rules + prompt-library test suites pass; StyLua not yet run -->
- [x] I've updated the README and/or relevant docs pages
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
