### PR TITLE
feat(adapters): add new `gemini_interactions` adapter

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 12
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 14
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -1,5 +1,3 @@
----Source: https://ai.google.dev/gemini-api/docs
-
 local adapter_utils = require("codecompanion.adapters.utils")
 local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")

--- a/lua/codecompanion/adapters/http/gemini_interactions.lua
+++ b/lua/codecompanion/adapters/http/gemini_interactions.lua
@@ -1,0 +1,771 @@
+---Source: https://ai.google.dev/gemini-api/docs/interactions-overview
+
+local adapter_utils = require("codecompanion.adapters.utils")
+local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
+local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
+
+---Track the step type at each stream index so a `step.delta` event knows
+---whether it belongs to a thought or a model_output
+---@type table<number, string>
+local step_types = {}
+
+---Extract the first complete JSON object from a potentially concatenated string
+---Workaround for Gemini bug where multiple JSON objects get concatenated
+---Ref: #2620
+---@param args string
+---@return string
+local function fix_concatenated_args(args)
+  local ok = pcall(vim.json.decode, args)
+  if ok then
+    return args
+  end
+
+  local depth = 0
+  local escaped = false
+  local in_string = false
+
+  for i = 1, #args do
+    local char = args:sub(i, i)
+
+    if escaped then
+      escaped = false
+    elseif char == "\\" and in_string then
+      escaped = true
+    elseif char == '"' then
+      in_string = not in_string
+    elseif not in_string then
+      if char == "{" then
+        depth = depth + 1
+      elseif char == "}" then
+        depth = depth - 1
+        if depth == 0 and i < #args then
+          return args:sub(1, i)
+        end
+      end
+    end
+  end
+
+  return args
+end
+
+---Decode a JSON arguments string to a table, applying concatenation fix
+---@param args string|table
+---@return table
+local function decode_args(args)
+  if type(args) == "table" then
+    return args
+  end
+  if type(args) ~= "string" or args == "" then
+    return {}
+  end
+
+  args = fix_concatenated_args(args)
+  local ok, decoded = pcall(vim.json.decode, args)
+  if ok then
+    return decoded
+  end
+  return {}
+end
+
+---Join the `text` blocks of a content/summary array into a single string
+---@param blocks? table
+---@return string|nil
+local function join_text_blocks(blocks)
+  local text
+  for _, block in ipairs(blocks or {}) do
+    if block.type == "text" then
+      text = (text or "") .. block.text
+    end
+  end
+  return text
+end
+
+---@class CodeCompanion.HTTPAdapter.GeminiInteractions: CodeCompanion.HTTPAdapter
+return {
+  name = "gemini_interactions",
+  vendor = "gemini",
+  formatted_name = "Gemini_Interactions",
+  roles = {
+    llm = "model",
+    user = "user",
+  },
+  features = {
+    text = true,
+    tokens = true,
+  },
+  opts = {
+    documents = true,
+    stream = true,
+    tools = true,
+    vision = true,
+  },
+  url = "https://generativelanguage.googleapis.com/v1beta/interactions${stream}",
+  env = {
+    api_key = "GEMINI_API_KEY",
+    stream = function(self)
+      if self.opts.stream then
+        return "?alt=sse"
+      end
+      return ""
+    end,
+  },
+  headers = {
+    ["Content-Type"] = "application/json",
+    ["x-goog-api-key"] = "${api_key}",
+  },
+  parameters = {
+    -- Use the stateless endpoint
+    store = false,
+  },
+  available_tools = {
+    ["google_search"] = {
+      description = "Allows the model to search the web via Google Search for the latest information before generating a response.",
+      ---@param self CodeCompanion.HTTPAdapter.GeminiInteractions
+      ---@param meta { tools: table }
+      callback = function(self, meta)
+        table.insert(meta.tools, {
+          type = "google_search",
+        })
+      end,
+    },
+  },
+  handlers = {
+    lifecycle = {
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return boolean
+      setup = function(self)
+        local model_opts = adapter_utils.model_choice(self)
+
+        self.opts.vision = true
+
+        if model_opts and model_opts.opts then
+          self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
+          if not model_opts.opts.has_vision then
+            self.opts.vision = false
+          end
+        end
+
+        if self.opts and self.opts.stream then
+          self.parameters.stream = true
+        end
+
+        return true
+      end,
+
+      ---Function to run when the request has completed
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param data? table
+      ---@return nil
+      on_exit = function(self, data)
+        step_types = {}
+        if data and data.status and data.status >= 400 then
+          log:error("Error: %s", data.body)
+        end
+      end,
+    },
+
+    request = {
+      ---Set the parameters
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param params table
+      ---@param messages table
+      ---@return table
+      build_parameters = function(self, params, messages)
+        return params
+      end,
+
+      ---Set the format of the role and content for the messages from the chat buffer
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param messages table
+      ---@return table
+      build_messages = function(self, messages)
+        local system_parts = {}
+        local input = {}
+        local i = 1
+
+        while i <= #messages do
+          local m = messages[i]
+
+          if m.role == "system" then
+            table.insert(system_parts, m.content)
+
+          -- Tool result -> function_result
+          -- https://ai.google.dev/gemini-api/docs/interactions-overview
+          elseif m.role == "tool" and m.tools then
+            local content = m.content
+            if type(content) ~= "string" then
+              content = vim.json.encode(content)
+            end
+
+            table.insert(input, {
+              type = "function_result",
+              name = m.tools.name,
+              call_id = m.tools.call_id,
+              result = { { type = "text", text = content } },
+            })
+
+          -- Image -> a user_input turn containing an image content part
+          elseif m._meta and m._meta.tag == tags.IMAGE and m.context and m.context.mimetype then
+            if self.opts and self.opts.vision then
+              local parts = {
+                { type = "image", data = m.content, mime_type = m.context.mimetype },
+              }
+
+              -- Combine with the following text message from the same user turn
+              local next_msg = messages[i + 1]
+              if
+                next_msg
+                and next_msg.role == m.role
+                and type(next_msg.content) == "string"
+                and not (next_msg._meta and next_msg._meta.tag == tags.IMAGE)
+              then
+                table.insert(parts, { type = "text", text = next_msg.content })
+                i = i + 1
+              end
+
+              table.insert(input, { type = "user_input", content = parts })
+            end
+
+          -- Document (PDF only) -> a user_input turn containing a document content part
+          elseif
+            m._meta
+            and m._meta.tag == tags.DOCUMENT
+            and m._meta.filetype == "pdf"
+            and m.context
+            and m.context.mimetype
+          then
+            if self.opts and self.opts.documents then
+              local parts = {
+                { type = "document", data = m.content, mime_type = m.context.mimetype },
+              }
+
+              -- Combine with the following text message from the same user turn
+              local next_msg = messages[i + 1]
+              if
+                next_msg
+                and next_msg.role == m.role
+                and type(next_msg.content) == "string"
+                and not (next_msg._meta and next_msg._meta.tag == tags.DOCUMENT)
+              then
+                table.insert(parts, { type = "text", text = next_msg.content })
+                i = i + 1
+              end
+
+              table.insert(input, { type = "user_input", content = parts })
+            else
+              log:warn(
+                "The `%s` model does not support documents so has been removed from the request",
+                self.formatted_name
+              )
+            end
+
+          -- LLM turn -> thought, model_output and function_call steps
+          elseif m.role == self.roles.llm then
+            if m.reasoning and (m.reasoning.content or m.reasoning.signature) then
+              table.insert(input, {
+                type = "thought",
+                signature = m.reasoning.signature,
+                summary = m.reasoning.content and { { type = "text", text = m.reasoning.content } } or nil,
+              })
+            end
+
+            if m.content and m.content ~= "" then
+              table.insert(input, {
+                type = "model_output",
+                content = { { type = "text", text = m.content } },
+              })
+            end
+
+            if m.tools and m.tools.calls then
+              for _, call in ipairs(m.tools.calls) do
+                table.insert(input, {
+                  type = "function_call",
+                  id = call.id,
+                  name = call["function"].name,
+                  arguments = decode_args(call["function"].arguments),
+                  signature = call.signature,
+                })
+              end
+            end
+
+          -- Regular user turn
+          else
+            table.insert(input, { type = "user_input", content = m.content })
+          end
+
+          i = i + 1
+        end
+
+        local result = { input = input }
+
+        if #system_parts > 0 then
+          result.system_instruction = table.concat(system_parts, "\n\n")
+        end
+
+        return result
+      end,
+
+      ---Provides the schemas of the tools that are available to the LLM
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param tools table<string, table>
+      ---@return table|nil
+      build_tools = function(self, tools)
+        if not self.opts.tools or not tools then
+          return nil
+        end
+        if vim.tbl_count(tools) == 0 then
+          return nil
+        end
+
+        local transformed = {}
+        for _, tool in pairs(tools) do
+          for _, schema in pairs(tool) do
+            if schema._meta and schema._meta.adapter_tool then
+              if self.available_tools[schema.name] then
+                self.available_tools[schema.name].callback(self, { tools = transformed })
+              end
+            else
+              table.insert(transformed, tool_transformer.to_gemini_interactions(schema))
+            end
+          end
+        end
+
+        return { tools = transformed }
+      end,
+
+      ---Form the structured output schema for the request body
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param schema CodeCompanion.StructuredOutput.Schema
+      ---@return table|nil
+      build_structured_output = function(self, schema)
+        if not schema then
+          return
+        end
+        if not self.opts.can_form_structured_outputs then
+          return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+        end
+        return require("codecompanion.adapters.utils.structured_outputs").to_gemini_interactions(schema)
+      end,
+
+      ---Form the reasoning output that is stored in the chat buffer
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param data table The reasoning output from the LLM
+      ---@return nil|{ content: string, signature: string }
+      build_reasoning = function(self, data)
+        local content = vim
+          .iter(data)
+          :map(function(item)
+            return item.content
+          end)
+          :filter(function(item_content)
+            return item_content ~= nil
+          end)
+          :join("")
+
+        local signature
+        for _, item in ipairs(data) do
+          if item.signature then
+            signature = (signature or "") .. item.signature
+          end
+        end
+
+        if content == "" and not signature then
+          return nil
+        end
+
+        return {
+          content = content ~= "" and content or nil,
+          signature = signature,
+        }
+      end,
+    },
+
+    response = {
+      ---Returns the number of tokens generated from the LLM
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param data string|table The data from the LLM
+      ---@return number|nil
+      parse_tokens = function(self, data)
+        if not data or data == "" then
+          return nil
+        end
+
+        if not self.opts.stream then
+          local data_mod = type(data) == "table" and data.body or data
+          local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
+          if ok and json.usage then
+            return json.usage.total_tokens
+          end
+          return nil
+        end
+
+        local data_mod = adapter_utils.clean_streamed_data(data)
+        local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
+        if ok and json.event_type == "interaction.completed" and json.interaction and json.interaction.usage then
+          return json.interaction.usage.total_tokens
+        end
+      end,
+
+      ---Output the data from the API ready for insertion into the chat buffer
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param data string|table The streamed or non-streamed data from the API
+      ---@param tools? table The table to write any tool output to
+      ---@return table|nil
+      parse_chat = function(self, data, tools)
+        if not data or data == "" then
+          return nil
+        end
+
+        if not self.opts.stream then
+          local data_mod = type(data) == "table" and data.body or data
+          local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
+          if not ok or not json.steps then
+            return nil
+          end
+
+          local reasoning = {}
+          local content
+          local tool_index = 0
+
+          for _, step in ipairs(json.steps) do
+            if step.type == "thought" then
+              reasoning.content = join_text_blocks(step.summary)
+              reasoning.signature = step.signature
+            elseif step.type == "model_output" then
+              content = (content or "") .. (join_text_blocks(step.content) or "")
+            elseif step.type == "function_call" and tools then
+              tool_index = tool_index + 1
+              table.insert(tools, {
+                _index = tool_index,
+                id = step.id,
+                name = step.name,
+                args = step.arguments,
+                signature = step.signature,
+              })
+            end
+          end
+
+          return {
+            status = "success",
+            output = {
+              content = content,
+              reasoning = next(reasoning) and reasoning or nil,
+              role = self.roles.llm,
+            },
+          }
+        end
+
+        -- Streaming: SSE events carry their own `event_type` in the JSON body,
+        -- so the `event:` line can be ignored (fails JSON decoding and is
+        -- skipped below)
+        local data_mod = adapter_utils.clean_streamed_data(data)
+        local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
+        if not ok then
+          return nil
+        end
+
+        if json.event_type == "step.start" and json.step then
+          step_types[json.index] = json.step.type
+
+          if json.step.type == "thought" then
+            local summary = join_text_blocks(json.step.summary)
+            local signature = json.step.signature and json.step.signature ~= "" and json.step.signature or nil
+            if not summary and not signature then
+              return nil
+            end
+            return {
+              status = "success",
+              output = { role = self.roles.llm, reasoning = { content = summary, signature = signature } },
+            }
+          elseif json.step.type == "model_output" then
+            local content = join_text_blocks(json.step.content)
+            if not content then
+              return nil
+            end
+            return { status = "success", output = { role = self.roles.llm, content = content } }
+          elseif json.step.type == "function_call" and tools then
+            -- The `arguments` field is only ever a placeholder (typically `{}`) at
+            -- step.start; the real arguments arrive as a JSON-encoded string via a
+            -- later `arguments_delta` step.delta event
+            local initial_args = type(json.step.arguments) == "table"
+                and next(json.step.arguments)
+                and vim.json.encode(json.step.arguments)
+              or nil
+
+            table.insert(tools, {
+              _index = json.index,
+              id = json.step.id,
+              name = json.step.name,
+              args = initial_args,
+              signature = json.step.signature,
+            })
+          end
+          return nil
+        end
+
+        if json.event_type == "step.delta" and json.delta then
+          local step_type = step_types[json.index]
+
+          if json.delta.type == "thought_signature" then
+            return {
+              status = "success",
+              output = { role = self.roles.llm, reasoning = { signature = json.delta.signature } },
+            }
+          elseif json.delta.type == "thought_summary" then
+            local text = json.delta.content and json.delta.content.text
+            if not text then
+              return nil
+            end
+            return { status = "success", output = { role = self.roles.llm, reasoning = { content = text } } }
+          elseif json.delta.type == "text" then
+            if step_type == "thought" then
+              return {
+                status = "success",
+                output = { role = self.roles.llm, reasoning = { content = json.delta.text } },
+              }
+            end
+            return { status = "success", output = { role = self.roles.llm, content = json.delta.text } }
+          elseif json.delta.type == "arguments_delta" and tools then
+            for _, tool in ipairs(tools) do
+              if tool._index == json.index then
+                tool.args = (tool.args or "") .. (json.delta.arguments or "")
+                break
+              end
+            end
+          end
+          return nil
+        end
+
+        return nil
+      end,
+
+      ---Output the data from the API ready for inlining into the current buffer
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param data string|table
+      ---@param context? table
+      ---@return table|nil
+      parse_inline = function(self, data, context)
+        if self.opts.stream then
+          return log:error("Inline output is not supported in streaming mode")
+        end
+
+        if data and data ~= "" then
+          local ok, json = pcall(vim.json.decode, data.body, { luanil = { object = true } })
+
+          if not ok then
+            log:error("Error decoding JSON: %s", data.body)
+            return { status = "error", output = json }
+          end
+
+          local content
+          for _, step in ipairs(json.steps or {}) do
+            if step.type == "model_output" then
+              content = (content or "") .. (join_text_blocks(step.content) or "")
+            end
+          end
+
+          if content then
+            return { status = "success", output = content }
+          end
+        end
+      end,
+    },
+
+    tools = {
+      ---Normalize raw tool calls from parse_chat into the internal format
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param tools table
+      ---@return table
+      format_calls = function(self, tools)
+        local formatted = {}
+        for _, tool in ipairs(tools) do
+          table.insert(formatted, {
+            _index = tool._index,
+            id = tool.id or string.format("call_%s_%d", os.time(), tool._index),
+            signature = tool.signature,
+            type = "function",
+            ["function"] = {
+              arguments = type(tool.args) == "table" and vim.json.encode(tool.args)
+                or (tool.args and tool.args ~= "" and tool.args or "{}"),
+              name = tool.name,
+            },
+          })
+        end
+        return formatted
+      end,
+
+      ---Format the tool response for inclusion in messages
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@param tool_call table
+      ---@param output string
+      ---@return table
+      format_response = function(self, tool_call, output)
+        return {
+          content = output,
+          opts = { visible = false },
+          role = "tool",
+          tools = {
+            call_id = tool_call.id,
+            name = tool_call["function"].name,
+          },
+        }
+      end,
+    },
+  },
+  schema = {
+    model = {
+      order = 1,
+      mapping = "parameters",
+      type = "enum",
+      desc = "The model that will complete your prompt. See https://ai.google.dev/gemini-api/docs/models/gemini for details.",
+      default = "gemini-3.1-pro-preview",
+      choices = {
+        -- Gemini 3
+        ["gemini-3.1-pro-preview"] = {
+          formatted_name = "Gemini 3.1 Pro",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+        ["gemini-3.5-flash"] = {
+          formatted_name = "Gemini 3.5 Flash",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+        ["gemini-3.1-flash-lite-preview"] = {
+          formatted_name = "Gemini 3.1 Flash Lite",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+        ["gemini-3-flash-preview"] = {
+          formatted_name = "Gemini 3 Flash",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+
+        -- Gemini 2.5
+        ["gemini-2.5-pro"] = {
+          formatted_name = "Gemini 2.5 Pro",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+        ["gemini-2.5-flash"] = {
+          formatted_name = "Gemini 2.5 Flash",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+        ["gemini-2.5-flash-lite"] = {
+          formatted_name = "Gemini 2.5 Flash Lite",
+          meta = { context_window = 1048576 },
+          opts = { can_form_structured_outputs = true, can_reason = true, has_vision = true },
+        },
+      },
+    },
+    max_output_tokens = {
+      order = 2,
+      mapping = "body.generation_config",
+      type = "integer",
+      optional = true,
+      default = nil,
+      desc = "The maximum number of tokens to include in a response candidate. Note: The default value varies by model.",
+      validate = function(n)
+        return n > 0, "Must be greater than 0"
+      end,
+    },
+    temperature = {
+      order = 3,
+      mapping = "body.generation_config",
+      type = "number",
+      optional = true,
+      default = nil,
+      desc = "Controls the randomness of the output.",
+      validate = function(n)
+        return n >= 0 and n <= 2, "Must be between 0 and 2"
+      end,
+    },
+    top_p = {
+      order = 4,
+      mapping = "body.generation_config",
+      type = "number",
+      optional = true,
+      default = nil,
+      desc = "The maximum cumulative probability of tokens to consider when sampling.",
+      validate = function(n)
+        return n > 0, "Must be greater than 0"
+      end,
+    },
+    top_k = {
+      order = 5,
+      mapping = "body.generation_config",
+      type = "integer",
+      optional = true,
+      default = nil,
+      desc = "The maximum number of tokens to consider when sampling.",
+      validate = function(n)
+        return n > 0, "Must be greater than 0"
+      end,
+    },
+    thinking_level = {
+      order = 6,
+      mapping = "body.generation_config",
+      type = "string",
+      optional = true,
+      ---@type fun(self: CodeCompanion.HTTPAdapter): boolean
+      enabled = function(self)
+        local model = self.schema.model.default
+        if type(model) == "function" then
+          model = model()
+        end
+        local choice = self.schema.model.choices[model]
+        if type(choice) == "table" and choice.opts then
+          return choice.opts.can_reason or false
+        end
+        return false
+      end,
+      default = "high",
+      desc = "Controls thinking effort for reasoning models. See https://ai.google.dev/gemini-api/docs/thinking.",
+      choices = {
+        "high",
+        "medium",
+        "low",
+        "none",
+      },
+    },
+    thinking_summaries = {
+      order = 7,
+      mapping = "body.generation_config",
+      type = "string",
+      optional = true,
+      ---@type fun(self: CodeCompanion.HTTPAdapter): boolean
+      enabled = function(self)
+        local model = self.schema.model.default
+        if type(model) == "function" then
+          model = model()
+        end
+        local choice = self.schema.model.choices[model]
+        if type(choice) == "table" and choice.opts then
+          return choice.opts.can_reason or false
+        end
+        return false
+      end,
+      default = "auto",
+      desc = "Controls whether a summary of the model's thinking is returned. See https://ai.google.dev/gemini-api/docs/thinking.",
+    },
+    presence_penalty = {
+      order = 8,
+      mapping = "body.generation_config",
+      type = "number",
+      optional = true,
+      default = nil,
+      desc = "Presence penalty applied to the next token's logprobs if the token has already been seen in the response.",
+    },
+    frequency_penalty = {
+      order = 9,
+      mapping = "body.generation_config",
+      type = "number",
+      optional = true,
+      default = nil,
+      desc = "Frequency penalty applied to the next token's logprobs, multiplied by the number of times each token has been seen in the response so far.",
+    },
+  },
+}

--- a/lua/codecompanion/adapters/http/gemini_interactions.lua
+++ b/lua/codecompanion/adapters/http/gemini_interactions.lua
@@ -5,8 +5,7 @@ local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
 local tool_transformer = require("codecompanion.adapters.utils.tool_transformers")
 
----Track the step type at each stream index so a `step.delta` event knows
----whether it belongs to a thought or a model_output
+---Track the step type at each stream index so a `step.delta` event knows whether it belongs to a thought or a model_output
 ---@type table<number, string>
 local step_types = {}
 
@@ -119,7 +118,7 @@ return {
     store = false,
   },
   available_tools = {
-    ["google_search"] = {
+    ["web_search"] = {
       description = "Allows the model to search the web via Google Search for the latest information before generating a response.",
       ---@param self CodeCompanion.HTTPAdapter.GeminiInteractions
       ---@param meta { tools: table }

--- a/lua/codecompanion/adapters/http/gemini_interactions.lua
+++ b/lua/codecompanion/adapters/http/gemini_interactions.lua
@@ -455,9 +455,6 @@ return {
           }
         end
 
-        -- Streaming: SSE events carry their own `event_type` in the JSON body,
-        -- so the `event:` line can be ignored (fails JSON decoding and is
-        -- skipped below)
         local data_mod = adapter_utils.clean_streamed_data(data)
         local ok, json = pcall(vim.json.decode, data_mod, { luanil = { object = true } })
         if not ok then

--- a/lua/codecompanion/adapters/utils/structured_outputs.lua
+++ b/lua/codecompanion/adapters/utils/structured_outputs.lua
@@ -54,39 +54,57 @@ function M.to_anthropic(input)
   }
 end
 
+---Strip fields that Gemini's restricted OpenAPI-subset schema rejects, e.g. `additionalProperties`
+---@param node any
+local function strip_unsupported_gemini_fields(node)
+  if type(node) ~= "table" then
+    return
+  end
+  node.additionalProperties = nil
+  if node.properties then
+    for _, value in pairs(node.properties) do
+      strip_unsupported_gemini_fields(value)
+    end
+  end
+  strip_unsupported_gemini_fields(node.items)
+  for _, combinator in ipairs({ "anyOf", "oneOf", "allOf" }) do
+    if type(node[combinator]) == "table" then
+      for _, branch in ipairs(node[combinator]) do
+        strip_unsupported_gemini_fields(branch)
+      end
+    end
+  end
+end
+
 ---Convert a structured-output schema to the Gemini generateContent body fragment
 ---Ref: https://ai.google.dev/gemini-api/docs/structured-output#rest
 ---@param input CodeCompanion.StructuredOutput.Schema
 ---@return table
 function M.to_gemini(input)
   local schema = vim.deepcopy(input.schema)
-
-  -- Gemini's responseSchema is a restricted OpenAPI subset that rejects `additionalProperties`
-  local function strip(node)
-    if type(node) ~= "table" then
-      return
-    end
-    node.additionalProperties = nil
-    if node.properties then
-      for _, value in pairs(node.properties) do
-        strip(value)
-      end
-    end
-    strip(node.items)
-    for _, combinator in ipairs({ "anyOf", "oneOf", "allOf" }) do
-      if type(node[combinator]) == "table" then
-        for _, branch in ipairs(node[combinator]) do
-          strip(branch)
-        end
-      end
-    end
-  end
-  strip(schema)
+  strip_unsupported_gemini_fields(schema)
 
   return {
     generationConfig = {
       responseMimeType = "application/json",
       responseSchema = schema,
+    },
+  }
+end
+
+---Convert a structured-output schema to the Gemini Interactions API body fragment
+---Ref: https://ai.google.dev/gemini-api/docs/interactions-overview
+---@param input CodeCompanion.StructuredOutput.Schema
+---@return table
+function M.to_gemini_interactions(input)
+  local schema = vim.deepcopy(input.schema)
+  strip_unsupported_gemini_fields(schema)
+
+  return {
+    response_format = {
+      type = "text",
+      mime_type = "application/json",
+      schema = schema,
     },
   }
 end

--- a/lua/codecompanion/adapters/utils/tool_transformers.lua
+++ b/lua/codecompanion/adapters/utils/tool_transformers.lua
@@ -160,4 +160,22 @@ M.to_gemini = function(schema)
   }
 end
 
+---Convert the OpenAI schema to Gemini's Interactions API tool schema
+---Ref: https://ai.google.dev/gemini-api/docs/interactions-overview
+---@param schema table
+---@return table
+M.to_gemini_interactions = function(schema)
+  local function_def = schema["function"]
+
+  local parameters = vim.deepcopy(function_def.parameters)
+  strip_unsupported_gemini_fields(parameters)
+
+  return {
+    type = "function",
+    name = function_def.name,
+    description = function_def.description,
+    parameters = parameters,
+  }
+end
+
 return M

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -17,6 +17,7 @@ local defaults = {
       copilot = "copilot",
       deepseek = "deepseek",
       gemini = "gemini",
+      gemini_interactions = "gemini_interactions",
       githubmodels = "githubmodels",
       huggingface = "huggingface",
       novita = "novita",

--- a/tests/adapters/http/stubs/gemini_interactions_non_streaming.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_non_streaming.txt
@@ -1,0 +1,22 @@
+{
+  "id": "v2_Chd...",
+  "status": "completed",
+  "usage": {
+    "total_tokens": 240,
+    "total_input_tokens": 60,
+    "total_output_tokens": 20
+  },
+  "steps": [
+    {
+      "type": "model_output",
+      "content": [
+        {
+          "type": "text",
+          "text": "There are 8 paws in your house. 2 dogs × 4 paws = 8 paws."
+        }
+      ]
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-3.5-flash"
+}

--- a/tests/adapters/http/stubs/gemini_interactions_reasoning_streaming.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_reasoning_streaming.txt
@@ -1,0 +1,26 @@
+event: interaction.created
+data: {"interaction":{"id":"v1_xxx","status":"in_progress","object":"interaction","model":"gemini-3.5-flash"},"event_type":"interaction.created"}
+
+event: step.start
+data: {"index":0,"step":{"signature":"","summary":[{"text":"**Evaluating the clues**\n\nI'm considering...","type":"text"}],"type":"thought"},"event_type":"step.start"}
+
+event: step.delta
+data: {"index":0,"delta":{"signature":"EpoGCpcGAXLI2nx/...","type":"thought_signature"},"event_type":"step.delta"}
+
+event: step.stop
+data: {"index":0,"event_type":"step.stop"}
+
+event: step.start
+data: {"index":1,"step":{"content":[{"text":"Based on the clues provided, here","type":"text"}],"type":"model_output"},"event_type":"step.start"}
+
+event: step.delta
+data: {"index":1,"delta":{"text":" is the answer to your question...","type":"text"},"event_type":"step.delta"}
+
+event: step.stop
+data: {"index":1,"event_type":"step.stop"}
+
+event: interaction.completed
+data: {"interaction":{"id":"v1_xxx","status":"completed","usage":{"total_tokens":530,"total_input_tokens":62,"total_output_tokens":171,"total_thought_tokens":297}},"event_type":"interaction.completed"}
+
+event: done
+data: [DONE]

--- a/tests/adapters/http/stubs/gemini_interactions_streaming.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_streaming.txt
@@ -1,0 +1,29 @@
+event: interaction.created
+data: {"interaction":{"id":"v1_Chd...","status":"in_progress","model":"gemini-3.5-flash"},"event_type":"interaction.created"}
+
+event: step.start
+data: {"index":0,"step":{"type":"thought"},"event_type":"step.start"}
+
+event: step.delta
+data: {"index":0,"delta":{"signature":"EvEFCu4F...","type":"thought_signature"},"event_type":"step.delta"}
+
+event: step.stop
+data: {"index":0,"event_type":"step.stop"}
+
+event: step.start
+data: {"index":1,"step":{"type":"model_output"},"event_type":"step.start"}
+
+event: step.delta
+data: {"index":1,"delta":{"text":"AI ","type":"text"},"event_type":"step.delta"}
+
+event: step.delta
+data: {"index":1,"delta":{"text":"works ","type":"text"},"event_type":"step.delta"}
+
+event: step.stop
+data: {"index":1,"event_type":"step.stop"}
+
+event: interaction.completed
+data: {"interaction":{"id":"v1_Chd...","status":"completed","usage":{"total_tokens":197}},"event_type":"interaction.completed"}
+
+event: done
+data: [DONE]

--- a/tests/adapters/http/stubs/gemini_interactions_structured_output.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_structured_output.txt
@@ -1,0 +1,17 @@
+{
+  "id": "v1_Chd...",
+  "status": "completed",
+  "steps": [
+    {
+      "type": "model_output",
+      "content": [
+        {
+          "type": "text",
+          "text": "{\n  \"recipe_name\": \"Classic Banana Bread\",\n  \"ingredients\": [\n    \"3 ripe bananas, mashed\",\n    \"1/3 cup melted butter\",\n    \"3/4 cup sugar\",\n    \"1 egg, beaten\",\n    \"1 teaspoon vanilla extract\",\n    \"1 teaspoon baking soda\",\n    \"Pinch of salt\",\n    \"1.5 cups all-purpose flour\"\n  ],\n  \"prep_time_minutes\": 15\n}"
+        }
+      ]
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-3.5-flash"
+}

--- a/tests/adapters/http/stubs/gemini_interactions_tools_completed.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_tools_completed.txt
@@ -1,0 +1,25 @@
+{
+  "id": "v1_Chd...",
+  "status": "completed",
+  "steps": [
+    {
+      "type": "function_call",
+      "id": "call_abc123",
+      "name": "get_current_temperature",
+      "arguments": {
+        "location": "London"
+      }
+    },
+    {
+      "type": "model_output",
+      "content": [
+        {
+          "type": "text",
+          "text": "The temperature in London is currently 22°C."
+        }
+      ]
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-3.5-flash"
+}

--- a/tests/adapters/http/stubs/gemini_interactions_tools_streaming.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_tools_streaming.txt
@@ -1,0 +1,32 @@
+event: interaction.created
+data: {"interaction":{"id":"","status":"in_progress","object":"interaction","model":"gemini-3.1-pro-preview"},"event_type":"interaction.created"}
+
+event: interaction.status_update
+data: {"interaction_id":"","status":"in_progress","event_type":"interaction.status_update"}
+
+event: step.start
+data: {"index":0,"step":{"type":"thought"},"event_type":"step.start"}
+
+event: step.delta
+data: {"index":0,"delta":{"content":{"text":"**Analyzing the Command**\n\nI've zeroed in on the core objective.","type":"text"},"type":"thought_summary"},"event_type":"step.delta"}
+
+event: step.delta
+data: {"index":0,"delta":{"signature":"","type":"thought_signature"},"event_type":"step.delta"}
+
+event: step.stop
+data: {"index":0,"event_type":"step.stop"}
+
+event: step.start
+data: {"index":1,"step":{"id":"n12wxk7h","signature":"Eo4MCosMAR...","type":"function_call","name":"run_command","arguments":{}},"event_type":"step.start"}
+
+event: step.delta
+data: {"index":1,"delta":{"arguments":"{\"cmd\":\"ls -la\"}","type":"arguments_delta"},"event_type":"step.delta"}
+
+event: step.stop
+data: {"index":1,"event_type":"step.stop"}
+
+event: interaction.completed
+data: {"interaction":{"id":"","status":"completed","usage":{"total_tokens":3450,"total_input_tokens":3062,"total_output_tokens":18,"total_thought_tokens":370},"object":"interaction","model":"gemini-3.1-pro-preview"},"event_type":"interaction.completed"}
+
+event: done
+data: [DONE]

--- a/tests/adapters/http/stubs/gemini_interactions_tools_turn1.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_tools_turn1.txt
@@ -1,0 +1,16 @@
+{
+  "id": "v1_Chd...",
+  "status": "requires_action",
+  "steps": [
+    {
+      "type": "function_call",
+      "id": "call_abc123",
+      "name": "get_current_temperature",
+      "arguments": {
+        "location": "London"
+      }
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-3.5-flash"
+}

--- a/tests/adapters/http/stubs/gemini_interactions_vision.txt
+++ b/tests/adapters/http/stubs/gemini_interactions_vision.txt
@@ -1,0 +1,20 @@
+{
+  "id": "v1_Chd...",
+  "status": "completed",
+  "usage": {
+    "total_tokens": 300
+  },
+  "steps": [
+    {
+      "type": "model_output",
+      "content": [
+        {
+          "type": "text",
+          "text": "The local image displays a pipe organ..."
+        }
+      ]
+    }
+  ],
+  "object": "interaction",
+  "model": "gemini-3.5-flash"
+}

--- a/tests/adapters/http/test_gemini_interactions.lua
+++ b/tests/adapters/http/test_gemini_interactions.lua
@@ -271,10 +271,10 @@ end
 T["Gemini Interactions adapter"]["can form the built-in google_search tool"] = function()
   local tools = {
     {
-      ["<tool>google_search</tool>"] = {
+      ["<tool>web_search</tool>"] = {
         _meta = { adapter_tool = true },
         description = "Allows the model to search the web via Google Search",
-        name = "google_search",
+        name = "web_search",
       },
     },
   }

--- a/tests/adapters/http/test_gemini_interactions.lua
+++ b/tests/adapters/http/test_gemini_interactions.lua
@@ -1,0 +1,509 @@
+local h = require("tests.helpers")
+local tags = require("codecompanion.interactions.shared.tags")
+local adapter
+
+local new_set = MiniTest.new_set
+T = new_set()
+
+T["Gemini Interactions adapter"] = new_set({
+  hooks = {
+    pre_case = function()
+      adapter = require("codecompanion.adapters").resolve("gemini_interactions")
+    end,
+  },
+})
+
+T["Gemini Interactions adapter"]["can form messages to be sent to the API"] = function()
+  local messages = {
+    {
+      content = "Follow the user's request",
+      role = "system",
+    },
+    {
+      content = "Respond in code",
+      role = "system",
+    },
+    {
+      content = "Explain Ruby in two words",
+      role = "user",
+    },
+  }
+
+  local output = {
+    input = {
+      {
+        type = "user_input",
+        content = "Explain Ruby in two words",
+      },
+    },
+    system_instruction = "Follow the user's request\n\nRespond in code",
+  }
+
+  h.eq(output, adapter.handlers.request.build_messages(adapter, messages))
+end
+
+T["Gemini Interactions adapter"]["can form messages without system prompt"] = function()
+  local messages = {
+    {
+      content = "hello",
+      role = "user",
+    },
+    {
+      content = "Hi, how can I help?",
+      role = "model",
+    },
+  }
+
+  local output = {
+    input = {
+      {
+        type = "user_input",
+        content = "hello",
+      },
+      {
+        type = "model_output",
+        content = { { type = "text", text = "Hi, how can I help?" } },
+      },
+    },
+  }
+
+  h.eq(output, adapter.handlers.request.build_messages(adapter, messages))
+end
+
+T["Gemini Interactions adapter"]["can form messages with tool calls and responses"] = function()
+  local messages = {
+    {
+      content = "What's the weather?",
+      role = "user",
+    },
+    {
+      role = "model",
+      tools = {
+        calls = {
+          {
+            _index = 1,
+            id = "call_1",
+            signature = "Ev0BCvoBAb4",
+            type = "function",
+            ["function"] = {
+              arguments = '{"location":"London"}',
+              name = "weather",
+            },
+          },
+        },
+      },
+    },
+    {
+      content = '{"temperature": 20}',
+      role = "tool",
+      tools = {
+        call_id = "call_1",
+        name = "weather",
+      },
+    },
+  }
+
+  local output = {
+    input = {
+      { type = "user_input", content = "What's the weather?" },
+      {
+        type = "function_call",
+        id = "call_1",
+        name = "weather",
+        arguments = { location = "London" },
+        signature = "Ev0BCvoBAb4",
+      },
+      {
+        type = "function_result",
+        name = "weather",
+        call_id = "call_1",
+        result = { { type = "text", text = '{"temperature": 20}' } },
+      },
+    },
+  }
+
+  h.eq(output, adapter.handlers.request.build_messages(adapter, messages))
+end
+
+T["Gemini Interactions adapter"]["can form messages with tool call text content"] = function()
+  local messages = {
+    {
+      content = "What's the weather?",
+      role = "user",
+    },
+    {
+      content = "I'll check the weather for you.",
+      role = "model",
+      tools = {
+        calls = {
+          {
+            _index = 1,
+            id = "call_1",
+            type = "function",
+            ["function"] = { arguments = '{"location":"London"}', name = "weather" },
+          },
+        },
+      },
+    },
+  }
+
+  local output = adapter.handlers.request.build_messages(adapter, messages)
+
+  h.eq(3, #output.input)
+  h.eq("model_output", output.input[2].type)
+  h.eq("I'll check the weather for you.", output.input[2].content[1].text)
+  h.eq("function_call", output.input[3].type)
+  h.eq("weather", output.input[3].name)
+  h.eq({ location = "London" }, output.input[3].arguments)
+end
+
+T["Gemini Interactions adapter"]["can form messages with reasoning"] = function()
+  local messages = {
+    {
+      content = "What's 2+2?",
+      role = "user",
+    },
+    {
+      content = "4",
+      reasoning = { content = "Let me compute", signature = "sig-abc" },
+      role = "model",
+    },
+  }
+
+  local output = adapter.handlers.request.build_messages(adapter, messages)
+
+  h.eq(3, #output.input)
+  h.eq({
+    type = "thought",
+    signature = "sig-abc",
+    summary = { { type = "text", text = "Let me compute" } },
+  }, output.input[2])
+  h.eq({
+    type = "model_output",
+    content = { { type = "text", text = "4" } },
+  }, output.input[3])
+end
+
+T["Gemini Interactions adapter"]["can form messages with an image and following text"] = function()
+  local messages = {
+    {
+      content = "base64encodedimage",
+      role = "user",
+      context = { mimetype = "image/jpeg" },
+      _meta = { tag = tags.IMAGE },
+    },
+    {
+      content = "Compare this local image and this remote audio file.",
+      role = "user",
+    },
+  }
+
+  local output = adapter.handlers.request.build_messages(adapter, messages)
+
+  h.eq(1, #output.input)
+  h.eq("user_input", output.input[1].type)
+  h.eq({
+    { type = "image", data = "base64encodedimage", mime_type = "image/jpeg" },
+    { type = "text", text = "Compare this local image and this remote audio file." },
+  }, output.input[1].content)
+end
+
+T["Gemini Interactions adapter"]["can form messages with a PDF document and following text"] = function()
+  local messages = {
+    {
+      content = "base64encodedpdf",
+      role = "user",
+      context = { mimetype = "application/pdf", path = "report.pdf" },
+      _meta = { tag = tags.DOCUMENT, filetype = "pdf" },
+    },
+    {
+      content = "Summarize this document",
+      role = "user",
+    },
+  }
+
+  local output = adapter.handlers.request.build_messages(adapter, messages)
+
+  h.eq(1, #output.input)
+  h.eq("user_input", output.input[1].type)
+  h.eq({
+    { type = "document", data = "base64encodedpdf", mime_type = "application/pdf" },
+    { type = "text", text = "Summarize this document" },
+  }, output.input[1].content)
+end
+
+T["Gemini Interactions adapter"]["only PDFs are converted into document blocks"] = function()
+  local messages = {
+    {
+      content = "base64encodeddocx",
+      role = "user",
+      context = { mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+      _meta = { tag = tags.DOCUMENT, filetype = "docx" },
+    },
+  }
+
+  local output = adapter.handlers.request.build_messages(adapter, messages)
+
+  h.eq("user_input", output.input[1].type)
+  h.eq("base64encodeddocx", output.input[1].content)
+end
+
+T["Gemini Interactions adapter"]["can form tools to be sent to the API"] = function()
+  local weather = require("tests.interactions.chat.tools.builtin.stubs.weather").schema
+  local tools = { weather = { weather } }
+
+  local output = adapter.handlers.request.build_tools(adapter, tools)
+
+  h.eq(1, #output.tools)
+  local decl = output.tools[1]
+  h.eq("function", decl.type)
+  h.eq("weather", decl.name)
+  h.eq(weather["function"].description, decl.description)
+  h.eq(weather["function"].parameters.type, decl.parameters.type)
+  h.eq(weather["function"].parameters.properties, decl.parameters.properties)
+  h.eq(weather["function"].parameters.required, decl.parameters.required)
+
+  -- Gemini does not support additionalProperties or strict
+  h.eq(nil, decl.parameters.additionalProperties)
+  h.eq(nil, decl.parameters.strict)
+end
+
+T["Gemini Interactions adapter"]["can form the built-in google_search tool"] = function()
+  local tools = {
+    {
+      ["<tool>google_search</tool>"] = {
+        _meta = { adapter_tool = true },
+        description = "Allows the model to search the web via Google Search",
+        name = "google_search",
+      },
+    },
+  }
+
+  h.eq({ tools = { { type = "google_search" } } }, adapter.handlers.request.build_tools(adapter, tools))
+end
+
+T["Gemini Interactions adapter"]["can form reasoning output from streamed chunks"] = function()
+  local input = {
+    { content = "Let me " },
+    { content = "think about this" },
+    { signature = "sig-part-1" },
+    { signature = "sig-part-2" },
+  }
+
+  h.eq({
+    content = "Let me think about this",
+    signature = "sig-part-1sig-part-2",
+  }, adapter.handlers.request.build_reasoning(adapter, input))
+end
+
+T["Gemini Interactions adapter"]["can normalize tool calls via format_calls"] = function()
+  local raw_tools = {
+    {
+      _index = 1,
+      args = { location = "London", units = "celsius" },
+      id = "call_1",
+      name = "weather",
+    },
+  }
+
+  local formatted = adapter.handlers.tools.format_calls(adapter, raw_tools)
+
+  h.eq(1, #formatted)
+  h.eq(1, formatted[1]._index)
+  h.eq("function", formatted[1].type)
+  h.eq("weather", formatted[1]["function"].name)
+
+  -- arguments should be a JSON string
+  local decoded = vim.json.decode(formatted[1]["function"].arguments)
+  h.eq("London", decoded.location)
+  h.eq("celsius", decoded.units)
+end
+
+T["Gemini Interactions adapter"]["can format tool response via format_response"] = function()
+  local tool_call = {
+    id = "call_123",
+    type = "function",
+    ["function"] = { arguments = '{"location":"London"}', name = "weather" },
+  }
+
+  local result = adapter.handlers.tools.format_response(adapter, tool_call, '{"temperature": 20}')
+
+  h.eq("tool", result.role)
+  h.eq("weather", result.tools.name)
+  h.eq("call_123", result.tools.call_id)
+  h.eq('{"temperature": 20}', result.content)
+end
+
+T["Gemini Interactions adapter"]["Streaming"] = new_set()
+
+T["Gemini Interactions adapter"]["Streaming"]["can output streamed data into the chat buffer"] = function()
+  local output = ""
+  local reasoning_signature
+  local lines = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_streaming.txt")
+  for _, line in ipairs(lines) do
+    local chat_output = adapter.handlers.response.parse_chat(adapter, line)
+    if chat_output then
+      if chat_output.output.content then
+        output = output .. chat_output.output.content
+      end
+      if chat_output.output.reasoning and chat_output.output.reasoning.signature then
+        reasoning_signature = (reasoning_signature or "") .. chat_output.output.reasoning.signature
+      end
+    end
+  end
+
+  h.eq("AI works ", output)
+  h.eq("EvEFCu4F...", reasoning_signature)
+end
+
+T["Gemini Interactions adapter"]["Streaming"]["can process reasoning summaries"] = function()
+  local reasoning_content
+  local reasoning_signature
+  local lines = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_reasoning_streaming.txt")
+  for _, line in ipairs(lines) do
+    local chat_output = adapter.handlers.response.parse_chat(adapter, line)
+    if chat_output and chat_output.output.reasoning then
+      if chat_output.output.reasoning.content then
+        reasoning_content = (reasoning_content or "") .. chat_output.output.reasoning.content
+      end
+      if chat_output.output.reasoning.signature then
+        reasoning_signature = (reasoning_signature or "") .. chat_output.output.reasoning.signature
+      end
+    end
+  end
+
+  h.expect_starts_with("**Evaluating the clues**", reasoning_content)
+  h.expect_starts_with("EpoGCpcGAXLI2nx/...", reasoning_signature)
+end
+
+T["Gemini Interactions adapter"]["Streaming"]["can process a streamed tool call"] = function()
+  -- Regression test: step.start only ever carries a placeholder `{}` for
+  -- arguments; the real arguments arrive later via an `arguments_delta`
+  -- step.delta as a JSON string. Thought summaries stream via a
+  -- `thought_summary` delta with nested `content.text`, not a flat `text` delta.
+  local tools = {}
+  local reasoning_content
+  local lines = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_tools_streaming.txt")
+  for _, line in ipairs(lines) do
+    local chat_output = adapter.handlers.response.parse_chat(adapter, line, tools)
+    if chat_output and chat_output.output.reasoning and chat_output.output.reasoning.content then
+      reasoning_content = (reasoning_content or "") .. chat_output.output.reasoning.content
+    end
+  end
+
+  h.expect_starts_with("**Analyzing the Command**", reasoning_content)
+
+  h.eq(1, #tools)
+  h.eq("run_command", tools[1].name)
+  h.eq('{"cmd":"ls -la"}', tools[1].args)
+
+  local formatted = adapter.handlers.tools.format_calls(adapter, tools)
+  h.eq("run_command", formatted[1]["function"].name)
+  h.eq({ cmd = "ls -la" }, vim.json.decode(formatted[1]["function"].arguments))
+end
+
+T["Gemini Interactions adapter"]["Streaming"]["can parse tokens from interaction.completed"] = function()
+  local tokens
+  local lines = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_streaming.txt")
+  for _, line in ipairs(lines) do
+    local count = adapter.handlers.response.parse_tokens(adapter, line)
+    if count then
+      tokens = count
+    end
+  end
+
+  h.eq(197, tokens)
+end
+
+T["Gemini Interactions adapter"]["No Streaming"] = new_set({
+  hooks = {
+    pre_case = function()
+      adapter = require("codecompanion.adapters").extend("gemini_interactions", {
+        opts = {
+          stream = false,
+        },
+      })
+    end,
+  },
+})
+
+T["Gemini Interactions adapter"]["No Streaming"]["can output for the chat buffer"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_non_streaming.txt")
+  data = table.concat(data, "\n")
+
+  local json = { body = data }
+  local result = adapter.handlers.response.parse_chat(adapter, json)
+
+  h.expect_starts_with("There are 8 paws", result.output.content)
+end
+
+T["Gemini Interactions adapter"]["No Streaming"]["can parse tokens"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_non_streaming.txt")
+  data = table.concat(data, "\n")
+
+  local json = { body = data }
+
+  h.eq(240, adapter.handlers.response.parse_tokens(adapter, json))
+end
+
+T["Gemini Interactions adapter"]["No Streaming"]["can process a requested tool call"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_tools_turn1.txt")
+  data = table.concat(data, "\n")
+
+  local tools = {}
+  local json = { body = data }
+  adapter.handlers.response.parse_chat(adapter, json, tools)
+
+  h.eq(1, #tools)
+  h.eq("call_abc123", tools[1].id)
+  h.eq("get_current_temperature", tools[1].name)
+  h.eq({ location = "London" }, tools[1].args)
+end
+
+T["Gemini Interactions adapter"]["No Streaming"]["can process a completed tool call with text"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_tools_completed.txt")
+  data = table.concat(data, "\n")
+
+  local tools = {}
+  local json = { body = data }
+  local result = adapter.handlers.response.parse_chat(adapter, json, tools)
+
+  h.eq(1, #tools)
+  h.eq("get_current_temperature", tools[1].name)
+  h.expect_starts_with("The temperature in London", result.output.content)
+end
+
+T["Gemini Interactions adapter"]["No Streaming"]["can output for the inline assistant"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_non_streaming.txt")
+  data = table.concat(data, "\n")
+
+  local json = { body = data }
+
+  h.expect_starts_with("There are 8 paws", adapter.handlers.response.parse_inline(adapter, json).output)
+end
+
+T["Gemini Interactions adapter"]["No Streaming"]["can output an image description"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_vision.txt")
+  data = table.concat(data, "\n")
+
+  local json = { body = data }
+
+  h.expect_starts_with(
+    "The local image displays a pipe organ",
+    adapter.handlers.response.parse_chat(adapter, json).output.content
+  )
+end
+
+T["Gemini Interactions adapter"]["No Streaming"]["can output a structured output response"] = function()
+  local data = vim.fn.readfile("tests/adapters/http/stubs/gemini_interactions_structured_output.txt")
+  data = table.concat(data, "\n")
+
+  local json = { body = data }
+  local content = adapter.handlers.response.parse_chat(adapter, json).output.content
+
+  local decoded = vim.json.decode(content)
+  h.eq("Classic Banana Bread", decoded.recipe_name)
+  h.eq(15, decoded.prep_time_minutes)
+end
+
+return T

--- a/tests/adapters/utils/stubs/gemini_interactions_structured_output.json
+++ b/tests/adapters/utils/stubs/gemini_interactions_structured_output.json
@@ -1,0 +1,24 @@
+{
+  "response_format": {
+    "type": "text",
+    "mime_type": "application/json",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "type": "string",
+          "description": "Weather conditions description"
+        },
+        "location": {
+          "type": "string",
+          "description": "City or location name"
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Temperature in Celsius"
+        }
+      },
+      "required": ["conditions", "location", "temperature"]
+    }
+  }
+}

--- a/tests/adapters/utils/test_structured_outputs.lua
+++ b/tests/adapters/utils/test_structured_outputs.lua
@@ -48,6 +48,22 @@ T["Structured Outputs"]["can transform to Gemini"] = function()
   h.eq(output[1], output[2])
 end
 
+T["Structured Outputs"]["can transform to Gemini Interactions"] = function()
+  local output = child.lua([[
+    local input = vim.fn.readfile("tests/adapters/utils/stubs/input.json")
+    input = vim.json.decode(table.concat(input, "\n"))
+
+    local gemini_interactions = vim.fn.readfile("tests/adapters/utils/stubs/gemini_interactions_structured_output.json")
+    gemini_interactions = vim.json.decode(table.concat(gemini_interactions, "\n"))
+
+    local output = transform.to_gemini_interactions(input)
+
+    return { gemini_interactions, output }
+  ]])
+
+  h.eq(output[1], output[2])
+end
+
 T["Structured Outputs"]["can transform to Ollama"] = function()
   local output = child.lua([[
     local input = vim.fn.readfile("tests/adapters/utils/stubs/input.json")

--- a/tests/scripts/structured_output.lua
+++ b/tests/scripts/structured_output.lua
@@ -29,6 +29,11 @@ local adapter_config = {
       api_key = "cmd:op read op://personal/Gemini_API/credential --no-newline",
     },
   }),
+  gemini_interactions = require("codecompanion.adapters").extend("gemini_interactions", {
+    env = {
+      api_key = "cmd:op read op://personal/Gemini_API/credential --no-newline",
+    },
+  }),
   mistral = require("codecompanion.adapters").extend("mistral", {
     env = {
       api_key = "cmd:op read op://personal/Mistral_API/credential --no-newline",
@@ -51,7 +56,7 @@ local adapter_config = {
   }),
 }
 
-local adapter_name = "mistral"
+local adapter_name = "gemini_interactions"
 local adapter = adapter_config[adapter_name]
 
 local structured_output = {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Gemini has a new `interactions` API with `generateContent` now being legacy. Whilst the latter is still supported, this PR adds support for `interactions` with the aim of making it the default in `v20`.

## Supporting Documentation

- https://ai.google.dev/gemini-api/docs/interactions-overview

## AI Usage

Claude Sonnet 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
