### PR TITLE
feat: configurable reasoning effort for Anthropic + a chat keymap to change it

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -4205,6 +4205,7 @@ available to the user in normal mode are:
 - `close`: `<C-c>` to close the chat buffer
 - `stop`: `q` to stop the current request
 - `change_adapter`: `ga` to change the adapter for the current chat
+- `change_effort`: `ge` to change the reasoning effort for the current model
 - `clear`: `gx` to clear the chat buffer's contents
 - `copilot_stats`: `gS` to show copilot usage stats
 - `btw`: `gm` type a message to the LLM whilst it's streaming

--- a/doc/usage/chat-buffer/index.md
+++ b/doc/usage/chat-buffer/index.md
@@ -138,6 +138,7 @@ The plugin has a host of keymaps available in the chat buffer. The keymaps avail
 - `stop`: `q` to stop the current request
 
 - `change_adapter`: `ga` to change the adapter for the current chat
+- `change_effort`: `ge` to change the reasoning effort for the current model
 - `clear`: `gx` to clear the chat buffer’s contents
 - `copilot_stats`: `gS` to show copilot usage stats
 - `btw`: `gm` type a message to the LLM whilst it's streaming

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -168,6 +168,14 @@ return {
         end
       end
 
+      -- Effort controls how many tokens Claude spends across thinking, text, and tool
+      -- calls. It lives at output_config.effort in the request body, not on `thinking`.
+      -- Ref: https://platform.claude.com/docs/en/build-with-claude/effort
+      local supported_efforts = models and models.opts and models.opts.reasoning and models.opts.reasoning.supported
+      if self.temp.effort and supported_efforts and vim.tbl_contains(supported_efforts, self.temp.effort) then
+        params.output_config = vim.tbl_deep_extend("force", params.output_config or {}, { effort = self.temp.effort })
+      end
+
       return params
     end,
 
@@ -773,8 +781,38 @@ return {
       end,
     },
     ---@type CodeCompanion.Schema
-    max_tokens = {
+    effort = {
       order = 5,
+      mapping = "temp",
+      type = "string",
+      optional = true,
+      desc = "Controls how many tokens Claude spends on the response, including thinking and tool calls. Higher effort favours thoroughness; lower effort favours speed and cost.",
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return string
+      default = function(self)
+        local models = adapter_utils.model_choice(self)
+        local supported = models and models.opts and models.opts.reasoning and models.opts.reasoning.supported
+        if supported and vim.tbl_contains(supported, "high") then
+          return "high"
+        end
+        return supported and supported[1] or "high"
+      end,
+      ---@param self CodeCompanion.HTTPAdapter
+      enabled = function(self)
+        local models = adapter_utils.model_choice(self)
+        return not not (models and models.opts and models.opts.reasoning and models.opts.reasoning.supported)
+      end,
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return string[]
+      choices = function(self)
+        local models = adapter_utils.model_choice(self)
+        local supported = models and models.opts and models.opts.reasoning and models.opts.reasoning.supported
+        return supported or { "low", "medium", "high", "xhigh", "max" }
+      end,
+    },
+    ---@type CodeCompanion.Schema
+    max_tokens = {
+      order = 6,
       mapping = "parameters",
       type = "number",
       optional = true,
@@ -792,7 +830,7 @@ return {
     },
     ---@type CodeCompanion.Schema
     temperature = {
-      order = 6,
+      order = 7,
       mapping = "parameters",
       type = "number",
       optional = true,
@@ -813,7 +851,7 @@ return {
     },
     ---@type CodeCompanion.Schema
     top_p = {
-      order = 7,
+      order = 8,
       mapping = "parameters",
       type = "number",
       optional = true,
@@ -825,7 +863,7 @@ return {
     },
     ---@type CodeCompanion.Schema
     top_k = {
-      order = 8,
+      order = 9,
       mapping = "parameters",
       type = "number",
       optional = true,
@@ -837,7 +875,7 @@ return {
     },
     ---@type CodeCompanion.Schema
     stop_sequences = {
-      order = 9,
+      order = 10,
       mapping = "parameters",
       type = "list",
       optional = true,

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -648,6 +648,12 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
           callback = "keymaps.change_adapter",
           description = "Change adapter and model",
         },
+        change_effort = {
+          modes = { n = "ge" },
+          index = 15,
+          callback = "keymaps.change_effort",
+          description = "Change the reasoning effort",
+        },
         fold_code = {
           modes = { n = "gf" },
           index = 15,

--- a/lua/codecompanion/interactions/chat/keymaps/change_effort.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_effort.lua
@@ -1,0 +1,148 @@
+local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
+
+local M = {}
+
+---Schema keys, most specific first, that adapters use to expose reasoning effort
+M.effort_keys = { "effort", "reasoning.effort", "reasoning_effort" }
+
+---Read a possibly-nested value from a table using a dotted key
+---@param tbl table
+---@param key string
+---@return any
+local function get_nested(tbl, key)
+  local current = tbl
+  for segment in key:gmatch("[^.]+") do
+    if type(current) ~= "table" then
+      return nil
+    end
+    current = current[segment]
+  end
+  return current
+end
+
+---Write a possibly-nested value into a table using a dotted key
+---@param tbl table
+---@param key string
+---@param value any
+---@return nil
+local function set_nested(tbl, key, value)
+  local segments = {}
+  for segment in key:gmatch("[^.]+") do
+    table.insert(segments, segment)
+  end
+  local current = tbl
+  for i = 1, #segments - 1 do
+    if type(current[segments[i]]) ~= "table" then
+      current[segments[i]] = {}
+    end
+    current = current[segments[i]]
+  end
+  current[segments[#segments]] = value
+end
+
+---Find the effort schema entry for the adapter, respecting its `enabled` gate
+---@param adapter CodeCompanion.HTTPAdapter
+---@return string|nil key, table|nil schema_entry
+function M.find_effort_schema(adapter)
+  local schema = adapter.schema or {}
+  for _, key in ipairs(M.effort_keys) do
+    local entry = schema[key]
+    if entry then
+      local enabled = entry.enabled
+      if type(enabled) == "function" and not enabled(adapter) then
+        return nil
+      end
+      return key, entry
+    end
+  end
+  return nil
+end
+
+---Resolve the list of effort levels the current model supports
+---@param adapter CodeCompanion.HTTPAdapter
+---@param schema_entry table
+---@return string[]
+local function resolve_levels(adapter, schema_entry)
+  local levels = schema_entry.choices
+  if type(levels) == "function" then
+    levels = levels(adapter)
+  end
+  if type(levels) ~= "table" or vim.tbl_isempty(levels) then
+    return { "low", "medium", "high", "xhigh", "max" }
+  end
+  return levels
+end
+
+---Resolve the currently selected effort level
+---@param chat CodeCompanion.Chat
+---@param adapter CodeCompanion.HTTPAdapter
+---@param key string
+---@param schema_entry table
+---@return string|nil
+local function resolve_current(chat, adapter, key, schema_entry)
+  local current = get_nested(chat.settings or {}, key)
+  if current ~= nil then
+    return current
+  end
+  local default = schema_entry.default
+  if type(default) == "function" then
+    return default(adapter)
+  end
+  return default
+end
+
+---Build vim.ui.select options that mark the current level
+---@param current string|nil
+---@return table
+local function select_opts(current)
+  return {
+    prompt = "Select Effort",
+    kind = "codecompanion.nvim",
+    format_item = function(item)
+      if current == item then
+        return "* " .. item
+      end
+      return "  " .. item
+    end,
+  }
+end
+
+---Main callback for the change_effort keymap
+---@param chat CodeCompanion.Chat
+---@return nil
+function M.callback(chat)
+  if config.display.chat.show_settings then
+    return utils.notify(
+      "Effort can't be changed when `display.chat.show_settings = true`",
+      vim.log.levels.WARN
+    )
+  end
+  if chat.adapter.type ~= "http" then
+    return utils.notify("Effort can only be changed for HTTP adapters", vim.log.levels.WARN)
+  end
+
+  local adapter = chat.adapter
+  ---@cast adapter CodeCompanion.HTTPAdapter
+
+  local key, schema_entry = M.find_effort_schema(adapter)
+  if not key or not schema_entry then
+    return utils.notify("The current model does not support a reasoning effort setting", vim.log.levels.WARN)
+  end
+
+  local levels = resolve_levels(adapter, schema_entry)
+  local current = resolve_current(chat, adapter, key, schema_entry)
+
+  vim.ui.select(levels, select_opts(current), function(selected)
+    if not selected then
+      return
+    end
+    chat.settings = chat.settings or {}
+    set_nested(chat.settings, key, selected)
+    log:debug("Effort set to `%s` for `%s`", selected, key)
+    return utils.notify(string.format("Effort set to `%s`", selected), vim.log.levels.INFO)
+  end)
+end
+
+return M

--- a/lua/codecompanion/interactions/chat/keymaps/init.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/init.lua
@@ -564,6 +564,13 @@ M.change_adapter = {
   end,
 }
 
+M.change_effort = {
+  desc = "Change the reasoning effort",
+  callback = function(chat)
+    return require("codecompanion.interactions.chat.keymaps.change_effort").callback(chat)
+  end,
+}
+
 M.fold_code = {
   callback = function(chat)
     chat.ui:fold_code()

--- a/tests/adapters/http/test_anthropic.lua
+++ b/tests/adapters/http/test_anthropic.lua
@@ -972,6 +972,47 @@ T["Anthropic adapter"]["No Streaming"]["can output for the inline assistant with
   )
 end
 
+T["Anthropic adapter"]["form_parameters"] = new_set()
+
+---Point the adapter at a model whose choices carry the given opts, so model_choice resolves them
+local function stub_model(name, opts)
+  adapter.schema.model.default = name
+  adapter.schema.model.choices = { [name] = { opts = opts } }
+end
+
+T["Anthropic adapter"]["form_parameters"]["sets output_config.effort for supported levels"] = function()
+  stub_model(
+    "claude-sonnet-5",
+    { can_reason = true, reasoning = { supported = { "low", "medium", "high", "xhigh", "max" } } }
+  )
+  adapter.temp.effort = "xhigh"
+
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+  h.eq({ effort = "xhigh" }, params.output_config)
+end
+
+T["Anthropic adapter"]["form_parameters"]["drops effort the model does not support"] = function()
+  stub_model("claude-sonnet-4-6", { can_reason = true, reasoning = { supported = { "low", "medium", "high", "max" } } })
+  adapter.temp.effort = "xhigh"
+
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+  h.eq(nil, params.output_config)
+end
+
+T["Anthropic adapter"]["form_parameters"]["leaves output_config unset when no effort is chosen"] = function()
+  stub_model(
+    "claude-sonnet-5",
+    { can_reason = true, reasoning = { supported = { "low", "medium", "high", "xhigh", "max" } } }
+  )
+  adapter.temp.effort = nil
+
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+  h.eq(nil, params.output_config)
+end
+
 T["Anthropic model_transformers"] = new_set()
 
 T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model list"] = function()
@@ -990,6 +1031,7 @@ T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model
   h.eq({ context_window = 1000000, max_tokens = 128000 }, result["claude-sonnet-5"].meta)
   h.eq(true, result["claude-sonnet-5"].opts.can_reason)
   h.eq(true, result["claude-sonnet-5"].opts.has_vision)
+  h.eq({ "low", "medium", "high", "xhigh", "max" }, result["claude-sonnet-5"].opts.reasoning.supported)
 
   -- Supports context_management as a whole, including compact_20260112
   h.eq(true, result["claude-sonnet-5"].opts.can_manage_context)

--- a/tests/interactions/chat/test_keymaps.lua
+++ b/tests/interactions/chat/test_keymaps.lua
@@ -12,6 +12,7 @@ T["Keymaps"] = new_set({
         h = require('tests.helpers')
         config = require("tests.config")
         change_adapter = require("codecompanion.interactions.chat.keymaps.change_adapter")
+        change_effort = require("codecompanion.interactions.chat.keymaps.change_effort")
       ]])
     end,
     post_once = child.stop,
@@ -192,6 +193,141 @@ T["Keymaps"]["change_adapter"]["list_acp_models returns nil when < 2 models"] = 
   ]])
 
   h.expect_truthy(result)
+end
+
+T["Keymaps"]["change_effort"] = new_set()
+
+T["Keymaps"]["change_effort"]["find_effort_schema discovers the `effort` key"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    local adapter = {
+      type = "http",
+      schema = {
+        effort = { enabled = function() return true end, choices = { "low", "high" } },
+      },
+    }
+    local key = change_effort.find_effort_schema(adapter)
+    return key
+  ]])
+
+  h.eq(result, "effort")
+end
+
+T["Keymaps"]["change_effort"]["find_effort_schema discovers the nested `reasoning.effort` key"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    local adapter = {
+      type = "http",
+      schema = {
+        ["reasoning.effort"] = { enabled = function() return true end, choices = { "low", "high" } },
+      },
+    }
+    return change_effort.find_effort_schema(adapter)
+  ]])
+
+  h.eq(result, "reasoning.effort")
+end
+
+T["Keymaps"]["change_effort"]["find_effort_schema returns nil when the schema entry is disabled"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    local adapter = {
+      type = "http",
+      schema = {
+        effort = { enabled = function() return false end, choices = { "low", "high" } },
+      },
+    }
+    return change_effort.find_effort_schema(adapter) == nil
+  ]])
+
+  h.expect_truthy(result)
+end
+
+T["Keymaps"]["change_effort"]["find_effort_schema returns nil when no effort key exists"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    local adapter = { type = "http", schema = { model = { default = "x" } } }
+    return change_effort.find_effort_schema(adapter) == nil
+  ]])
+
+  h.expect_truthy(result)
+end
+
+T["Keymaps"]["change_effort"]["callback applies the selected level to a flat key"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    vim.ui.select = function(items, opts, on_choice)
+      on_choice("xhigh")
+    end
+    local chat = {
+      adapter = {
+        type = "http",
+        schema = { effort = { enabled = function() return true end, choices = { "low", "high", "xhigh" } } },
+      },
+      settings = {},
+    }
+    change_effort.callback(chat)
+    return chat.settings.effort
+  ]])
+
+  h.eq(result, "xhigh")
+end
+
+T["Keymaps"]["change_effort"]["callback applies the selected level to a nested key"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    vim.ui.select = function(items, opts, on_choice)
+      on_choice("medium")
+    end
+    local chat = {
+      adapter = {
+        type = "http",
+        schema = { ["reasoning.effort"] = { enabled = function() return true end, choices = { "low", "medium" } } },
+      },
+      settings = {},
+    }
+    change_effort.callback(chat)
+    return chat.settings.reasoning.effort
+  ]])
+
+  h.eq(result, "medium")
+end
+
+T["Keymaps"]["change_effort"]["callback marks the current level with an asterisk"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    local marked
+    vim.ui.select = function(items, opts, on_choice)
+      marked = opts.format_item("high")
+    end
+    local chat = {
+      adapter = {
+        type = "http",
+        schema = { effort = { enabled = function() return true end, choices = { "low", "high" } } },
+      },
+      settings = { effort = "high" },
+    }
+    change_effort.callback(chat)
+    return marked
+  ]])
+
+  h.eq(result, "* high")
+end
+
+T["Keymaps"]["change_effort"]["callback does not open the picker when effort is unsupported"] = function()
+  local result = child.lua([[
+    h.setup_plugin()
+    local opened = false
+    vim.ui.select = function() opened = true end
+    local chat = {
+      adapter = { type = "http", schema = { model = { default = "x" } } },
+      settings = {},
+    }
+    change_effort.callback(chat)
+    return opened
+  ]])
+
+  h.eq(result, false)
 end
 
 return T


### PR DESCRIPTION
## Description

This PR adds two things:

1. **Configurable reasoning effort for the Anthropic adapter.** Anthropic's `/v1/messages` API accepts an `output_config.effort` level that controls how many tokens Claude spends across thinking, text, and tool calls. The adapter now exposes an `effort` schema option, gated per-model on the effort levels the model advertises (parsed from `capabilities.effort` in the models list), and sets `output_config.effort` in the request body only when the chosen level is supported by the active model.

2. **A generic `ge` chat keymap to change the reasoning effort.** It mirrors the existing `ga` adapter/model picker: it opens a `vim.ui.select` of the current model's supported effort levels (current one marked), and writes the choice into `chat.settings` so it flows through the normal request path with no adapter-specific glue. The picker is deliberately adapter-agnostic — it discovers the effort setting by probing known schema keys (`effort`, `reasoning.effort`, `reasoning_effort`) and reads the valid levels and default straight from that schema entry.

### Adapter support

Because the picker is generic, any HTTP adapter that already exposes an effort-style schema entry under one of the probed keys works with `ge` for free.

**Confirmed working**

- **Anthropic** (`effort`) — verified against the live API (field placement and valid levels `low`/`medium`/`high`/`xhigh`/`max`, per-model gating), plus unit tests for both the adapter wiring and the picker.

**Should work, not manually tested** (already expose a matching effort schema key, so the generic picker should drive them unchanged):

- **OpenAI** (`reasoning_effort`)
- **OpenAI Responses / Codex** (`reasoning.effort`)
- **OpenRouter** (`reasoning.effort`)
- **GitHub Models** (`reasoning_effort`)
- **DeepSeek** (`reasoning_effort`)

**Needs extra effort**

- **Gemini** — has an effort-style control, but under the key `thinkingLevel`, which the picker doesn't currently probe. Adding it is a one-line change to the picker's key list (not included here).
- **All other adapters** (xAI/Grok, Azure OpenAI, OpenAI-compatible, Novita, Mistral, Copilot, Ollama, Hugging Face) expose no effort schema entry. Adding support to any of these is a per-adapter task: parse the provider's effort capability into `opts.reasoning.supported`, add a gated schema entry, and wire the value into the request body — the same pattern this PR applies to Anthropic.

## Supporting Documentation

- Anthropic effort: https://platform.claude.com/docs/en/build-with-claude/effort
- Anthropic models list (effort capability): https://platform.claude.com/docs/en/api/models-list


## AI Usage

This PR was written with AI assistance (CodeCompanion, using Anthropic Claude). The AI was used to investigate the Anthropic API (confirming the exact request field and valid values against the live endpoint), to draft the adapter wiring and the generic `change_effort` keymap, and to write the accompanying tests. All changes were reviewed and directed by me.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

#### Reasoning Effort Picker (after pressing `ge`)

<img width="912" height="128" alt="image" src="https://github.com/user-attachments/assets/7263d0dc-4e8e-47ef-86d7-6f980e0ddee2" />

#### Effort selection confirmation notification

<img width="376" height="78" alt="image" src="https://github.com/user-attachments/assets/cfeab88c-b9c8-4490-aac3-45d1ef4373d1" />

#### Chat debug window shows selected effort

<img width="459" height="282" alt="image" src="https://github.com/user-attachments/assets/875413f8-174b-49f1-a157-d90c418e692a" />


#### `which-key` preview after pressing `g`

<img width="272" height="19" alt="image" src="https://github.com/user-attachments/assets/6f84fdaa-451c-4bc9-8070-a7d5dd48c22e" />


## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
