### PR TITLE
fix(ui): extmarks being placed incorrectly

### DIFF
--- a/lua/codecompanion/interactions/chat/ui/builder.lua
+++ b/lua/codecompanion/interactions/chat/ui/builder.lua
@@ -197,6 +197,13 @@ function Builder:add_message(data, opts)
     opts._icon_info.line_offset = (opts._icon_info.line_offset or 0) + pre_content_lines
   end
 
+  -- The formatter numbers its fold offsets from the start of its own content,
+  -- unaware a header was prepended above it. Push them down past the header.
+  if fold_info and pre_content_lines > 0 then
+    fold_info.start_offset = fold_info.start_offset + pre_content_lines
+    fold_info.end_offset = fold_info.end_offset + pre_content_lines
+  end
+
   local insert_line, icon_id
   if not vim.tbl_isempty(lines) then
     insert_line, icon_id = self:_write_to_buffer(lines, {

--- a/tests/interactions/chat/ui/test_builder_state.lua
+++ b/tests/interactions/chat/ui/test_builder_state.lua
@@ -144,4 +144,39 @@ T["Builder state"]["_should_start_new_block is based on type change"] = function
   h.eq(sB.chunks_in_block, 1)
 end
 
+T["Builder state"]["tool fold is placed on the content line when the tool message creates the header"] = function()
+  -- Mirrors adapters (e.g. OpenRouter) that emit a tool call with no rendered
+  -- text first, so the tool output is the message that renders the LLM header.
+  -- The fold must sit on the tool content, not back up in the user's section.
+  child.lua([[
+    require("codecompanion.config").interactions.chat.tools.opts.folds.enabled = true
+
+    _G.chat:add_buf_message(
+      { role = "llm", content = "tool line 1\ntool line 2\ntool line 3" },
+      { type = _G.MT.TOOL_MESSAGE }
+    )
+    vim.wait(200, function() return false end)
+  ]])
+
+  local res = child.lua([[
+    local bufnr = _G.chat.bufnr
+    local folds = require("codecompanion.interactions.chat.ui.folds").fold_summaries[bufnr] or {}
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
+
+    local content_row0 = nil
+    for i, l in ipairs(lines) do
+      if l == "tool line 1" then
+        content_row0 = i - 1
+        break
+      end
+    end
+
+    return { content_row0 = content_row0, fold = content_row0 and folds[content_row0] or nil }
+  ]])
+
+  h.not_eq(res.content_row0, nil, "Expected to find the tool content in the buffer")
+  h.not_eq(res.fold, nil, "Expected a tool fold keyed on the content line")
+  h.eq(res.fold.type, "tool")
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

In instances where an LLM's first response is a tool call, sometimes the extmark to denote the success of a tool call would be placed incorrectly.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 4.8

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="1610" height="1224" alt="2026-07-15 15_11_59 - Ghostty@2x" src="https://github.com/user-attachments/assets/2f723284-8a5e-419b-8ac9-41db098f4dc7" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
