### PR TITLE
fix: consistency of four markdown backticks

### DIFF
--- a/doc/configuration/prompt-library.md
+++ b/doc/configuration/prompt-library.md
@@ -118,7 +118,7 @@ require("codecompanion").setup({
           role = "user",
           content = function(context)
             local text = require("codecompanion.helpers.code").get_code(context.start_line, context.end_line)
-            return "Please explain the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```"
+            return "Please explain the following code:\n\n````" .. context.filetype .. "\n" .. text .. "\n````"
           end,
         },
       },

--- a/lua/codecompanion/action_palette/static.lua
+++ b/lua/codecompanion/action_palette/static.lua
@@ -32,7 +32,7 @@ return {
           role = config.constants.USER_ROLE,
           content = function(context)
             local text = require("codecompanion.helpers.code").get_code(context.start_line, context.end_line)
-            return "I have the following code:\n\n```" .. context.filetype .. "\n" .. text .. "\n```\n\n"
+            return "I have the following code:\n\n````" .. context.filetype .. "\n" .. text .. "\n````\n\n"
           end,
           opts = {
             contains_code = true,

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/help.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/help.lua
@@ -74,10 +74,9 @@ local function send_output(SlashCommand, content, selected)
     role = config.constants.USER_ROLE,
     content = string.format(
       [[Help context for `%s`:
-
-```%s
+````%s
 %s
-```
+````
 
 Note the path to the help file is `%s`.
 ]],

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/symbols.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/symbols.lua
@@ -211,10 +211,9 @@ function SlashCommand:output(selected, opts)
   if selected.description then
     description = fmt(
       [[%s
-
-```%s
+````%s
 %s
-```]],
+````]],
       selected.description,
       ft,
       content

--- a/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
@@ -232,7 +232,7 @@ Refers to line 335 of the init.lua file</grepSearchTool>]]
       if type(data) == "table" then
         -- Results were found - data is an array of file paths
         local results = #data
-        local results_msg = fmt("Searched text for `%s`, %d results\n```\n%s\n```", query, results, output)
+        local results_msg = fmt("Searched text for `%s`, %d results\n````\n%s\n````", query, results, output)
         chat:add_tool_output(self, fmt(llm_output, results_msg), results_msg)
       else
         -- No results found - data is a string message

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -406,11 +406,11 @@ function UI:render(context, messages, opts)
   -- If the user has visually selected some text, add that to the chat buffer
   if context and context.is_visual and not opts.stop_context_insertion then
     log:trace("Adding visual selection to chat buffer")
-    table.insert(lines, "```" .. context.filetype)
+    table.insert(lines, "````" .. context.filetype)
     for _, line in ipairs(context.lines) do
       table.insert(lines, line)
     end
-    table.insert(lines, "```")
+    table.insert(lines, "````")
   end
 
   self:unlock_buf()

--- a/lua/codecompanion/interactions/inline/init.lua
+++ b/lua/codecompanion/interactions/inline/init.lua
@@ -139,9 +139,9 @@ local function code_block(message, filetype, code)
   return fmt(
     [[%s
 <code>
-```%s
+````%s
 %s
-```
+````
 </code>]],
     message,
     filetype,

--- a/tests/interactions/inline/test_inline.lua
+++ b/tests/interactions/inline/test_inline.lua
@@ -129,7 +129,7 @@ T["Inline"]["forms correct prompts"] = function()
   h.expect_starts_with("You are a knowledgeable", prompts[1].content)
   -- Visual selection
   h.eq(
-    "For context, this is the code that I've visually selected in the buffer, which is relevant to my prompt:\n<code>\n```lua\nlocal x = 1\n```\n</code>",
+    "For context, this is the code that I've visually selected in the buffer, which is relevant to my prompt:\n<code>\n````lua\nlocal x = 1\n````\n</code>",
     prompts[3].content
   )
   -- User prompt


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Ensure that all markdown code blocks use 4 backticks.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
