### PR TITLE
feat(chat): annotate and track edited files

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -4866,7 +4866,7 @@ to leave a comment for the LLM. These can then be shared with your LLM by using
 <
 
 
-  [!NOTE] Annotations are cleared after being shared wth the LLM. You can use
+  [!NOTE] Annotations are cleared after being shared with the LLM. You can use
   them once per message cycle.
 
 #BUFFER ~

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3970,6 +3970,11 @@ selection to make a comment. Repeat across as many buffers and lines as you
 like, then share them with a chat with the
 |codecompanion-usage-chat-buffer-editor-context-annotations| context.
 
+To navigate to the files an agent has edited or created, use
+`:CodeCompanionChat Changes` to open them in the quickfix list. Every file the
+LLM touches in your Neovim session is tracked, across chats and the CLI, so you
+can jump between them as you annotate.
+
 
 NAVIGATING BETWEEN RESPONSES IN THE CHAT BUFFER ~
 
@@ -5725,6 +5730,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLIHidden` - Fired after a CLI buffer has been hidden
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
+- `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -555,10 +555,13 @@ However, there are multiple options available:
 - `CodeCompanion <prompt>` - Prompt the inline interaction
 - `CodeCompanion adapter=<adapter> <prompt>` - Prompt the inline interaction with a specific adapter
 - `CodeCompanion /<prompt library>` - Call an item via its alias from the |codecompanion-configuration-prompt-library|
+- `CodeCompanionActions Refresh` - Refresh the action palette and any items in the prompt library
 - `CodeCompanionChat <prompt>` - Send a prompt to the LLM via a chat buffer
 - `CodeCompanionChat adapter=<adapter> model=<model>` - Open a chat buffer with a specific http adapter and model
 - `CodeCompanionChat adapter=<adapter> command=<command>` - Open a chat buffer with a specific ACP adapter and command
 - `CodeCompanionChat Add` - Add visually selected chat to the current chat buffer
+- `CodeCompanionChat Annotate` - Add a comment to the pending |codecompanion-usage-chat-buffer-editor-context-annotations| list
+- `CodeCompanionChat Changes` - Open the quickfix list with all files that have been changed by the LLM
 - `CodeCompanionChat RefreshCache` - Used to refresh conditional elements in the chat buffer
 - `CodeCompanionChat Toggle` - Toggle a chat buffer
 - `CodeCompanionCLI` - Open a new CLI interaction
@@ -3389,7 +3392,7 @@ If you add or modify markdown prompts whilst your Neovim session is running,
 you can refresh the prompt library to pick up the changes with:
 
 >
-    :CodeCompanionActions refresh
+    :CodeCompanionActions Refresh
 <
 
 
@@ -4031,7 +4034,7 @@ The built-in prompts can be turned off by setting
 `display.action_palette.opts.show_preset_prompts = false`.
 
 You can also refresh the markdown prompts in your prompt library with
-`:CodeCompanionActions refresh`
+`:CodeCompanionActions Refresh`
 
 
 CHAT BUFFER                                  *codecompanion-usage-chat-buffer*

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 18
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 19
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -3962,6 +3962,15 @@ to run a test suite on your behalf and give insight on failing cases. Simply
 tag the `@run_command` in the chat buffer and ask it run your tests.
 
 
+LEAVING REVIEW COMMENTS FOR AN LLM ~
+
+Rather than switching to the chat buffer to type out every comment on an
+agent's changes, use `:CodeCompanionChat Annotate` over a line or visual
+selection to make a comment. Repeat across as many buffers and lines as you
+like, then share them with a chat with the
+|codecompanion-usage-chat-buffer-editor-context-annotations| context.
+
+
 NAVIGATING BETWEEN RESPONSES IN THE CHAT BUFFER ~
 
 You can quickly move between responses in the chat buffer using `[[` or `]]`.
@@ -4844,6 +4853,21 @@ message to the LLM.
   captures a point-in-time snapshot when your message is sent. If the underlying
   data changes (e.g. new diagnostics, a different quickfix list), simply use the
   context again in a new message to share the latest state.
+
+#ANNOTATIONS ~
+
+The `annotations` context shares any pending annotations you've made across
+your buffers. Use `:CodeCompanionChat Annotate` over a line or visual selection
+to leave a comment for the LLM. These can then be shared with your LLM by using
+`#{annotations}` in any open chat buffer.
+
+>md
+    Sharing my #{annotations} with you for review and to make any necessary changes
+<
+
+
+  [!NOTE] Annotations are cleared after being shared wth the LLM. You can use
+  them once per message cycle.
 
 #BUFFER ~
 

--- a/doc/configuration/prompt-library.md
+++ b/doc/configuration/prompt-library.md
@@ -55,7 +55,7 @@ require("codecompanion").setup({
 If you add or modify markdown prompts whilst your Neovim session is running, you can refresh the prompt library to pick up the changes with:
 
 ```
-:CodeCompanionActions refresh
+:CodeCompanionActions Refresh
 ```
 
 ## Creating Prompts

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -254,10 +254,13 @@ However, there are multiple options available:
 - `CodeCompanion <prompt>` - Prompt the inline interaction
 - `CodeCompanion adapter=<adapter> <prompt>` - Prompt the inline interaction with a specific adapter
 - `CodeCompanion /<prompt library>` - Call an item via its alias from the [prompt library](configuration/prompt-library)
+- `CodeCompanionActions Refresh` - Refresh the action palette and any items in the prompt library
 - `CodeCompanionChat <prompt>` - Send a prompt to the LLM via a chat buffer
 - `CodeCompanionChat adapter=<adapter> model=<model>` - Open a chat buffer with a specific http adapter and model
 - `CodeCompanionChat adapter=<adapter> command=<command>` - Open a chat buffer with a specific ACP adapter and command
 - `CodeCompanionChat Add` - Add visually selected chat to the current chat buffer
+- `CodeCompanionChat Annotate` - Add a comment to the pending [annotations](/usage/chat-buffer/editor-context#annotations) list
+- `CodeCompanionChat Changes` - Open the quickfix list with all files that have been changed by the LLM
 - `CodeCompanionChat RefreshCache` - Used to refresh conditional elements in the chat buffer
 - `CodeCompanionChat Toggle` - Toggle a chat buffer
 - `CodeCompanionCLI` - Open a new CLI interaction

--- a/doc/usage/action-palette.md
+++ b/doc/usage/action-palette.md
@@ -29,4 +29,4 @@ The plugin also contains two built-in workflows, `Code workflow` and `Edit test 
 
 The built-in prompts can be turned off by setting `display.action_palette.opts.show_preset_prompts = false`.
 
-You can also refresh the markdown prompts in your prompt library with `:CodeCompanionActions refresh`
+You can also refresh the markdown prompts in your prompt library with `:CodeCompanionActions Refresh`

--- a/doc/usage/chat-buffer/editor-context.md
+++ b/doc/usage/chat-buffer/editor-context.md
@@ -19,6 +19,17 @@ Editor context uses the `#{context}` syntax to dynamically insert content into y
 > [!IMPORTANT]
 > With the exception of `#{buffer}` and `#{buffers}`, editor context captures a point-in-time snapshot when your message is sent. If the underlying data changes (e.g. new diagnostics, a different quickfix list), simply use the context again in a new message to share the latest state.
 
+## #annotations
+
+The _annotations_ context shares any pending annotations you've made across your buffers. Use `:CodeCompanionChat Annotate` over a line or visual selection to leave a comment for the LLM. These can then be shared with your LLM by using `#{annotations}` in any open chat buffer.
+
+```md
+Sharing my #{annotations} with you for review and to make any necessary changes
+```
+
+> [!NOTE]
+> Annotations are cleared after being shared wth the LLM. You can use them once per message cycle.
+
 ## #buffer
 
 > [!NOTE]

--- a/doc/usage/chat-buffer/editor-context.md
+++ b/doc/usage/chat-buffer/editor-context.md
@@ -28,7 +28,7 @@ Sharing my #{annotations} with you for review and to make any necessary changes
 ```
 
 > [!NOTE]
-> Annotations are cleared after being shared wth the LLM. You can use them once per message cycle.
+> Annotations are cleared after being shared with the LLM. You can use them once per message cycle.
 
 ## #buffer
 

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -33,6 +33,7 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLIHidden` - Fired after a CLI buffer has been hidden
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
+- `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat

--- a/doc/usage/introduction.md
+++ b/doc/usage/introduction.md
@@ -22,6 +22,8 @@ The [run_command](/usage/chat-buffer/agents-tools#run-command) tool enables an L
 
 Rather than switching to the chat buffer to type out every comment on an agent's changes, use `:CodeCompanionChat Annotate` over a line or visual selection to make a comment. Repeat across as many buffers and lines as you like, then share them with a chat with the [#annotations](/usage/chat-buffer/editor-context#annotations) context.
 
+To navigate to the files an agent has edited or created, use `:CodeCompanionChat Changes` to open them in the quickfix list. Every file the LLM touches in your Neovim session is tracked, across chats and the CLI, so you can jump between them as you annotate.
+
 ## Navigating between responses in the chat buffer
 
 You can quickly move between responses in the chat buffer using `[[` or `]]`.

--- a/doc/usage/introduction.md
+++ b/doc/usage/introduction.md
@@ -18,6 +18,10 @@ The [@insert_edit_into_file](/usage/chat-buffer/agents-tools#files) tool, combin
 
 The [run_command](/usage/chat-buffer/agents-tools#run-command) tool enables an LLM to execute commands on your machine. This can be useful if you wish the LLM to run a test suite on your behalf and give insight on failing cases. Simply tag the `@run_command` in the chat buffer and ask it run your tests.
 
+## Leaving review comments for an LLM
+
+Rather than switching to the chat buffer to type out every comment on an agent's changes, use `:CodeCompanionChat Annotate` over a line or visual selection to make a comment. Repeat across as many buffers and lines as you like, then share them with a chat with the [#annotations](/usage/chat-buffer/editor-context#annotations) context.
+
 ## Navigating between responses in the chat buffer
 
 You can quickly move between responses in the chat buffer using `[[` or `]]`.

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -776,6 +776,7 @@ function Connection:handle_fs_write_file_request(id, params)
   local ok, err = fs.write_text_file(path, content)
   if ok then
     self:send_result(id, vim.NIL)
+    utils.fire("FileEdited", { path = path, tool = (self.adapter and self.adapter.name) or "acp" })
     local info = { path = path, bytes = #content, sessionId = params.sessionId }
     if self._active_prompt and self._active_prompt.handlers and self._active_prompt.handlers.write_text_file then
       pcall(self._active_prompt.handlers.write_text_file, info)

--- a/lua/codecompanion/commands/init.lua
+++ b/lua/codecompanion/commands/init.lua
@@ -381,7 +381,7 @@ return {
       range = true,
       nargs = "*",
       complete = function(arg_lead, cmdline, _cursor_pos)
-        return { "refresh" }
+        return { "Refresh" }
       end,
     },
   },

--- a/lua/codecompanion/commands/init.lua
+++ b/lua/codecompanion/commands/init.lua
@@ -140,12 +140,13 @@ return {
       local params = {}
       local prompt = {}
       local subcommand = nil
+      local subcommands = { add = true, annotate = true, refreshcache = true, toggle = true }
 
       for _, arg in ipairs(opts.fargs) do
         local key, value = arg:match("^(%w+)=(.+)$")
         if key and value then
           params[key] = value
-        elseif arg:lower() == "toggle" or arg:lower() == "add" or arg:lower() == "refreshcache" then
+        elseif subcommands[arg:lower()] then
           subcommand = arg:lower()
         else
           -- Anything else is a prompt
@@ -255,6 +256,7 @@ return {
             "model=",
             "Toggle",
             "Add",
+            "Annotate",
             "RefreshCache",
           }
 

--- a/lua/codecompanion/commands/init.lua
+++ b/lua/codecompanion/commands/init.lua
@@ -140,7 +140,7 @@ return {
       local params = {}
       local prompt = {}
       local subcommand = nil
-      local subcommands = { add = true, annotate = true, refreshcache = true, toggle = true }
+      local subcommands = { add = true, annotate = true, changes = true, refreshcache = true, toggle = true }
 
       for _, arg in ipairs(opts.fargs) do
         local key, value = arg:match("^(%w+)=(.+)$")
@@ -257,6 +257,7 @@ return {
             "Toggle",
             "Add",
             "Annotate",
+            "Changes",
             "RefreshCache",
           }
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -684,7 +684,7 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
           modes = { n = "gty" },
           index = 20,
           callback = "keymaps.yolo_mode",
-          description = "Toggle auto-approval of tool calls",
+          description = "Toggle YOLO/auto-approval of tool calls",
         },
         goto_file_under_cursor = {
           modes = { n = "gR" },
@@ -853,6 +853,13 @@ The user is working on a %s machine. Please respond with system specific command
               "help",
               "terminal",
             },
+          },
+        },
+        ["annotations"] = {
+          path = "interactions.shared.editor_context.annotations",
+          description = "Share your pending annotations with the LLM",
+          opts = {
+            contains_code = true,
           },
         },
         ["buffer"] = {

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -123,6 +123,12 @@ CodeCompanion.annotate = function(args)
   return require("codecompanion.interactions.shared.annotations").create(args)
 end
 
+---Open the files the LLM has edited this session in the quickfix list
+---@return nil
+CodeCompanion.changes = function()
+  return require("codecompanion.interactions.shared.edited_files").to_quickfix()
+end
+
 ---Open a chat buffer and converse with an LLM
 ---@param args? table
 ---@return CodeCompanion.Chat|nil
@@ -152,6 +158,8 @@ CodeCompanion.chat = function(args)
       return CodeCompanion.add(args)
     elseif args.subcommand == "annotate" then
       return CodeCompanion.annotate(args)
+    elseif args.subcommand == "changes" then
+      return CodeCompanion.changes()
     elseif args.subcommand == "toggle" then
       return CodeCompanion.toggle_chat(args)
     elseif args.subcommand == "refreshcache" then
@@ -502,6 +510,8 @@ CodeCompanion.setup = function(opts)
   for _, cmd in ipairs(cmds) do
     api.nvim_create_user_command(cmd.cmd, cmd.callback, cmd.opts)
   end
+
+  require("codecompanion.interactions.shared.edited_files").setup()
 
   -- Load the main completion module first to register its autocmds
   require("codecompanion.providers.completion")

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -150,6 +150,8 @@ CodeCompanion.chat = function(args)
   if args.subcommand then
     if args.subcommand == "add" then
       return CodeCompanion.add(args)
+    elseif args.subcommand == "annotate" then
+      return CodeCompanion.annotate(args)
     elseif args.subcommand == "toggle" then
       return CodeCompanion.toggle_chat(args)
     elseif args.subcommand == "refreshcache" then

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -102,15 +102,25 @@ CodeCompanion.add = function(args)
 
   chat:add_buf_message({
     role = config.constants.USER_ROLE,
-    content = "Here is some code from "
-      .. context.path
-      .. ":\n\n```"
-      .. context.filetype
-      .. "\n"
-      .. content
-      .. "\n```\n",
+    content = string.format(
+      [[Here is some code from %s:
+````%s
+%s
+````
+]],
+      context.path,
+      context.filetype,
+      content
+    ),
   })
   chat.ui:open()
+end
+
+---Annotate the current line or visual selection with a comment for the LLM
+---@param args table
+---@return nil
+CodeCompanion.annotate = function(args)
+  return require("codecompanion.interactions.shared.annotations").create(args)
 end
 
 ---Open a chat buffer and converse with an LLM

--- a/lua/codecompanion/interactions/chat/tools/builtin/create_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/create_file.lua
@@ -1,6 +1,7 @@
 local files = require("codecompanion.utils.files")
 local helpers = require("codecompanion.interactions.chat.tools.builtin.helpers")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local fmt = string.format
 
@@ -80,6 +81,7 @@ local function create(action)
   end
 
   -- If we reach here, all operations (open, write, close) were successful
+  utils.fire("FileEdited", { path = filepath, tool = "create_file" })
   return {
     status = "success",
     data = fmt([[Created `%s`]], action.filepath),
@@ -158,12 +160,10 @@ return {
 
       local llm_output = fmt("<createFileTool>%s</createFileTool>", "Created file `%s` successfully")
 
-      -- Get the file extension for syntax highlighting
       local file_ext = vim.fn.fnamemodify(args.filepath, ":e")
 
       local result_msg = fmt(
         [[Created file `%s`
-
 ````%s
 %s
 ````]],

--- a/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/init.lua
@@ -36,6 +36,7 @@ local process_mod = require("codecompanion.interactions.chat.tools.builtin.inser
 
 local buf_utils = require("codecompanion.utils.buffers")
 local file_utils = require("codecompanion.utils.files")
+local utils = require("codecompanion.utils")
 
 local api = vim.api
 local fmt = string.format
@@ -97,6 +98,7 @@ local function make_file_source(action)
     file_info = file_info,
     display_name = display_name,
     ft = vim.filetype.match({ filename = path }) or "text",
+    path = path,
     process_opts = { path = path, file_info = file_info, mode = action.mode },
     write = function(new_content)
       return io_mod.write_file(path, new_content, file_info)
@@ -124,10 +126,12 @@ local function make_buffer_source(bufnr, action)
   }
 
   return {
+    bufnr = bufnr,
     content = content,
     file_info = file_info,
     display_name = display_name,
     ft = vim.bo[bufnr].filetype or "text",
+    path = buffer_name,
     process_opts = { buffer = bufnr, file_info = file_info, mode = action.mode },
     write = function(new_content)
       local new_lines = vim.split(new_content, "\n", { plain = true })
@@ -138,6 +142,19 @@ local function make_buffer_source(bufnr, action)
       return true, nil
     end,
   }
+end
+
+---Return the first line number where the edited content differs
+---@param from_lines string[]
+---@param to_lines string[]
+---@return number
+local function first_changed_line(from_lines, to_lines)
+  for i = 1, math.max(#from_lines, #to_lines) do
+    if from_lines[i] ~= to_lines[i] then
+      return i
+    end
+  end
+  return 1
 end
 
 ---Execute an edit operation against a content source
@@ -161,14 +178,23 @@ local function execute_edit(source, action, opts)
 
   local success_msg = fmt("Edited `%s`%s", source.display_name, extract_explanation(action))
 
+  local from_lines = vim.split(source.content, "\n", { plain = true })
+  local to_lines = vim.split(edit.content, "\n", { plain = true })
+
   return diff.review({
-    from_lines = vim.split(source.content, "\n", { plain = true }),
-    to_lines = vim.split(edit.content, "\n", { plain = true }),
+    from_lines = from_lines,
+    to_lines = to_lines,
     apply = function()
       local write_ok, write_err = source.write(edit.content)
       if not write_ok then
         return opts.output_cb(make_response("error", fmt("Error writing to `%s`: %s", source.display_name, write_err)))
       end
+      utils.fire("FileEdited", {
+        bufnr = source.bufnr,
+        line = first_changed_line(from_lines, to_lines),
+        path = source.path,
+        tool = "insert_edit_into_file",
+      })
       opts.output_cb(make_response("success", success_msg))
     end,
     approved = approvals:is_approved(opts.chat_bufnr, { tool_name = "insert_edit_into_file" }),

--- a/lua/codecompanion/interactions/shared/annotations.lua
+++ b/lua/codecompanion/interactions/shared/annotations.lua
@@ -1,0 +1,86 @@
+local config = require("codecompanion.config")
+local input = require("codecompanion.interactions.shared.input")
+local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
+
+local api = vim.api
+local fmt = string.format
+
+---@class CodeCompanion.Annotation
+---@field comment string
+---@field code string
+---@field filetype string
+---@field path string
+---@field start_line number
+---@field end_line number
+
+local store = {} ---@type CodeCompanion.Annotation[]
+
+local M = {}
+
+---Add an annotation to the store
+---@param annotation CodeCompanion.Annotation
+---@return nil
+function M.add(annotation)
+  table.insert(store, annotation)
+end
+
+---Return all pending annotations
+---@return CodeCompanion.Annotation[]
+function M.all()
+  return store
+end
+
+---Return the number of pending annotations
+---@return number
+function M.count()
+  return #store
+end
+
+---Remove all pending annotations
+---@return nil
+function M.clear()
+  store = {}
+end
+
+---Snapshot the code and location the user is annotating
+---@param bufnr number
+---@param args? table
+---@return { code: string, filetype: string, path: string, start_line: number, end_line: number }
+local function snapshot(bufnr, args)
+  local buffer_context = require("codecompanion.utils.context").get(bufnr, args)
+  local lines = buffer_context.lines
+
+  if not buffer_context.is_visual then
+    lines = api.nvim_buf_get_lines(bufnr, buffer_context.start_line - 1, buffer_context.start_line, false)
+  end
+
+  return {
+    code = table.concat(lines, "\n"),
+    filetype = buffer_context.filetype,
+    path = buffer_context.relative_path,
+    start_line = buffer_context.start_line,
+    end_line = buffer_context.end_line,
+  }
+end
+
+---Annotate the current line or visual selection with a comment
+---@param args? table
+---@return nil
+function M.create(args)
+  if not config.can_send_code() then
+    return log:warn("Sending of code has been disabled")
+  end
+
+  local annotated = snapshot(api.nvim_get_current_buf(), args)
+
+  input.open({
+    title = " Annotate ",
+    on_submit = function(comment)
+      M.add(vim.tbl_extend("force", annotated, { comment = comment }))
+      utils.notify(fmt("Annotation added (%d pending)", M.count()))
+    end,
+  })
+end
+
+return M

--- a/lua/codecompanion/interactions/shared/edited_files.lua
+++ b/lua/codecompanion/interactions/shared/edited_files.lua
@@ -1,0 +1,72 @@
+local utils = require("codecompanion.utils")
+
+---@class CodeCompanion.EditedFile
+---@field path string The absolute path of the edited file
+---@field tool string What made the edit (e.g. "insert_edit_into_file", "create_file", "claude_code")
+---@field line? number The first line the edit touched, when known
+---@field bufnr? number The buffer the edit was made in, when known
+
+local store = {} ---@type CodeCompanion.EditedFile[]
+local positions = {} ---@type table<string, number> Lookup of path to position in the store
+
+local M = {}
+
+---Record an edited file, refreshing its entry if it has been edited before
+---@param edit CodeCompanion.EditedFile
+---@return nil
+local function record(edit)
+  if not edit.path or edit.path == "" then
+    return
+  end
+
+  local position = positions[edit.path]
+  if position then
+    store[position] = vim.tbl_extend("force", store[position], edit)
+    return
+  end
+
+  table.insert(store, edit)
+  positions[edit.path] = #store
+end
+
+---Return the files the LLM has edited, in the order they were first edited
+---@return CodeCompanion.EditedFile[]
+function M.all()
+  return store
+end
+
+---Open the edited files in the quickfix list
+---@return nil
+function M.to_quickfix()
+  if #store == 0 then
+    return utils.notify("No files have been edited this session", vim.log.levels.WARN)
+  end
+
+  local items = {}
+  for _, edit in ipairs(store) do
+    table.insert(items, {
+      filename = edit.path,
+      lnum = edit.line or 1,
+      text = (edit.tool == "create_file" and "created" or "edited") .. " by " .. edit.tool,
+    })
+  end
+
+  -- A new list is pushed onto the stack, so :colder restores the user's own list
+  vim.fn.setqflist({}, " ", { title = "Files edited by the LLM", items = items })
+  vim.cmd.copen()
+end
+
+---Track the files an LLM edits for the life of the Neovim instance
+---@return nil
+function M.setup()
+  vim.api.nvim_create_autocmd("User", {
+    group = vim.api.nvim_create_augroup("codecompanion.edited_files", { clear = true }),
+    pattern = "CodeCompanionFileEdited",
+    desc = "Track the files that an LLM edits or creates",
+    callback = function(args)
+      record(args.data)
+    end,
+  })
+end
+
+return M

--- a/lua/codecompanion/interactions/shared/editor_context/annotations.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/annotations.lua
@@ -1,0 +1,90 @@
+local annotations = require("codecompanion.interactions.shared.annotations")
+local config = require("codecompanion.config")
+local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
+
+local fmt = string.format
+
+---@class CodeCompanion.EditorContext.Annotations: CodeCompanion.EditorContext
+local EditorContext = {}
+
+---@param args CodeCompanion.EditorContextArgs
+function EditorContext.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    buffer_context = args.buffer_context or (args.Chat and args.Chat.buffer_context),
+    config = args.config,
+    params = args.params,
+  }, { __index = EditorContext })
+
+  return self
+end
+
+---Format an annotation into an `<annotation>` block
+---@param annotation CodeCompanion.Annotation
+---@return string
+local function format_annotation(annotation)
+  return fmt(
+    [[<annotation file="%s" lines="%d-%d">
+````%s
+%s
+````
+%s
+</annotation>]],
+    annotation.path,
+    annotation.start_line,
+    annotation.end_line,
+    annotation.filetype or "",
+    annotation.code,
+    annotation.comment
+  )
+end
+
+---Format all pending annotations into a single message
+---@param pending CodeCompanion.Annotation[]
+---@return string
+local function format_all(pending)
+  local blocks = {}
+  for _, annotation in ipairs(pending) do
+    table.insert(blocks, format_annotation(annotation))
+  end
+
+  return "Here are my annotations:\n\n" .. table.concat(blocks, "\n\n")
+end
+
+---Render in the chat interaction
+---@return nil
+function EditorContext:chat_render()
+  local pending = annotations.all()
+  if #pending == 0 then
+    return log:warn("No annotations found")
+  end
+
+  self.Chat:add_message({
+    role = config.constants.USER_ROLE,
+    content = format_all(pending),
+  }, { _meta = { source = "editor_context", tag = tags.ANNOTATIONS }, visible = false })
+
+  annotations.clear()
+end
+
+---Render in the CLI interaction
+---@return { inline: string, block: string }|nil
+function EditorContext:cli_render()
+  local pending = annotations.all()
+  if #pending == 0 then
+    log:warn("No annotations found")
+    return nil
+  end
+
+  local result = {
+    inline = "my annotations",
+    block = format_all(pending),
+  }
+
+  annotations.clear()
+
+  return result
+end
+
+return EditorContext

--- a/lua/codecompanion/interactions/shared/tags.lua
+++ b/lua/codecompanion/interactions/shared/tags.lua
@@ -1,5 +1,6 @@
 ---@class CodeCompanion.Chat.MessageTags
 local M = {
+  ANNOTATIONS = "annotations",
   BUFFER = "buffer",
   COMPACT_SUMMARY = "compact_summary",
   DIAGNOSTICS = "diagnostics",

--- a/tests/interactions/chat/tools/builtin/insert_edit_into_file/test_edit_file.lua
+++ b/tests/interactions/chat/tools/builtin/insert_edit_into_file/test_edit_file.lua
@@ -60,6 +60,37 @@ T["Core Functionality"]["performs basic single edit"] = function()
   h.eq(output, { "function getFullName() {", "  return 'John Doe';", "}" })
 end
 
+T["Core Functionality"]["fires FileEdited with the first changed line"] = function()
+  child.lua([[
+    local initial = "before\ntarget\nafter"
+    vim.fn.writefile(vim.split(initial, "\n"), _G.TEST_TMPFILE)
+
+    _G.file_edits = {}
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionFileEdited",
+      callback = function(args)
+        table.insert(_G.file_edits, args.data)
+      end,
+    })
+
+    local tool = {{
+      ["function"] = {
+        name = "insert_edit_into_file",
+        arguments = string.format('{"filepath": "%s", "edits": [{"oldText": "target", "newText": "replacement"}]}', _G.TEST_TMPFILE)
+      },
+    }}
+
+    tools:execute(chat, tool)
+    vim.wait(10)
+  ]])
+
+  local edits = child.lua_get("_G.file_edits")
+  h.eq(1, #edits)
+  h.eq(child.lua_get("_G.TEST_TMPFILE"), edits[1].path)
+  h.eq("insert_edit_into_file", edits[1].tool)
+  h.eq(2, edits[1].line)
+end
+
 T["Core Functionality"]["handles multiple sequential edits"] = function()
   child.lua([[
     local initial = "function getName() {\n  return 'John';\n}\n\nfunction getAge() {\n  return 25;\n}"

--- a/tests/interactions/chat/tools/builtin/test_create_file.lua
+++ b/tests/interactions/chat/tools/builtin/test_create_file.lua
@@ -65,4 +65,37 @@ T["can create files"] = function()
   h.eq(output, { "import pygame", "import time", "import random" }, "File was not created")
 end
 
+T["fires FileEdited when a file is created"] = function()
+  child.lua([[
+    vim.uv.chdir(_G.TEST_CWD)
+
+    _G.file_edits = {}
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionFileEdited",
+      callback = function(args)
+        table.insert(_G.file_edits, args.data)
+      end,
+    })
+
+    local tool = {
+      {
+        ["function"] = {
+          name = "create_file",
+          arguments = string.format('{"filepath": "%s", "content": "local x = 1"}', _G.TEST_TMPFILE_ABSOLUTE)
+        },
+      },
+    }
+    tools:execute(chat, tool)
+
+    vim.wait(5000, function()
+      return #_G.file_edits > 0
+    end, 50)
+  ]])
+
+  local edits = child.lua_get("_G.file_edits")
+  h.eq(1, #edits)
+  h.eq(child.lua_get("_G.TEST_TMPFILE_ABSOLUTE"), edits[1].path)
+  h.eq("create_file", edits[1].tool)
+end
+
 return T

--- a/tests/interactions/shared/test_annotations.lua
+++ b/tests/interactions/shared/test_annotations.lua
@@ -1,0 +1,117 @@
+local h = require("tests.helpers")
+
+local child = MiniTest.new_child_neovim()
+local new_set = MiniTest.new_set
+
+T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        h = require('tests.helpers')
+        h.setup_plugin()
+
+        _G.annotations = require("codecompanion.interactions.shared.annotations")
+
+        -- Stub the input popup so `create` submits a comment immediately
+        _G.stub_input = function(comment)
+          package.loaded["codecompanion.interactions.shared.input"].open = function(opts)
+            opts.on_submit(comment)
+          end
+        end
+      ]])
+    end,
+    post_case = function()
+      child.lua([[annotations.clear()]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["Annotations"] = new_set()
+
+T["Annotations"]["add appends to the store"] = function()
+  child.lua([[
+    annotations.add({
+      comment = "Handle the nil case",
+      code = "local x = 1",
+      filetype = "lua",
+      relative_path = "lua/foo.lua",
+      start_line = 1,
+      end_line = 1,
+    })
+  ]])
+
+  h.eq(1, child.lua_get("annotations.count()"))
+  h.eq("Handle the nil case", child.lua_get("annotations.all()[1].comment"))
+end
+
+T["Annotations"]["CLEAR empties the store"] = function()
+  child.lua([[
+    annotations.add({ comment = "one", code = "", filetype = "lua", relative_path = "foo.lua", start_line = 1, end_line = 1 })
+    annotations.add({ comment = "two", code = "", filetype = "lua", relative_path = "foo.lua", start_line = 2, end_line = 2 })
+    annotations.clear()
+  ]])
+
+  h.eq(0, child.lua_get("annotations.count()"))
+end
+
+T["Annotations"]["CREATE snapshots the current line when there is no visual selection"] = function()
+  child.lua([[
+    stub_input("This should handle the nil case")
+
+    vim.cmd("edit! test_annotations_fixture.lua")
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "local a = 1", "local b = 2", "local c = 3" })
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+    annotations.create({ range = 0 })
+  ]])
+
+  local pending = child.lua_get("annotations.all()")
+  h.eq(1, #pending)
+  h.eq("This should handle the nil case", pending[1].comment)
+  h.eq("local b = 2", pending[1].code)
+  h.eq(2, pending[1].start_line)
+  h.eq(2, pending[1].end_line)
+
+  child.lua([[vim.cmd("bwipeout! test_annotations_fixture.lua")]])
+end
+
+T["Annotations"]["CREATE snapshots a visual selection"] = function()
+  child.lua([[
+    stub_input("Rename these")
+
+    vim.cmd("edit! test_annotations_fixture.lua")
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "local a = 1", "local b = 2", "local c = 3" })
+    vim.api.nvim_buf_set_mark(buf, "<", 1, 0, {})
+    vim.api.nvim_buf_set_mark(buf, ">", 2, 10, {})
+
+    annotations.create({ range = 2 })
+  ]])
+
+  local pending = child.lua_get("annotations.all()")
+  h.eq(1, #pending)
+  h.eq("Rename these", pending[1].comment)
+  h.eq("local a = 1\nlocal b = 2", pending[1].code)
+  h.eq(1, pending[1].start_line)
+  h.eq(2, pending[1].end_line)
+
+  child.lua([[vim.cmd("bwipeout! test_annotations_fixture.lua")]])
+end
+
+T["Annotations"]["CREATE does nothing when sending code is disabled"] = function()
+  child.lua([[
+    stub_input("Should not be added")
+    config = require('codecompanion.config')
+    config.opts.send_code = false
+
+    annotations.create({ range = 0 })
+
+    config.opts.send_code = true
+  ]])
+
+  h.eq(0, child.lua_get("annotations.count()"))
+end
+
+return T

--- a/tests/interactions/shared/test_edited_files.lua
+++ b/tests/interactions/shared/test_edited_files.lua
@@ -1,0 +1,89 @@
+local h = require("tests.helpers")
+
+local child = MiniTest.new_child_neovim()
+local new_set = MiniTest.new_set
+
+T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        h = require('tests.helpers')
+        h.setup_plugin()
+
+        _G.edited_files = require("codecompanion.interactions.shared.edited_files")
+        _G.fire = function(data)
+          vim.api.nvim_exec_autocmds("User", { pattern = "CodeCompanionFileEdited", data = data })
+        end
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["Edited files"] = new_set()
+
+T["Edited files"]["starts empty"] = function()
+  h.eq(0, child.lua_get("#edited_files.all()"))
+end
+
+T["Edited files"]["records an edited file from the FileEdited event"] = function()
+  child.lua([[fire({ path = "/project/lua/foo.lua", tool = "insert_edit_into_file", line = 40 })]])
+
+  local edits = child.lua_get("edited_files.all()")
+  h.eq(1, #edits)
+  h.eq("/project/lua/foo.lua", edits[1].path)
+  h.eq("insert_edit_into_file", edits[1].tool)
+  h.eq(40, edits[1].line)
+end
+
+T["Edited files"]["ignores edits without a path"] = function()
+  child.lua([[fire({ tool = "insert_edit_into_file" })]])
+
+  h.eq(0, child.lua_get("#edited_files.all()"))
+end
+
+T["Edited files"]["refreshes the entry when a file is edited again"] = function()
+  child.lua([[
+    fire({ path = "/project/lua/foo.lua", tool = "insert_edit_into_file", line = 40 })
+    fire({ path = "/project/lua/bar.lua", tool = "create_file" })
+    fire({ path = "/project/lua/foo.lua", tool = "insert_edit_into_file", line = 88 })
+  ]])
+
+  local edits = child.lua_get("edited_files.all()")
+  h.eq(2, #edits)
+  h.eq("/project/lua/foo.lua", edits[1].path)
+  h.eq(88, edits[1].line)
+  h.eq("/project/lua/bar.lua", edits[2].path)
+end
+
+T["Edited files"]["to_quickfix notifies when no files have been edited"] = function()
+  child.lua([[
+    package.loaded["codecompanion.utils"].notify = function(msg, level)
+      _G.notified = msg
+    end
+
+    edited_files.to_quickfix()
+  ]])
+
+  h.eq("No files have been edited this session", child.lua_get("_G.notified"))
+  h.eq(0, child.lua_get("#vim.fn.getqflist()"))
+end
+
+T["Edited files"]["to_quickfix lists the edited files"] = function()
+  child.lua([[
+    fire({ path = "/project/lua/foo.lua", tool = "insert_edit_into_file", line = 40 })
+    fire({ path = "/project/lua/bar.lua", tool = "create_file" })
+
+    edited_files.to_quickfix()
+  ]])
+
+  local qf = child.lua_get("vim.fn.getqflist({ title = true, items = true })")
+  h.eq("Files edited by the LLM", qf.title)
+  h.eq(2, #qf.items)
+  h.eq(40, qf.items[1].lnum)
+  h.eq("edited by insert_edit_into_file", qf.items[1].text)
+  h.eq("created by create_file", qf.items[2].text)
+end
+
+return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When working with an agent or an LLM, you'll often find yourself reviewing many files. And oftentimes, you'll have specific feedback for your model about its edits. Currently in CodeCompanion, there's no easy way to review a file, inline your comments, and then share them in the chat buffer. 

This PR introduces annotations. Using the command `:CodeCompanionChat Annotate`, users can type their comments in their buffers, inline, entering them into a store before sharing them with an LLM in the chat buffer using `#{annotations}`.

This PR also introduces the ability for LLM edited files to be sent to the quickfix list. This works for all types of adapters and is available with `:CodeCompanionChat Changes`.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Sonnet 5 and Kimi K3

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
