### PR TITLE
fix(acp): update Codex authentication method IDs

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 18
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 19
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -1397,9 +1397,8 @@ take the following steps:
 
 SETUP: CODEX ~
 
-To use OpenAI's Codex <https://openai.com/codex/>, install an ACP-compatible
-adapter like this <https://github.com/zed-industries/codex-acp> one from Zed
-<https://zed.dev>.
+To use OpenAI's Codex <https://openai.com/codex/>, install codex-acp
+<https://github.com/agentclientprotocol/codex-acp>.
 
 By default, the adapter will look for an `OPENAI_API_KEY` in your shell,
 however you can also authenticate via ChatGPT. This can be customized in the
@@ -1412,7 +1411,7 @@ plugin configuration:
           codex = function()
             return require("codecompanion.adapters").extend("codex", {
               defaults = {
-                auth_method = "openai-api-key", -- "openai-api-key"|"codex-api-key"|"chatgpt"
+                auth_method = "api-key", -- "api-key"|"chat-gpt"
               },
               env = {
                 OPENAI_API_KEY = "my-api-key",

--- a/doc/configuration/adapters-acp.md
+++ b/doc/configuration/adapters-acp.md
@@ -324,7 +324,7 @@ To use [Cline CLI](https://cline.bot/cli) within CodeCompanion, you'll need to t
 
 ## Setup: Codex
 
-To use OpenAI's [Codex](https://openai.com/codex/), install an ACP-compatible adapter like [this](https://github.com/zed-industries/codex-acp) one from [Zed](https://zed.dev).
+To use OpenAI's [Codex](https://openai.com/codex/), install [codex-acp](https://github.com/agentclientprotocol/codex-acp).
 
 By default, the adapter will look for an `OPENAI_API_KEY` in your shell, however you can also authenticate via ChatGPT. This can be customized in the plugin configuration:
 
@@ -335,7 +335,7 @@ require("codecompanion").setup({
       codex = function()
         return require("codecompanion.adapters").extend("codex", {
           defaults = {
-            auth_method = "openai-api-key", -- "openai-api-key"|"codex-api-key"|"chatgpt"
+            auth_method = "api-key", -- "api-key"|"chat-gpt"
           },
           env = {
             OPENAI_API_KEY = "my-api-key",

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -216,11 +216,22 @@ function Connection:_authenticate()
     if #auth_methods > 0 then
       local wanted = self.adapter_modified.defaults.auth_method
       local method_id
+      local available_method_ids = {}
       for _, m in ipairs(auth_methods) do
+        table.insert(available_method_ids, m.id)
         if m.id == wanted then
           method_id = m.id
           break
         end
+      end
+
+      if wanted and not method_id then
+        log:error(
+          "[acp::_authenticate] Auth method %s is not advertised by the agent; available methods: %s",
+          wanted,
+          table.concat(available_method_ids, ", ")
+        )
+        return false
       end
       method_id = method_id or (auth_methods[1] and auth_methods[1].id)
 

--- a/lua/codecompanion/adapters/acp/codex.lua
+++ b/lua/codecompanion/adapters/acp/codex.lua
@@ -18,7 +18,7 @@ return {
     },
   },
   defaults = {
-    auth_method = "openai-api-key", -- "openai-api-key"|"codex-api-key"|"chatgpt"
+    auth_method = "api-key", -- "api-key"|"chat-gpt"
     mcpServers = {},
     timeout = 20000, -- 20 seconds
   },


### PR DESCRIPTION
The new codex-acp [adapter](https://github.com/agentclientprotocol/codex-acp) (versioned 1.x) advertises `api-key` and `chat-gpt` as auth methods, while the built-in adapter still selects the method IDs from the retired Zed adapter. This fails with a misleading Responses API 401 in codecompanion.

Use the current method IDs and link the setup documentation to the new repository.

Also: Reject an explicitly configured method that the agent does not advertise and list the available IDs in the error; adapters without an explicit selection retain the first advertised method fallback (guards against silently picking the first advertised method).

<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

Codex 5.6 Sol.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [x] _(optional)_ I've updated the README and/or relevant docs pages
