### PR TITLE
fix(chat): track edits from acp adapters

### DIFF
--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -48,6 +48,30 @@ local function merge_tool_call(existing, incoming)
   return out
 end
 
+---If a file has been edited, fire an event
+---@param tool_call table The merged tool call
+---@param adapter_name string
+---@return nil
+local function fire_file_edited(tool_call, adapter_name)
+  local fired = {}
+  local function fire(path, line)
+    if type(path) ~= "string" or path == "" or fired[path] then
+      return
+    end
+    fired[path] = true
+    utils.fire("FileEdited", { path = path, tool = adapter_name, line = line })
+  end
+
+  for _, location in ipairs(tool_call.locations or {}) do
+    fire(location.path, location.line)
+  end
+  for _, content in ipairs(tool_call.content or {}) do
+    if content.type == "diff" then
+      fire(content.path)
+    end
+  end
+end
+
 ---Submit payload to ACP and handle streaming response
 ---@param payload table The payload to send to the LLM
 ---@return table|nil Request object or nil on error
@@ -246,6 +270,10 @@ function ACPHandler:process_tool_call(tool_call)
     self.tools[id] = nil
   else
     self.tools[id] = merged
+  end
+
+  if tool_call.status == "completed" and tool_call.kind == "edit" then
+    fire_file_edited(tool_call, self.chat.adapter.name)
   end
 
   -- Pending tool calls are awaiting approval or streaming input, so hold them

--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -52,8 +52,10 @@ end
 ---@param tool_call table The merged tool call
 ---@param adapter_name string
 ---@return nil
-local function fire_file_edited(tool_call, adapter_name)
+local function file_edited(tool_call, adapter_name)
   local fired = {}
+
+  -- Fire an event but only once per file
   local function fire(path, line)
     if type(path) ~= "string" or path == "" or fired[path] then
       return
@@ -273,7 +275,7 @@ function ACPHandler:process_tool_call(tool_call)
   end
 
   if tool_call.status == "completed" and tool_call.kind == "edit" then
-    fire_file_edited(tool_call, self.chat.adapter.name)
+    file_edited(tool_call, self.chat.adapter.name)
   end
 
   -- Pending tool calls are awaiting approval or streaming input, so hold them

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -585,6 +585,170 @@ T["ACPHandler"]["handles no connection"] = function()
   h.eq("\\cost", result.content)
 end
 
+T["ACPHandler"]["Edited Files"] = new_set()
+
+T["ACPHandler"]["Edited Files"]["fires FileEdited when an edit tool call completes"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+    chat.add_buf_message = function() end
+
+    local events = {}
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionFileEdited",
+      callback = function(args)
+        table.insert(events, args.data)
+      end,
+    })
+
+    -- Replays the update sequence Claude Code sends for a direct-to-disk edit
+    local id = "toolu_0145UJoLG4Q6dsWnaTu8fr3n"
+    handler:process_tool_call({
+      toolCallId = id,
+      sessionUpdate = "tool_call",
+      status = "pending",
+      title = "Edit",
+      kind = "edit",
+      content = {},
+      locations = {},
+    })
+    handler:process_tool_call({
+      toolCallId = id,
+      sessionUpdate = "tool_call_update",
+      title = "Edit version.txt",
+      kind = "edit",
+      content = {
+        { type = "diff", path = "/tmp/version.txt", oldText = "19.20.0", newText = "19.21.0" },
+      },
+      locations = { { path = "/tmp/version.txt" } },
+    })
+    handler:process_tool_call({
+      toolCallId = id,
+      sessionUpdate = "tool_call_update",
+      content = {
+        { type = "diff", path = "/tmp/version.txt", oldText = "19.20.0", newText = "19.21.0" },
+      },
+      locations = { { path = "/tmp/version.txt", line = 1 } },
+    })
+    handler:process_tool_call({
+      toolCallId = id,
+      sessionUpdate = "tool_call_update",
+      status = "completed",
+      rawOutput = "The file /tmp/version.txt has been updated successfully.",
+    })
+
+    return {
+      event_count = #events,
+      path = events[1] and events[1].path,
+      line = events[1] and events[1].line,
+      tool = events[1] and events[1].tool,
+    }
+  ]])
+
+  h.eq(1, result.event_count)
+  h.eq("/tmp/version.txt", result.path)
+  h.eq(1, result.line)
+  h.eq("test_acp", result.tool)
+end
+
+T["ACPHandler"]["Edited Files"]["falls back to diff content when locations are absent"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+    chat.add_buf_message = function() end
+
+    local events = {}
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionFileEdited",
+      callback = function(args)
+        table.insert(events, args.data)
+      end,
+    })
+
+    handler:process_tool_call({
+      toolCallId = "toolu_diff_only",
+      sessionUpdate = "tool_call",
+      status = "completed",
+      kind = "edit",
+      content = {
+        { type = "diff", path = "/tmp/a.lua", oldText = "a", newText = "b" },
+      },
+    })
+
+    return {
+      event_count = #events,
+      path = events[1] and events[1].path,
+      line = events[1] and events[1].line,
+    }
+  ]])
+
+  h.eq(1, result.event_count)
+  h.eq("/tmp/a.lua", result.path)
+  h.eq(nil, result.line)
+end
+
+T["ACPHandler"]["Edited Files"]["ignores failed edits and non-edit tool calls"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+    chat.add_buf_message = function() end
+
+    local events = {}
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionFileEdited",
+      callback = function(args)
+        table.insert(events, args.data)
+      end,
+    })
+
+    handler:process_tool_call({
+      toolCallId = "toolu_failed",
+      sessionUpdate = "tool_call",
+      status = "failed",
+      kind = "edit",
+      locations = { { path = "/tmp/failed.lua" } },
+    })
+    handler:process_tool_call({
+      toolCallId = "toolu_execute",
+      sessionUpdate = "tool_call",
+      status = "completed",
+      kind = "execute",
+      locations = { { path = "/tmp/executed.lua" } },
+    })
+
+    return #events
+  ]])
+
+  h.eq(0, result)
+end
+
 T["ACPHandler"]["Permission Queue"] = new_set()
 
 T["ACPHandler"]["Permission Queue"]["queues concurrent requests and presents one at a time"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This fixes #3237 where ACP adapter edits were not properly captured when a user does `:CodeCompanionChat Changes`

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Kimi K3

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
