### PR TITLE
fix(acp): normalize session/list responses

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -327,7 +327,7 @@ function Connection:session_list(opts)
       end
     end
 
-    cursor = result.nextCursor
+    cursor = type(result.nextCursor) == "string" and result.nextCursor or nil
   until not cursor or #all_sessions >= max_sessions
 
   return all_sessions


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

On the [codex-acp](https://github.com/agentclientprotocol/codex-acp) adapter, running `session/list` does not correctly produce results inside of codecompanion, because `nextCursor`, a JSON null value, becomes a truthy vim.NIL value and starts session listing again, hitting the 500 sessions limit.

Also, collapse session titles to one line for the picker while preserving the original session metadata used to load the selection. Codex sends session "titles" as the full initial input (including system prompts, user prompt etc...), resulting in very very long multi-line session "titles". This preserves the same text while swapping e.g. newlines to one blank space, so essentially makes everything one line. Still not ideal, but a proper fix is codex-acp territory, not codecompanion.

## Supporting Documentation

- ACP schema - [nextCursor documentation](https://github.com/agentclientprotocol/agent-client-protocol/blob/b06dc4b4e1c2dd9ab388847111bfee0a016782bd/schema/v1/schema.json#L2375-L2378)

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

Codex 5.6 Sol

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
