### PR TITLE
fix(acp): gate async RPC path on yieldability

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -481,7 +481,7 @@ function Connection:send_rpc_request(method, params)
   end
 
   -- Async path: yield and let store_rpc_response resume us
-  if coroutine.running() then
+  if coroutine.isyieldable() then
     return async.wait(function(callback)
       self._pending_callbacks[id] = callback
     end)


### PR DESCRIPTION
`/resume` in a fresh chat sends the `session/list` request, but fails before it can handle the response or open the picker. It runs from Neovim's `CompleteDone` callback, where `coroutine.running()` is truthy even though that context *cannot yield*; checking `coroutine.isyieldable()` keeps it on the existing synchronous path instead.

Nothing gets printed after typing `/resume`. The command just gets eaten and no session listing fires. Session listing correctly fires after the fix.

## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
