### PR TITLE
Improve `ask_questions` tool

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,4 +1,4 @@
-*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 19
+*codecompanion.txt*          For NVIM v0.11          Last change: 2026 July 20
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -4435,19 +4435,13 @@ ASK_QUESTIONS
 
   [!NOTE] By default, this tool is hidden and is only accessible via the
   `@{agent}` tool group
-This tool enables an LLM to ask clarifying questions before proceeding with a
-task. It's useful when the LLM encounters ambiguous requirements, needs to
+This tool enables an LLM to ask clarifying questions before taking further
+action. This is useful when the LLM encounters ambiguous requirements, needs to
 choose between implementation approaches, or wants to validate assumptions.
-Questions can have predefined options (presented via `vim.ui.select`) or accept
-free text input (via `vim.ui.input`):
 
 >md
     @{agent} Can you refactor the authentication module?
 <
-
-The LLM may use this tool to ask which auth strategy you prefer before making
-changes. The tool is limited to one call per response to prevent excessive
-questioning.
 
 
 CREATE_FILE

--- a/doc/usage/chat-buffer/agents-tools.md
+++ b/doc/usage/chat-buffer/agents-tools.md
@@ -124,13 +124,11 @@ Use the lorem_ipsum tool to generate a random paragraph
 > [!NOTE]
 > By default, this tool is hidden and is only accessible via the `@{agent}` tool group
 
-This tool enables an LLM to ask clarifying questions before proceeding with a task. It's useful when the LLM encounters ambiguous requirements, needs to choose between implementation approaches, or wants to validate assumptions. Questions can have predefined options (presented via `vim.ui.select`) or accept free text input (via `vim.ui.input`):
+This tool enables an LLM to ask clarifying questions before taking further action. This is useful when the LLM encounters ambiguous requirements, needs to choose between implementation approaches, or wants to validate assumptions.
 
 ```md
 @{agent} Can you refactor the authentication module?
 ```
-
-The LLM may use this tool to ask which auth strategy you prefer before making changes. The tool is limited to one call per response to prevent excessive questioning.
 
 ### create_file
 

--- a/lua/codecompanion/interactions/chat/helpers/question_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/question_prompt.lua
@@ -1,0 +1,227 @@
+local config = require("codecompanion.config")
+local keymaps = require("codecompanion.utils.keymaps")
+local ui_utils = require("codecompanion.utils.ui")
+local utils = require("codecompanion.utils")
+
+local api = vim.api
+local fmt = string.format
+
+local CONSTANTS = {
+  MAX_OPTIONS = 9,
+
+  YES_KEY = "g1",
+  NO_KEY = "g2",
+  SKIP_KEY = "gs",
+  CUSTOM_ANSWER_KEY = "gc",
+
+  DESC = "CodeCompanion question",
+}
+
+CONSTANTS.DESC_CUSTOM_ANSWER = CONSTANTS.DESC .. ": write a custom answer"
+CONSTANTS.DESC_SKIP = CONSTANTS.DESC .. ": skip this question"
+
+---@class CodeCompanion.Chat.QuestionPrompt
+local M = {}
+
+---@param option table
+---@return string
+local function format_label(option)
+  local label = option.label
+  if option.recommended then
+    label = label .. " (recommended)"
+  end
+  if option.description then
+    label = label .. " - " .. option.description
+  end
+  return label
+end
+
+---Build the line that shows which option is being answered in a multi-select question
+---@param label string
+---@return string
+local function include_prompt(label)
+  return fmt("Include '%s'?", label)
+end
+
+---Build the markdown lines for a question
+---@param opts { question: table, index: number, total: number }
+---@return string[]
+local function build_lines(opts)
+  local question = opts.question
+  local options = question.options or {}
+
+  local header = fmt("**Question %d of %d**", opts.index, opts.total)
+  if question.multiSelect then
+    header = header .. " (select multiple)"
+  end
+
+  local lines = { "", "", "---", header, "", question.question, "" }
+
+  if #options == 0 then
+    table.insert(lines, fmt("- `%s` - Write your answer", CONSTANTS.CUSTOM_ANSWER_KEY))
+    table.insert(lines, fmt("- `%s` - Skip this question", CONSTANTS.SKIP_KEY))
+    table.insert(lines, "")
+    return lines
+  end
+
+  if question.multiSelect then
+    for _, option in ipairs(options) do
+      table.insert(lines, "- " .. format_label(option))
+    end
+    table.insert(lines, "")
+    table.insert(
+      lines,
+      fmt("`%s` Yes · `%s` No · `%s` Skip question", CONSTANTS.YES_KEY, CONSTANTS.NO_KEY, CONSTANTS.SKIP_KEY)
+    )
+    table.insert(lines, "")
+
+    -- NOTE: The line must stay last: its line number is tracked so it can be updated in place
+    table.insert(lines, include_prompt(options[1].label))
+    return lines
+  end
+
+  table.insert(lines, "Please select an option:")
+  for i = 1, math.min(#options, CONSTANTS.MAX_OPTIONS) do
+    table.insert(lines, fmt("- `g%d` - %s", i, format_label(options[i])))
+  end
+  table.insert(lines, fmt("- `%s` - Write a custom answer", CONSTANTS.CUSTOM_ANSWER_KEY))
+  table.insert(lines, fmt("- `%s` - Skip this question", CONSTANTS.SKIP_KEY))
+  table.insert(lines, "")
+  return lines
+end
+
+---Add the answer summary to the chat buffer
+---@param chat CodeCompanion.Chat
+---@param answer string|nil
+local function add_summary(chat, answer)
+  local icons = config.display.chat.icons
+  if answer then
+    return chat:add_buf_message(
+      { content = fmt("%sYou answered: %s\n\n---\n", icons.tool_success, answer) },
+      { _icon_info = { has_icon = true, status = "completed" } }
+    )
+  end
+
+  chat:add_buf_message(
+    { content = fmt("%sYou skipped this question\n\n---\n", icons.tool_failure) },
+    { _icon_info = { has_icon = true, status = "failed" } }
+  )
+end
+
+---Bind keymaps for a multi-select question, advancing through each option in turn
+---@param prompt { chat: CodeCompanion.Chat, options: table[], include_line: number|nil, bind: fun(lhs: string, callback: function, desc: string), finish: fun(answer: string|nil), skip: function }
+local function bind_multi_select(prompt)
+  local selected = {}
+  local option_index = 1
+
+  -- Ensure the summary message is on its own line
+  local function clear_include_line()
+    if prompt.include_line then
+      prompt.chat:update_buf_line(prompt.include_line, "")
+    end
+  end
+
+  local function advance()
+    option_index = option_index + 1
+    if option_index > #prompt.options then
+      clear_include_line()
+      return prompt.finish(#selected > 0 and table.concat(selected, ", ") or nil)
+    end
+    if prompt.include_line then
+      prompt.chat:update_buf_line(prompt.include_line, include_prompt(prompt.options[option_index].label))
+    end
+  end
+
+  prompt.bind(CONSTANTS.YES_KEY, function()
+    table.insert(selected, prompt.options[option_index].label)
+    advance()
+  end, CONSTANTS.DESC .. ": include this option")
+  prompt.bind(CONSTANTS.NO_KEY, advance, CONSTANTS.DESC .. ": exclude this option")
+  prompt.bind(CONSTANTS.SKIP_KEY, function()
+    clear_include_line()
+    prompt.skip()
+  end, CONSTANTS.DESC_SKIP)
+end
+
+---Bind keymaps for a single-select question
+---@param prompt { options: table[], bind: fun(lhs: string, callback: function, desc: string), finish: fun(answer: string|nil), custom_answer: function }
+local function bind_single_select(prompt)
+  for i = 1, math.min(#prompt.options, CONSTANTS.MAX_OPTIONS) do
+    prompt.bind("g" .. i, function()
+      prompt.finish(prompt.options[i].label)
+    end, CONSTANTS.DESC .. ": " .. prompt.options[i].label)
+  end
+  prompt.bind(CONSTANTS.CUSTOM_ANSWER_KEY, prompt.custom_answer, CONSTANTS.DESC_CUSTOM_ANSWER)
+end
+
+---Present a question in the chat buffer and resolve the answer through keymaps
+---@param chat CodeCompanion.Chat
+---@param opts { question: table, index: number, total: number, callback: fun(answer: string|nil) }
+---@return nil
+function M.ask(chat, opts)
+  local bufnr = chat.bufnr
+  if not api.nvim_buf_is_valid(bufnr) then
+    return opts.callback(nil)
+  end
+
+  local options = opts.question.options or {}
+  local last_line = chat:add_buf_message({
+    role = config.constants.LLM_ROLE,
+    content = table.concat(build_lines(opts), "\n"),
+  })
+
+  if config.interactions.chat.tools.opts.notify_on_approval and not ui_utils.buf_is_active(bufnr) then
+    utils.notify("The LLM has a question for you")
+  end
+
+  local overrides = keymaps.Override.new(bufnr)
+  local resolved = false
+
+  local function bind(lhs, callback, desc)
+    overrides:set(lhs, callback, { desc = desc })
+  end
+
+  ---@param answer string|nil
+  local function finish(answer)
+    if resolved then
+      return
+    end
+    resolved = true
+    overrides:restore()
+    add_summary(chat, answer)
+    opts.callback(answer)
+  end
+
+  local function custom_answer()
+    vim.ui.input({ prompt = "Answer: " }, function(input)
+      -- A cancelled input leaves the question active so the user can still press another key
+      if input and input ~= "" then
+        finish(input)
+      end
+    end)
+  end
+
+  local function skip()
+    finish(nil)
+  end
+
+  if #options == 0 then
+    bind(CONSTANTS.SKIP_KEY, skip, CONSTANTS.DESC_SKIP)
+    bind(CONSTANTS.CUSTOM_ANSWER_KEY, custom_answer, CONSTANTS.DESC_CUSTOM_ANSWER)
+    return
+  end
+  if opts.question.multiSelect then
+    return bind_multi_select({
+      chat = chat,
+      options = options,
+      include_line = last_line,
+      bind = bind,
+      finish = finish,
+      skip = skip,
+    })
+  end
+  bind(CONSTANTS.SKIP_KEY, skip, CONSTANTS.DESC_SKIP)
+  bind_single_select({ options = options, bind = bind, finish = finish, custom_answer = custom_answer })
+end
+
+return M

--- a/lua/codecompanion/interactions/chat/tools/builtin/ask_questions.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/ask_questions.lua
@@ -1,3 +1,5 @@
+local question_prompt = require("codecompanion.interactions.chat.helpers.question_prompt")
+
 local log = require("codecompanion.utils.log")
 
 local fmt = string.format
@@ -18,100 +20,30 @@ local function format_answers(questions, answers)
   return table.concat(parts, "\n")
 end
 
----Present a single question to the user via vim.ui.select or vim.ui.input
----@param question table The question object from the LLM
----@param callback fun(answer: string|nil) Called with the user's answer
-local function ask_one(question, callback)
-  local options = question.options
-
-  -- No options: free text input
-  if not options or #options == 0 then
-    vim.ui.input({ prompt = question.question .. ": " }, function(input)
-      if input == nil or input == "" then
-        callback(nil)
-      else
-        callback(input)
-      end
-    end)
-    return
-  end
-
-  -- Build choice labels
-  local labels = {}
-  local label_map = {}
-  for _, opt in ipairs(options) do
-    local label = opt.label
-    if opt.recommended then
-      label = label .. " (recommended)"
-    end
-    if opt.description then
-      label = label .. " - " .. opt.description
-    end
-    table.insert(labels, label)
-    label_map[label] = opt.label
-  end
-
-  if question.multiSelect then
-    -- Multi-select: present as multiple confirm prompts
-    local selected = {}
-    local idx = 0
-
-    local function next_option()
-      idx = idx + 1
-      if idx > #labels then
-        if #selected == 0 then
-          callback(nil)
-        else
-          callback(table.concat(selected, ", "))
-        end
-        return
-      end
-
-      local choice_label = labels[idx]
-      local prompt_text = fmt("%s\n\nInclude '%s'?", question.question, label_map[choice_label])
-      vim.ui.select({ "Yes", "No" }, { prompt = prompt_text }, function(choice)
-        if choice == "Yes" then
-          table.insert(selected, label_map[choice_label])
-        end
-        next_option()
-      end)
-    end
-
-    next_option()
-  else
-    -- Single select
-    vim.ui.select(labels, { prompt = question.question }, function(choice)
-      if choice == nil then
-        callback(nil)
-      else
-        callback(label_map[choice] or choice)
-      end
-    end)
-  end
-end
-
----Ask all questions sequentially, collecting answers
+---Ask all questions sequentially in the chat buffer, collecting answers
+---@param chat CodeCompanion.Chat
 ---@param questions table Array of question objects
 ---@param callback fun(answers: table<string, string>) Called with all collected answers
-local function ask_all(questions, callback)
+local function ask_all(chat, questions, callback)
   local answers = {}
-  local idx = 0
+  local index = 0
 
   local function next_question()
-    idx = idx + 1
-    if idx > #questions then
+    index = index + 1
+    if index > #questions then
       return callback(answers)
     end
 
-    local question = questions[idx]
-    ask_one(question, function(answer)
-      if answer then
-        answers[question.header] = answer
-      else
-        answers[question.header] = "No answer provided"
-      end
-      next_question()
-    end)
+    local question = questions[index]
+    question_prompt.ask(chat, {
+      question = question,
+      index = index,
+      total = #questions,
+      callback = function(answer)
+        answers[question.header] = answer or "No answer provided"
+        next_question()
+      end,
+    })
   end
 
   next_question()
@@ -131,7 +63,7 @@ return {
       end
 
       vim.schedule(function()
-        ask_all(questions, function(answers)
+        ask_all(self.chat, questions, function(answers)
           local response = format_answers(questions, answers)
           if response == "" then
             response = "The user did not provide any answers"
@@ -220,7 +152,8 @@ return {
     success = function(self, stdout, meta)
       local chat = meta.tools.chat
       local llm_output = vim.iter(stdout):flatten():join("\n")
-      chat:add_tool_output(self, llm_output, "User answered questions")
+      -- The question prompt already displays the user's answers in the chat buffer
+      chat:add_tool_output(self, llm_output, "")
     end,
 
     ---@param self CodeCompanion.Tool.AskQuestions

--- a/lua/codecompanion/utils/keymaps.lua
+++ b/lua/codecompanion/utils/keymaps.lua
@@ -1,4 +1,4 @@
--- Taken from:
+-- Part taken from:
 -- https://github.com/stevearc/oil.nvim/blob/master/lua/oil/keymap_util.lua
 
 ---@class CodeCompanion.Keymaps
@@ -6,6 +6,7 @@
 ---@field callbacks table The callbacks to execute for each keymap
 ---@field data table The CodeCompanion class
 ---@field keymaps table The keymaps from the user's config
+---@field Override CodeCompanion.Keymaps.Override
 
 ---Get the current position of the cursor when the keymap was triggered
 ---@return table
@@ -115,5 +116,69 @@ function Keymaps:set(opts)
     ::continue::
   end
 end
+
+--[[
+  Overrides keymaps in a buffer, storing any mappings so they can be restored later
+--]]
+
+---@class CodeCompanion.Keymaps.Override
+---@field bufnr number The buffer the keymaps are applied to
+---@field bound string[] The lhs of each overridden keymap, in the order they were set
+---@field overwritten table<string, table|false> The mappings that were replaced, keyed by lhs
+local Override = {}
+
+---@param bufnr number
+---@return CodeCompanion.Keymaps.Override
+function Override.new(bufnr)
+  return setmetatable({ bufnr = bufnr, bound = {}, overwritten = {} }, { __index = Override }) ---@type CodeCompanion.Keymaps.Override
+end
+
+---Set a normal-mode keymap on the buffer, remembering any mapping it replaces
+---@param lhs string
+---@param rhs string|function
+---@param opts? { desc?: string }
+---@return nil
+function Override:set(lhs, rhs, opts)
+  if self.overwritten[lhs] == nil then
+    self.overwritten[lhs] = false
+    for _, map in ipairs(vim.api.nvim_buf_get_keymap(self.bufnr, "n")) do
+      if map.lhs == lhs then
+        self.overwritten[lhs] = map
+        break
+      end
+    end
+  end
+
+  opts = vim.tbl_extend("force", { buffer = self.bufnr, nowait = true, silent = true }, opts or {})
+  vim.keymap.set("n", lhs, rhs, opts)
+  table.insert(self.bound, lhs)
+end
+
+---Remove the overridden keymaps and restore any mappings they replaced
+---@return nil
+function Override:restore()
+  for _, lhs in ipairs(self.bound) do
+    pcall(vim.keymap.del, "n", lhs, { buffer = self.bufnr })
+
+    local saved = self.overwritten[lhs]
+    if saved then
+      local rhs = saved.callback
+      if not rhs and saved.rhs and saved.rhs ~= "" then
+        rhs = saved.rhs
+      end
+      if rhs then
+        pcall(vim.keymap.set, "n", lhs, rhs, {
+          buffer = self.bufnr,
+          desc = saved.desc,
+          expr = saved.expr == 1,
+          nowait = saved.nowait == 1,
+          silent = saved.silent == 1,
+        })
+      end
+    end
+  end
+end
+
+Keymaps.Override = Override
 
 return Keymaps

--- a/tests/interactions/chat/tools/builtin/test_ask_questions.lua
+++ b/tests/interactions/chat/tools/builtin/test_ask_questions.lua
@@ -10,6 +10,44 @@ local T = new_set({
       child.lua([[
         h = require('tests.helpers')
         chat, tools = h.setup_chat_buffer()
+
+        -- The chat buffer binds its own keys (e.g. gc, gs), so only match the
+        -- question prompt's mappings via their desc prefix
+        function _G.wait_for_keymap(lhs, previous)
+          local found
+          vim.wait(2000, function()
+            for _, map in ipairs(vim.api.nvim_buf_get_keymap(chat.bufnr, 'n')) do
+              if map.lhs == lhs
+                and map.callback
+                and map.callback ~= previous
+                and map.desc
+                and map.desc:find('CodeCompanion question', 1, true) == 1
+              then
+                found = map.callback
+                return true
+              end
+            end
+            return false
+          end, 20)
+          assert(found, 'Expected question keymap `' .. lhs .. '` to be set on the chat buffer')
+          return found
+        end
+
+        function _G.press(lhs, previous)
+          local callback = _G.wait_for_keymap(lhs, previous)
+          callback()
+          return callback
+        end
+
+        function _G.wait_for_tool_output()
+          vim.wait(2000, function()
+            return #chat.messages > 1
+          end, 20)
+        end
+
+        function _G.buffer_text()
+          return table.concat(vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false), '\n')
+        end
       ]])
     end,
     post_case = function()
@@ -23,11 +61,10 @@ local T = new_set({
 
 T["ask_questions"] = new_set()
 
-T["ask_questions"]["asks a free text question via vim.ui.input"] = function()
+T["ask_questions"]["answers a free text question"] = function()
   child.lua([[
-    -- Mock vim.ui.input to auto-respond
     vim.ui.input = function(opts, callback)
-      callback("Use TypeScript")
+      callback('Use TypeScript')
     end
 
     local tool = {
@@ -46,22 +83,21 @@ T["ask_questions"]["asks a free text question via vim.ui.input"] = function()
       },
     }
     tools:execute(chat, tool)
-    vim.wait(1000, function()
-      return #chat.messages > 1
-    end, 50)
+
+    _G.press('gc')
+    _G.wait_for_tool_output()
   ]])
 
-  local last_msg = child.lua_get([[chat.messages[#chat.messages].content]])
-  h.expect_contains("TypeScript", last_msg)
+  local output = child.lua_get([[chat.messages[#chat.messages].content]])
+  h.expect_contains("TypeScript", output)
+
+  local buffer = child.lua_get([[_G.buffer_text()]])
+  h.expect_contains("Which language should I use?", buffer)
+  h.expect_contains("You answered: Use TypeScript", buffer)
 end
 
-T["ask_questions"]["asks a question with options via vim.ui.select"] = function()
+T["ask_questions"]["answers a single select question with a keymap"] = function()
   child.lua([[
-    -- Mock vim.ui.select to pick the first option
-    vim.ui.select = function(items, opts, callback)
-      callback(items[1])
-    end
-
     local tool = {
       {
         ["function"] = {
@@ -72,7 +108,7 @@ T["ask_questions"]["asks a question with options via vim.ui.select"] = function(
                 header = "Framework",
                 question = "Which framework?",
                 options = {
-                  { label = "React" },
+                  { label = "React", description = "Most popular" },
                   { label = "Vue" },
                   { label = "Svelte" },
                 },
@@ -83,27 +119,33 @@ T["ask_questions"]["asks a question with options via vim.ui.select"] = function(
       },
     }
     tools:execute(chat, tool)
-    vim.wait(1000, function()
-      return #chat.messages > 1
-    end, 50)
+
+    _G.press('g1')
+    _G.wait_for_tool_output()
   ]])
 
-  local last_msg = child.lua_get([[chat.messages[#chat.messages].content]])
-  h.expect_contains("React", last_msg)
+  local output = child.lua_get([[chat.messages[#chat.messages].content]])
+  h.expect_contains("React", output)
+
+  local buffer = child.lua_get([[_G.buffer_text()]])
+  h.expect_contains("`g1` - React - Most popular", buffer)
+  h.expect_contains("`g2` - Vue", buffer)
+
+  -- The chat's own gc and gs keymaps are restored after the question is answered
+  local gc_desc = child.lua_get([[
+    (function()
+      for _, map in ipairs(vim.api.nvim_buf_get_keymap(chat.bufnr, 'n')) do
+        if map.lhs == 'gc' then
+          return map.desc
+        end
+      end
+    end)()
+  ]])
+  h.eq("Insert an empty codeblock", gc_desc)
 end
 
-T["ask_questions"]["handles multiple questions"] = function()
+T["ask_questions"]["asks multiple questions in sequence"] = function()
   child.lua([[
-    local question_count = 0
-    vim.ui.input = function(opts, callback)
-      question_count = question_count + 1
-      if question_count == 1 then
-        callback("src/")
-      else
-        callback("MIT")
-      end
-    end
-
     local tool = {
       {
         ["function"] = {
@@ -113,10 +155,18 @@ T["ask_questions"]["handles multiple questions"] = function()
               {
                 header = "Directory",
                 question = "Where should I create the files?",
+                options = {
+                  { label = "src/" },
+                  { label = "lua/" },
+                },
               },
               {
                 header = "License",
                 question = "Which license?",
+                options = {
+                  { label = "MIT" },
+                  { label = "Apache" },
+                },
               },
             },
           }),
@@ -124,14 +174,88 @@ T["ask_questions"]["handles multiple questions"] = function()
       },
     }
     tools:execute(chat, tool)
-    vim.wait(1000, function()
-      return #chat.messages > 1
-    end, 50)
+
+    local first_question = _G.press('g1')
+    _G.press('g1', first_question)
+    _G.wait_for_tool_output()
   ]])
 
-  local last_msg = child.lua_get([[chat.messages[#chat.messages].content]])
-  h.expect_contains("src/", last_msg)
-  h.expect_contains("MIT", last_msg)
+  local output = child.lua_get([[chat.messages[#chat.messages].content]])
+  h.expect_contains("src/", output)
+  h.expect_contains("MIT", output)
+end
+
+T["ask_questions"]["answers a multi select question"] = function()
+  child.lua([[
+    local tool = {
+      {
+        ["function"] = {
+          name = "ask_questions",
+          arguments = vim.json.encode({
+            questions = {
+              {
+                header = "Modules",
+                question = "Which modules should own this logic?",
+                multiSelect = true,
+                options = {
+                  { label = "queue" },
+                  { label = "orchestrator" },
+                  { label = "runner" },
+                },
+              },
+            },
+          }),
+        },
+      },
+    }
+    tools:execute(chat, tool)
+
+    _G.press('g1') -- include queue
+    _G.press('g2') -- exclude orchestrator
+    _G.press('g1') -- include runner
+    _G.wait_for_tool_output()
+  ]])
+
+  local output = child.lua_get([[chat.messages[#chat.messages].content]])
+  h.expect_contains("queue", output)
+  h.expect_contains("runner", output)
+  h.eq(nil, string.match(output, "orchestrator"))
+
+  local buffer = child.lua_get([[_G.buffer_text()]])
+  h.eq(nil, string.match(buffer, "Include '"))
+end
+
+T["ask_questions"]["records a skipped question as no answer"] = function()
+  child.lua([[
+    local tool = {
+      {
+        ["function"] = {
+          name = "ask_questions",
+          arguments = vim.json.encode({
+            questions = {
+              {
+                header = "Directory",
+                question = "Where should I create the files?",
+                options = {
+                  { label = "src/" },
+                },
+              },
+            },
+          }),
+        },
+      },
+    }
+    tools:execute(chat, tool)
+
+    _G.press('gs')
+    _G.wait_for_tool_output()
+  ]])
+
+  local output = child.lua_get([[chat.messages[#chat.messages].content]])
+  h.expect_contains("No answer provided", output)
+
+  local buffer = child.lua_get([[_G.buffer_text()]])
+  h.expect_contains("You skipped this question", buffer)
 end
 
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Previously, the `ask_questions` tool used `vim.ui.select` to present options to a user. This was bad from a readability and usability perspective. This PR builds on this by putting questions inline in the chat buffer and binding key maps to specific responses, as can be seen in the image below. 

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Kimi K3

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="2106" height="1266" alt="2026-07-20 15_11_23 - Ghostty" src="https://github.com/user-attachments/assets/7ce26b7f-decb-4431-9c0a-8f4843a07c2b" />

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
