### PR TITLE
fix(interactions): starting a chat from a focused chat window crashes with an empty message role

### DIFF
--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -133,7 +133,9 @@ function Interactions:chat()
     return self:workflow()
   end
 
-  local mode = self.buffer_context.mode:lower()
+  -- Prompts are only keyed by "n" and "v"; collapse any other captured mode
+  -- (e.g. picker insert mode leaking through) to normal so the correct branch runs
+  local mode = self.buffer_context.is_visual and "v" or "n"
   local prompts = self.selected.prompts
 
   if type(prompts[mode]) == "function" then

--- a/tests/prompt_library/test_prompt_library.lua
+++ b/tests/prompt_library/test_prompt_library.lua
@@ -270,4 +270,46 @@ T["Prompt Library"]["can ignore system prompt"] = function()
   h.eq(false, has_system_tag)
 end
 
+-- Regression: launching the action palette from a focused chat window captures
+-- the picker's insert mode. The "Chat" prompt table is keyed only by "n" and "v",
+-- so a leaked "i" mode must still resolve to the normal-mode branch rather than
+-- flattening the prompt table into messages with empty roles (which the API rejects).
+T["Prompt Library"]["collapses a leaked mode to normal for n/v keyed prompts"] = function()
+  local has_empty_role = child.lua([[
+    local Interactions = require("codecompanion.interactions")
+    local config = require("codecompanion.config")
+    local selected = {
+      name = "Chat",
+      interaction = "chat",
+      opts = { stop_context_insertion = true },
+      prompts = {
+        n = function()
+          return require("codecompanion").chat()
+        end,
+        v = {
+          {
+            role = config.constants.USER_ROLE,
+            content = "visual prompt",
+          },
+        },
+      },
+    }
+    Interactions.new({
+      buffer_context = { mode = "i", is_visual = false, is_normal = true, filetype = "lua" },
+      selected = selected,
+    }):start("chat")
+
+    local chat = require("codecompanion").last_chat()
+    local has_empty_role = false
+    for _, msg in ipairs(chat.messages) do
+      if msg.role == "" then
+        has_empty_role = true
+      end
+    end
+    return has_empty_role
+  ]])
+
+  h.eq(false, has_empty_role)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Starting a new chat from the action palette **while a chat window is focused** produces a broken chat: the request fails and the new chat is unusable. With the Anthropic adapter the error is:

```
Error 400: messages.0.role: Input should be 'user', 'assistant', 'system'
```

**Reproduction:**
1. Focus an existing chat window.
2. Press your action palette mapping (e.g. `<leader>a`) → this opens the *chat* command palette because the buffer is a `codecompanion` buffer.
3. Select **"CodeCompanion actions"**, then select **"Chat"**.

The resulting chat's message stack contains two messages with `role = ""`, which the API rejects.

**Root cause:**
Selecting "CodeCompanion actions" calls `require("codecompanion").actions()` from *inside* the picker's selection callback. With a picker whose prompt runs in insert mode (e.g. Telescope), the buffer context captured by `codecompanion.utils.context.get` records `mode = "i"`.

In `Interactions:chat()` the prompt key was derived from that raw mode:

```lua
local mode = self.buffer_context.mode:lower()  -- "i"
```

The built-in "Chat" prompt table is keyed only by `n` and `v`:

```lua
prompts = {
  n = function() return codecompanion.chat() end,
  v = { ... },
}
```

So `prompts["i"]` is `nil`, and the code falls through to `evaluate_prompts(prompts, ...)`, which iterates the whole `{ n = <fn>, v = <table> }` table and, for each entry lacking a `role`, emits `role = prompt.role or ""` — producing two empty-role messages.

**Fix:**
The prompt dispatch only distinguishes visual from non-visual, so derive the key from the authoritative `is_visual` flag rather than the raw captured mode. Any non-visual mode (including a leaked `"i"`) now collapses to normal and takes the correct branch:

```lua
local mode = self.buffer_context.is_visual and "v" or "n"
```

This prevents the whole class of "leaked mode" bugs regardless of which picker provider is used.

## Supporting Documentation

N/A — no external protocol/LLM documentation involved.

## AI Usage

I used CodeCompanion (Anthropic `claude-opus` via a Databricks adapter) to help diagnose the root cause and draft the fix, the regression test, and this description. I reviewed the analysis, confirmed the reproduction, and verified the fix and test myself.

## Related Issue(s)

<!-- Add if an issue exists, e.g. Fixes #1234 -->

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
