### PR TITLE
fix(adapters): exclude deprecated temperature from opus 5 + sonnet 5

### DIFF
--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -801,7 +801,8 @@ return {
       enabled = function(self)
         local model = adapter_utils.model(self)
         if
-          vim.tbl_contains({ "claude-opus-4-7", "claude-opus-4-8" }, model) or vim.startswith(model, "claude-fable")
+          vim.tbl_contains({ "claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5" }, model)
+          or vim.startswith(model, "claude-fable")
         then
           return false
         end

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -156,9 +156,8 @@ return {
             type = "adaptive",
           }
         end
-        -- Thinking isn't compatible with temperature or top_k
+        -- Thinking isn't compatible with top_k
         -- Ref: https://platform.claude.com/docs/en/build-with-claude/extended-thinking#feature-compatibility
-        params.temperature = nil
         params.top_k = nil
 
         -- top_p must be between 1 and 0.95
@@ -788,28 +787,6 @@ return {
       desc = "The maximum number of tokens to generate before stopping. This parameter only specifies the absolute maximum number of tokens to generate. Different models have different maximum values for this parameter.",
       validate = function(n)
         return n > 0 and n <= 128000, "Must be between 0 and 128000"
-      end,
-    },
-    ---@type CodeCompanion.Schema
-    temperature = {
-      order = 6,
-      mapping = "parameters",
-      type = "number",
-      optional = true,
-      default = 0,
-      desc = "Amount of randomness injected into the response. Ranges from 0.0 to 1.0. Use temperature closer to 0.0 for analytical / multiple choice, and closer to 1.0 for creative and generative tasks. Note that even with temperature of 0.0, the results will not be fully deterministic.",
-      enabled = function(self)
-        local model = adapter_utils.model(self)
-        if
-          vim.tbl_contains({ "claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5" }, model)
-          or vim.startswith(model, "claude-fable")
-        then
-          return false
-        end
-        return true
-      end,
-      validate = function(n)
-        return n >= 0 and n <= 1, "Must be between 0 and 1.0"
       end,
     },
     ---@type CodeCompanion.Schema


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

This PR updates the exclusion list for the latest claude models (opus 5, sonnet 5). I was also experiencing the behavior found in https://github.com/olimorris/codecompanion.nvim/issues/3229

To my understanding, the underlying cause is a race condition where it includes temperature because it hasn't fully retrieved the model's metadata saying temperature is deprecated. Only users with slower network speeds are affected, hence the reproducability issue.

I wonder if making the call synchronous instead and cached would be better? Unsure how invalidation would work if some LLM providers have breaking changes per model snapshot. I saw these per-model exclusions present already though so I figured I should simply follow suit instead of doing any major changes like that.

### Note

I attempted to run the test suite and got fairly far, however I did have one error about the UTC conversion test failing after running `make all`:

<details>
<summary>Test Output</summary>

```txt
Fails (1) and Notes (41)

FAIL in tests/utils/test_utils.lua | Utils | timestamp_from_iso() | parses a UTC timestamp back to the same UTC fields:
  Failed expectation for equality
  Cause: different character at position 13, left = "1", right = "2"
  Left:  "2026-03-18T21:29:29"
  Right: "2026-03-18T22:29:29"
  Traceback:
    tests/utils/test_utils.lua:316
 ```
 </details>
 
 Not sure how my change could have affected that. It could be that I misconfigured my timezone on my system. The 41 notes were about my not having NeoVim 13.x on my system.
 
 Edit: Ran `make all` against `main` as well and achieved the same output, so it's on my end.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

N/A

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

Cloned the repo and asked sonnet 5 (using the `ga` trick to re-select the model first) to point me to where temperature would be set, then it was a simple matter of adding these 2 new exclusions.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

Fixes #3229

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

N/A

## Checklist


- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
