### PR TITLE
feat(chat): add LLM judge for approving tool calls

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -2295,66 +2295,6 @@ The `info` table passed to `on_before_submit` contains:
 - `adapter` - A safe copy of the current adapter (with name, model, features, schema, etc.)
 
 
-TOOL SAFETY CHECK
-
-When |codecompanion-usage-chat-buffer-agents-tools-yolo-mode| is on, tools are
-auto-approved. Some tools (such as `run_command` and `delete_file`), by
-default, will always ask you first, owing to their destructive nature. The
-judge offers a middle ground: a background LLM judges the specific action and
-only interrupts you when it is judged to be unsafe.
-
->lua
-    require("codecompanion").setup({
-      interactions = {
-        background = {
-          gates = {
-            judge = {
-              enabled = true,
-              action = "interactions.background.builtin.tools_judge",
-            },
-          },
-        },
-      },
-    })
-<
-
-The judge runs for a tool only when:
-
-- You set `opts.judge_in_yolo_mode = true` on the tool's config; `and`
-- The tool defines a `gates.judge_context` handler
-
-Regarding for former, this can be accomplished with:
-
->lua
-    require("codecompanion").setup({
-      interactions = {
-        chat = {
-          tools = {
-            ["run_command"] = {
-              opts = {
-                judge_in_yolo_mode = true,
-              },
-            },
-          },
-        },
-      },
-    })
-<
-
-If the judge decides the action is safe, it executes immediately. The verdict
-is cached so re-running the exact same command won't be re-judged that session.
-A different command is judged on its own - approving `make test` does not
-approve `make test && rm -rf foo`. If the request to check the command fails,
-or the adapter can't produce structured output, you'll be automatically asked
-to approve manually.
-
-For this per-command caching, the tool must also set `opts.require_cmd_approval
-= true`. Without it, a single safe verdict is cached against the whole tool and
-every later action of that tool runs unjudged for the rest of the session. This
-is automatically set for `run_command` and `delete_file` but can be applied to
-any tool.
-
-
 TRUNCATING TOOL OUTPUT
 
 The `on_tool_output` callback fires before a tool's output is added to the
@@ -2706,6 +2646,72 @@ chat buffers:
 opts = { default_tools = { "my_tool", "my_tool_group" } }, } } } })`
 
 This also works for |codecompanion-configuration-extensions|.
+
+
+LLM JUDGE
+
+When |codecompanion-usage-chat-buffer-agents-tools-yolo-mode| is on, tools are
+auto-approved. Some tools (such as `run_command` and `delete_file`), by
+default, will always ask you first, owing to their destructive nature. The
+judge offers a middle ground: a background LLM judges the specific action and
+only interrupts you when it is judged to be unsafe.
+
+To fully enable the LLM judge:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        background = {
+          gates = {
+            judge = {
+              enabled = true,
+            },
+          },
+        },
+        chat = {
+          tools = {
+            ["delete_file"] = {
+              opts = {
+                judge_in_yolo_mode = true,
+              },
+            },
+            ["run_command"] = {
+              opts = {
+                judge_in_yolo_mode = true,
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
+The judge runs for a tool only when:
+
+- You set `background.gates.judge.enabled = true`
+- You set `opts.judge_in_yolo_mode = true` on the tool's config; `and`
+- The tool defines a `gates.judge_context` handler (already the case for the built-in `run_command` and `delete_file` tools)
+
+You can also point the judge at a different adapter to the one used in the chat
+buffer, for example, if you want a cheaper or faster model handling the check:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        background = {
+          gates = {
+            judge = {
+              enabled = true,
+              adapter = { name = "openrouter", model = "openai/gpt-oss-120b" },
+            },
+          },
+        },
+      },
+    })
+<
+
+See the |codecompanion-usage-chat-buffer-agents-tools-yolo-mode| usage section
+for how the judge behaves once enabled.
 
 
 USER INTERFACE (UI) ~
@@ -5100,12 +5106,17 @@ prompting the user. However, some tools such as `run_command` and `delete_file`
 are excluded from this as they have `allowed_in_yolo_mode = false` set by
 default.
 
-If you've configured
-|codecompanion-configuration-chat-buffer-tool-safety-check| then their commands
-will be sent to an LLM judge to verify that they're safe. This assumes that
-your chosen adapter supports structured outputs and the tool itself supports
-safety checks. The |codecompanion--delete_file| and
-|codecompanion--run_command| tools both support safety checks.
+If you've configured the |codecompanion-configuration-chat-buffer-llm-judge|
+then a tool's commands will be sent to an LLM to verify that they're safe. This
+assumes that your chosen adapter supports structured outputs and the tool
+itself supports the judge. The |codecompanion--delete_file| and
+|codecompanion--run_command| tools support this out of the box.
+
+If the judge decides the action is safe, it executes immediately and the
+verdict is cached so re-running the exact same command won't be re-judged that
+session. For example, approving `make test` does not result in `make test && rm
+-rf foo` being auto-approved. If the request to the judge fails, or the adapter
+can't produce structured output, the tool will require manual approval.
 
 
   [!WARNING] Running tools in YOLO mode is dangerous and it is recommend that you

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1714,6 +1714,37 @@ Custom adapters can be added to the plugin as follows:
 <
 
 
+BACKGROUND INTERACTION ADAPTERS ~
+
+Background interactions are calls that CodeCompanion can make…in the
+background! That is, no user input is made and a request is sent to an LLM.
+
+By default every background action uses the shared
+`interactions.background.adapter`. However, you can override this at an action
+level:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        background = {
+          chat = {
+            callbacks = {
+              ["on_ready"] = {
+                actions = {
+                  {
+                    path = "interactions.background.builtin.chat_make_title",
+                    adapter = { name = "copilot", model = "claude-haiku-4.5" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
+
 CONTROLLING MODEL CHOICES ~
 
 When switching between adapters, the plugin typically displays all available
@@ -2223,20 +2254,10 @@ The `actions` table contains module paths that are resolved and executed
 asynchronously. See the |codecompanion-usage-chat-buffer--generating-titles|
 section for a working example.
 
-By default every background action uses the shared
-`interactions.background.adapter`. An action can override this - for instance
-to judge with a cheaper, faster model - by declaring it as a table with its own
-`adapter`:
 
->lua
-    actions = {
-      {
-        path = "interactions.background.builtin.chat_make_title",
-        adapter = { name = "copilot", model = "claude-haiku-4.5" },
-      },
-    },
-<
-
+  [!TIP] You can change the adapters used for background callbacks, see the
+  |codecompanion-configuration-adapters-http-background-interaction-adapters|
+  section
 
 PREVENTING SUBMISSION
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -86,7 +86,7 @@ FEATURES                                      *codecompanion-welcome-features*
 -  Support for LLMs from Anthropic <https://platform.claude.com/docs/en/about-claude/models/overview>, DeepSeek <https://www.deepseek.com>, Google Gemini <https://ai.google.dev/gemini-api/docs/models>, GitHub Copilot <https://github.com/features/copilot>, GitHub Models <https://docs.github.com/en/github-models>, Kimi <https://platform.kimi.ai>, Mistral <https://mistral.ai/>, Novita <https://novita.ai/>, Ollama <https://ollama.com/>, OpenAI <https://developers.openai.com/api/docs/models>, Azure OpenAI, OpenRouter <https://openrouter.ai/>, HuggingFace <https://huggingface.co/> and xAI <https://docs.x.ai/developers/models> out of the box (or |codecompanion-extending-adapters|)
 -  Support for Agent Client Protocol <https://agentclientprotocol.com/overview/introduction>, enabling coding with agents like Augment Code <https://docs.augmentcode.com/cli/overview>, Cagent <https://github.com/docker/cagent> from Docker, Claude Code <https://docs.anthropic.com/en/docs/claude-code/overview>, Cline CLI <https://docs.cline.bot/home>, Codex <https://openai.com/codex>, Copilot CLI <https://github.com/features/copilot/cli>, Gemini CLI <https://github.com/google-gemini/gemini-cli>, Goose <https://block.github.io/goose/>, Cursor CLI <https://cursor.com/docs/cli/overview>, Kilo Code <https://kilo.ai>, Kimi CLI <https://github.com/MoonshotAI/kimi-cli>, Kiro <https://kiro.dev/cli/>, Mistral Vibe <https://github.com/mistralai/mistral-vibe> and OpenCode <https://opencode.ai>
 -  User contributed and supported |codecompanion-configuration-adapters-http-community-adapters|
--  |codecompanion-usage-code-reviews| enabling you to comment on and approve/reject agent code
+-  |codecompanion-usage-code-review| enabling you to comment on and approve/reject agent code
 -  Support for |codecompanion-model-context-protocol|
 -  |codecompanion-usage-inline|, code creation and refactoring
 -  |codecompanion-usage-chat-buffer-editor-context|, |codecompanion-usage-chat-buffer-slash-commands|, |codecompanion-usage-chat-buffer-agents-tools| and |codecompanion-usage-workflows| to improve LLM output
@@ -572,7 +572,7 @@ However, there are multiple options available:
 - `CodeCompanionCLI! <prompt>` - Send and auto-submit a prompt, keeping focus in the current buffer
 - `CodeCompanionCLI agent=<agent> <prompt>` - Start a new CLI interaction with a specific agent
 - `CodeCompanionCLI Ask` - Open the rich input buffer for CLI prompts
-- `CodeCompanionCodeReview` - Open an agent's changes in the quickfix list for |codecompanion-usage-code-reviews|
+- `CodeCompanionCodeReview` - Open an agent's changes in the quickfix list for |codecompanion-usage-code-review|
 - `CodeCompanionCodeReview Comment` - Leave a review comment on the current line or visual selection
 
 
@@ -2223,6 +2223,20 @@ The `actions` table contains module paths that are resolved and executed
 asynchronously. See the |codecompanion-usage-chat-buffer--generating-titles|
 section for a working example.
 
+By default every background action uses the shared
+`interactions.background.adapter`. An action can override this - for instance
+to judge with a cheaper, faster model - by declaring it as a table with its own
+`adapter`:
+
+>lua
+    actions = {
+      {
+        path = "interactions.background.builtin.chat_make_title",
+        adapter = { name = "copilot", model = "claude-haiku-4.5" },
+      },
+    },
+<
+
 
 PREVENTING SUBMISSION
 
@@ -2258,6 +2272,66 @@ This is useful for implementing safeguards such as token/context limit checks:
 The `info` table passed to `on_before_submit` contains:
 
 - `adapter` - A safe copy of the current adapter (with name, model, features, schema, etc.)
+
+
+TOOL SAFETY CHECK
+
+When |codecompanion-usage-chat-buffer-agents-tools-yolo-mode| is on, tools are
+auto-approved. Some tools (such as `run_command` and `delete_file`), by
+default, will always ask you first, owing to their destructive nature. The tool
+safety check offers a middle ground: a background LLM judges the specific
+action and only interrupts you when it is judged to be unsafe.
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        background = {
+          gates = {
+            safety_check = {
+              enabled = true,
+              action = "interactions.background.builtin.tool_safety_check",
+            },
+          },
+        },
+      },
+    })
+<
+
+The check runs for a tool only when:
+
+- You set `opts.safety_check = true` on the tool's config; `and`
+- The tool defines a `gates.safety_context` handler
+
+Regarding for former, this can be accomplished with:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        chat = {
+          tools = {
+            ["run_command"] = {
+              opts = {
+                safety_check = true,
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
+If the judge decides the action is safe, it executes immediately. The verdict
+is cached so re-running the exact same command won't be re-judged that session.
+A different command is judged on its own - approving `make test` does not
+approve `make test && rm -rf foo`. If the request to check the command fails,
+or the adapter can't produce structured output, you'll be automatically asked
+to approve manually.
+
+For this per-command caching, the tool must also set `opts.require_cmd_approval
+= true`. Without it, a single safe verdict is cached against the whole tool and
+every later action of that tool runs unjudged for the rest of the session. This
+is automatically set for `run_command` and `delete_file` but can be applied to
+any tool.
 
 
 TRUNCATING TOOL OUTPUT
@@ -3056,8 +3130,7 @@ You can also pass `width` and `height` overrides via the Lua API:
 CODE REVIEWS                        *codecompanion-configuration-code-reviews*
 
 CodeCompanion enables users to undertake code reviews and easily share feedback
-with an agent. Find out how they work in the
-|codecompanion-usage-code-reviews|.
+with an agent. Find out how they work in the |codecompanion-usage-code-review|.
 
 
 DISABLING ~
@@ -4167,7 +4240,7 @@ chat buffer with `@files` or `@insert_edit_into_file`.
 
 CODE REVIEW AN LLM/AGENT'S CHANGES ~
 
-You can |codecompanion-usage-code-reviews| like a pull request.
+You can |codecompanion-usage-code-review| like a pull request.
 `:CodeCompanionCodeReview` opens every change in the quickfix list, one entry
 per hunk. You can step through them, leave in place comments with
 `:CodeCompanionCodeReview Comment` and then share the review in a chat buffer
@@ -5006,6 +5079,15 @@ prompting the user. However, note that some tools such as `run_command` and
 `delete_file` are excluded from this as they have `allowed_in_yolo_mode =
 false` set.
 
+If you've configured
+|codecompanion-configuration-chat-buffer-tool-safety-check| then any commands
+from those tools will be sent to an LLM judge to verify if they're safe. This
+assumes that your chosen adapter supports structured outputs and the tool
+itself supports safety checks.
+
+
+  [!TIP] The |codecompanion--delete_file| and |codecompanion--run_command| tools
+  both support safety checks
 
 COMPATIBILITY ~
 
@@ -5024,9 +5106,11 @@ Below is the tool use status of various adapters and models in CodeCompanion:
 
   Gemini                                      Dependent on the model
 
-  GitHub Models  All                          Not supported yet
+  GitHub Models                               Not supported yet
 
-  Huggingface    All                          Not supported yet
+  Huggingface                                 Not supported yet
+
+  Kimi                                        Dependent on the model
 
   Mistral                                     Dependent on the model
 
@@ -5037,7 +5121,12 @@ Below is the tool use status of various adapters and models in CodeCompanion:
 
   OpenAI                                      Dependent on the model
 
-  xAI            All                          Not supported yet
+  OpenAI                                      Dependent on the model
+  Responses                                   
+
+  OpenRouter                                  Dependent on the model
+
+  xAI                                         Not supported yet
   ------------------------------------------------------------------------
 
   [!IMPORTANT] When using Mistral, you will need to set
@@ -5132,10 +5221,10 @@ filtered out.
 
 #CODE_REVIEW ~
 
-The `code_review` context shares your |codecompanion-usage-code-reviews| with
-an LLM. Every pending comment you've left with `:CodeCompanionCodeReview
-Comment` is sent when you submit the chat buffer and the review baseline
-advances so the next review only shows what changes in the next iteration.
+The `code_review` context shares your |codecompanion-usage-code-review| with an
+LLM. Every pending comment you've left with `:CodeCompanionCodeReview Comment`
+is sent when you submit the chat buffer and the review baseline advances so the
+next review only shows what changes in the next iteration.
 
 >md
     Please action #{code_review}
@@ -6237,13 +6326,6 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
-- `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
-- `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
-- `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
-- `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
-- `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request
-- `CodeCompanionToolStarted` - Fired when a tool has started executing
-- `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction
 - `CodeCompanionInlineFinished` - Fired at the end of the Inline interaction
 - `CodeCompanionMCPServerStart` - Fired when an MCP server is started
@@ -6253,6 +6335,15 @@ The events that are fired from within the plugin are:
 - `CodeCompanionRequestStarted` - Fired at the start of any API request
 - `CodeCompanionRequestStreaming` - Fired at the start of a streaming API request
 - `CodeCompanionRequestFinished` - Fired at the end of any API request
+- `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
+- `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
+- `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request
+- `CodeCompanionToolStarted` - Fired when a tool has started executing
+- `CodeCompanionToolFinished` - Fired when a tool has finished executing
+- `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
+- `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
+- `CodeCompanionToolSafetyCheckStarted` - Fired when a background safety check begins judging a tool call
+- `CodeCompanionToolSafetyCheckFinished` - Fired when a background safety check returns its verdict
 
 In addition to these events, the chat buffer has its own **callback system**
 for hooking into lifecycle events like `on_before_submit`, `on_checkpoint` and

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                   For NVIM v0.11    Last change: 2026 July 26
+                                   For NVIM v0.11    Last change: 2026 July 27
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -2299,18 +2299,18 @@ TOOL SAFETY CHECK
 
 When |codecompanion-usage-chat-buffer-agents-tools-yolo-mode| is on, tools are
 auto-approved. Some tools (such as `run_command` and `delete_file`), by
-default, will always ask you first, owing to their destructive nature. The tool
-safety check offers a middle ground: a background LLM judges the specific
-action and only interrupts you when it is judged to be unsafe.
+default, will always ask you first, owing to their destructive nature. The
+judge offers a middle ground: a background LLM judges the specific action and
+only interrupts you when it is judged to be unsafe.
 
 >lua
     require("codecompanion").setup({
       interactions = {
         background = {
           gates = {
-            safety_check = {
+            judge = {
               enabled = true,
-              action = "interactions.background.builtin.tool_safety_check",
+              action = "interactions.background.builtin.tools_judge",
             },
           },
         },
@@ -2318,10 +2318,10 @@ action and only interrupts you when it is judged to be unsafe.
     })
 <
 
-The check runs for a tool only when:
+The judge runs for a tool only when:
 
-- You set `opts.safety_check = true` on the tool's config; `and`
-- The tool defines a `gates.safety_context` handler
+- You set `opts.judge_in_yolo_mode = true` on the tool's config; `and`
+- The tool defines a `gates.judge_context` handler
 
 Regarding for former, this can be accomplished with:
 
@@ -2332,7 +2332,7 @@ Regarding for former, this can be accomplished with:
           tools = {
             ["run_command"] = {
               opts = {
-                safety_check = true,
+                judge_in_yolo_mode = true,
               },
             },
           },
@@ -5096,19 +5096,21 @@ YOLO MODE
 
 To bypass the approval system, you can use `gty` in the chat buffer to enable
 YOLO mode. This will automatically approve all tool executions without
-prompting the user. However, note that some tools such as `run_command` and
-`delete_file` are excluded from this as they have `allowed_in_yolo_mode =
-false` set.
+prompting the user. However, some tools such as `run_command` and `delete_file`
+are excluded from this as they have `allowed_in_yolo_mode = false` set by
+default.
 
 If you've configured
-|codecompanion-configuration-chat-buffer-tool-safety-check| then any commands
-from those tools will be sent to an LLM judge to verify if they're safe. This
-assumes that your chosen adapter supports structured outputs and the tool
-itself supports safety checks.
+|codecompanion-configuration-chat-buffer-tool-safety-check| then their commands
+will be sent to an LLM judge to verify that they're safe. This assumes that
+your chosen adapter supports structured outputs and the tool itself supports
+safety checks. The |codecompanion--delete_file| and
+|codecompanion--run_command| tools both support safety checks.
 
 
-  [!TIP] The |codecompanion--delete_file| and |codecompanion--run_command| tools
-  both support safety checks
+  [!WARNING] Running tools in YOLO mode is dangerous and it is recommend that you
+  only use it in a safe environment where potential data loss can be recovered.
+  You are responsible for any damage that may occur when using YOLO mode.
 
 COMPATIBILITY ~
 
@@ -6363,8 +6365,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
-- `CodeCompanionToolSafetyCheckStarted` - Fired when a background safety check begins judging a tool call
-- `CodeCompanionToolSafetyCheckFinished` - Fired when a background safety check returns its verdict
+- `CodeCompanionToolsJudgeStarted` - Fired when the background judge begins vetting a tool call
+- `CodeCompanionToolsJudgeFinished` - Fired when the background judge returns its verdict
 
 In addition to these events, the chat buffer has its own **callback system**
 for hooking into lifecycle events like `on_before_submit`, `on_checkpoint` and

--- a/doc/configuration/adapters-http.md
+++ b/doc/configuration/adapters-http.md
@@ -213,7 +213,6 @@ require("codecompanion").setup({
 })
 ```
 
-
 ## Controlling Model Choices
 
 When switching between adapters, the plugin typically displays all available model choices for the selected adapter. If you want to simplify the interface and have the default model automatically chosen (without showing any model selection UI), you can set the `show_model_choices` option to `false`:

--- a/doc/configuration/adapters-http.md
+++ b/doc/configuration/adapters-http.md
@@ -186,6 +186,34 @@ require("codecompanion").setup({
 })
 ```
 
+## Background Interaction Adapters
+
+Background interactions are calls that CodeCompanion can make...in the background! That is, no user input is made and a request is sent to an LLM.
+
+By default every background action uses the shared `interactions.background.adapter`. However, you can override this at an action level:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    background = {
+      chat = {
+        callbacks = {
+          ["on_ready"] = {
+            actions = {
+              {
+                path = "interactions.background.builtin.chat_make_title",
+                adapter = { name = "copilot", model = "claude-haiku-4.5" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+
 ## Controlling Model Choices
 
 When switching between adapters, the plugin typically displays all available model choices for the selected adapter. If you want to simplify the interface and have the default model automatically chosen (without showing any model selection UI), you can set the `show_model_choices` option to `false`:

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -179,54 +179,6 @@ The `info` table passed to `on_before_submit` contains:
 
 - `adapter` - A safe copy of the current adapter (with name, model, features, schema, etc.)
 
-### Tool Safety Check
-
-When [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) is on, tools are auto-approved. Some tools (such as `run_command` and `delete_file`), by default, will always ask you first, owing to their destructive nature. The judge offers a middle ground: a background LLM judges the specific action and only interrupts you when it is judged to be unsafe.
-
-```lua
-require("codecompanion").setup({
-  interactions = {
-    background = {
-      gates = {
-        judge = {
-          enabled = true,
-          action = "interactions.background.builtin.tools_judge",
-        },
-      },
-    },
-  },
-})
-```
-
-The judge runs for a tool only when:
-
-- You set `opts.judge_in_yolo_mode = true` on the tool's config; _and_
-- The tool defines a `gates.judge_context` handler
-
-Regarding for former, this can be accomplished with:
-
-```lua
-require("codecompanion").setup({
-  interactions = {
-    chat = {
-      tools = {
-        ["run_command"] = {
-          opts = {
-            judge_in_yolo_mode = true,
-          },
-        },
-      },
-    },
-  },
-})
-```
-
-If the judge decides the action is safe, it executes immediately. The verdict is cached so re-running the exact same command won't be re-judged that session. A different command is judged on its own - approving `make test` does not approve `make test && rm -rf foo`. If the request to check the command fails, or the adapter can't produce structured output, you'll be automatically asked to approve manually.
-
-For this per-command caching, the tool must also set `opts.require_cmd_approval = true`. Without it, a single safe verdict is cached against the whole tool and every later action of that tool runs unjudged for the rest of the session. This is automatically set for `run_command` and `delete_file` but can be applied to any tool.
-
-
-
 ### Truncating Tool Output
 
 The `on_tool_output` callback fires before a tool's output is added to the chat. The `args` table contains `tool` (the tool name), `for_llm` (the content sent to the LLM) and `for_user` (what's shown in the buffer). Mutate `args.for_llm` and/or `args.for_user` to modify the output:
@@ -885,6 +837,65 @@ require("codecompanion").setup({
 ```
 
 This also works for [extensions](/configuration/extensions).
+
+### LLM Judge
+
+When [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) is on, tools are auto-approved. Some tools (such as `run_command` and `delete_file`), by default, will always ask you first, owing to their destructive nature. The judge offers a middle ground: a background LLM judges the specific action and only interrupts you when it is judged to be unsafe.
+
+To fully enable the LLM judge:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    background = {
+      gates = {
+        judge = {
+          enabled = true,
+        },
+      },
+    },
+    chat = {
+      tools = {
+        ["delete_file"] = {
+          opts = {
+            judge_in_yolo_mode = true,
+          },
+        },
+        ["run_command"] = {
+          opts = {
+            judge_in_yolo_mode = true,
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+The judge runs for a tool only when:
+
+- You set `background.gates.judge.enabled = true`
+- You set `opts.judge_in_yolo_mode = true` on the tool's config; _and_
+- The tool defines a `gates.judge_context` handler (already the case for the built-in `run_command` and `delete_file` tools)
+
+You can also point the judge at a different adapter to the one used in the chat buffer, for example, if you want a cheaper or faster model handling the check:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    background = {
+      gates = {
+        judge = {
+          enabled = true,
+          adapter = { name = "openrouter", model = "openai/gpt-oss-120b" },
+        },
+      },
+    },
+  },
+})
+```
+
+See the [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) usage section for how the judge behaves once enabled.
 
 ## User Interface (UI)
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -145,16 +145,8 @@ require("codecompanion").setup({
 
 The `actions` table contains module paths that are resolved and executed asynchronously. See the [generating titles](/usage/chat-buffer/#generating-titles) section for a working example.
 
-By default every background action uses the shared `interactions.background.adapter`. An action can override this - for instance to judge with a cheaper, faster model - by declaring it as a table with its own `adapter`:
-
-```lua
-actions = {
-  {
-    path = "interactions.background.builtin.chat_make_title",
-    adapter = { name = "copilot", model = "claude-haiku-4.5" },
-  },
-},
-```
+> [!TIP]
+> You can change the adapters used for background callbacks, see the [background interaction adapters](/configuration/adapters-http#background-interaction-adapters) section
 
 ### Preventing Submission
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -145,6 +145,17 @@ require("codecompanion").setup({
 
 The `actions` table contains module paths that are resolved and executed asynchronously. See the [generating titles](/usage/chat-buffer/#generating-titles) section for a working example.
 
+By default every background action uses the shared `interactions.background.adapter`. An action can override this - for instance to judge with a cheaper, faster model - by declaring it as a table with its own `adapter`:
+
+```lua
+actions = {
+  {
+    path = "interactions.background.builtin.chat_make_title",
+    adapter = { name = "copilot", model = "claude-haiku-4.5" },
+  },
+},
+```
+
 ### Preventing Submission
 
 The `on_before_submit` callback can return `false` to prevent a message from being sent to the LLM. When cancelled, `chat:restore()` is called automatically, which resets the buffer to an editable state and fires a `CodeCompanionChatRestored` event. The user's message remains in the buffer so it can be edited and resubmitted.
@@ -175,6 +186,54 @@ vim.api.nvim_create_autocmd("User", {
 The `info` table passed to `on_before_submit` contains:
 
 - `adapter` - A safe copy of the current adapter (with name, model, features, schema, etc.)
+
+### Tool Safety Check
+
+When [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) is on, tools are auto-approved. Some tools (such as `run_command` and `delete_file`), by default, will always ask you first, owing to their destructive nature. The tool safety check offers a middle ground: a background LLM judges the specific action and only interrupts you when it is judged to be unsafe.
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    background = {
+      gates = {
+        safety_check = {
+          enabled = true,
+          action = "interactions.background.builtin.tool_safety_check",
+        },
+      },
+    },
+  },
+})
+```
+
+The check runs for a tool only when:
+
+- You set `opts.safety_check = true` on the tool's config; _and_
+- The tool defines a `gates.safety_context` handler
+
+Regarding for former, this can be accomplished with:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      tools = {
+        ["run_command"] = {
+          opts = {
+            safety_check = true,
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+If the judge decides the action is safe, it executes immediately. The verdict is cached so re-running the exact same command won't be re-judged that session. A different command is judged on its own - approving `make test` does not approve `make test && rm -rf foo`. If the request to check the command fails, or the adapter can't produce structured output, you'll be automatically asked to approve manually.
+
+For this per-command caching, the tool must also set `opts.require_cmd_approval = true`. Without it, a single safe verdict is cached against the whole tool and every later action of that tool runs unjudged for the rest of the session. This is automatically set for `run_command` and `delete_file` but can be applied to any tool.
+
+
 
 ### Truncating Tool Output
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -181,16 +181,16 @@ The `info` table passed to `on_before_submit` contains:
 
 ### Tool Safety Check
 
-When [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) is on, tools are auto-approved. Some tools (such as `run_command` and `delete_file`), by default, will always ask you first, owing to their destructive nature. The tool safety check offers a middle ground: a background LLM judges the specific action and only interrupts you when it is judged to be unsafe.
+When [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) is on, tools are auto-approved. Some tools (such as `run_command` and `delete_file`), by default, will always ask you first, owing to their destructive nature. The judge offers a middle ground: a background LLM judges the specific action and only interrupts you when it is judged to be unsafe.
 
 ```lua
 require("codecompanion").setup({
   interactions = {
     background = {
       gates = {
-        safety_check = {
+        judge = {
           enabled = true,
-          action = "interactions.background.builtin.tool_safety_check",
+          action = "interactions.background.builtin.tools_judge",
         },
       },
     },
@@ -198,10 +198,10 @@ require("codecompanion").setup({
 })
 ```
 
-The check runs for a tool only when:
+The judge runs for a tool only when:
 
-- You set `opts.safety_check = true` on the tool's config; _and_
-- The tool defines a `gates.safety_context` handler
+- You set `opts.judge_in_yolo_mode = true` on the tool's config; _and_
+- The tool defines a `gates.judge_context` handler
 
 Regarding for former, this can be accomplished with:
 
@@ -212,7 +212,7 @@ require("codecompanion").setup({
       tools = {
         ["run_command"] = {
           opts = {
-            safety_check = true,
+            judge_in_yolo_mode = true,
           },
         },
       },

--- a/doc/usage/chat-buffer/agents-tools.md
+++ b/doc/usage/chat-buffer/agents-tools.md
@@ -395,12 +395,12 @@ Approvals can be reset for the given chat buffer by using the `gtx` keymap.
 
 ### YOLO mode
 
-To bypass the approval system, you can use `gty` in the chat buffer to enable YOLO mode. This will automatically approve all tool executions without prompting the user. However, note that some tools such as `run_command` and `delete_file` are excluded from this as they have `allowed_in_yolo_mode = false` set.
+To bypass the approval system, you can use `gty` in the chat buffer to enable YOLO mode. This will automatically approve all tool executions without prompting the user. However, some tools such as `run_command` and `delete_file` are excluded from this as they have `allowed_in_yolo_mode = false` set by default.
 
-If you've configured [tool safety checks](/configuration/chat-buffer#tool-safety-check) then any commands from those tools will be sent to an LLM judge to verify if they're safe. This assumes that your chosen adapter supports structured outputs and the tool itself supports safety checks.
+If you've configured [tool safety checks](/configuration/chat-buffer#tool-safety-check) then their commands will be sent to an LLM judge to verify that they're safe. This assumes that your chosen adapter supports structured outputs and the tool itself supports safety checks. The [delete_file](#delete_file) and [run_command](#run_command) tools both support safety checks.
 
-> [!TIP]
-> The [delete_file](#delete_file) and [run_command](#run_command) tools both support safety checks
+> [!WARNING]
+> Running tools in YOLO mode is dangerous and it is recommend that you only use it in a safe environment where potential data loss can be recovered. You are responsible for any damage that may occur when using YOLO mode.
 
 ## Compatibility
 

--- a/doc/usage/chat-buffer/agents-tools.md
+++ b/doc/usage/chat-buffer/agents-tools.md
@@ -397,7 +397,9 @@ Approvals can be reset for the given chat buffer by using the `gtx` keymap.
 
 To bypass the approval system, you can use `gty` in the chat buffer to enable YOLO mode. This will automatically approve all tool executions without prompting the user. However, some tools such as `run_command` and `delete_file` are excluded from this as they have `allowed_in_yolo_mode = false` set by default.
 
-If you've configured [tool safety checks](/configuration/chat-buffer#tool-safety-check) then their commands will be sent to an LLM judge to verify that they're safe. This assumes that your chosen adapter supports structured outputs and the tool itself supports safety checks. The [delete_file](#delete_file) and [run_command](#run_command) tools both support safety checks.
+If you've configured the [LLM judge](/configuration/chat-buffer#llm-judge) then a tool's commands will be sent to an LLM to verify that they're safe. This assumes that your chosen adapter supports structured outputs and the tool itself supports the judge. The [delete_file](#delete_file) and [run_command](#run_command) tools support this out of the box.
+
+If the judge decides the action is safe, it executes immediately and the verdict is cached so re-running the exact same command won't be re-judged that session. For example, approving `make test` does not result in `make test && rm -rf foo` being auto-approved. If the request to the judge fails, or the adapter can't produce structured output, the tool will require manual approval.
 
 > [!WARNING]
 > Running tools in YOLO mode is dangerous and it is recommend that you only use it in a safe environment where potential data loss can be recovered. You are responsible for any damage that may occur when using YOLO mode.

--- a/doc/usage/chat-buffer/agents-tools.md
+++ b/doc/usage/chat-buffer/agents-tools.md
@@ -397,6 +397,11 @@ Approvals can be reset for the given chat buffer by using the `gtx` keymap.
 
 To bypass the approval system, you can use `gty` in the chat buffer to enable YOLO mode. This will automatically approve all tool executions without prompting the user. However, note that some tools such as `run_command` and `delete_file` are excluded from this as they have `allowed_in_yolo_mode = false` set.
 
+If you've configured [tool safety checks](/configuration/chat-buffer#tool-safety-check) then any commands from those tools will be sent to an LLM judge to verify if they're safe. This assumes that your chosen adapter supports structured outputs and the tool itself supports safety checks.
+
+> [!TIP]
+> The [delete_file](#delete_file) and [run_command](#run_command) tools both support safety checks
+
 ## Compatibility
 
 Below is the tool use status of various adapters and models in CodeCompanion:
@@ -408,13 +413,16 @@ Below is the tool use status of various adapters and models in CodeCompanion:
 | Copilot           |                   | :white_check_mark: | Dependent on the model              |
 | DeepSeek          |                   | :white_check_mark: | Dependent on the model              |
 | Gemini            |                   | :white_check_mark: | Dependent on the model              |
-| GitHub Models     | All               | :x:                | Not supported yet                   |
-| Huggingface       | All               | :x:                | Not supported yet                   |
+| GitHub Models     | | :x:                | Not supported yet                   |
+| Huggingface       | | :x:                | Not supported yet                   |
+| Kimi            |                   | :white_check_mark: | Dependent on the model              |
 | Mistral           |                   | :white_check_mark: | Dependent on the model              |
 | Novita            |                   | :white_check_mark: | Dependent on the model              |
 | Ollama            | Tested with Qwen3 | :white_check_mark: | Dependent on the model              |
 | OpenAI            |                   | :white_check_mark: | Dependent on the model              |
-| xAI               | All               | :x:                | Not supported yet                   |
+| OpenAI Responses            |                   | :white_check_mark: | Dependent on the model              |
+| OpenRouter            |                   | :white_check_mark: | Dependent on the model              |
+| xAI               | | :x:                | Not supported yet                   |
 
 
 > [!IMPORTANT]

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -34,13 +34,6 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
-- `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
-- `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
-- `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
-- `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
-- `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request
-- `CodeCompanionToolStarted` - Fired when a tool has started executing
-- `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction
 - `CodeCompanionInlineFinished` - Fired at the end of the Inline interaction
 - `CodeCompanionMCPServerStart` - Fired when an MCP server is started
@@ -50,6 +43,16 @@ The events that are fired from within the plugin are:
 - `CodeCompanionRequestStarted` - Fired at the start of any API request
 - `CodeCompanionRequestStreaming` - Fired at the start of a streaming API request
 - `CodeCompanionRequestFinished` - Fired at the end of any API request
+- `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
+- `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
+- `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request
+- `CodeCompanionToolStarted` - Fired when a tool has started executing
+- `CodeCompanionToolFinished` - Fired when a tool has finished executing
+- `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
+- `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
+- `CodeCompanionToolSafetyCheckStarted` - Fired when a background safety check begins judging a tool call
+- `CodeCompanionToolSafetyCheckFinished` - Fired when a background safety check returns its verdict
+
 
 In addition to these events, the chat buffer has its own **callback system** for hooking into lifecycle events like `on_before_submit`, `on_checkpoint` and `on_tool_output`. These callbacks receive the chat instance and can inspect or mutate chat state. See the [callbacks](/configuration/chat-buffer#callbacks) section for details.
 

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -50,8 +50,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated
 - `CodeCompanionToolsFinished` - Fired when the tool system has finished running all tools
-- `CodeCompanionToolSafetyCheckStarted` - Fired when a background safety check begins judging a tool call
-- `CodeCompanionToolSafetyCheckFinished` - Fired when a background safety check returns its verdict
+- `CodeCompanionToolsJudgeStarted` - Fired when the background judge begins vetting a tool call
+- `CodeCompanionToolsJudgeFinished` - Fired when the background judge returns its verdict
 
 
 In addition to these events, the chat buffer has its own **callback system** for hooking into lifecycle events like `on_before_submit`, `on_checkpoint` and `on_tool_output`. These callbacks receive the chat instance and can inspect or mutate chat state. See the [callbacks](/configuration/chat-buffer#callbacks) section for details.

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -115,7 +115,7 @@ return {
       end
 
       -- Make sure the individual model options are set
-      local model_opts = adapter_utils.model_choice(self)
+      local model_opts = adapter_utils.model_choice(self, { async = false })
       if model_opts and model_opts.opts then
         self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
         if not model_opts.opts.has_vision then
@@ -475,11 +475,8 @@ return {
     ---@param schema CodeCompanion.StructuredOutput.Schema
     ---@return table|nil
     form_structured_output = function(self, schema)
-      if not schema then
-        return
-      end
-      if not self.opts.can_form_structured_outputs then
-        return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+      if not schema or not self.opts.can_form_structured_outputs then
+        return nil
       end
       return require("codecompanion.adapters.utils.structured_outputs").to_anthropic(schema)
     end,

--- a/lua/codecompanion/adapters/http/copilot/init.lua
+++ b/lua/codecompanion/adapters/http/copilot/init.lua
@@ -293,11 +293,8 @@ return {
     ---@param schema CodeCompanion.StructuredOutput.Schema
     ---@return table|nil
     form_structured_output = function(self, schema)
-      if not schema then
-        return
-      end
-      if not self.opts.can_form_structured_outputs then
-        return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+      if not schema or not self.opts.can_form_structured_outputs then
+        return nil
       end
       return handlers(self).form_structured_output(self, schema)
     end,

--- a/lua/codecompanion/adapters/http/deepseek.lua
+++ b/lua/codecompanion/adapters/http/deepseek.lua
@@ -1,5 +1,4 @@
 local adapter_utils = require("codecompanion.adapters.utils")
-local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
 ---Set the format of the role and content for the messages from the chat buffer
@@ -107,17 +106,14 @@ return {
         end
         local choices = self.schema.model.choices
         if type(choices) == "function" then
-          -- Ensure that the model list is cached before checking for the model's capabilities
           choices = choices(self, { async = false })
         end
         local model_opts = choices and choices[model]
 
-        -- Merge model opts
         if model_opts and model_opts.opts then
           self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
         end
 
-        -- Set stream
         if self.opts and self.opts.stream then
           self.parameters.stream = true
           self.parameters.stream_options = { include_usage = true }

--- a/lua/codecompanion/adapters/http/deepseek.lua
+++ b/lua/codecompanion/adapters/http/deepseek.lua
@@ -107,7 +107,8 @@ return {
         end
         local choices = self.schema.model.choices
         if type(choices) == "function" then
-          choices = choices(self)
+          -- Ensure that the model list is cached before checking for the model's capabilities
+          choices = choices(self, { async = false })
         end
         local model_opts = choices and choices[model]
 

--- a/lua/codecompanion/adapters/http/gemini.lua
+++ b/lua/codecompanion/adapters/http/gemini.lua
@@ -287,11 +287,8 @@ return {
     ---@param schema CodeCompanion.StructuredOutput.Schema
     ---@return table|nil
     form_structured_output = function(self, schema)
-      if not schema then
-        return
-      end
-      if not self.opts.can_form_structured_outputs then
-        return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+      if not schema or not self.opts.can_form_structured_outputs then
+        return nil
       end
       return require("codecompanion.adapters.utils.structured_outputs").to_gemini(schema)
     end,

--- a/lua/codecompanion/adapters/http/gemini_interactions.lua
+++ b/lua/codecompanion/adapters/http/gemini_interactions.lua
@@ -134,7 +134,7 @@ return {
       ---@param self CodeCompanion.HTTPAdapter
       ---@return boolean
       setup = function(self)
-        local model_opts = adapter_utils.model_choice(self)
+        local model_opts = adapter_utils.model_choice(self, { async = false })
 
         self.opts.vision = true
 
@@ -338,11 +338,8 @@ return {
       ---@param schema CodeCompanion.StructuredOutput.Schema
       ---@return table|nil
       build_structured_output = function(self, schema)
-        if not schema then
-          return
-        end
-        if not self.opts.can_form_structured_outputs then
-          return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+        if not schema or not self.opts.can_form_structured_outputs then
+          return nil
         end
         return require("codecompanion.adapters.utils.structured_outputs").to_gemini_interactions(schema)
       end,

--- a/lua/codecompanion/adapters/http/kimi.lua
+++ b/lua/codecompanion/adapters/http/kimi.lua
@@ -35,7 +35,7 @@ return {
       setup = function(self)
         deepseek.handlers.lifecycle.setup(self)
 
-        local model_choice = adapter_utils.model_choice(self)
+        local model_choice = adapter_utils.model_choice(self, { async = false })
         self.opts.vision = (model_choice and model_choice.opts and model_choice.opts.has_vision) == true
 
         return true

--- a/lua/codecompanion/adapters/http/mistral.lua
+++ b/lua/codecompanion/adapters/http/mistral.lua
@@ -1,7 +1,6 @@
 local adapter_utils = require("codecompanion.adapters.utils")
 local config = require("codecompanion.config")
 local fetch_models = require("codecompanion.adapters.utils.models.fetch")
-local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
 local models_source = {
@@ -48,7 +47,7 @@ return {
         self.parameters.stream = true
       end
 
-      local model_opts = adapter_utils.model_choice(self)
+      local model_opts = adapter_utils.model_choice(self, { async = false })
       if model_opts and model_opts.opts then
         self.opts = vim.tbl_deep_extend("force", self.opts, model_opts.opts)
         if not model_opts.opts.has_vision then
@@ -77,12 +76,9 @@ return {
     ---@param schema CodeCompanion.StructuredOutput.Schema
     ---@return table|nil
     form_structured_output = function(self, schema)
-      if not schema then
-        return
-      end
       ---Ref: https://docs.mistral.ai/studio-api/conversations/structured-output/custom
-      if not self.opts.can_form_structured_outputs then
-        return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+      if not schema or not self.opts.can_form_structured_outputs then
+        return nil
       end
       return openai.handlers.form_structured_output(self, schema)
     end,

--- a/lua/codecompanion/adapters/http/novita.lua
+++ b/lua/codecompanion/adapters/http/novita.lua
@@ -91,7 +91,8 @@ return {
         model = model(self)
       end
       if type(choices) == "function" then
-        choices = choices(self)
+        -- Ensure that the model list is cached before checking for the model's capabilities
+        choices = choices(self, { async = false })
       end
       local model_opts = choices[model]
 

--- a/lua/codecompanion/adapters/http/novita.lua
+++ b/lua/codecompanion/adapters/http/novita.lua
@@ -91,7 +91,6 @@ return {
         model = model(self)
       end
       if type(choices) == "function" then
-        -- Ensure that the model list is cached before checking for the model's capabilities
         choices = choices(self, { async = false })
       end
       local model_opts = choices[model]

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -222,11 +222,8 @@ return {
     ---@param schema CodeCompanion.StructuredOutput.Schema
     ---@return table|nil
     form_structured_output = function(self, schema)
-      if not schema then
-        return
-      end
-      if not self.opts.can_form_structured_outputs then
-        return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+      if not schema or not self.opts.can_form_structured_outputs then
+        return nil
       end
       return require("codecompanion.adapters.utils.structured_outputs").to_openai(schema)
     end,

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -57,7 +57,7 @@ return {
       ---@param self CodeCompanion.HTTPAdapter
       ---@return boolean
       setup = function(self)
-        local model_opts = adapter_utils.model_choice(self)
+        local model_opts = adapter_utils.model_choice(self, { async = false })
 
         self.opts.vision = true
 
@@ -329,14 +329,8 @@ return {
       ---@param schema CodeCompanion.StructuredOutput.Schema
       ---@return table|nil
       build_structured_output = function(self, schema)
-        if not schema then
+        if not schema or not self.opts.can_form_structured_outputs then
           return nil
-        end
-        if not self.opts.can_form_structured_outputs then
-          return log:warn(
-            "[openai_responses] Model '%s' does not support structured outputs",
-            self.model and self.model.name
-          )
         end
         return require("codecompanion.adapters.utils.structured_outputs").to_openai_responses(schema)
       end,

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -1,5 +1,4 @@
 local fetch_models = require("codecompanion.adapters.utils.models.fetch")
-local log = require("codecompanion.utils.log")
 local openai = require("codecompanion.adapters.http.openai")
 
 local models_source = {
@@ -90,7 +89,8 @@ return {
         model = model(self)
       end
       if type(choices) == "function" then
-        choices = choices(self)
+        -- Ensure that the model list is cached before checking for the model's capabilities
+        choices = choices(self, { async = false })
       end
       local model_opts = choices[model]
 
@@ -188,12 +188,9 @@ return {
     ---@param schema CodeCompanion.StructuredOutput.Schema
     ---@return table|nil
     form_structured_output = function(self, schema)
-      if not schema then
-        return
-      end
       ---Ref: https://openrouter.ai/docs/guides/features/structured-outputs#using-structured-outputs
-      if not self.opts.can_form_structured_outputs then
-        return log:warn("Model `%s` does not support structured outputs", self.model and self.model.name)
+      if not schema or not self.opts.can_form_structured_outputs then
+        return nil
       end
       return openai.handlers.form_structured_output(self, schema)
     end,

--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -89,7 +89,6 @@ return {
         model = model(self)
       end
       if type(choices) == "function" then
-        -- Ensure that the model list is cached before checking for the model's capabilities
         choices = choices(self, { async = false })
       end
       local model_opts = choices[model]

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -421,11 +421,12 @@ end
 
 ---Helper function to return the model from the choices
 ---@param adapter CodeCompanion.HTTPAdapter
+---@param opts? { async?: boolean } Pass `async = false` to block until the model list has been fetched
 ---@return table?
-function M.model_choice(adapter)
+function M.model_choice(adapter, opts)
   local choices = adapter.schema.model.choices
   if type(choices) == "function" then
-    choices = choices(adapter)
+    choices = choices(adapter, opts)
   end
   if type(choices) ~= "table" then
     return nil

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -96,9 +96,9 @@ local defaults = {
         },
       },
       gates = {
-        safety_check = {
+        judge = {
           enabled = true,
-          action = "interactions.background.builtin.tool_safety_check",
+          action = "interactions.background.builtin.tools_judge",
         },
       },
     },
@@ -216,7 +216,7 @@ The user is working on a %s machine. Please respond with system specific command
             allowed_in_yolo_mode = false,
             require_approval_before = true,
             require_cmd_approval = true,
-            safety_check = false,
+            judge_in_yolo_mode = false,
           },
         },
         ["fetch_webpage"] = {
@@ -291,7 +291,7 @@ The user is working on a %s machine. Please respond with system specific command
             allowed_in_yolo_mode = false,
             require_approval_before = true,
             require_cmd_approval = true,
-            safety_check = false,
+            judge_in_yolo_mode = false,
           },
         },
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -95,6 +95,12 @@ local defaults = {
           enabled = false, -- Enable ALL background chat interactions?
         },
       },
+      gates = {
+        safety_check = {
+          enabled = true,
+          action = "interactions.background.builtin.tool_safety_check",
+        },
+      },
     },
     -- CHAT INTERACTION -------------------------------------------------------
     chat = {
@@ -209,6 +215,8 @@ The user is working on a %s machine. Please respond with system specific command
           opts = {
             allowed_in_yolo_mode = false,
             require_approval_before = true,
+            require_cmd_approval = true,
+            safety_check = false,
           },
         },
         ["fetch_webpage"] = {
@@ -283,6 +291,7 @@ The user is working on a %s machine. Please respond with system specific command
             allowed_in_yolo_mode = false,
             require_approval_before = true,
             require_cmd_approval = true,
+            safety_check = false,
           },
         },
 

--- a/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
+++ b/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
@@ -1,4 +1,3 @@
-local adapters = require("codecompanion.adapters")
 local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
 
@@ -65,15 +64,6 @@ function M.on_done(result)
   return title and title ~= "" and title or nil
 end
 
----@param background CodeCompanion.Background
----@return boolean
-local function supports_structured_output(background)
-  local adapter = background.adapter
-  return adapters.get_handler(adapter, "build_structured_output") ~= nil
-    and adapter.opts ~= nil
-    and adapter.opts.can_form_structured_outputs == true
-end
-
 ---Make the request to generate a title for the chat
 ---@param background CodeCompanion.Background
 ---@param chat CodeCompanion.Chat
@@ -98,7 +88,7 @@ function M.request(background, chat, opts)
   }, {
     method = "async",
     silent = true,
-    structured_output = supports_structured_output(background) and TITLE_SCHEMA or nil,
+    structured_output = TITLE_SCHEMA,
     on_done = function(result)
       local title = M.on_done(result)
       if title then

--- a/lua/codecompanion/interactions/background/builtin/tool_safety_check.lua
+++ b/lua/codecompanion/interactions/background/builtin/tool_safety_check.lua
@@ -1,0 +1,91 @@
+local log = require("codecompanion.utils.log")
+
+local fmt = string.format
+
+local M = {}
+
+local SAFETY_SCHEMA = {
+  name = "safety",
+  schema = {
+    type = "object",
+    properties = {
+      safe = {
+        type = "boolean",
+        description = "True if the action is safe to run without asking the user, false if it needs their approval",
+      },
+      reason = {
+        type = "string",
+        description = "A short explanation of the verdict, shown to the user when approval is required",
+      },
+    },
+    required = { "safe", "reason" },
+    additionalProperties = false,
+  },
+  strict = true,
+}
+
+local SYSTEM_PROMPT =
+  [[You are a security reviewer for an AI coding assistant. The assistant wants to run a tool on the user's machine while the user is away (in "auto-approve" mode). Your job is to decide whether the action is safe to run automatically, or whether the user must approve it first.
+
+Judge the action as unsafe when it could destroy or exfiltrate data, alter the system in ways that are hard to reverse, or run something the user would reasonably want to see first. Prefer caution: when in doubt, require approval.
+
+Reply only through the provided schema.]]
+
+---Parse the structured verdict from the request result
+---@param result table|nil
+---@return { safe: boolean, reason: string }|nil
+local function parse_verdict(result)
+  if not result or (result.status and result.status == "error") then
+    return nil
+  end
+
+  local content = result.output and result.output.content
+  if not content then
+    return nil
+  end
+
+  local ok, decoded = pcall(vim.json.decode, content)
+  if not ok or type(decoded) ~= "table" or type(decoded.safe) ~= "boolean" then
+    return nil
+  end
+
+  return { safe = decoded.safe, reason = decoded.reason or "" }
+end
+
+---Ask the judge whether a tool's action is safe to run automatically
+---@param background CodeCompanion.Background
+---@param request { tool_name: string, context: string }
+---@param callback fun(verdict: { safe: boolean, reason: string })
+function M.request(background, request, callback)
+  -- Fail closed: any failure to reach a clear verdict requires user approval
+  local function require_approval(reason)
+    callback({ safe = false, reason = reason })
+  end
+
+  background:ask({
+    { role = "system", content = SYSTEM_PROMPT },
+    {
+      role = "user",
+      content = fmt("The `%s` tool wants to perform this action:\n\n%s", request.tool_name, request.context),
+    },
+  }, {
+    method = "async",
+    silent = true,
+    structured_output = SAFETY_SCHEMA,
+    on_done = function(result)
+      local verdict = parse_verdict(result)
+      if not verdict then
+        log:debug("[background::tool_safety_check] Could not read a verdict; requiring approval")
+        return require_approval("The safety check returned an unreadable response")
+      end
+      log:debug("[background::tool_safety_check] Verdict for `%s`: safe=%s", request.tool_name, verdict.safe)
+      callback(verdict)
+    end,
+    on_error = function(err)
+      log:debug("[background::tool_safety_check] Request failed: %s", err)
+      require_approval("The safety check could not be completed")
+    end,
+  })
+end
+
+return M

--- a/lua/codecompanion/interactions/background/builtin/tools_judge.lua
+++ b/lua/codecompanion/interactions/background/builtin/tools_judge.lua
@@ -4,7 +4,7 @@ local fmt = string.format
 
 local M = {}
 
-local SAFETY_SCHEMA = {
+local VERDICT_SCHEMA = {
   name = "safety",
   schema = {
     type = "object",
@@ -71,19 +71,19 @@ function M.request(background, request, callback)
   }, {
     method = "async",
     silent = true,
-    structured_output = SAFETY_SCHEMA,
+    structured_output = VERDICT_SCHEMA,
     on_done = function(result)
       local verdict = parse_verdict(result)
       if not verdict then
-        log:debug("[background::tool_safety_check] Could not read a verdict; requiring approval")
-        return require_approval("The safety check returned an unreadable response")
+        log:debug("[background::tools_judge] Could not read a verdict; requiring approval")
+        return require_approval("The judge returned an unreadable response")
       end
-      log:debug("[background::tool_safety_check] Verdict for `%s`: safe=%s", request.tool_name, verdict.safe)
+      log:debug("[background::tools_judge] Verdict for `%s`: safe=%s", request.tool_name, verdict.safe)
       callback(verdict)
     end,
     on_error = function(err)
-      log:debug("[background::tool_safety_check] Request failed: %s", err)
-      require_approval("The safety check could not be completed")
+      log:debug("[background::tools_judge] Request failed: %s", err)
+      require_approval("The judge request failed")
     end,
   })
 end

--- a/lua/codecompanion/interactions/background/callbacks.lua
+++ b/lua/codecompanion/interactions/background/callbacks.lua
@@ -3,10 +3,10 @@ local log = require("codecompanion.utils.log")
 
 local M = {}
 
----Resolve a callback module from a given path
+---Resolve a background action module from a given path
 ---@param path string The path to the module
 ---@return table|nil The loaded action module or nil on failure
-local function resolve(path)
+function M.resolve(path)
   local ok, action = pcall(require, "codecompanion." .. path)
   if ok then
     return action
@@ -19,23 +19,22 @@ local function resolve(path)
   end
 
   -- Try loading the tool from the user's config using a file path
-  local action, err = loadfile(vim.fs.normalize(path))
-  if err then
+  local chunk, err = loadfile(vim.fs.normalize(path))
+  if err or not chunk then
     return
   end
 
-  if action then
-    return action()
-  end
+  return chunk()
 end
 
 ---Execute an action
----@param path string The path to the module
+---@param action_config { path: string, adapter?: CodeCompanion.HTTPAdapter|string }
 ---@param chat CodeCompanion.Chat The chat instance
 ---@param opts? { deregister: fun() }
 ---@return nil
-local function execute_action(path, chat, opts)
-  local action = resolve(path)
+local function execute_action(action_config, chat, opts)
+  local path = action_config.path
+  local action = M.resolve(path)
   if not action then
     return log:error("[background::callbacks] File `%s` could not be found", path)
   end
@@ -43,11 +42,10 @@ local function execute_action(path, chat, opts)
     return log:error("[background::callbacks] File `%s` does not have a request function", path)
   end
 
-  -- Create a background instance using the configured adapter
+  -- Per-action adapter overrides the shared background adapter
   local Background = require("codecompanion.interactions.background")
-  local background_config = config.interactions.background
   local background = Background.new({
-    adapter = background_config.adapter,
+    adapter = action_config.adapter or config.interactions.background.adapter,
   })
 
   if not background then
@@ -76,10 +74,11 @@ function M.register_chat_callbacks(chat)
   -- Register each action as its own callback so it can deregister itself once done
   for event, event_config in pairs(background_config.callbacks) do
     if event_config.enabled and event_config.actions then
-      for _, path in ipairs(event_config.actions) do
+      for _, action in ipairs(event_config.actions) do
+        local action_config = type(action) == "string" and { path = action } or action
         local callback
         callback = function(c)
-          execute_action(path, c, {
+          execute_action(action_config, c, {
             deregister = function()
               c:remove_callback(event, callback)
             end,

--- a/lua/codecompanion/interactions/chat/tools/builtin/cmd_tool.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/cmd_tool.lua
@@ -8,7 +8,7 @@ local fmt = string.format
 ---executes shell commands. Users provide a minimal spec and get a fully
 ---functional tool with schema, approval prompts, and output handling.
 ---
----@param spec { name: string, description: string, schema: { properties: table, required: table, additionalProperties?: boolean }, build_cmd: fun(args: table): string, system_prompt?: string|fun(schema: table): string, handlers?: table, output?: table }
+---@param spec { name: string, description: string, schema: { properties: table, required: table, additionalProperties?: boolean }, build_cmd: fun(args: table): string, system_prompt?: string|fun(schema: table): string, handlers?: table, output?: table, gates?: table }
 ---@return CodeCompanion.Tools.Tool
 local function cmd_tool(spec)
   -- Build the full schema envelope from the user's property spec
@@ -116,6 +116,7 @@ local function cmd_tool(spec)
     system_prompt = spec.system_prompt,
     handlers = vim.tbl_extend("force", default_handlers, spec.handlers or {}),
     output = vim.tbl_extend("force", default_output, spec.output or {}),
+    gates = spec.gates,
   }
 end
 

--- a/lua/codecompanion/interactions/chat/tools/builtin/delete_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/delete_file.lua
@@ -135,4 +135,13 @@ return {
       helpers.rejected(self, meta)
     end,
   },
+  gates = {
+    ---The action handed to the background judge to vet in yolo mode
+    ---@param self CodeCompanion.Tool.DeleteFile
+    ---@param meta { tools: CodeCompanion.Tools }
+    ---@return string
+    safety_context = function(self, meta)
+      return fmt("Delete the file: %s", self.args.filepath)
+    end,
+  },
 }

--- a/lua/codecompanion/interactions/chat/tools/builtin/delete_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/delete_file.lua
@@ -140,7 +140,7 @@ return {
     ---@param self CodeCompanion.Tool.DeleteFile
     ---@param meta { tools: CodeCompanion.Tools }
     ---@return string
-    safety_context = function(self, meta)
+    judge_context = function(self, meta)
       return fmt("Delete the file: %s", self.args.filepath)
     end,
   },

--- a/lua/codecompanion/interactions/chat/tools/builtin/run_command.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/run_command.lua
@@ -69,4 +69,13 @@ return cmd_tool({
       helpers.rejected(self, meta)
     end,
   },
+  gates = {
+    ---The action handed to the background judge to vet in yolo mode
+    ---@param self CodeCompanion.Tool.RunCommand
+    ---@param meta {tools: CodeCompanion.Tools}
+    ---@return string
+    safety_context = function(self, meta)
+      return self.args.cmd
+    end,
+  },
 })

--- a/lua/codecompanion/interactions/chat/tools/builtin/run_command.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/run_command.lua
@@ -74,7 +74,7 @@ return cmd_tool({
     ---@param self CodeCompanion.Tool.RunCommand
     ---@param meta {tools: CodeCompanion.Tools}
     ---@return string
-    safety_context = function(self, meta)
+    judge_context = function(self, meta)
       return self.args.cmd
     end,
   },

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -241,12 +241,12 @@ function Orchestrator:_setup_handlers()
   }
 
   self.gates = {
-    safety_context = function()
+    judge_context = function()
       if not self.tool then
         return
       end
-      if self.tool.gates and self.tool.gates.safety_context then
-        return self.tool.gates.safety_context(self.tool, { tools = self.tools })
+      if self.tool.gates and self.tool.gates.judge_context then
+        return self.tool.gates.judge_context(self.tool, { tools = self.tools })
       end
       return nil
     end,
@@ -309,8 +309,8 @@ function Orchestrator:setup_next_tool(input)
   end
 
   -- In yolo mode, let a background judge decide whether to execute or ask the user for approval
-  if self:_should_run_safety_check() then
-    return self:_run_safety_check({ cmd = cmd, input = input })
+  if self:_should_run_judge() then
+    return self:_run_judge({ cmd = cmd, input = input })
   end
 
   return self:_prompt_for_approval({ cmd = cmd, input = input })
@@ -379,39 +379,39 @@ end
 
 ---Should a background judge vet this tool before we ask the user to approve it?
 ---@return boolean
-function Orchestrator:_should_run_safety_check()
-  local safety_check = config.interactions.background.gates and config.interactions.background.gates.safety_check
-  if not (safety_check and safety_check.enabled) then
+function Orchestrator:_should_run_judge()
+  local judge = config.interactions.background.gates and config.interactions.background.gates.judge
+  if not (judge and judge.enabled) then
     return false
   end
-  if not self.tool.opts.safety_check then
+  if not self.tool.opts.judge_in_yolo_mode then
     return false
   end
-  if not (self.tool.gates and self.tool.gates.safety_context) then
+  if not (self.tool.gates and self.tool.gates.judge_context) then
     return false
   end
   return Approvals:is_approved(self.tools.bufnr)
 end
 
----Run a background safety check, then execute the tool or fall back to a prompt
+---Run the background judge, then execute the tool or fall back to a prompt
 ---@param args { cmd: function, input?: any }
 ---@return nil
-function Orchestrator:_run_safety_check(args)
-  local safety_check = config.interactions.background.gates.safety_check
+function Orchestrator:_run_judge(args)
+  local judge = config.interactions.background.gates.judge
 
   local Background = require("codecompanion.interactions.background")
   local background = Background.new({
-    adapter = safety_check.adapter or config.interactions.background.adapter,
+    adapter = judge.adapter or config.interactions.background.adapter,
   })
 
-  local action = require("codecompanion.interactions.background.callbacks").resolve(safety_check.action)
-  local context = self.gates.safety_context()
+  local action = require("codecompanion.interactions.background.callbacks").resolve(judge.action)
+  local context = self.gates.judge_context()
   if not background or not action or context == nil then
-    log:debug("[Orchestrator::_run_safety_check] Cannot run the check; asking the user")
+    log:debug("[Orchestrator::_run_judge] Cannot run the judge; asking the user")
     return self:_prompt_for_approval(args)
   end
 
-  utils.fire("ToolSafetyCheckStarted", {
+  utils.fire("ToolsJudgeStarted", {
     bufnr = self.tools.bufnr,
     context = context,
     id = self.id,
@@ -419,7 +419,7 @@ function Orchestrator:_run_safety_check(args)
   })
 
   action.request(background, { tool_name = self.tool.name, context = context }, function(verdict)
-    utils.fire("ToolSafetyCheckFinished", {
+    utils.fire("ToolsJudgeFinished", {
       bufnr = self.tools.bufnr,
       id = self.id,
       reason = verdict.reason,

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -2,6 +2,7 @@ local Approvals = require("codecompanion.interactions.chat.tools.approvals")
 local Queue = require("codecompanion.interactions.chat.tools.runtime.queue")
 local Runner = require("codecompanion.interactions.chat.tools.runtime.runner")
 
+local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local os_utils = require("codecompanion.utils.os")
 local ui_utils = require("codecompanion.utils.ui")
@@ -238,6 +239,18 @@ function Orchestrator:_setup_handlers()
       end
     end,
   }
+
+  self.gates = {
+    safety_context = function()
+      if not self.tool then
+        return
+      end
+      if self.tool.gates and self.tool.gates.safety_context then
+        return self.tool.gates.safety_context(self.tool, { tools = self.tools })
+      end
+      return nil
+    end,
+  }
 end
 
 ---When the tools coordinator is finished, finalize it via an autocmd
@@ -274,79 +287,153 @@ function Orchestrator:setup_next_tool(input)
   local cmd = self.tool.cmds[1]
   log:debug("[Orchestrator::setup_next_tool] `%s` tool", self.tool.name)
 
-  -- Check if the tool requires approval
   if
-    self.tool.opts
-    and not Approvals:is_approved(self.tools.bufnr, { cmd = self.output.cmd_string(), tool_name = self.tool.name })
+    not self.tool.opts
+    or Approvals:is_approved(self.tools.bufnr, { cmd = self.output.cmd_string(), tool_name = self.tool.name })
   then
-    local require_approval_before = self.tool.opts.require_approval_before
-
-    if require_approval_before and type(require_approval_before) == "function" then
-      require_approval_before = require_approval_before(self.tool, self.tools)
-    end
-    if require_approval_before and type(require_approval_before) ~= "boolean" then
-      require_approval_before = self.handlers.prompt_condition()
-    end
-
-    if require_approval_before then
-      log:debug("[Orchestrator::setup_next_tool] Asking for approval")
-
-      local prompt = self.output.prompt()
-      if prompt == nil or prompt == "" then
-        prompt = ("Run the %q tool?"):format(self.tool.name)
-      end
-
-      local labels = require("codecompanion.interactions.chat.tools.labels")
-      local keys = labels.keymaps()
-      require("codecompanion.interactions.chat.helpers.approval_prompt").request(self.tools.chat, {
-        id = self.id,
-        name = self.tool.name,
-        prompt = prompt,
-        choices = {
-          {
-            keymap = keys.always_accept,
-            label = labels.always_accept,
-            callback = function()
-              Approvals:always(self.tools.bufnr, { cmd = self.output.cmd_string(), tool_name = self.tool.name })
-              self:execute_tool({ cmd = cmd, input = input })
-            end,
-          },
-          {
-            keymap = keys.accept,
-            label = labels.accept,
-            callback = function()
-              self:execute_tool({ cmd = cmd, input = input })
-            end,
-          },
-          {
-            keymap = keys.reject,
-            label = labels.reject,
-            callback = function()
-              ui_utils.input({ prompt = fmt("Reason for rejecting `%s`: ", self.tool.name) }, function(i)
-                self.output.rejected(cmd, { reason = i })
-                self:setup_next_tool()
-              end)
-            end,
-          },
-          {
-            keymap = keys.cancel,
-            label = labels.cancel,
-            callback = function()
-              self.output.cancelled(cmd)
-              self:finalize_tool()
-              self:cancel_pending_tools()
-              self:_finalize_tools()
-            end,
-          },
-        },
-      })
-    else
-      return self:execute_tool({ cmd = cmd, input = input })
-    end
-  else
     log:debug("[Orchestrator::setup_next_tool] No tool approval required")
     return self:execute_tool({ cmd = cmd, input = input })
   end
+
+  local require_approval_before = self.tool.opts.require_approval_before
+
+  if require_approval_before and type(require_approval_before) == "function" then
+    require_approval_before = require_approval_before(self.tool, self.tools)
+  end
+  if require_approval_before and type(require_approval_before) ~= "boolean" then
+    require_approval_before = self.handlers.prompt_condition()
+  end
+
+  if not require_approval_before then
+    return self:execute_tool({ cmd = cmd, input = input })
+  end
+
+  -- In yolo mode, let a background judge decide whether to execute or ask the user for approval
+  if self:_should_run_safety_check() then
+    return self:_run_safety_check({ cmd = cmd, input = input })
+  end
+
+  return self:_prompt_for_approval({ cmd = cmd, input = input })
+end
+
+---Ask the user to approve the pending tool before it runs
+---@param args { cmd: function, input?: any, reason?: string }
+---@return nil
+function Orchestrator:_prompt_for_approval(args)
+  local cmd, input = args.cmd, args.input
+  log:debug("[Orchestrator::_prompt_for_approval] Asking for approval")
+
+  local prompt = self.output.prompt()
+  if prompt == nil or prompt == "" then
+    prompt = ("Run the %q tool?"):format(self.tool.name)
+  end
+  if args.reason and args.reason ~= "" then
+    prompt = fmt('%s\nJudge: _"%s"_', prompt, args.reason)
+  end
+
+  local labels = require("codecompanion.interactions.chat.tools.labels")
+  local keys = labels.keymaps()
+  require("codecompanion.interactions.chat.helpers.approval_prompt").request(self.tools.chat, {
+    id = self.id,
+    name = self.tool.name,
+    prompt = prompt,
+    choices = {
+      {
+        keymap = keys.always_accept,
+        label = labels.always_accept,
+        callback = function()
+          Approvals:always(self.tools.bufnr, { cmd = self.output.cmd_string(), tool_name = self.tool.name })
+          self:execute_tool({ cmd = cmd, input = input })
+        end,
+      },
+      {
+        keymap = keys.accept,
+        label = labels.accept,
+        callback = function()
+          self:execute_tool({ cmd = cmd, input = input })
+        end,
+      },
+      {
+        keymap = keys.reject,
+        label = labels.reject,
+        callback = function()
+          ui_utils.input({ prompt = fmt("Reason for rejecting `%s`: ", self.tool.name) }, function(i)
+            self.output.rejected(cmd, { reason = i })
+            self:setup_next_tool()
+          end)
+        end,
+      },
+      {
+        keymap = keys.cancel,
+        label = labels.cancel,
+        callback = function()
+          self.output.cancelled(cmd)
+          self:finalize_tool()
+          self:cancel_pending_tools()
+          self:_finalize_tools()
+        end,
+      },
+    },
+  })
+end
+
+---Should a background judge vet this tool before we ask the user to approve it?
+---@return boolean
+function Orchestrator:_should_run_safety_check()
+  local safety_check = config.interactions.background.gates and config.interactions.background.gates.safety_check
+  if not (safety_check and safety_check.enabled) then
+    return false
+  end
+  if not self.tool.opts.safety_check then
+    return false
+  end
+  if not (self.tool.gates and self.tool.gates.safety_context) then
+    return false
+  end
+  return Approvals:is_approved(self.tools.bufnr)
+end
+
+---Run a background safety check, then execute the tool or fall back to a prompt
+---@param args { cmd: function, input?: any }
+---@return nil
+function Orchestrator:_run_safety_check(args)
+  local safety_check = config.interactions.background.gates.safety_check
+
+  local Background = require("codecompanion.interactions.background")
+  local background = Background.new({
+    adapter = safety_check.adapter or config.interactions.background.adapter,
+  })
+
+  local action = require("codecompanion.interactions.background.callbacks").resolve(safety_check.action)
+  local context = self.gates.safety_context()
+  if not background or not action or context == nil then
+    log:debug("[Orchestrator::_run_safety_check] Cannot run the check; asking the user")
+    return self:_prompt_for_approval(args)
+  end
+
+  utils.fire("ToolSafetyCheckStarted", {
+    bufnr = self.tools.bufnr,
+    context = context,
+    id = self.id,
+    tool = self.tool.name,
+  })
+
+  action.request(background, { tool_name = self.tool.name, context = context }, function(verdict)
+    utils.fire("ToolSafetyCheckFinished", {
+      bufnr = self.tools.bufnr,
+      id = self.id,
+      reason = verdict.reason,
+      safe = verdict.safe,
+      status = verdict.safe and "success" or "error",
+      tool = self.tool.name,
+    })
+
+    if verdict.safe then
+      Approvals:always(self.tools.bufnr, { cmd = self.output.cmd_string(), tool_name = self.tool.name })
+      return self:execute_tool(args)
+    end
+    return self:_prompt_for_approval(vim.tbl_extend("force", args, { reason = verdict.reason }))
+  end)
 end
 
 ---Cancel all pending tools in the queue

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -174,7 +174,7 @@
 ---@field opts? table The options for the tool
 ---@field env? fun(schema: table): table|nil Any environment variables that can be used in the *_cmd fields. Receives the parsed schema from the LLM
 ---@field gates? table Handlers which decide whether a tool may run
----@field gates.safety_context? fun(self: CodeCompanion.Tools.Tool, meta: table): string|nil The action, described in plain English, for the background judge to vet
+---@field gates.judge_context? fun(self: CodeCompanion.Tools.Tool, meta: table): string|nil The action, described in plain English, for the background judge to vet
 ---@field handlers table Functions which handle the execution of a tool
 ---@field handlers.setup? fun(self: CodeCompanion.Tools.Tool, tools: CodeCompanion.Tools): any Function used to setup the tool. Called before any commands
 ---@field handlers.prompt_condition? fun(self: CodeCompanion.Tools.Tool, tools: CodeCompanion.Tools, config: table): boolean Function to determine whether to show the promp to the user or not

--- a/lua/codecompanion/types.lua
+++ b/lua/codecompanion/types.lua
@@ -173,6 +173,8 @@
 ---@field system_prompt string | fun(schema: table): string The system prompt to the LLM explaining the tool and the schema
 ---@field opts? table The options for the tool
 ---@field env? fun(schema: table): table|nil Any environment variables that can be used in the *_cmd fields. Receives the parsed schema from the LLM
+---@field gates? table Handlers which decide whether a tool may run
+---@field gates.safety_context? fun(self: CodeCompanion.Tools.Tool, meta: table): string|nil The action, described in plain English, for the background judge to vet
 ---@field handlers table Functions which handle the execution of a tool
 ---@field handlers.setup? fun(self: CodeCompanion.Tools.Tool, tools: CodeCompanion.Tools): any Function used to setup the tool. Called before any commands
 ---@field handlers.prompt_condition? fun(self: CodeCompanion.Tools.Tool, tools: CodeCompanion.Tools, config: table): boolean Function to determine whether to show the promp to the user or not

--- a/tests/adapters/http/test_anthropic.lua
+++ b/tests/adapters/http/test_anthropic.lua
@@ -972,6 +972,22 @@ T["Anthropic adapter"]["No Streaming"]["can output for the inline assistant with
   )
 end
 
+T["Anthropic adapter"]["resolves model capabilities on the first request"] = function()
+  adapter.schema.model.default = "claude-sonnet-5"
+  adapter.schema.model.choices = function(_, opts)
+    if not (opts and opts.async == false) then
+      return {}
+    end
+    return { ["claude-sonnet-5"] = { opts = { can_form_structured_outputs = true, has_vision = true } } }
+  end
+
+  adapter.parameters = {}
+  adapter.handlers.setup(adapter)
+
+  h.eq(true, adapter.opts.can_form_structured_outputs)
+  h.not_eq(nil, adapter.handlers.form_structured_output(adapter, { name = "verdict", schema = {} }))
+end
+
 T["Anthropic model_transformers"] = new_set()
 
 T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model list"] = function()
@@ -990,6 +1006,7 @@ T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model
   h.eq({ context_window = 1000000, max_tokens = 128000 }, result["claude-sonnet-5"].meta)
   h.eq(true, result["claude-sonnet-5"].opts.can_reason)
   h.eq(true, result["claude-sonnet-5"].opts.has_vision)
+  h.eq(true, result["claude-sonnet-5"].opts.can_form_structured_outputs)
 
   -- Supports context_management as a whole, including compact_20260112
   h.eq(true, result["claude-sonnet-5"].opts.can_manage_context)

--- a/tests/adapters/http/test_gemini_interactions.lua
+++ b/tests/adapters/http/test_gemini_interactions.lua
@@ -510,8 +510,6 @@ T["Gemini Interactions adapter"]["resolves model capabilities on the first reque
   local adapters = require("codecompanion.adapters")
 
   adapter.schema.model.default = "gemini-3-pro-preview"
-  -- The model fetcher only returns the list when asked to block; without that it
-  -- fires the request and returns an empty table until the response lands
   adapter.schema.model.choices = function(_, opts)
     if not (opts and opts.async == false) then
       return {}

--- a/tests/adapters/http/test_gemini_interactions.lua
+++ b/tests/adapters/http/test_gemini_interactions.lua
@@ -506,4 +506,24 @@ T["Gemini Interactions adapter"]["No Streaming"]["can output a structured output
   h.eq(15, decoded.prep_time_minutes)
 end
 
+T["Gemini Interactions adapter"]["resolves model capabilities on the first request"] = function()
+  local adapters = require("codecompanion.adapters")
+
+  adapter.schema.model.default = "gemini-3-pro-preview"
+  -- The model fetcher only returns the list when asked to block; without that it
+  -- fires the request and returns an empty table until the response lands
+  adapter.schema.model.choices = function(_, opts)
+    if not (opts and opts.async == false) then
+      return {}
+    end
+    return { ["gemini-3-pro-preview"] = { opts = { can_form_structured_outputs = true } } }
+  end
+
+  adapter.parameters = {}
+  adapters.call_handler(adapter, "setup")
+
+  h.eq(true, adapter.opts.can_form_structured_outputs)
+  h.not_eq(nil, adapters.call_handler(adapter, "build_structured_output", { name = "verdict", schema = {} }))
+end
+
 return T

--- a/tests/adapters/http/test_kimi.lua
+++ b/tests/adapters/http/test_kimi.lua
@@ -1,0 +1,34 @@
+local h = require("tests.helpers")
+local adapter
+
+local new_set = MiniTest.new_set
+T = new_set()
+
+T["Kimi adapter"] = new_set({
+  hooks = {
+    pre_case = function()
+      adapter = require("codecompanion.adapters").resolve("kimi")
+    end,
+  },
+})
+
+T["Kimi adapter"]["resolves model capabilities on the first request"] = function()
+  local adapters = require("codecompanion.adapters")
+
+  adapter.schema.model.default = "kimi-k2.7-code"
+  -- The model fetcher only returns the list when asked to block; without that it
+  -- fires the request and returns an empty table until the response lands
+  adapter.schema.model.choices = function(_, opts)
+    if not (opts and opts.async == false) then
+      return {}
+    end
+    return { ["kimi-k2.7-code"] = { opts = { has_vision = true } } }
+  end
+
+  adapter.parameters = {}
+  adapters.call_handler(adapter, "setup")
+
+  h.eq(true, adapter.opts.vision)
+end
+
+return T

--- a/tests/adapters/http/test_kimi.lua
+++ b/tests/adapters/http/test_kimi.lua
@@ -16,8 +16,6 @@ T["Kimi adapter"]["resolves model capabilities on the first request"] = function
   local adapters = require("codecompanion.adapters")
 
   adapter.schema.model.default = "kimi-k2.7-code"
-  -- The model fetcher only returns the list when asked to block; without that it
-  -- fires the request and returns an empty table until the response lands
   adapter.schema.model.choices = function(_, opts)
     if not (opts and opts.async == false) then
       return {}

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -819,8 +819,6 @@ T["Responses"]["resolves model capabilities on the first request"] = function()
   local adapters = require("codecompanion.adapters")
 
   adapter.schema.model.default = "gpt-5.4"
-  -- The model fetcher only returns the list when asked to block; without that it
-  -- fires the request and returns an empty table until the response lands
   adapter.schema.model.choices = function(_, opts)
     if not (opts and opts.async == false) then
       return {}

--- a/tests/adapters/http/test_openai_responses.lua
+++ b/tests/adapters/http/test_openai_responses.lua
@@ -815,4 +815,24 @@ T["Responses"]["Compaction"]["Streaming"]["captures compaction from output_item.
   h.eq("gAAAABcancelledcompactiondata", compaction_items.encrypted_content)
 end
 
+T["Responses"]["resolves model capabilities on the first request"] = function()
+  local adapters = require("codecompanion.adapters")
+
+  adapter.schema.model.default = "gpt-5.4"
+  -- The model fetcher only returns the list when asked to block; without that it
+  -- fires the request and returns an empty table until the response lands
+  adapter.schema.model.choices = function(_, opts)
+    if not (opts and opts.async == false) then
+      return {}
+    end
+    return { ["gpt-5.4"] = { opts = { can_form_structured_outputs = true, can_use_tools = true } } }
+  end
+
+  adapter.parameters = {}
+  adapters.call_handler(adapter, "setup")
+
+  h.eq(true, adapter.opts.can_form_structured_outputs)
+  h.not_eq(nil, adapters.call_handler(adapter, "build_structured_output", { name = "verdict", schema = {} }))
+end
+
 return T

--- a/tests/adapters/http/test_openrouter.lua
+++ b/tests/adapters/http/test_openrouter.lua
@@ -268,4 +268,21 @@ T["OpenRouter adapter"]["No Streaming"]["can process tools"] = function()
   h.eq(tool_output, tools)
 end
 
+T["OpenRouter adapter"]["resolves model capabilities on the first request"] = function()
+  local structured = require("codecompanion.adapters").resolve("openrouter")
+  structured.schema.model.default = "openai/gpt-5.4-mini"
+  structured.schema.model.choices = function(_, opts)
+    if not (opts and opts.async == false) then
+      return {}
+    end
+    return { ["openai/gpt-5.4-mini"] = { opts = { can_form_structured_outputs = true } } }
+  end
+
+  structured.parameters = {}
+  structured.handlers.setup(structured)
+
+  h.eq(true, structured.opts.can_form_structured_outputs)
+  h.not_eq(nil, structured.handlers.form_structured_output(structured, { name = "verdict", schema = {} }))
+end
+
 return T

--- a/tests/interactions/background/catalog/test_tool_safety_check.lua
+++ b/tests/interactions/background/catalog/test_tool_safety_check.lua
@@ -1,0 +1,82 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+
+local child = MiniTest.new_child_neovim()
+T = new_set({
+  hooks = {
+    pre_once = function()
+      h.child_start(child)
+      child.lua([[
+        h = require('tests.helpers')
+        h.setup_plugin()
+        builtin = require("codecompanion.interactions.background.builtin.tool_safety_check")
+
+        -- A background whose `ask` immediately replays a canned result to on_done
+        function _G.background_returning(result)
+          return {
+            ask = function(_, _, opts)
+              opts.on_done(result)
+            end,
+          }
+        end
+
+        -- A background whose `ask` immediately fails via on_error
+        _G.background_erroring = {
+          ask = function(_, _, opts)
+            opts.on_error("boom")
+          end,
+        }
+
+        function _G.judge(background)
+          local verdict
+          builtin.request(background, { tool_name = "run_command", context = "rm -rf /" }, function(v)
+            verdict = v
+          end)
+          return verdict
+        end
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["tool_safety_check"] = new_set()
+
+T["tool_safety_check"]["passes a safe verdict through"] = function()
+  local verdict = child.lua([[
+    return _G.judge(_G.background_returning({
+      output = { content = '{"safe":true,"reason":"lists files"}' },
+    }))
+  ]])
+
+  h.eq(verdict.safe, true)
+  h.eq(verdict.reason, "lists files")
+end
+
+T["tool_safety_check"]["passes an unsafe verdict through"] = function()
+  local verdict = child.lua([[
+    return _G.judge(_G.background_returning({
+      output = { content = '{"safe":false,"reason":"deletes everything"}' },
+    }))
+  ]])
+
+  h.eq(verdict.safe, false)
+  h.eq(verdict.reason, "deletes everything")
+end
+
+T["tool_safety_check"]["requires approval when the response is unreadable"] = function()
+  local verdict = child.lua([[
+    return _G.judge(_G.background_returning({ output = { content = "not json" } }))
+  ]])
+
+  h.eq(verdict.safe, false)
+end
+
+T["tool_safety_check"]["requires approval when the request errors"] = function()
+  local verdict = child.lua([[return _G.judge(_G.background_erroring)]])
+
+  h.eq(verdict.safe, false)
+end
+
+return T

--- a/tests/interactions/background/catalog/test_tools_judge.lua
+++ b/tests/interactions/background/catalog/test_tools_judge.lua
@@ -10,7 +10,7 @@ T = new_set({
       child.lua([[
         h = require('tests.helpers')
         h.setup_plugin()
-        builtin = require("codecompanion.interactions.background.builtin.tool_safety_check")
+        builtin = require("codecompanion.interactions.background.builtin.tools_judge")
 
         -- A background whose `ask` immediately replays a canned result to on_done
         function _G.background_returning(result)
@@ -41,9 +41,9 @@ T = new_set({
   },
 })
 
-T["tool_safety_check"] = new_set()
+T["tools_judge"] = new_set()
 
-T["tool_safety_check"]["passes a safe verdict through"] = function()
+T["tools_judge"]["passes a safe verdict through"] = function()
   local verdict = child.lua([[
     return _G.judge(_G.background_returning({
       output = { content = '{"safe":true,"reason":"lists files"}' },
@@ -54,7 +54,7 @@ T["tool_safety_check"]["passes a safe verdict through"] = function()
   h.eq(verdict.reason, "lists files")
 end
 
-T["tool_safety_check"]["passes an unsafe verdict through"] = function()
+T["tools_judge"]["passes an unsafe verdict through"] = function()
   local verdict = child.lua([[
     return _G.judge(_G.background_returning({
       output = { content = '{"safe":false,"reason":"deletes everything"}' },
@@ -65,7 +65,7 @@ T["tool_safety_check"]["passes an unsafe verdict through"] = function()
   h.eq(verdict.reason, "deletes everything")
 end
 
-T["tool_safety_check"]["requires approval when the response is unreadable"] = function()
+T["tools_judge"]["requires approval when the response is unreadable"] = function()
   local verdict = child.lua([[
     return _G.judge(_G.background_returning({ output = { content = "not json" } }))
   ]])
@@ -73,7 +73,7 @@ T["tool_safety_check"]["requires approval when the response is unreadable"] = fu
   h.eq(verdict.safe, false)
 end
 
-T["tool_safety_check"]["requires approval when the request errors"] = function()
+T["tools_judge"]["requires approval when the request errors"] = function()
   local verdict = child.lua([[return _G.judge(_G.background_erroring)]])
 
   h.eq(verdict.safe, false)

--- a/tests/interactions/background/test_callbacks.lua
+++ b/tests/interactions/background/test_callbacks.lua
@@ -55,6 +55,38 @@ T["callbacks"]["can register chat callbacks"] = function()
   h.is_true(result)
 end
 
+T["callbacks"]["registers actions declared with a per-action adapter"] = function()
+  child.lua([[
+    _G.chat = h.setup_chat_buffer()
+
+    config.interactions.background.chat = {
+      opts = { enabled = true },
+      callbacks = {
+        test_event = {
+          enabled = true,
+          actions = {
+            { path = "some.background.action", adapter = { name = "copilot", model = "claude-haiku-4.5" } },
+          },
+        },
+      },
+    }
+
+    local original_add_callback = _G.chat.add_callback
+    local callback_registered = false
+    _G.chat.add_callback = function(self, event, callback)
+      if event == "test_event" then
+        callback_registered = true
+      end
+      return original_add_callback(self, event, callback)
+    end
+
+    callbacks.register_chat_callbacks(_G.chat)
+    _G.callback_registered = callback_registered
+  ]])
+
+  h.is_true(child.lua([[return _G.callback_registered]]))
+end
+
 T["callbacks"]["can't register disabled callbacks"] = function()
   child.lua([[
     _G.chat = h.setup_chat_buffer()

--- a/tests/interactions/chat/tools/test_orchestrator.lua
+++ b/tests/interactions/chat/tools/test_orchestrator.lua
@@ -164,4 +164,111 @@ T["tools only receive output that relates to their execution"] = function()
   h.eq({ "Data 2" }, output)
 end
 
+---Queue a tool that is gated by the background safety check, in yolo mode, and
+---replay a canned verdict from a stubbed judge
+---@param verdict { safe: boolean, reason: string }
+local function setup_yolo_mode_with_safety_check(verdict)
+  child.lua(string.format(
+    [[
+    _G.executed = {}
+    _G.prompted_with = nil
+
+    -- The judge, stubbed so no request is made. Registered under a module path
+    -- so it also covers `gates.safety_check.action` being configurable
+    package.loaded["stub_judge"] = {
+      request = function(_, request, callback)
+        _G.judged_context = request.context
+        callback(%s)
+      end,
+    }
+
+    local cfg = {
+      interactions = {
+        background = {
+          gates = { safety_check = { enabled = true, action = "stub_judge" } },
+        },
+        chat = {
+          tools = {
+            opts = { auto_submit_success = false, auto_submit_errors = false },
+            dangerous = {
+              enabled = true,
+              opts = {
+                allowed_in_yolo_mode = false,
+                require_approval_before = true,
+                require_cmd_approval = true,
+                safety_check = true,
+              },
+              callback = function()
+                return {
+                  name = "dangerous",
+                  cmds = {
+                    function(self, args, opts)
+                      table.insert(_G.executed, "dangerous")
+                      opts.output_cb({ status = "success", data = "ran" })
+                    end,
+                  },
+                  schema = {
+                    type = "function",
+                    ["function"] = {
+                      name = "dangerous",
+                      description = "A tool worth vetting",
+                      parameters = { type = "object", properties = {} },
+                    },
+                  },
+                  opts = {
+                    allowed_in_yolo_mode = false,
+                    require_approval_before = true,
+                    require_cmd_approval = true,
+                    safety_check = true,
+                  },
+                  output = {
+                    cmd_string = function()
+                      return "rm -rf /"
+                    end,
+                  },
+                  gates = {
+                    safety_context = function()
+                      return "rm -rf /"
+                    end,
+                  },
+                }
+              end,
+            },
+          },
+        },
+      },
+    }
+
+    local chat, tools = h.setup_chat_buffer(cfg)
+    _G.chat, _G.tools = chat, tools
+
+    require("codecompanion.interactions.chat.tools.approvals"):toggle_yolo_mode(tools.bufnr)
+
+    local ap = require("codecompanion.interactions.chat.helpers.approval_prompt")
+    ap.request = function(_, opts)
+      _G.prompted_with = opts.prompt
+    end
+
+    _G.tools:execute(_G.chat, { { ["function"] = { name = "dangerous", arguments = "{}" } } })
+    vim.wait(250)
+  ]],
+    vim.inspect(verdict)
+  ))
+end
+
+T["safe verdict runs the tool without prompting"] = function()
+  setup_yolo_mode_with_safety_check({ safe = true, reason = "reads only" })
+
+  h.eq({ "dangerous" }, child.lua_get("_G.executed"))
+  h.eq(vim.NIL, child.lua_get("_G.prompted_with"))
+  h.eq("rm -rf /", child.lua_get("_G.judged_context"))
+end
+
+T["unsafe verdict prompts with the judge's reason instead of running"] = function()
+  setup_yolo_mode_with_safety_check({ safe = false, reason = "deletes the filesystem" })
+
+  h.eq({}, child.lua_get("_G.executed"))
+  h.eq('Run the "dangerous" tool?\nJudge: _"deletes the filesystem"_', child.lua_get("_G.prompted_with"))
+end
+
 return T

--- a/tests/interactions/chat/tools/test_orchestrator.lua
+++ b/tests/interactions/chat/tools/test_orchestrator.lua
@@ -164,17 +164,16 @@ T["tools only receive output that relates to their execution"] = function()
   h.eq({ "Data 2" }, output)
 end
 
----Queue a tool that is gated by the background safety check, in yolo mode, and
----replay a canned verdict from a stubbed judge
+---Queue a tool that is gated by the background judge, in yolo mode, replying with a canned verdict
 ---@param verdict { safe: boolean, reason: string }
-local function setup_yolo_mode_with_safety_check(verdict)
+local function setup_yolo_mode_with_judge(verdict)
   child.lua(string.format(
     [[
     _G.executed = {}
     _G.prompted_with = nil
 
     -- The judge, stubbed so no request is made. Registered under a module path
-    -- so it also covers `gates.safety_check.action` being configurable
+    -- so it also covers `gates.judge.action` being configurable
     package.loaded["stub_judge"] = {
       request = function(_, request, callback)
         _G.judged_context = request.context
@@ -185,7 +184,7 @@ local function setup_yolo_mode_with_safety_check(verdict)
     local cfg = {
       interactions = {
         background = {
-          gates = { safety_check = { enabled = true, action = "stub_judge" } },
+          gates = { judge = { enabled = true, action = "stub_judge" } },
         },
         chat = {
           tools = {
@@ -196,7 +195,7 @@ local function setup_yolo_mode_with_safety_check(verdict)
                 allowed_in_yolo_mode = false,
                 require_approval_before = true,
                 require_cmd_approval = true,
-                safety_check = true,
+                judge_in_yolo_mode = true,
               },
               callback = function()
                 return {
@@ -219,7 +218,7 @@ local function setup_yolo_mode_with_safety_check(verdict)
                     allowed_in_yolo_mode = false,
                     require_approval_before = true,
                     require_cmd_approval = true,
-                    safety_check = true,
+                    judge_in_yolo_mode = true,
                   },
                   output = {
                     cmd_string = function()
@@ -227,7 +226,7 @@ local function setup_yolo_mode_with_safety_check(verdict)
                     end,
                   },
                   gates = {
-                    safety_context = function()
+                    judge_context = function()
                       return "rm -rf /"
                     end,
                   },
@@ -257,7 +256,7 @@ local function setup_yolo_mode_with_safety_check(verdict)
 end
 
 T["safe verdict runs the tool without prompting"] = function()
-  setup_yolo_mode_with_safety_check({ safe = true, reason = "reads only" })
+  setup_yolo_mode_with_judge({ safe = true, reason = "reads only" })
 
   h.eq({ "dangerous" }, child.lua_get("_G.executed"))
   h.eq(vim.NIL, child.lua_get("_G.prompted_with"))
@@ -265,7 +264,7 @@ T["safe verdict runs the tool without prompting"] = function()
 end
 
 T["unsafe verdict prompts with the judge's reason instead of running"] = function()
-  setup_yolo_mode_with_safety_check({ safe = false, reason = "deletes the filesystem" })
+  setup_yolo_mode_with_judge({ safe = false, reason = "deletes the filesystem" })
 
   h.eq({}, child.lua_get("_G.executed"))
   h.eq('Run the "dangerous" tool?\nJudge: _"deletes the filesystem"_', child.lua_get("_G.prompted_with"))


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Currently, CodeCompanion enables users to trigger [YOLO mode](https://codecompanion.olimorris.dev/usage/chat-buffer/agents-tools#yolo-mode). However, by default, commands like [delete_file](https://codecompanion.olimorris.dev/usage/chat-buffer/agents-tools#delete-file) and [run_command](https://codecompanion.olimorris.dev/usage/chat-buffer/agents-tools#run-command) will always ask the user for approval, unless this is disabled.

This PR offers a middle ground, whereby the tool calls are sent to an LLM judge for review. The judge reviews them against how destructive and dangerous they might be and delegates to the human as required.

This features requires http adapters to have structured output parsing (which most of them do btw!).

To test this out:

```lua
require("codecompanion").setup({
  interactions = {
    background = {
      gates = {
        judge = {
          enabled = true,
        },
      },
    },
    chat = {
      tools = {
        ["delete_file"] = {
          opts = {
            judge_in_yolo_mode = true,
          },
        },
        ["run_command"] = {
          opts = {
            judge_in_yolo_mode = true,
          },
        },
      },
    },
  },
})
```

> [!NOTE]
> Of course selecting an adapter of your choosing

Then, open a chat buffer, enable YOLO mode and type:

```
Can you use the @{run_command} to run some basic commands on my machine? I'm testing that the tool works
```

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 4.8 and 5

## Related Issue(s)

Partial discussion in #3184

## Screenshots

https://github.com/user-attachments/assets/37dbbd05-c5ac-4850-862f-629710ba6ee6

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
