### PR TITLE
refactor(chat): change opts name for code review context

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -924,7 +924,7 @@ The user is working on a %s machine. Please respond with system specific command
           description = "Share your pending code review comments with the LLM",
           opts = {
             contains_code = true,
-            replacement = "my comments from the code review, which I've attached",
+            replacement_message = "my comments from the code review, which I've attached",
           },
         },
         ["diagnostics"] = {

--- a/lua/codecompanion/interactions/shared/editor_context/code_review.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/code_review.lua
@@ -102,7 +102,7 @@ end
 ---@param message string
 ---@return string
 function EditorContext.replace(prefix, message)
-  local replacement = config.interactions.shared.editor_context.code_review.opts.replacement
+  local replacement = config.interactions.shared.editor_context.code_review.opts.replacement_message
 
   message = message:gsub(prefix .. CONSTANTS.EDITOR_CONTEXT_TAG .. "{[^}]*}", replacement)
   message = message:gsub(prefix .. CONSTANTS.EDITOR_CONTEXT_TAG, replacement)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Change the `code_review` editor context from `replacement` to `replacement_message` to be more explicit.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
