### PR TITLE
refactor(background): remove system prompts from title generation

### DIFF
--- a/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
+++ b/lua/codecompanion/interactions/background/builtin/chat_make_title.lua
@@ -24,11 +24,14 @@ function M.format_messages(messages)
   local exclude_tags = {
     [tags.IMAGE] = "[Image content omitted]",
     [tags.RULES] = "",
-    [tags.SYSTEM_PROMPT_FROM_CONFIG] = "",
   }
 
   local chat_messages = {}
   for _, m in ipairs(messages or {}) do
+    if m.role == "system" then
+      goto continue
+    end
+
     local tag = m._meta and m._meta.tag
     local replacement = exclude_tags[tag]
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When an LLM read a conversation to try and generate a title, a system prompt might have been sent for review.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Sonnet 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
