### PR TITLE
feat(tools): can view `create_file` content

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -4761,15 +4761,18 @@ choose between implementation approaches, or wants to validate assumptions.
 CREATE_FILE
 
 
-  [!NOTE] By default, this tool requires user approval before it can be executed
+  [!NOTE] By default, this tool shows a preview of the file's contents and
+  requires user confirmation before it can be executed
 Create a file within the current working directory:
 
 >md
     Can you create some test fixtures using @{create_file}?
 <
 
-**Options:** - `require_approval_before` require approval before creating a
-file? (Default: true)
+**Options:** - `require_approval_before` (boolean) require approval before
+showing the file preview? (Default: false) - `require_confirmation_after`
+(boolean) show a preview of the file's contents and require confirmation before
+creating it? (Default: true)
 
 
 DELETE_FILE

--- a/doc/usage/chat-buffer/agents-tools.md
+++ b/doc/usage/chat-buffer/agents-tools.md
@@ -133,7 +133,7 @@ This tool enables an LLM to ask clarifying questions before taking further actio
 ### create_file
 
 > [!NOTE]
-> By default, this tool requires user approval before it can be executed
+> By default, this tool shows a preview of the file's contents and requires user confirmation before it can be executed
 
 Create a file within the current working directory:
 
@@ -142,7 +142,8 @@ Can you create some test fixtures using @{create_file}?
 ```
 
 **Options:**
-- `require_approval_before` require approval before creating a file? (Default: true)
+- `require_approval_before` (boolean) require approval before showing the file preview? (Default: false)
+- `require_confirmation_after` (boolean) show a preview of the file's contents and require confirmation before creating it? (Default: true)
 
 ### delete_file
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -206,7 +206,8 @@ The user is working on a %s machine. Please respond with system specific command
           path = "interactions.chat.tools.builtin.create_file",
           description = "Create a file in the current working directory",
           opts = {
-            require_approval_before = true,
+            require_approval_before = false,
+            require_confirmation_after = true,
           },
         },
         ["delete_file"] = {

--- a/lua/codecompanion/interactions/chat/tools/builtin/create_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/create_file.lua
@@ -1,3 +1,5 @@
+local approvals = require("codecompanion.interactions.chat.tools.approvals")
+local diff = require("codecompanion.interactions.chat.tools.builtin.helpers.diff")
 local files = require("codecompanion.utils.files")
 local helpers = require("codecompanion.interactions.chat.tools.builtin.helpers")
 local log = require("codecompanion.utils.log")
@@ -5,82 +7,36 @@ local utils = require("codecompanion.utils")
 
 local fmt = string.format
 
+---Validate that a file can be created at the given path
+---@param filepath string The absolute path to check
+---@return boolean ok
+---@return string|nil error_message
+local function validate_creation_path(filepath)
+  if not files.exists(filepath) then
+    return true, nil
+  end
+
+  return false, fmt([[Failed creating `%s` - File/directory already exists]], filepath)
+end
+
 ---Create a file and the surrounding folders
 ---@param action {filepath: string, content: string} The action containing the filepath and content
 ---@return {status: "success"|"error", data: string}
 local function create(action)
   local filepath = vim.fs.normalize(action.filepath)
 
-  -- Check if file already exists
-  local stat = vim.uv.fs_stat(filepath)
-  if stat then
-    if stat.type == "directory" then
-      return {
-        status = "error",
-        data = fmt([[Failed creating `%s` - Already exists as a directory]], action.filepath),
-      }
-    elseif stat.type == "file" then
-      return {
-        status = "error",
-        data = fmt([[Failed creating `%s` - File already exists]], action.filepath),
-      }
-    end
-  end
-
-  local parent_dir = vim.fs.dirname(filepath)
-
-  -- Ensure parent directory exists
-  if not vim.uv.fs_stat(parent_dir) then
-    local success, err_msg = files.create_dir_recursive(parent_dir)
-    if not success then
-      local error_message = fmt([[Failed creating `%s` - %s]], action.filepath, err_msg)
-      log:error(error_message)
-      return { status = "error", data = error_message }
-    end
-  end
-
-  -- Create file with safer error handling
-  local fd, fs_open_err, fs_open_errname = vim.uv.fs_open(filepath, "w", 420) -- 0644 permissions
-  if not fd then
-    local error_message = fmt([[Failed creating `%s` - %s - %s ]], action.filepath, fs_open_err, fs_open_errname)
-    log:error(error_message)
+  local ok, error_message = validate_creation_path(filepath)
+  if not ok then
     return { status = "error", data = error_message }
   end
 
-  -- Try to write to the file
-  local bytes_written, fs_write_err, _ = vim.uv.fs_write(fd, action.content)
-  local write_error_message
-  if not bytes_written then
-    write_error_message = fmt([[Failed creating `%s` - %s]], action.filepath, fs_write_err)
-  elseif bytes_written ~= #action.content then
-    write_error_message = fmt([[Failed creating `%s` - Could only write %s bytes]], action.filepath, bytes_written)
-  end
-
-  -- Always try to close the file descriptor
-  local close_success, fs_close_err, _ = vim.uv.fs_close(fd)
-  local close_error_message
-  if not close_success then
-    close_error_message = fmt([[Failed creating `%s` - Could not close the file - %s ]], action.filepath, fs_close_err)
-  end
-
-  -- Combine errors if any
-  local final_error_message
-  if write_error_message and close_error_message then
-    final_error_message = write_error_message .. ". Additionally, " .. close_error_message
-  elseif write_error_message then
-    final_error_message = write_error_message
-  elseif close_error_message then
-    final_error_message = close_error_message
-  end
-
-  -- If any error occurred during write or close, return error
-  if final_error_message then
-    local full_error = fmt([[Failed creating `%s` - %s]], action.filepath, final_error_message)
+  local write_ok, write_err = pcall(files.write_to_path, filepath, action.content or "")
+  if not write_ok then
+    local full_error = fmt([[Failed creating `%s` - %s]], action.filepath, write_err)
     log:error(full_error)
     return { status = "error", data = full_error }
   end
 
-  -- If we reach here, all operations (open, write, close) were successful
   utils.fire("FileEdited", { path = filepath, tool = "create_file" })
   return {
     status = "success",
@@ -93,12 +49,35 @@ return {
   name = "create_file",
   cmds = {
     ---Execute the file commands
-    ---@param self CodeCompanion.Tool.CreateFile
+    ---@param self CodeCompanion.Tools
     ---@param args table The arguments from the LLM's tool call
-    ---@param input? any The output from the previous function call
-    ---@return { status: "success"|"error", data: string }
-    function(self, args, input)
-      return create(args)
+    ---@param opts { output_cb: fun(response: {status: "success"|"error", data: string}) }
+    ---@return nil
+    function(self, args, opts)
+      local filepath = vim.fs.normalize(args.filepath)
+
+      local ok, error_message = validate_creation_path(filepath)
+      if not ok then
+        return opts.output_cb({ status = "error", data = error_message })
+      end
+
+      local display_path = vim.fn.fnamemodify(args.filepath, ":.")
+
+      return diff.review({
+        from_lines = {},
+        to_lines = vim.split(args.content or "", "\n", { plain = true }),
+        apply = function()
+          opts.output_cb(create(args))
+        end,
+        approved = approvals:is_approved(self.chat.bufnr, { tool_name = "create_file" }),
+        chat = self.chat,
+        chat_bufnr = self.chat.bufnr,
+        ft = vim.filetype.match({ filename = filepath }) or "text",
+        output_cb = opts.output_cb,
+        require_confirmation_after = self.tool.opts.require_confirmation_after,
+        title = display_path,
+        tool_name = "create_file",
+      })
     end,
   },
   schema = {
@@ -142,14 +121,6 @@ return {
       return self.args.filepath
     end,
 
-    ---The message which is shared with the user when asking for their approval
-    ---@param self CodeCompanion.Tools.Tool
-    ---@param meta { tools: CodeCompanion.Tools }
-    ---@return nil|string
-    prompt = function(self, meta)
-      return fmt("Create a file at `%s`?", vim.fn.fnamemodify(self.args.filepath, ":."))
-    end,
-
     ---@param self CodeCompanion.Tool.CreateFile
     ---@param stdout table The output from the command
     ---@param meta { tools: CodeCompanion.Tools, cmd: table }
@@ -158,7 +129,7 @@ return {
       local args = self.args
       local display_path = vim.fn.fnamemodify(args.filepath, ":.")
 
-      local llm_output = fmt("<createFileTool>%s</createFileTool>", "Created file `%s` successfully")
+      local llm_output = fmt("Created file `%s` successfully", display_path)
 
       local file_ext = vim.fn.fnamemodify(args.filepath, ":e")
 

--- a/lua/codecompanion/interactions/chat/tools/builtin/helpers/diff.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/helpers/diff.lua
@@ -35,13 +35,13 @@ local function open_diff_view(opts)
     from_lines = opts.from_lines,
     to_lines = opts.to_lines,
     title = opts.title,
-    tool_name = "insert_edit_into_file",
+    tool_name = opts.tool_name,
     keymaps = {
       on_always_accept = function()
         if opts.on_done then
           opts.on_done(labels.always_accept)
         end
-        approvals:always(opts.chat_bufnr, { tool_name = "insert_edit_into_file" })
+        approvals:always(opts.chat_bufnr, { tool_name = opts.tool_name })
       end,
       on_accept = function()
         if opts.on_done then
@@ -54,7 +54,7 @@ local function open_diff_view(opts)
           opts.on_done(labels.reject)
         end
         get_rejection_reason(function(reason)
-          local msg = fmt('User rejected the edits for `%s`, with the reason "%s"', opts.title, reason)
+          local msg = fmt('User rejected the changes for `%s`, with the reason "%s"', opts.title, reason)
           opts.output_cb(make_response("error", msg))
         end)
       end,
@@ -82,7 +82,7 @@ local function build_approval_choices(opts)
       keymap = keys.always_accept,
       label = labels.always_accept,
       callback = function()
-        approvals:always(opts.chat_bufnr, { tool_name = "insert_edit_into_file" })
+        approvals:always(opts.chat_bufnr, { tool_name = opts.tool_name })
         opts.apply()
       end,
     },
@@ -98,7 +98,7 @@ local function build_approval_choices(opts)
       label = labels.reject,
       callback = function()
         get_rejection_reason(function(reason)
-          local msg = fmt('User rejected the edits for `%s`, with the reason "%s"', opts.title, reason)
+          local msg = fmt('User rejected the changes for `%s`, with the reason "%s"', opts.title, reason)
           opts.output_cb(make_response("error", msg))
         end)
       end,
@@ -107,7 +107,7 @@ local function build_approval_choices(opts)
       keymap = keys.cancel,
       label = labels.cancel,
       callback = function()
-        opts.output_cb(make_response("error", fmt("User cancelled the edits for `%s`", opts.title)))
+        opts.output_cb(make_response("error", fmt("User cancelled the changes for `%s`", opts.title)))
       end,
     },
   }
@@ -125,8 +125,8 @@ local function approve_in_chat(chat, opts)
   })
 end
 
----Show diff and handle approval flow for edits
----@param opts table
+---Show a diff and handle the approval flow for a tool's proposed changes
+---@param opts { from_lines: string[], to_lines: string[], ft: string, title: string, tool_name: string, chat: CodeCompanion.Chat, chat_bufnr: number, approved: boolean, require_confirmation_after: boolean, apply: fun(), output_cb: fun(response: table) }
 ---@return any
 function M.review(opts)
   local diff_enabled = config.display.diff.enabled == true
@@ -135,7 +135,7 @@ function M.review(opts)
     return opts.apply()
   end
 
-  opts.title = fmt("Proposed edits for `%s`:", opts.title)
+  opts.title = fmt("Proposed changes for `%s`:", opts.title)
 
   local approval_prompt = require("codecompanion.interactions.chat.helpers.approval_prompt")
   approval_prompt.present_diff({

--- a/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/insert_edit_into_file/init.lua
@@ -28,7 +28,7 @@
 local Path = require("plenary.path")
 local approvals = require("codecompanion.interactions.chat.tools.approvals")
 local constants = require("codecompanion.interactions.chat.tools.builtin.insert_edit_into_file.constants")
-local diff = require("codecompanion.interactions.chat.tools.builtin.insert_edit_into_file.diff")
+local diff = require("codecompanion.interactions.chat.tools.builtin.helpers.diff")
 local io_mod = require("codecompanion.interactions.chat.tools.builtin.insert_edit_into_file.io")
 local json_repair = require("codecompanion.interactions.chat.tools.builtin.insert_edit_into_file.json_repair")
 local match_selector = require("codecompanion.interactions.chat.tools.builtin.insert_edit_into_file.match_selector")
@@ -205,6 +205,7 @@ local function execute_edit(source, action, opts)
     require_confirmation_after = opts.tool_opts.require_confirmation_after,
     success_msg = success_msg,
     title = source.display_name,
+    tool_name = "insert_edit_into_file",
   })
 end
 

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -109,6 +109,7 @@ return {
         ["create_file"] = {
           opts = {
             require_approval_before = false,
+            require_confirmation_after = false,
           },
         },
         ["delete_file"] = {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As raised in the discussion below, it would be useful when an agent is creating a file to be able to view the contents of the file so you can provide feedback to the agent. 

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Sonnet 5

## Related Issue(s)

#3264

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
