### PR TITLE
fix(adapters): correct OpenAI GPT-5.6 models

### DIFF
--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -431,7 +431,7 @@ return {
       choices = {
         -- Frontier models
         ["gpt-5.6-sol"] = {
-          formatted_name = "GPT 5.5",
+          formatted_name = "GPT 5.6 Sol",
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,
@@ -443,6 +443,17 @@ return {
         },
         ["gpt-5.6-terra"] = {
           formatted_name = "GPT 5.6 Terra",
+          meta = { context_window = 1050000 },
+          opts = {
+            can_form_structured_outputs = true,
+            can_manage_context = true,
+            can_use_tools = true,
+            has_vision = true,
+            can_reason = true,
+          },
+        },
+        ["gpt-5.6-luna"] = {
+          formatted_name = "GPT 5.6 Luna",
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,


### PR DESCRIPTION
## Summary

- Correct the `gpt-5.6-sol` display name in the OpenAI Chat Completions adapter.
- Add `gpt-5.6-luna` with the same supported capabilities as the rest of the GPT-5.6 family.

## Why

The OpenAI adapter labeled `gpt-5.6-sol` as `GPT 5.5`, creating two indistinguishable `GPT 5.5` choices in the model picker. It also omitted `gpt-5.6-luna`, even though the model supports the Chat Completions endpoint.

OpenAI's model documentation lists Chat Completions, reasoning, image input, function calling, and structured outputs for both [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol) and [GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna).

## Impact

Users can distinguish GPT-5.6 Sol from GPT-5.5 and select GPT-5.6 Luna from the plain OpenAI adapter without overriding its model catalog.

## Verification

- `stylua --check .` with the CI-pinned StyLua 2.4.1
- `make test`: 1,201 cases, 0 failures
