### PR TITLE
fix(adapters): correct OpenAI GPT-5.6 models

### DIFF
--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -431,7 +431,7 @@ return {
       choices = {
         -- Frontier models
         ["gpt-5.6-sol"] = {
-          formatted_name = "GPT 5.5",
+          formatted_name = "GPT 5.6 Sol",
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,
@@ -443,6 +443,17 @@ return {
         },
         ["gpt-5.6-terra"] = {
           formatted_name = "GPT 5.6 Terra",
+          meta = { context_window = 1050000 },
+          opts = {
+            can_form_structured_outputs = true,
+            can_manage_context = true,
+            can_use_tools = true,
+            has_vision = true,
+            can_reason = true,
+          },
+        },
+        ["gpt-5.6-luna"] = {
+          formatted_name = "GPT 5.6 Luna",
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,


### PR DESCRIPTION
## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

- Correct the `gpt-5.6-sol` display name in the OpenAI Chat Completions adapter.
- Add `gpt-5.6-luna` with the same supported capabilities as the rest of the GPT-5.6 family.

The OpenAI adapter labeled `gpt-5.6-sol` as `GPT 5.5`, creating two indistinguishable `GPT 5.5` choices in the model picker. It also omitted `gpt-5.6-luna`, even though the model supports the Chat Completions endpoint.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

OpenAI's model documentation lists Chat Completions, reasoning, image input, function calling, and structured outputs for both [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol) and [GPT-5.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna).

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

I used Codex to submit the PR, hence it tried to use its own PR template format initially.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
