### PR TITLE
fix(acp): use `SIGTERM` in place of `SIGKILL`

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -545,7 +545,7 @@ end
 ---Disconnect and clean up the ACP process
 ---@return nil
 function Connection:disconnect()
-  assert(self._state.handle):kill(9)
+  assert(self._state.handle):kill(15)
 end
 
 ---Process the output


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The ACP disconnect method used `SIGKILL`. I recall this was because agents that supported ACP, circa 12 months ago, were somewhat unreliable in how they shutdown.

This PR switches the disconnect to `SIGTERM` to request a graceful shutdown.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

#3274

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
