### PR TITLE
fix(tools): can be cancelled and `run_command` has timeout

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -293,6 +293,7 @@ The user is working on a %s machine. Please respond with system specific command
             require_approval_before = true,
             require_cmd_approval = true,
             judge_in_yolo_mode = false,
+            timeout = 300000, -- Timeout for commands (milliseconds) - 5 mins by default
           },
         },
 

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -14,7 +14,6 @@
 ---@field context CodeCompanion.Chat.Context
 ---@field context_items? table<CodeCompanion.Chat.Context> Context which is sent to the LLM e.g. buffers, slash command output
 ---@field current_request table|nil The current request being executed
----@field current_tool table The current tool being executed
 ---@field cycle number Records the number of turn-based interactions (User -> LLM) that have taken place
 ---@field editor_context? CodeCompanion.EditorContext The editor context available to the user
 ---@field from_prompt_library? boolean Whether the chat was initiated from the prompt library
@@ -32,6 +31,7 @@
 ---@field title? string The title of the chat buffer
 ---@field tokens? number|table The tokens reported by the adapter
 ---@field tools CodeCompanion.Tools The tools coordinator that executes available tools
+---@field tool_orchestrator? CodeCompanion.Tools.Orchestrator Coordinates the tools that the LLM has asked to run
 ---@field tool_registry CodeCompanion.Chat.ToolRegistry Methods for handling interactions between the chat buffer and tools
 ---@field ui CodeCompanion.Chat.UI The UI of the chat buffer
 ---@field window_opts? table Window configuration options for the chat buffer
@@ -1724,13 +1724,14 @@ function Chat:stop()
   self:dispatch("on_cancelled")
   utils.fire("ChatStopped", { bufnr = self.bufnr, id = self.id })
 
-  if self.current_tool then
-    local tool_job = self.current_tool
-    self.current_tool = nil
-
-    pcall(function()
-      tool_job.cancel()
+  if self.tool_orchestrator then
+    local ok, err = pcall(function()
+      self.tool_orchestrator:cancel()
     end)
+    self.tool_orchestrator = nil
+    if not ok then
+      log:error("Failed to cancel the running tools: %s", err)
+    end
   end
 
   pcall(function()

--- a/lua/codecompanion/interactions/chat/keymaps/init.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/init.lua
@@ -363,7 +363,7 @@ M.close = {
 
 M.stop = {
   callback = function(chat)
-    if chat.current_request then
+    if chat.current_request or chat.tool_orchestrator then
       chat:stop()
     end
   end,

--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -295,6 +295,7 @@ function Tools:execute(chat, tools)
     end
 
     utils.fire("ToolsStarted", { id = id, bufnr = self.bufnr })
+    chat.tool_orchestrator = orchestrator
     orchestrator:setup_next_tool()
   end
 

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -31,24 +31,26 @@ end
 ---Execute a shell command with platform-specific handling
 ---@param opts { cmd: table, timeout?: number }
 ---@param callback function
+---@return vim.SystemObj
 local function execute_shell_command(opts, callback)
   if vim.fn.has("win32") == 1 then
     -- See PR #2186
     local shell_cmd = table.concat(opts.cmd, " ") .. "\r\nEXIT %ERRORLEVEL%\r\n"
-    vim.system({ "cmd.exe", "/Q", "/K" }, {
+    return vim.system({ "cmd.exe", "/Q", "/K" }, {
       stdin = shell_cmd,
       env = { PROMPT = "\r\n" },
       timeout = opts.timeout,
     }, callback)
-  else
-    vim.system(os_utils.build_shell_command(opts.cmd), { timeout = opts.timeout }, callback)
   end
+
+  return vim.system(os_utils.build_shell_command(opts.cmd), { timeout = opts.timeout }, callback)
 end
 
 ---Converts a cmd-based tool to a function-based tool.
 ---@param tool CodeCompanion.Tools.Tool
+---@param orchestrator CodeCompanion.Tools.Orchestrator
 ---@return CodeCompanion.Tools.Tool
-local function cmd_to_func_tool(tool)
+local function cmd_to_func_tool(tool, orchestrator)
   local timeout = tool.opts and tool.opts.timeout
 
   tool.cmds = vim
@@ -67,7 +69,9 @@ local function cmd_to_func_tool(tool)
       ---@param tools CodeCompanion.Tools
       return function(tools, _, opts)
         local cb = vim.schedule_wrap(opts.output_cb)
-        execute_shell_command({ cmd = cmd, timeout = timeout }, function(out)
+        orchestrator.current_job = execute_shell_command({ cmd = cmd, timeout = timeout }, function(out)
+          orchestrator.current_job = nil
+
           if flag then
             tools.chat.tool_registry.flags = tools.chat.tool_registry.flags or {}
             tools.chat.tool_registry.flags[flag] = (out.code == 0)
@@ -102,6 +106,8 @@ local function cmd_to_func_tool(tool)
 end
 
 ---@class CodeCompanion.Tools.Orchestrator
+---@field cancelled boolean Whether the user has stopped the execution
+---@field current_job vim.SystemObj? The shell command that's currently running
 ---@field id number The id of the tools coordinator
 ---@field index number The index of the current command
 ---@field handlers table<string, function>
@@ -117,6 +123,7 @@ local Orchestrator = {}
 ---@param id number
 function Orchestrator.new(tools, id)
   local self = setmetatable({
+    cancelled = false,
     id = id,
     queue = Queue.new(),
     tools = tools,
@@ -264,6 +271,8 @@ end
 ---@return nil
 function Orchestrator:_finalize_tools()
   self.tools.tool = nil
+  self.tools.chat.tool_orchestrator = nil
+
   return utils.fire("ToolsFinished", {
     bufnr = self.tools.bufnr,
     id = self.id,
@@ -275,6 +284,9 @@ end
 ---@param input? any
 ---@return nil
 function Orchestrator:setup_next_tool(input)
+  if self.cancelled then
+    return
+  end
   if self.queue:is_empty() then
     return self:_finalize_tools()
   end
@@ -287,7 +299,7 @@ function Orchestrator:setup_next_tool(input)
   self.handlers.setup() -- Call this early as run_command needs to setup its cmds dynamically
 
   -- Transform cmd-based tools to func-based
-  self.tool = cmd_to_func_tool(self.tool)
+  self.tool = cmd_to_func_tool(self.tool, self)
 
   -- Get the first command to run
   local cmd = self.tool.cmds[1]
@@ -462,10 +474,45 @@ function Orchestrator:cancel_pending_tools()
   end
 end
 
+---Stop the tool that's currently running and cancel anything still queued
+---@return nil
+function Orchestrator:cancel()
+  if self.cancelled then
+    return
+  end
+  self.cancelled = true
+
+  if self.current_job then
+    pcall(function()
+      self.current_job:kill("sigterm")
+    end)
+    self.current_job = nil
+  end
+
+  if self.tool then
+    local ok, err = pcall(function()
+      self.output.cancelled(self.tool.cmds and self.tool.cmds[1])
+    end)
+    if not ok then
+      log:error("Failed to run cancelled handler for tool %s: %s", tostring(self.tool.name), err)
+    end
+    self:finalize_tool()
+  end
+
+  self:cancel_pending_tools()
+
+  self.tools.tool = nil
+  self.tools:reset({ auto_submit = false })
+end
+
 ---Execute the tool command
 ---@param args { cmd: function, input?: any }
 ---@return nil
 function Orchestrator:execute_tool(args)
+  if self.cancelled then
+    return
+  end
+
   utils.fire("ToolStarted", {
     bufnr = self.tools.bufnr,
     id = self.id,

--- a/lua/codecompanion/interactions/chat/tools/orchestrator.lua
+++ b/lua/codecompanion/interactions/chat/tools/orchestrator.lua
@@ -29,18 +29,19 @@ local send_response_to_chat = function(exec, llm_message, user_message)
 end
 
 ---Execute a shell command with platform-specific handling
----@param cmd table
+---@param opts { cmd: table, timeout?: number }
 ---@param callback function
-local function execute_shell_command(cmd, callback)
+local function execute_shell_command(opts, callback)
   if vim.fn.has("win32") == 1 then
     -- See PR #2186
-    local shell_cmd = table.concat(cmd, " ") .. "\r\nEXIT %ERRORLEVEL%\r\n"
+    local shell_cmd = table.concat(opts.cmd, " ") .. "\r\nEXIT %ERRORLEVEL%\r\n"
     vim.system({ "cmd.exe", "/Q", "/K" }, {
       stdin = shell_cmd,
       env = { PROMPT = "\r\n" },
+      timeout = opts.timeout,
     }, callback)
   else
-    vim.system(os_utils.build_shell_command(cmd), {}, callback)
+    vim.system(os_utils.build_shell_command(opts.cmd), { timeout = opts.timeout }, callback)
   end
 end
 
@@ -48,6 +49,8 @@ end
 ---@param tool CodeCompanion.Tools.Tool
 ---@return CodeCompanion.Tools.Tool
 local function cmd_to_func_tool(tool)
+  local timeout = tool.opts and tool.opts.timeout
+
   tool.cmds = vim
     .iter(tool.cmds)
     :map(function(cmd)
@@ -64,7 +67,7 @@ local function cmd_to_func_tool(tool)
       ---@param tools CodeCompanion.Tools
       return function(tools, _, opts)
         local cb = vim.schedule_wrap(opts.output_cb)
-        execute_shell_command(cmd, function(out)
+        execute_shell_command({ cmd = cmd, timeout = timeout }, function(out)
           if flag then
             tools.chat.tool_registry.flags = tools.chat.tool_registry.flags or {}
             tools.chat.tool_registry.flags[flag] = (out.code == 0)
@@ -79,6 +82,9 @@ local function cmd_to_func_tool(tool)
             })
           else
             local combined = {}
+            if out.code == 124 then
+              table.insert(combined, fmt("Command timed out after %dms and was terminated", timeout))
+            end
             if out.stderr and out.stderr ~= "" then
               vim.list_extend(combined, strip_ansi(vim.split(out.stderr, eol_pattern, { trimempty = true })))
             end

--- a/lua/codecompanion/interactions/chat/tools/runtime/runner.lua
+++ b/lua/codecompanion/interactions/chat/tools/runtime/runner.lua
@@ -82,7 +82,7 @@ function Runner:run_tool(tool_cmd, action, args)
 
   ---@param msg {status:"success"|"error", data:any}
   local function output_handler(msg)
-    if tool_finished then
+    if tool_finished or self.orchestrator.cancelled then
       return
     end
     tool_finished = true

--- a/tests/interactions/chat/tools/builtin/test_run_command.lua
+++ b/tests/interactions/chat/tools/builtin/test_run_command.lua
@@ -39,6 +39,35 @@ T["run_command tool"] = function()
   h.expect_screenshot(child.get_screenshot())
 end
 
+T["run_command tool times out a long running command"] = function()
+  child.lua([[
+    local cfg = {
+      interactions = {
+        chat = {
+          tools = {
+            run_command = { opts = { timeout = 100 } }
+          }
+        }
+      }
+    }
+    chat, tools = h.setup_chat_buffer(cfg)
+
+    local tool = {
+      {
+        ["function"] = {
+          name = "run_command",
+          arguments = '{"cmd": "sleep 2"}',
+        },
+      },
+    }
+    tools:execute(chat, tool)
+    vim.wait(500)
+  ]])
+
+  local output = child.lua_get("chat.messages[#chat.messages].content")
+  h.expect_contains("timed out", output)
+end
+
 T["Windows"] = new_set()
 
 T["Windows"]["run_command handles Windows pipe command with empty string argument"] = function()

--- a/tests/interactions/chat/tools/builtin/test_run_command.lua
+++ b/tests/interactions/chat/tools/builtin/test_run_command.lua
@@ -68,6 +68,32 @@ T["run_command tool times out a long running command"] = function()
   h.expect_contains("timed out", output)
 end
 
+T["stopping the chat kills a running command"] = function()
+  child.lua([[
+    _G.marker = vim.fn.tempname()
+
+    local tool = {
+      {
+        ["function"] = {
+          name = "run_command",
+          arguments = string.format('{"cmd": "sleep 1 && touch %s"}', _G.marker),
+        },
+      },
+    }
+    tools:execute(chat, tool)
+    vim.wait(200)
+
+    _G.running = chat.tool_orchestrator ~= nil and chat.tool_orchestrator.current_job ~= nil
+    chat:stop()
+    vim.wait(1500)
+  ]])
+
+  h.eq(true, child.lua_get("_G.running"))
+  h.eq(0, child.lua_get("vim.fn.filereadable(_G.marker)"))
+  h.eq(vim.NIL, child.lua_get("chat.tool_orchestrator"))
+  h.expect_contains("cancelled", child.lua_get("chat.messages[#chat.messages].content"))
+end
+
 T["Windows"] = new_set()
 
 T["Windows"]["run_command handles Windows pipe command with empty string argument"] = function()

--- a/tests/interactions/chat/tools/builtin/test_run_command.lua
+++ b/tests/interactions/chat/tools/builtin/test_run_command.lua
@@ -40,6 +40,10 @@ T["run_command tool"] = function()
 end
 
 T["run_command tool times out a long running command"] = function()
+  if vim.fn.has("win32") == 1 then
+    MiniTest.skip("`sleep` isn't available on Windows")
+  end
+
   child.lua([[
     local cfg = {
       interactions = {
@@ -61,7 +65,9 @@ T["run_command tool times out a long running command"] = function()
       },
     }
     tools:execute(chat, tool)
-    vim.wait(500)
+    vim.wait(10000, function()
+      return #chat.messages > 1
+    end, 25)
   ]])
 
   local output = child.lua_get("chat.messages[#chat.messages].content")
@@ -69,6 +75,10 @@ T["run_command tool times out a long running command"] = function()
 end
 
 T["stopping the chat kills a running command"] = function()
+  if vim.fn.has("win32") == 1 then
+    MiniTest.skip("`sleep` isn't available on Windows")
+  end
+
   child.lua([[
     _G.marker = vim.fn.tempname()
 
@@ -81,10 +91,16 @@ T["stopping the chat kills a running command"] = function()
       },
     }
     tools:execute(chat, tool)
-    vim.wait(200)
+    _G.running = vim.wait(5000, function()
+      return chat.tool_orchestrator ~= nil and chat.tool_orchestrator.current_job ~= nil
+    end, 25)
 
-    _G.running = chat.tool_orchestrator ~= nil and chat.tool_orchestrator.current_job ~= nil
     chat:stop()
+    vim.wait(5000, function()
+      return #chat.messages > 1
+    end, 25)
+
+    -- Outlive the command so that the marker would exist had it survived the stop
     vim.wait(1500)
   ]])
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

I ran into an issue where an LLM called `run_command` with `make test_file FILE=<file does not exist>`. The command hung indefinately and it was not possible to recover from.

This PR adds the following as a fix:
- `run_command` will timeout after 5 minutes (this is configurable)
- tools can be cancelled with `q`

## Supporting Documentation


## AI Usage

Opus 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
