### PR TITLE
refactor: unify how sysobj are terminated/killed

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -545,7 +545,7 @@ end
 ---Disconnect and clean up the ACP process
 ---@return nil
 function Connection:disconnect()
-  assert(self._state.handle):kill(15)
+  assert(self._state.handle):kill("sigterm")
 end
 
 ---Process the output

--- a/lua/codecompanion/mcp/client.lua
+++ b/lua/codecompanion/mcp/client.lua
@@ -185,14 +185,14 @@ function StdioTransport:stop()
   self.methods.defer_fn(function()
     if self._sysobj then
       pcall(function()
-        self._sysobj:kill(vim.uv.constants.SIGTERM)
+        self._sysobj:kill("sigterm")
       end)
 
       -- Step 3: Schedule SIGKILL as last resort
       self.methods.defer_fn(function()
         if self._sysobj then
           pcall(function()
-            self._sysobj:kill(vim.uv.constants.SIGKILL)
+            self._sysobj:kill("sigkill")
           end)
         end
       end, CONSTANTS.SIGTERM_TIMEOUT)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Previously had a mixture of constants and strings to terminate or kill a signal. Unify it in this PR.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
