### PR TITLE
Fix code reviewer bug

### DIFF
--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -21,7 +21,7 @@ local function notify(message, level)
   return utils.notify(message, level or vim.log.levels.INFO, { title = "CodeCompanion Code Review" })
 end
 
-local get_storage_root = baseline.storage_root
+local get_storage_root = baseline.storage_root --[[@as function]]
 
 ---Fetch the context of where the use is commenting in the buffer
 ---@param bufnr number
@@ -35,14 +35,10 @@ local function get_context(bufnr, args)
     lines = api.nvim_buf_get_lines(bufnr, buffer_context.start_line - 1, buffer_context.start_line, false)
   end
 
-  -- Comments are stored against the storage root, which can be git root or cwd
-  local name = api.nvim_buf_get_name(bufnr)
-  local path = vim.fs.relpath(get_storage_root(), name) or name
-
   return {
     code = table.concat(lines, "\n"),
     filetype = buffer_context.filetype,
-    path = path,
+    path = vim.fs.relpath(get_storage_root(), buffer_context.path) or buffer_context.path,
     start_line = buffer_context.start_line,
     end_line = buffer_context.end_line,
   }
@@ -68,10 +64,9 @@ end
 ---@return nil
 local function edit_comment(existing)
   input.open({
-    title = " Edit Comment ",
+    allow_empty = true, -- An empty submission deletes the comment
     initial_content = existing.comment.comment,
-    -- Empty submission deletes the comment
-    allow_empty = true,
+    title = " Edit Comment ",
     on_submit = function(comment)
       local root = get_storage_root()
       local comments = store.comments(root)

--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -35,10 +35,14 @@ local function get_context(bufnr, args)
     lines = api.nvim_buf_get_lines(bufnr, buffer_context.start_line - 1, buffer_context.start_line, false)
   end
 
+  -- Comments are stored against the storage root, which can be git root or cwd
+  local name = api.nvim_buf_get_name(bufnr)
+  local path = vim.fs.relpath(get_storage_root(), name) or name
+
   return {
     code = table.concat(lines, "\n"),
     filetype = buffer_context.filetype,
-    path = buffer_context.relative_path,
+    path = path,
     start_line = buffer_context.start_line,
     end_line = buffer_context.end_line,
   }
@@ -66,6 +70,8 @@ local function edit_comment(existing)
   input.open({
     title = " Edit Comment ",
     initial_content = existing.comment.comment,
+    -- Empty submission deletes the comment
+    allow_empty = true,
     on_submit = function(comment)
       local root = get_storage_root()
       local comments = store.comments(root)

--- a/lua/codecompanion/interactions/shared/input.lua
+++ b/lua/codecompanion/interactions/shared/input.lua
@@ -8,6 +8,7 @@ local HISTORY_MAX = 20
 local M = {}
 
 ---@class CodeCompanion.Input
+---@field allow_empty boolean|nil
 ---@field aug number|nil
 ---@field bufnr number
 ---@field on_submit fun(text: string, submit_opts: { bang: boolean })|nil
@@ -48,14 +49,15 @@ local function _buf_send(opts)
 
   local lines = api.nvim_buf_get_lines(_input.bufnr, 0, -1, false)
   local text = vim.trim(table.concat(lines, "\n"))
-  if text == "" then
+  if text == "" and not _input.allow_empty then
     return
   end
 
-  -- Add to history
-  table.insert(_history, text)
-  if #_history > HISTORY_MAX then
-    table.remove(_history, 1)
+  if text ~= "" then
+    table.insert(_history, text)
+    if #_history > HISTORY_MAX then
+      table.remove(_history, 1)
+    end
   end
   _history_index = 0
   _draft = ""
@@ -123,12 +125,13 @@ local function _history_down()
 end
 
 ---Open an input buffer
----@param opts { title?: string, on_submit: fun(text: string, submit_opts: { bang: boolean }), on_open?: fun(bufnr: number, winnr: number), initial_content?: string }
+---@param opts { title?: string, on_submit: fun(text: string, submit_opts: { bang: boolean }), on_open?: fun(bufnr: number, winnr: number), initial_content?: string, allow_empty?: boolean }
 ---@return nil
 function M.open(opts)
   -- Buffer already exists — re-show the window
   if _input and api.nvim_buf_is_valid(_input.bufnr) then
     _input.on_submit = opts.on_submit
+    _input.allow_empty = opts.allow_empty
 
     if M.is_visible() then
       api.nvim_set_current_win(_input.winnr)
@@ -164,6 +167,7 @@ function M.open(opts)
   end
 
   _input = {
+    allow_empty = opts.allow_empty,
     aug = nil,
     bufnr = bufnr,
     on_submit = opts.on_submit,

--- a/tests/interactions/code_review/test_code_review.lua
+++ b/tests/interactions/code_review/test_code_review.lua
@@ -97,6 +97,40 @@ T["Review"]["comment stores a visual selection"] = function()
   h.eq(2, pending[1].end_line)
 end
 
+T["Review"]["comment on a file in a subdirectory stores a root-relative path"] = function()
+  child.lua([[
+    stub_input("Nested file comment")
+    vim.fn.mkdir(vim.fs.joinpath(repo, "src"), "p")
+    -- cd into the subdir so cwd is not the git root
+    vim.cmd.cd(vim.fs.joinpath(repo, "src"))
+    vim.cmd("edit! foo.lua")
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "local a = 1" })
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+    review.comment({ range = 0 })
+  ]])
+
+  local pending = child.lua_get("review.pending()")
+  h.eq(1, #pending)
+  h.eq("src/foo.lua", pending[1].path)
+end
+
+T["Review"]["editing a comment to empty removes it"] = function()
+  child.lua([[
+    stub_input("First pass")
+    vim.cmd("edit! notes")
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "line one" })
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    review.comment({ range = 0 })
+
+    -- Second call on the same line hits edit_comment; empty submit deletes it
+    stub_input("")
+    review.comment({ range = 0 })
+  ]])
+
+  h.eq(0, child.lua_get("#review.pending()"))
+end
+
 T["Review"]["comment does nothing when sending code is disabled"] = function()
   child.lua([[
     stub_input("Should not be added")


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fixes two bugs using `CodeCompanionCodeReview`:

1. Cannot edit existing review comment to empty "" to remove it
2. Cannot mark review comments correctly under subdirectory (not in git root)

### Manual Tests

1. Use codecompanion from this branch
<img width="2392" height="318" alt="image" src="https://github.com/user-attachments/assets/3d0a0935-cd8c-44c9-8e0e-909e156c9a3a" />

- Test 1: Ensure comments can be deleted when remove content in the comment


https://github.com/user-attachments/assets/7c2ecca7-17d6-41e6-9bc9-ba4f366d8fb9

- Test 2: Ensure we can:
    1. See existing comments after cd into sub directory
    2. Add more comments in the sub directory


https://github.com/user-attachments/assets/8c031d15-c8c2-4192-92d5-4c2e4cda0c36



## Supporting Documentation

https://codecompanion.olimorris.dev/usage/code-review#commenting

## AI Usage

- Use Claude code Opus for this. Asked it to update the code and test. All code changes are reviewed by myself.

## Related Issue(s)


## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
