### PR TITLE
perf(tools): faster `grep_search` and `read_file` processing

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -296,7 +296,6 @@ The user is working on a %s machine. Please respond with system specific command
             timeout = 300000, -- Timeout for commands (milliseconds) - 5 mins by default
           },
         },
-
         ["web_search"] = {
           path = "interactions.chat.tools.builtin.web_search",
           description = "Search the web for information",
@@ -359,7 +358,7 @@ If a tool exists to do a task, use the tool instead of asking the user to manual
 If you say that you will take an action, then go ahead and use the tool to do it. No need to ask permission.
 Never use a tool that does not exist. Use tools using the proper procedure, DO NOT write out a json codeblock with the tool inputs.
 Never say the name of a tool to a user. For example, instead of saying that you'll use the insert_edit_into_file tool, say "I'll edit the file".
-If you think running multiple tools can answer the user's question, prefer calling them in parallel whenever possible.
+For maximum efficiency, whenever you need to perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially.
 When invoking a tool that takes a file path, always use the file path you have been given by the user or by the output of a tool.
 </toolUseInstructions>
 <outputFormatting>

--- a/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/grep_search.lua
@@ -3,29 +3,11 @@ local log = require("codecompanion.utils.log")
 
 local fmt = string.format
 
----Search the current working directory for text using ripgrep
+---Build the ripgrep command for a search
 ---@param action { query: string, is_regexp: boolean?, include_pattern: string? }
 ---@param opts table
----@return { status: "success"|"error", data: string|table }
-local function grep_search(action, opts)
-  opts = opts or {}
-  local query = action.query
-
-  if not query or query == "" then
-    return {
-      status = "error",
-      data = "Query parameter is required and cannot be empty",
-    }
-  end
-
-  -- Check if ripgrep is available
-  if vim.fn.executable("rg") ~= 1 then
-    return {
-      status = "error",
-      data = "ripgrep (rg) is not installed or not in PATH",
-    }
-  end
-
+---@return string[]
+local function build_command(action, opts)
   local cmd = { "rg" }
   local cwd = vim.fn.getcwd()
   local max_results = opts.max_results or 100
@@ -66,21 +48,19 @@ local function grep_search(action, opts)
 
   -- Add the query
   table.insert(cmd, "-e") -- Use -e option to explicitly specify search pattern
-  table.insert(cmd, query)
+  table.insert(cmd, action.query)
 
   -- Add the search path
   table.insert(cmd, cwd)
 
-  log:debug("[Grep Search Tool] Running command: %s", table.concat(cmd, " "))
+  return cmd
+end
 
-  -- Execute
-  local result = vim
-    .system(cmd, {
-      text = true,
-      timeout = 30000, -- 30 second timeout
-    })
-    :wait()
-
+---Turn ripgrep's output into `filepath:line` entries
+---@param result vim.SystemCompleted
+---@param max_results number
+---@return { status: "success"|"error", data: string|table }
+local function parse_output(result, max_results)
   if result.code ~= 0 then
     local error_msg = result.stderr or "Unknown error"
 
@@ -154,10 +134,24 @@ return {
     ---Execute the search commands
     ---@param self CodeCompanion.Tool.GrepSearch
     ---@param args table The arguments from the LLM's tool call
-    ---@param input? any The output from the previous function call
-    ---@return { status: "success"|"error", data: string|table }
-    function(self, args, input)
-      return grep_search(args, self.tool.opts)
+    ---@param opts { input: any, output_cb: fun(msg: table), register_job: fun(job: vim.SystemObj) }
+    ---@return { status: "success"|"error", data: string|table }|nil
+    function(self, args, opts)
+      if not args.query or args.query == "" then
+        return { status = "error", data = "Query parameter is required and cannot be empty" }
+      end
+      if vim.fn.executable("rg") ~= 1 then
+        return { status = "error", data = "ripgrep (rg) is not installed or not in PATH" }
+      end
+
+      local tool_opts = self.tool.opts or {}
+      local cmd = build_command(args, tool_opts)
+      log:debug("[Grep Search Tool] Running command: %s", table.concat(cmd, " "))
+
+      local cb = vim.schedule_wrap(opts.output_cb)
+      opts.register_job(vim.system(cmd, { text = true, timeout = 30000 }, function(result)
+        cb(parse_output(result, tool_opts.max_results or 100))
+      end))
     end,
   },
   schema = {

--- a/lua/codecompanion/interactions/chat/tools/builtin/read_file.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/read_file.lua
@@ -1,4 +1,3 @@
-local Path = require("plenary.path")
 local tool_helpers = require("codecompanion.interactions.chat.tools.builtin.helpers")
 
 local file_utils = require("codecompanion.utils.files")
@@ -6,20 +5,11 @@ local log = require("codecompanion.utils.log")
 
 local fmt = string.format
 
----Read the contents of a file
+---Slice the requested line range out of a file's contents
 ---@param action {filepath: string, start_line_number_base_zero: number, end_line_number_base_zero: number} The action containing the filepath
+---@param lines string[] Every line in the file
 ---@return {status: "success"|"error", data: string}
-local function read(action)
-  local path = file_utils.validate_and_normalize_path(action.filepath)
-  local p = Path:new(path)
-  if not p:exists() or not p:is_file() then
-    return {
-      status = "error",
-      data = fmt("Error reading `%s`\nFile does not exist or is not a file", path),
-    }
-  end
-
-  local lines = p:readlines()
+local function extract_range(action, lines)
   local start_line_zero = tonumber(action.start_line_number_base_zero)
   local end_line_zero = tonumber(action.end_line_number_base_zero)
 
@@ -96,11 +86,10 @@ Invalid line range - start_line_number_base_zero (%d) comes after end_line_numbe
   end
 
   local content = table.concat(selected_lines, "\n")
-  local file_ext = vim.fn.fnamemodify(p.filename, ":e")
+  local file_ext = vim.fn.fnamemodify(action.filepath, ":e")
 
   local output = fmt(
     [[Read file `%s` from line %d to %d:
-
 ````%s
 %s
 ````]],
@@ -123,10 +112,21 @@ return {
     ---Execute the file commands
     ---@param self CodeCompanion.Tool.ReadFile
     ---@param args table The arguments from the LLM's tool call
-    ---@param input? any The output from the previous function call
-    ---@return { status: "success"|"error", data: string }
-    function(self, args, input)
-      return read(args)
+    ---@param opts { input: any, output_cb: fun(msg: table) }
+    ---@return nil
+    function(self, args, opts)
+      local path = file_utils.validate_and_normalize_path(args.filepath)
+      local cb = vim.schedule_wrap(opts.output_cb)
+
+      file_utils.read_async(path, function(content, error_message)
+        if not content then
+          return cb({
+            status = "error",
+            data = fmt("Error reading `%s`\n%s", path, error_message),
+          })
+        end
+        cb(extract_range(args, vim.split(file_utils.normalize_content(content), "\n")))
+      end)
     end,
   },
   schema = {

--- a/lua/codecompanion/interactions/chat/tools/runtime/runner.lua
+++ b/lua/codecompanion/interactions/chat/tools/runtime/runner.lua
@@ -71,7 +71,7 @@ function Runner:go_to_next_tool(output)
 end
 
 ---Run the tool's function
----@param tool_cmd fun(self: CodeCompanion.Tools, actions: table, input: any, output_handler: fun(msg:{status:"success"|"error", data:any}):any):{status:"success"|"error", data:any}?
+---@param tool_cmd fun(self: CodeCompanion.Tools, actions: table, opts: {input: any, output_cb: fun(msg:{status:"success"|"error", data:any}), register_job: fun(job: vim.SystemObj)}):{status:"success"|"error", data:any}?
 ---@param action table
 ---@param args {input?: any, callback?: fun(output: any)}
 ---@return nil
@@ -86,6 +86,7 @@ function Runner:run_tool(tool_cmd, action, args)
       return
     end
     tool_finished = true
+    self.orchestrator.current_job = nil
     if msg.status == self.orchestrator.tools.constants.STATUS_ERROR then
       self.orchestrator:error({ action = action, error = msg.data or "An error occurred" })
       return
@@ -102,7 +103,13 @@ function Runner:run_tool(tool_cmd, action, args)
   self.orchestrator.tools.tool = self.orchestrator.tool
 
   local ok, output = pcall(function()
-    return tool_cmd(self.orchestrator.tools, action, { input = args.input, output_cb = output_handler })
+    return tool_cmd(self.orchestrator.tools, action, {
+      input = args.input,
+      output_cb = output_handler,
+      register_job = function(job)
+        self.orchestrator.current_job = job
+      end,
+    })
   end)
   if not ok then
     self.orchestrator:error({ action = action, error = output })

--- a/lua/codecompanion/utils/files.lua
+++ b/lua/codecompanion/utils/files.lua
@@ -185,6 +185,37 @@ function M.read(path)
   return data
 end
 
+---Read the content of a file without blocking the editor
+---@param path string The file to read
+---@param callback fun(content: string?, error_message: string?)
+---@return nil
+function M.read_async(path, callback)
+  uv.fs_open(path, "r", 420, function(open_err, fd)
+    if open_err or not fd then
+      return callback(nil, open_err or fmt("Could not open %s", path))
+    end
+
+    uv.fs_fstat(fd, function(stat_err, stat)
+      if stat_err or not stat then
+        uv.fs_close(fd)
+        return callback(nil, stat_err or fmt("Could not stat %s", path))
+      end
+      if stat.type ~= "file" then
+        uv.fs_close(fd)
+        return callback(nil, fmt("%s is not a file", path))
+      end
+
+      uv.fs_read(fd, stat.size, 0, function(read_err, data)
+        uv.fs_close(fd)
+        if read_err then
+          return callback(nil, read_err)
+        end
+        callback(data or "")
+      end)
+    end)
+  end)
+end
+
 ---Base64 encode a given file using the `base64` command.
 ---@param path string The path to the file to encode
 ---@return string?, string? The output and error message


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR improves the `grep_search` and `read_file` tools significantly.

- `grep_search` is now async. Previously I had a `:wait()` at the end of `vim.system` (why, Oli, why?!).
- `read_file` has ditched `plenary.nvim` and reads files async

A good prompt to test this out, if you're in the CodeCompanion repo:

```md
In this codebase, find me the file and line where each of these lives. Don't read any file in full:
1. How tool approvals are remembered so the user isn't asked twice
2. How ACP adapters terminate a running session
3. How the inline interaction decides where to place its edit
4. How the chat buffer folds tool output

Search for all four at once, then report.
@{files}
```

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
