### PR TITLE
refactor(adapters): add tests and update schema for `openrouter`

### DIFF
--- a/lua/codecompanion/adapters/http/openrouter.lua
+++ b/lua/codecompanion/adapters/http/openrouter.lua
@@ -42,7 +42,7 @@ return {
     vision = true,
   },
   available_tools = {
-    ["web_fetch"] = {
+    ["fetch_webpage"] = {
       description = "Gives any model the ability to fetch content from a specific URL",
       ---@param self CodeCompanion.HTTPAdapter.OpenRouter
       ---@param meta { tools: table }
@@ -363,7 +363,7 @@ return {
       enabled = function(self)
         return model_supports(self, "temperature")
       end,
-      desc = "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or top_p but not both.",
+      desc = "This setting influences the variety in the model’s responses. Lower values lead to more predictable and typical responses, while higher values encourage more diverse and less common responses. At 0, the model always gives the same response for a given input.",
       validate = function(n)
         return n >= 0 and n <= 2, "Must be between 0 and 2"
       end,
@@ -377,7 +377,7 @@ return {
       enabled = function(self)
         return model_supports(self, "top_p")
       end,
-      desc = "An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or temperature but not both.",
+      desc = "This setting limits the model’s choices to a percentage of likely tokens: only the top tokens whose probabilities add up to P. A lower value makes the model’s responses more predictable, while the default setting allows for a full range of token choices. Think of it like a dynamic Top-K.",
       validate = function(n)
         return n >= 0 and n <= 1, "Must be between 0 and 1"
       end,
@@ -387,13 +387,13 @@ return {
       mapping = "parameters",
       type = "number",
       optional = true,
-      default = -1,
+      default = 0,
       enabled = function(self)
         return model_supports(self, "top_k")
       end,
-      desc = "Integer that controls the number of top tokens to consider. Set to -1 to consider all tokens",
+      desc = "This limits the model’s choice of tokens at each step, making it choose from a smaller set. A value of 1 means the model will always pick the most likely next token, leading to predictable results. By default this setting is disabled, making the model to consider all choices.",
       validate = function(n)
-        return n >= -1, "Must be greater than or equal to -1"
+        return n >= 1, "Must be greater than or equal to 1"
       end,
     },
     min_p = {
@@ -405,7 +405,7 @@ return {
       enabled = function(self)
         return model_supports(self, "min_p")
       end,
-      desc = "Float that represents the minimum probability for a token to be considered, relative to the probability of the most likely token",
+      desc = "Represents the minimum probability for a token to be considered, relative to the probability of the most likely token. (The value changes depending on the confidence level of the most probable token.) If your Min-P is set to 0.1, that means it will only allow for tokens that are at least 1/10th as probable as the best possible option.",
       validate = function(n)
         return n >= 0 and n <= 1, "Must be between 0 and 1"
       end,
@@ -436,7 +436,7 @@ return {
       enabled = function(self)
         return model_supports(self, "presence_penalty")
       end,
-      desc = "Float that penalizes new tokens based on whether they appear in the generated text so far. Values > 0 encourage the model to use new tokens, while values < 0 encourage the model to repeat tokens",
+      desc = "Adjusts how often the model repeats specific tokens already used in the input. Higher values make such repetition less likely, while negative values do the opposite. Token penalty does not scale with the number of occurrences. Negative values will encourage token reuse.",
       validate = function(n)
         return n >= -2 and n <= 2, "Must be between -2 and 2"
       end,
@@ -450,34 +450,14 @@ return {
       enabled = function(self)
         return model_supports(self, "frequency_penalty")
       end,
-      desc = "Float that penalizes new tokens based on their frequency in the generated text so far. Values > 0 encourage the model to use new tokens, while values < 0 encourage the model to repeat tokens",
+      desc = "This setting aims to control the repetition of tokens based on how often they appear in the input. It tries to use less frequently those tokens that appear more in the input, proportional to how frequently they occur. Token penalty scales with the number of occurrences. Negative values will encourage token reuse.",
       validate = function(n)
         return n >= -2 and n <= 2, "Must be between -2 and 2"
       end,
     },
-    logit_bias = {
-      order = 10,
-      mapping = "parameters",
-      type = "map",
-      optional = true,
-      default = nil,
-      enabled = function(self)
-        return model_supports(self, "logit_bias")
-      end,
-      desc = "Modify the likelihood of specified tokens appearing in the completion. Maps tokens (specified by their token ID) to an associated bias value from -100 to 100. Use https://platform.openai.com/tokenizer to find token IDs.",
-      subtype_key = {
-        type = "integer",
-      },
-      subtype = {
-        type = "integer",
-        validate = function(n)
-          return n >= -100 and n <= 100, "Must be between -100 and 100"
-        end,
-      },
-    },
     -- Ref: https://openrouter.ai/docs/guides/features/presets
     preset = {
-      order = 11,
+      order = 10,
       mapping = "parameters",
       type = "string",
       optional = true,
@@ -486,7 +466,7 @@ return {
     },
     -- Ref: https://openrouter.ai/docs/guides/routing/provider-selection
     provider = {
-      order = 12,
+      order = 11,
       mapping = "parameters",
       type = "map",
       optional = true,

--- a/tests/adapters/http/test_openrouter.lua
+++ b/tests/adapters/http/test_openrouter.lua
@@ -285,4 +285,23 @@ T["OpenRouter adapter"]["resolves model capabilities on the first request"] = fu
   h.not_eq(nil, structured.handlers.form_structured_output(structured, { name = "verdict", schema = {} }))
 end
 
+T["OpenRouter model_transformers"] = new_set()
+
+T["OpenRouter model_transformers"]["from_openrouter() transforms the stubbed model list"] = function()
+  local model_transformers = require("codecompanion.adapters.utils.models.transform")
+
+  local body = table.concat(vim.fn.readfile("tests/adapters/http/stubs/model_list/openrouter.json"), "\n")
+  local json = vim.json.decode(body)
+
+  local result = {}
+  for _, model in ipairs(json.data) do
+    local id, entry = model_transformers.from_openrouter(model)
+    result[id] = entry
+  end
+
+  h.eq("Anthropic: Claude Sonnet 5", result["anthropic/claude-sonnet-5"].formatted_name)
+  h.eq({ context_window = 1000000 }, result["anthropic/claude-sonnet-5"].meta)
+  h.eq(true, result["anthropic/claude-sonnet-5"].opts.has_vision)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Some tweaks to the OpenRouter adapter that sees its fetch webpage tool renamed to CodeCompanion's. Schema items have been updated to match the official OpenRouter docs.

Also adds a test to ensure that the OpenRouter transform works as expected. Previous oversight not to include a test for this.

## Supporting Documentation

https://openrouter.ai/docs/api_reference/parameters

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
