### PR TITLE
fix(adapters): prevent double context management

### DIFF
--- a/.codecompanion/adapters/adapters.md
+++ b/.codecompanion/adapters/adapters.md
@@ -184,11 +184,17 @@ There are some functions that are shared between the two adapter types and these
 
 This is the logic for the HTTP adapters. Various logic sits within this file which allows the adapter to be resolved into a CodeCompanion.HTTPAdapter object before it's used throughout the plugin to connect to an LLM endpoint.
 
-### Example Adapter: openai.lua
+### Example Adapter: OpenAI Responses
 
-@./lua/codecompanion/adapters/http/openai.lua
+@./lua/codecompanion/adapters/http/openai_responses.lua
 
-Sharing an example HTTP adapter for OpenAI. Note: This adapter currently uses the old flat format but will be migrated to the new nested format in a future update.
+Sharing an example HTTP adapter for OpenAI Responses. This adapter uses the new handler structure
+
+### Example Adapter: Anthropic
+
+@./lua/codecompanion/adapters/http/anthropic.lua
+
+Sharing an example HTTP adapter for Anthropic. It uses the old handler structure.
 
 ## HTTP Client
 
@@ -204,4 +210,4 @@ The http.lua module implements a provider-agnostic HTTP client for CodeCompanion
 ## Tests
 
 @./tests/adapters/test_adapters.lua
-@./tests/adapters/http/test_openai.lua
+@./tests/adapters/http/test_openai_responses.lua

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                   For NVIM v0.11    Last change: 2026 July 27
+                                   For NVIM v0.11    Last change: 2026 July 31
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -2375,16 +2375,22 @@ stack:
 CONTEXT MANAGEMENT ~
 
 CodeCompanion can manage context in the chat buffer to try and prevent
-breaching the LLM's context window. It can be enabled with:
+breaching the LLM's context window and to avoid context rot
+<https://towardsdatascience.com/governed-context-managing-context-rot-in-claude-code/>
+setting in. It can be enabled with:
 
 
 CodeCompanion runs two operations to keep the chat buffer under the context
-window: **editing** (lighter — trims old tool results) and **compaction**
-(heavier — summarises the chat). Each has its own trigger, expressed either
-as a decimal (a percentage of the context window) or an integer (an absolute
-token count). You can read more about how the two operations work in the
+window: **editing** (which removes old tool results from the message history)
+and **compaction** (which summarises the message history). Both are triggered
+separately and can be expressed as a decimal (for a percentage of the context
+window) or an integer (for an absolute token count). You can read more about
+how the two operations work in the
 |codecompanion-architecture-in-the-chat-buffer| section.
 
+
+  [!NOTE] Some adapters (Anthropic, OpenAI Responses) manage context themselves,
+  server-side, as part of the request
 
 
 EDITING
@@ -2392,9 +2398,8 @@ EDITING
 Editing replaces the content of older tool results with a placeholder, leaving
 the conversation shape intact. By default, the most recent 3 cycles (a cycle
 being one user turn plus everything the LLM did in response) are preserved in
-full; older cycles are aged. You can also exclude specific tools from being
-edited — useful for tools whose output is referenced again later in the
-conversation.
+full. You can also exclude specific tools from being edited — useful for
+tools whose output is referenced again later in the conversation.
 
 >lua
     require("codecompanion").setup({

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -250,7 +250,7 @@ vim.api.nvim_create_autocmd("User", {
 
 ## Context Management
 
-CodeCompanion can manage context in the chat buffer to try and prevent breaching the LLM's context window. It can be enabled with:
+CodeCompanion can manage context in the chat buffer to try and prevent breaching the LLM's context window and to avoid [context rot](https://towardsdatascience.com/governed-context-managing-context-rot-in-claude-code/) setting in. It can be enabled with:
 
 ::: code-group
 
@@ -289,7 +289,10 @@ require("codecompanion").setup({
 
 :::
 
-CodeCompanion runs two operations to keep the chat buffer under the context window: **editing** (lighter — trims old tool results) and **compaction** (heavier — summarises the chat). Each has its own trigger, expressed either as a decimal (a percentage of the context window) or an integer (an absolute token count). You can read more about how the two operations work in the [architecture](/architecture#in-the-chat-buffer) section.
+CodeCompanion runs two operations to keep the chat buffer under the context window: **editing** (which removes old tool results from the message history) and **compaction** (which summarises the message history). Both are triggered separately and can be expressed as a decimal (for a percentage of the context window) or an integer (for an absolute token count). You can read more about how the two operations work in the [architecture](/architecture#in-the-chat-buffer) section.
+
+> [!NOTE]
+> Some adapters (Anthropic, OpenAI Responses) manage context themselves, server-side, as part of the request
 
 ::: code-group
 
@@ -335,7 +338,7 @@ require("codecompanion").setup({
 
 #### Editing
 
-Editing replaces the content of older tool results with a placeholder, leaving the conversation shape intact. By default, the most recent 3 cycles (a cycle being one user turn plus everything the LLM did in response) are preserved in full; older cycles are aged. You can also exclude specific tools from being edited — useful for tools whose output is referenced again later in the conversation.
+Editing replaces the content of older tool results with a placeholder, leaving the conversation shape intact. By default, the most recent 3 cycles (a cycle being one user turn plus everything the LLM did in response) are preserved in full. You can also exclude specific tools from being edited — useful for tools whose output is referenced again later in the conversation.
 
 ```lua
 require("codecompanion").setup({

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -126,6 +126,7 @@ return {
         if self.opts.compaction ~= false and model_opts.opts.can_manage_context then
           self.opts.can_manage_context = true
           adapter_utils.add_header(self.headers, "anthropic-beta", "compact-2026-01-12")
+          adapter_utils.add_header(self.headers, "anthropic-beta", "context-management-2025-06-27")
         else
           self.opts.can_manage_context = false
           adapter_utils.remove_header(self.headers, "anthropic-beta", "compact-2026-01-12")
@@ -375,6 +376,7 @@ return {
       local context_management = nil
       if self.opts.can_manage_context then
         local helpers = require("codecompanion.interactions.chat.helpers")
+        local editing_trigger = helpers.trigger_context_management(self, { operation = "editing" })
 
         context_management = {
           ["edits"] = {
@@ -385,17 +387,18 @@ return {
             --     value = 3,
             --   },
             -- },
-            -- {
-            --   type = "clear_tool_uses_20250919",
-            --   keep = {
-            --     type = "tool_uses",
-            --     value = 5,
-            --   },
-            --   trigger = {
-            --     type = "input_tokens",
-            --     value = 50000,
-            --   },
-            -- },
+            {
+              type = "clear_tool_uses_20250919",
+              keep = {
+                type = "tool_uses",
+                value = 5,
+              },
+              -- Omitted when we can't resolve a context window, which leaves the API default of 100,000
+              trigger = editing_trigger > 0 and {
+                type = "input_tokens",
+                value = editing_trigger,
+              } or nil,
+            },
             {
               type = "compact_20260112",
               trigger = {

--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -435,7 +435,6 @@ return {
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,
-            can_manage_context = true,
             can_use_tools = true,
             can_reason = true,
             has_vision = true,
@@ -446,7 +445,6 @@ return {
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,
-            can_manage_context = true,
             can_use_tools = true,
             has_vision = true,
             can_reason = true,
@@ -457,7 +455,6 @@ return {
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,
-            can_manage_context = true,
             can_use_tools = true,
             has_vision = true,
             can_reason = true,
@@ -470,7 +467,6 @@ return {
           meta = { context_window = 1050000 },
           opts = {
             can_form_structured_outputs = true,
-            can_manage_context = true,
             can_use_tools = true,
             has_vision = true,
             can_reason = true,

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -69,4 +69,21 @@ function M.context_window(adapter)
   return nil
 end
 
+---Whether the provider compacts its own context server-side for the current model
+---@param adapter CodeCompanion.HTTPAdapter
+---@return boolean
+function M.manages_own_context(adapter)
+  if not adapter or not adapter.opts or adapter.opts.compaction == false then
+    return false
+  end
+
+  local ok, model = pcall(adapter_utils.model_choice, adapter, { async = false })
+  if not ok then
+    log:debug("[Context Management] Failed to resolve model for `%s` adapter: %s", adapter.name, model)
+    return false
+  end
+
+  return (model and model.opts and model.opts.can_manage_context) == true
+end
+
 return M

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -77,7 +77,10 @@ function M.manages_own_context(adapter)
     return false
   end
 
-  local ok, model = pcall(adapter_utils.model_choice, adapter, { async = false })
+  -- A number of adapters are dynamic, and their capabilities are cached.
+  -- So there's a small chance that we need to refresh the cache,
+  -- which might require re-authentication or reauthorization
+  local ok, model = pcall(adapter_utils.model_choice, adapter, { async = true })
   if not ok then
     log:debug("[Context Management] Failed to resolve model for `%s` adapter: %s", adapter.name, model)
     return false

--- a/lua/codecompanion/interactions/chat/context_management/compaction.lua
+++ b/lua/codecompanion/interactions/chat/context_management/compaction.lua
@@ -303,7 +303,7 @@ end
 ---@return nil
 local function abort(chat, reason)
   chat._compacting = false
-  chat:ready_for_input()
+  chat:finish()
   log:error("[Compaction] Failed: %s", reason)
 end
 
@@ -343,18 +343,20 @@ end
 ---@field fallback_to_chat_adapter? boolean Silently retry with the chat adapter on failure (default false)
 ---@field min_token_savings? number Skip if estimated savings under this (default 10000)
 
----Run compaction on a chat buffer
+---Run compaction on a chat buffer, outputting whether it's in flight or not
 ---@param chat CodeCompanion.Chat
 ---@param opts? CodeCompanion.Chat.ContextManagement.Compaction.Opts
----@return nil
+---@return boolean
 function M.compact(chat, opts)
   opts = opts or {}
 
   if chat.adapter and chat.adapter.type == "acp" then
-    return log:warn("[Compaction] Skipped — ACP adapters handle context themselves")
+    log:debug("[Compaction] Skipped — ACP adapters handle context themselves")
+    return false
   end
   if chat._compacting then
-    return log:debug("[Compaction] Skipped — a compaction is already in progress")
+    log:debug("[Compaction] Skipped — a compaction is already in progress")
+    return false
   end
 
   local original = chat.messages or {}
@@ -363,12 +365,14 @@ function M.compact(chat, opts)
   local savings = estimate_savings(original, retained)
 
   if savings < min_token_savings then
-    return log:warn("[Compaction] Skipped — estimated savings (%d) below threshold (%d)", savings, min_token_savings)
+    log:debug("[Compaction] Skipped — estimated savings (%d) below threshold (%d)", savings, min_token_savings)
+    return false
   end
 
   local messages_text = messages_to_summarize(original)
   if messages_text == "" then
-    return log:warn("[Compaction] Skipped — nothing to summarise")
+    log:debug("[Compaction] Skipped — nothing to summarise")
+    return false
   end
 
   chat._compacting = true
@@ -385,6 +389,8 @@ function M.compact(chat, opts)
   local fallback_adapter = (opts.fallback_to_chat_adapter == true and adapter ~= chat.adapter) and chat.adapter or nil
 
   run_summary(chat, retained, messages_text, adapter, fallback_adapter)
+
+  return true
 end
 
 return M

--- a/lua/codecompanion/interactions/chat/context_management/init.lua
+++ b/lua/codecompanion/interactions/chat/context_management/init.lua
@@ -17,8 +17,11 @@ local function is_enabled(chat)
   if type(enabled) == "function" then
     return enabled(chat.adapter)
   end
+  if enabled ~= true then
+    return false
+  end
 
-  return enabled == true
+  return not require("codecompanion.adapters.shared").manages_own_context(chat.adapter)
 end
 
 ---Get the token count for the conversation
@@ -39,21 +42,21 @@ local function get_tokens(messages)
   return tokens.get_tokens(messages)
 end
 
----Check token thresholds and run editing or compaction if needed
+---Run editing or compaction against the chat if its token thresholds are met
 ---@param chat CodeCompanion.Chat
----@return nil
-function M.check(chat)
+---@return boolean compacting Whether a compaction is in flight and will end the turn itself
+function M.apply(chat)
   if chat.adapter and chat.adapter.type == "acp" then
-    return
+    return false
   end
   if not is_enabled(chat) then
-    return
+    return false
   end
   if chat._compacting then
-    return
+    return false
   end
   if chat:has_orphaned_tool_calls() then
-    return
+    return false
   end
 
   local token_count = get_tokens(chat.messages)
@@ -62,12 +65,11 @@ function M.check(chat)
   local compaction_threshold = helpers.trigger_context_management(chat.adapter, { operation = "compaction" })
   if compaction_threshold > 0 and token_count >= compaction_threshold then
     local compaction = require("codecompanion.interactions.chat.context_management.compaction")
-    compaction.compact(chat, {
+    return compaction.compact(chat, {
       adapter = ctx_mgmt_config.compaction.adapter,
       fallback_to_chat_adapter = ctx_mgmt_config.compaction.fallback_to_chat_adapter,
       min_token_savings = ctx_mgmt_config.compaction.min_token_savings,
     })
-    return
   end
 
   local editing_threshold = helpers.trigger_context_management(chat.adapter, { operation = "editing" })
@@ -82,6 +84,9 @@ function M.check(chat)
       log:info("[Context Management] Edited %d tool result(s)", cleared)
     end
   end
+
+  -- Editing rewrites messages in place, so the turn ends as normal
+  return false
 end
 
 return M

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1540,9 +1540,16 @@ function Chat:done(output, reasoning, tools, meta, opts)
   end
 
   self:checkpoint()
-  if require("codecompanion.interactions.chat.context_management").check(self) then
+  -- A compaction request ends the turn itself once its summary lands
+  if require("codecompanion.interactions.chat.context_management").apply(self) then
     return
   end
+  self:finish()
+end
+
+---End the turn, handing the chat buffer back to the user
+---@return nil
+function Chat:finish()
   self:ready_for_input()
 
   self:dispatch("on_completed", { status = self.status })

--- a/tests/interactions/chat/context_management/test_init.lua
+++ b/tests/interactions/chat/context_management/test_init.lua
@@ -14,9 +14,9 @@ local T = MiniTest.new_set({
   },
 })
 
-T["check"] = MiniTest.new_set()
+T["apply"] = MiniTest.new_set()
 
-T["check"]["edits aged tool results when the editing threshold is met"] = function()
+T["apply"]["edits aged tool results when the editing threshold is met"] = function()
   child.lua([==[
     require("codecompanion.config").interactions.chat.opts.context_management = {
       enabled = true,
@@ -52,14 +52,14 @@ T["check"]["edits aged tool results when the editing threshold is met"] = functi
       },
     }
 
-    require("codecompanion.interactions.chat.context_management").check(_G.chat)
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
   ]==])
 
   local messages = child.lua_get("_G.chat.messages")
   h.is_true(messages[3]._meta.context_management.edited)
 end
 
-T["check"]["compacts when the compaction threshold is met"] = function()
+T["apply"]["compacts when the compaction threshold is met"] = function()
   child.lua([==[
     package.loaded["codecompanion.interactions.background"] = {
       new = function()
@@ -95,7 +95,7 @@ T["check"]["compacts when the compaction threshold is met"] = function()
     }
 
     _G.compact_summary_tag = require("codecompanion.interactions.shared.tags").COMPACT_SUMMARY
-    require("codecompanion.interactions.chat.context_management").check(_G.chat)
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
   ]==])
 
   local messages = child.lua_get("_G.chat.messages")
@@ -104,7 +104,7 @@ T["check"]["compacts when the compaction threshold is met"] = function()
   h.expect_match(summary.content, "Summary")
 end
 
-T["check"]["skips when the chat is mid-tool-loop"] = function()
+T["apply"]["skips when the chat is mid-tool-loop"] = function()
   child.lua([==[
     require("codecompanion.config").interactions.chat.opts.context_management = {
       enabled = true,
@@ -129,13 +129,13 @@ T["check"]["skips when the chat is mid-tool-loop"] = function()
     }
 
     _G.before = vim.deepcopy(_G.chat.messages)
-    require("codecompanion.interactions.chat.context_management").check(_G.chat)
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
   ]==])
 
   h.eq(child.lua_get("_G.before"), child.lua_get("_G.chat.messages"))
 end
 
-T["check"]["skips when a compaction is already running"] = function()
+T["apply"]["skips when a compaction is already running"] = function()
   child.lua([==[
     require("codecompanion.config").interactions.chat.opts.context_management = {
       enabled = true,
@@ -167,13 +167,167 @@ T["check"]["skips when a compaction is already running"] = function()
     }
 
     _G.before = vim.deepcopy(_G.chat.messages)
-    require("codecompanion.interactions.chat.context_management").check(_G.chat)
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
   ]==])
 
   h.eq(child.lua_get("_G.before"), child.lua_get("_G.chat.messages"))
 end
 
-T["check"]["does nothing when the token count is below all thresholds"] = function()
+T["apply"]["skips when the model compacts its own context server-side"] = function()
+  child.lua([==[
+    require("codecompanion.config").interactions.chat.opts.context_management = {
+      enabled = true,
+      editing = { trigger = 1, exclude_tools = {}, keep_cycles = 1 },
+      compaction = { trigger = 1, min_token_savings = 1 },
+    }
+
+    _G.chat.adapter.schema.model.choices = {
+      ["gpt-3.5-turbo"] = { opts = { can_manage_context = true } },
+    }
+
+    _G.chat.cycle = 5
+    _G.chat.messages = {
+      {
+        role = "llm",
+        content = "",
+        _meta = { cycle = 1, id = 1 },
+        opts = { visible = false },
+        tools = {
+          calls = {
+            { id = "c1", type = "function", ["function"] = { name = "read_file", arguments = "{}" } },
+          },
+        },
+      },
+      {
+        role = "tool",
+        content = string.rep("some tool output content ", 200),
+        _meta = { cycle = 1, id = 2 },
+        opts = { visible = true },
+        tools = { call_id = "c1", is_error = false, type = "tool_result" },
+      },
+    }
+
+    _G.before = vim.deepcopy(_G.chat.messages)
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
+  ]==])
+
+  h.eq(child.lua_get("_G.before"), child.lua_get("_G.chat.messages"))
+end
+
+T["apply"]["runs when a server-side compacting model has compaction turned off"] = function()
+  child.lua([==[
+    require("codecompanion.config").interactions.chat.opts.context_management = {
+      enabled = true,
+      editing = { trigger = 10, exclude_tools = {}, keep_cycles = 1 },
+      compaction = { trigger = 999999 },
+    }
+
+    _G.chat.adapter.opts.compaction = false
+    _G.chat.adapter.schema.model.choices = {
+      ["gpt-3.5-turbo"] = { opts = { can_manage_context = true } },
+    }
+
+    _G.chat.cycle = 5
+    _G.chat.messages = {
+      {
+        role = "llm",
+        content = "",
+        _meta = { cycle = 1, id = 1 },
+        opts = { visible = false },
+        tools = {
+          calls = {
+            { id = "c1", type = "function", ["function"] = { name = "read_file", arguments = "{}" } },
+          },
+        },
+      },
+      {
+        role = "tool",
+        content = string.rep("some tool output content ", 200),
+        _meta = { cycle = 1, id = 2 },
+        opts = { visible = true },
+        tools = { call_id = "c1", is_error = false, type = "tool_result" },
+      },
+    }
+
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
+  ]==])
+
+  local messages = child.lua_get("_G.chat.messages")
+  h.is_true(messages[2]._meta.context_management.edited)
+end
+
+T["apply"]["reports the turn as handled only while a summary request is in flight"] = function()
+  child.lua([==[
+    package.loaded["codecompanion.interactions.background"] = {
+      new = function()
+        return { ask = function() end }
+      end,
+    }
+
+    require("codecompanion.config").interactions.chat.opts.context_management = {
+      enabled = true,
+      editing = { trigger = 999999, exclude_tools = {}, keep_cycles = 3 },
+      compaction = { trigger = 10, min_token_savings = 1 },
+    }
+
+    local big_chunk = string.rep("payload ", 3000)
+    _G.chat.cycle = 3
+    _G.chat.messages = {
+      { role = "user", content = big_chunk, _meta = { cycle = 1, id = 1 }, opts = { visible = true } },
+      { role = "llm", content = big_chunk, _meta = { cycle = 1, id = 2 }, opts = { visible = true } },
+    }
+
+    _G.handled = require("codecompanion.interactions.chat.context_management").apply(_G.chat)
+
+    -- The savings are now far below the threshold, so nothing is started
+    _G.chat._compacting = false
+    require("codecompanion.config").interactions.chat.opts.context_management.compaction.min_token_savings = 999999
+    _G.skipped = require("codecompanion.interactions.chat.context_management").apply(_G.chat)
+  ]==])
+
+  h.eq(true, child.lua_get("_G.handled"))
+  h.eq(false, child.lua_get("_G.skipped"))
+end
+
+T["apply"]["ends the turn when the summary request fails"] = function()
+  child.lua([==[
+    package.loaded["codecompanion.interactions.background"] = {
+      new = function()
+        return {
+          ask = function(_, _, opts)
+            opts.on_error("summary adapter exploded")
+          end,
+        }
+      end,
+    }
+
+    require("codecompanion.config").interactions.chat.opts.context_management = {
+      enabled = true,
+      editing = { trigger = 999999, exclude_tools = {}, keep_cycles = 3 },
+      compaction = { trigger = 10, min_token_savings = 1 },
+    }
+
+    _G.chat_done = false
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionChatDone",
+      callback = function() _G.chat_done = true end,
+    })
+
+    local big_chunk = string.rep("payload ", 3000)
+    _G.chat.cycle = 3
+    _G.chat.messages = {
+      { role = "user", content = big_chunk, _meta = { cycle = 1, id = 1 }, opts = { visible = true } },
+      { role = "llm", content = big_chunk, _meta = { cycle = 1, id = 2 }, opts = { visible = true } },
+    }
+
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
+  ]==])
+
+  h.is_true(child.lua_get("_G.chat_done"))
+  h.eq(false, child.lua_get("_G.chat._compacting"))
+end
+
+T["apply"]["does nothing when the token count is below all thresholds"] = function()
   child.lua([==[
     require("codecompanion.config").interactions.chat.opts.context_management = {
       enabled = true,
@@ -204,7 +358,7 @@ T["check"]["does nothing when the token count is below all thresholds"] = functi
     }
 
     _G.before = vim.deepcopy(_G.chat.messages)
-    require("codecompanion.interactions.chat.context_management").check(_G.chat)
+    require("codecompanion.interactions.chat.context_management").apply(_G.chat)
   ]==])
 
   h.eq(child.lua_get("_G.before"), child.lua_get("_G.chat.messages"))


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The `anthropic` and `openai_responses` adapters manage context themselves, with `CodeCompanion` managing it for other adapters. Until this PR, there was no way of separating the adapters that manage their own context versus other adapters. 

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
