### PR TITLE
fix(code_review): various fixes

### DIFF
--- a/.codecompanion/code_review.md
+++ b/.codecompanion/code_review.md
@@ -1,0 +1,79 @@
+# Code Review
+
+Code reviews let a user leave comments against an agent's changes where the code actually is, rather than typing out file names and line numbers by hand. Comments are collected up, sent to the agent in one go, and the review then advances a _baseline_ so the next review only shows what the agent changed in response. It's the same loop as a pull request: comment, submit, re-review.
+
+The baseline lives in git and the comments are persisted to disk, so a review survives across sessions and Neovim instances. Reviews work with CodeCompanion's own tools, ACP agents, and CLI agents running outside of Neovim.
+
+## Init
+
+@./lua/codecompanion/interactions/code_review/init.lua
+
+The entry point and the only module the rest of the plugin talks to. It owns the user-facing actions - commenting on a line, selection or quickfix hunk, opening the changes in the quickfix list, accepting and ignoring hunks, and draining the comments to send them. It also registers the autocmds that snapshot the baseline when an agent starts working and track the files it edits.
+
+The `advance_baseline` helper is the shared path behind `consume`, `share` and `approve`. It moves the baseline and clears the per-round state, reporting to the user if the snapshot fails.
+
+## Baseline
+
+@./lua/codecompanion/interactions/code_review/baseline.lua
+
+All of the git plumbing. A baseline is a commit holding a snapshot of the worktree, stored under `refs/worktree/codecompanion/baselines/<branch>`, with a stable alias at `refs/worktree/codecompanion/baseline` for gitsigns and diffview to point at. The `refs/worktree` namespace is per-worktree, like HEAD, so agents in linked worktrees never share a baseline.
+
+Snapshots are built against a temporary index via `GIT_INDEX_FILE`, so `git add` never runs against the user's own index. Both sides of a diff are worktree snapshots produced the same way, which is what makes untracked files visible to a review while whatever the user has staged is ignored. `--ignore-errors` keeps a snapshot going past paths git can't index, such as a nested repo with no commit checked out.
+
+This module also parses unified diff output into one entry per hunk, each with a content hash that stays stable until the change itself changes.
+
+## Store
+
+@./lua/codecompanion/interactions/code_review/store.lua
+
+Everything persisted to disk, under the configured `storage_dir` and keyed by a flattened repo path, then by branch. It holds the pending comments as a markdown file the user can hand-edit, plus the sets tracking which files an agent edited, which hunks were accepted, and which files were ignored. `submit` writes the review out to a file for sharing with an agent outside of CodeCompanion.
+
+## Diff
+
+@./lua/codecompanion/interactions/code_review/diff.lua
+
+Shows a single hunk against the baseline, either in Neovim's native diff or through the configured diff provider.
+
+## UI
+
+@./lua/codecompanion/interactions/code_review/ui.lua
+
+Draws the pending comments into the buffers they were written against, as extmarks, and keeps them in step as files are opened or the comments file is edited. It only watches for buffers while there are comments left to draw.
+
+## Keymaps
+
+@./lua/codecompanion/interactions/code_review/keymaps.lua
+
+Binds the review actions to the quickfix buffer, remembering what they replaced so they can be handed back. Because the quickfix list is shared, these check the review still owns the current list before acting.
+
+## Editor context
+
+@./lua/codecompanion/interactions/shared/editor_context/code_review.lua
+
+How a review reaches an agent. This formats the pending comments into `<comment>` blocks and swaps them in for the `#{code_review}` tag, for both the chat buffer and the CLI interaction. It's the caller of `consume`, so sending a review is what advances the baseline.
+
+## Commands
+
+@./lua/codecompanion/commands/init.lua
+
+`:CodeCompanionCodeReview` and its subcommands - `Accept`, `All`, `Approve`, `Comment`, `Comments`, `Ignore`.
+
+## Config
+
+@./lua/codecompanion/config.lua
+
+Under `interactions.code_review`. Covers whether the feature is enabled, the storage directory, the diff provider, and the quickfix keymaps.
+
+## Tests
+
+@./tests/interactions/code_review/test_ui.lua
+@./tests/interactions/code_review/test_store.lua
+@./tests/interactions/code_review/test_baseline.lua
+@./tests/interactions/code_review/test_code_review.lua
+
+Mini.Test with child processes. Each case gets a fresh git repo and storage directory. Note that opening a file with a real extension pulls in filetype plugins and treesitter, so the cases use extension-less names where the filetype doesn't matter.
+
+## Docs
+
+@./doc/usage/code-review.md
+@./doc/configuration/code-review.md

--- a/.codecompanion/rules.md
+++ b/.codecompanion/rules.md
@@ -87,6 +87,12 @@ The default config for rules is:
             ".codecompanion/acp/claude_code_acp.md",
           },
         },
+        ["code-review"] = {
+          description = "The code review implementation",
+          files = {
+            ".codecompanion/code_review.md",
+          },
+        },
         ["rules"] = {
           description = "Rules in the plugin",
           files = {

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                   For NVIM v0.11    Last change: 2026 July 31
+                                 For NVIM v0.11    Last change: 2026 August 02
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -6104,6 +6104,10 @@ disk, your progress is stored across sessions and Neovim instances.
 Because the diff is recomputed from disk every time, line numbers are never
 stored and so can never rot.
 
+
+  [!IMPORTANT] Snapshots are produced against a temporary index, so `git add`
+  never runs against your own. This means your staged changes and anything you
+  push are unaffected by a code review
 
 COMMANDS ~
 

--- a/doc/usage/code-review.md
+++ b/doc/usage/code-review.md
@@ -47,6 +47,9 @@ When an agent begins working in a git repository, CodeCompanion snapshots the wo
 
 Because the diff is recomputed from disk every time, line numbers are never stored and so can never rot.
 
+> [!IMPORTANT]
+> Snapshots are produced against a temporary index, so `git add` never runs against your own. This means your staged changes and anything you push are unaffected by a code review
+
 ## Commands
 
 | Command | Description |

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1093,6 +1093,12 @@ The user is working on a %s machine. Please respond with system specific command
             ".codecompanion/acp/claude_code_acp.md",
           },
         },
+        ["code-review"] = {
+          description = "The code review implementation",
+          files = {
+            ".codecompanion/code_review.md",
+          },
+        },
         ["rules"] = {
           description = "Rules in the plugin",
           files = {

--- a/lua/codecompanion/interactions/code_review/baseline.lua
+++ b/lua/codecompanion/interactions/code_review/baseline.lua
@@ -139,8 +139,9 @@ local function write_worktree(root)
   local index = vim.fn.tempname()
   local env = { GIT_INDEX_FILE = index }
 
-  local staged = git(root, { "add", "--all", "." }, env)
-  local tree = staged and git(root, { "write-tree" }, env)
+  -- Skip the paths that git can't index e.g. nested repos with no commit checked out
+  git(root, { "add", "--all", "--ignore-errors", "." }, env)
+  local tree = git(root, { "write-tree" }, env)
 
   vim.uv.fs_unlink(index)
   return tree
@@ -156,7 +157,7 @@ function M.snapshot(root)
   local updated = commit and git(root, { "update-ref", ref, commit })
 
   if not updated then
-    log:error("[Code Review] Could not snapshot the review baseline")
+    log:info("[Code Review] Could not snapshot the review baseline")
     return nil
   end
 

--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -131,9 +131,13 @@ end
 
 ---Advance the baseline so only changes made from now on appear in a review
 ---@param root string
----@return boolean success Whether the baseline moved; state is kept intact when the snapshot fails
+---@return boolean success
 local function advance_baseline(root)
   if baseline.get_root() and not baseline.snapshot(root) then
+    notify(
+      "Could not advance the baseline. Your next review will include changes from this round",
+      vim.log.levels.ERROR
+    )
     return false
   end
   store.clear_edited(root)
@@ -233,7 +237,6 @@ function M.approve()
   end
 
   if not advance_baseline(root) then
-    notify("Could not advance the baseline", vim.log.levels.ERROR)
     return
   end
 

--- a/tests/interactions/code_review/test_baseline.lua
+++ b/tests/interactions/code_review/test_baseline.lua
@@ -129,6 +129,23 @@ T["Baseline"]["diff scopes to the given paths"] = function()
   h.eq("a.lua", hunks[1].path)
 end
 
+T["Baseline"]["a nested repo with no commits doesn't block the review"] = function()
+  child.lua([[
+    write("a.lua", { "local a = 1" })
+    vim.system({ "git", "init", "--quiet", vim.fs.joinpath(repo, "nested") }):wait()
+    vim.fn.writefile({ "local n = 1" }, vim.fs.joinpath(repo, "nested", "n.lua"))
+    baseline.snapshot(repo)
+    write("a.lua", { "local a = 2" })
+  ]])
+
+  h.expect_match(child.lua_get("baseline.get(repo)"), "^%x+$")
+
+  -- The nested repo can't be indexed, so it's left out of the review entirely
+  local hunks = child.lua_get("baseline.diff(repo)")
+  h.eq(1, #hunks)
+  h.eq("a.lua", hunks[1].path)
+end
+
 T["Baseline"]["baselines are scoped per branch"] = function()
   child.lua([[
     commit("init")

--- a/tests/interactions/code_review/test_code_review.lua
+++ b/tests/interactions/code_review/test_code_review.lua
@@ -103,7 +103,7 @@ T["Review"]["comment on a file in a subdirectory stores a root-relative path"] =
     vim.fn.mkdir(vim.fs.joinpath(repo, "src"), "p")
     -- cd into the subdir so cwd is not the git root
     vim.cmd.cd(vim.fs.joinpath(repo, "src"))
-    vim.cmd("edit! foo.lua")
+    vim.cmd("edit! notes")
     vim.api.nvim_buf_set_lines(0, 0, -1, false, { "local a = 1" })
     vim.api.nvim_win_set_cursor(0, { 1, 0 })
 
@@ -112,7 +112,7 @@ T["Review"]["comment on a file in a subdirectory stores a root-relative path"] =
 
   local pending = child.lua_get("review.pending()")
   h.eq(1, #pending)
-  h.eq("src/foo.lua", pending[1].path)
+  h.eq("src/notes", pending[1].path)
 end
 
 T["Review"]["editing a comment to empty removes it"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR address a number of items:

- Continuously notifying users if a baseline could not be produced
- Prevents an unindexable path from aborting the snapshot
- Adds a `code_review` rules file

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus

## Related Issue(s)

- #3285

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
