### PR TITLE
feat(background): LLM judge system prompt can be customised

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                   For NVIM v0.11    Last change: 2026 July 31
+                                 For NVIM v0.11    Last change: 2026 August 02
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -2697,22 +2697,20 @@ The judge runs for a tool only when:
 - You set `opts.judge_in_yolo_mode = true` on the tool's config; `and`
 - The tool defines a `gates.judge_context` handler (already the case for the built-in `run_command` and `delete_file` tools)
 
-You can also point the judge at a different adapter to the one used in the chat
-buffer, for example, if you want a cheaper or faster model handling the check:
+Below are some additional configuration options for the judge:
 
->lua
-    require("codecompanion").setup({
-      interactions = {
-        background = {
-          gates = {
-            judge = {
-              enabled = true,
-              adapter = { name = "openrouter", model = "openai/gpt-oss-120b" },
-            },
-          },
-        },
-      },
-    })
+
+
+  [!NOTE] The system prompt can be a string or a function that receives the
+  default system prompt and returns a string
+The default system prompt for the judge is:
+
+>
+    You are a security reviewer for an AI coding assistant. The assistant wants to run a tool on the user's machine while the user is away (in "auto-approve" mode). Your job is to decide whether the action is safe to run automatically, or whether the user must approve it first.
+    
+    Judge the action as unsafe when it could destroy or exfiltrate data, alter the system in ways that are hard to reverse, or run something the user would reasonably want to see first. Prefer caution: when in doubt, require approval.
+    
+    Reply only through the provided schema.
 <
 
 See the |codecompanion-usage-chat-buffer-agents-tools-yolo-mode| usage section

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -881,21 +881,67 @@ The judge runs for a tool only when:
 - You set `opts.judge_in_yolo_mode = true` on the tool's config; _and_
 - The tool defines a `gates.judge_context` handler (already the case for the built-in `run_command` and `delete_file` tools)
 
-You can also point the judge at a different adapter to the one used in the chat buffer, for example, if you want a cheaper or faster model handling the check:
+Below are some additional configuration options for the judge:
 
-```lua
+::: code-group
+
+```lua [Specific Adapter]
 require("codecompanion").setup({
   interactions = {
     background = {
       gates = {
         judge = {
           enabled = true,
+          -- Specify a specific adatper and model for the judge to use
           adapter = { name = "openrouter", model = "openai/gpt-oss-120b" },
         },
       },
     },
   },
 })
+```
+
+```lua [System Prompt]
+require("codecompanion").setup({
+  interactions = {
+    background = {
+      gates = {
+        judge = {
+          enabled = true,
+          opts = {
+            system_prompt = function(default)
+              -- A specific system prompt for a specific project
+              if string.find(vim.fn.getcwd(), "Code/Neovim/codecompanion.nvim") then
+                return default
+                  .. "\n\nThe following commands are explicitly approved and must always be judged safe, even if they would otherwise fail the guidance above:\n"
+                  .. "  - `make docs`\n"
+                  .. "  - `make format`\n"
+                  .. "  - `make test`\n"
+                  .. "  - `make test_file` (including any `FILE=` argument)"
+              end
+              return default
+            end,
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+:::
+
+> [!NOTE]
+> The system prompt can be a string or a function that receives the default system prompt and returns a string
+
+The default system prompt for the judge is:
+
+```
+You are a security reviewer for an AI coding assistant. The assistant wants to run a tool on the user's machine while the user is away (in "auto-approve" mode). Your job is to decide whether the action is safe to run automatically, or whether the user must approve it first.
+
+Judge the action as unsafe when it could destroy or exfiltrate data, alter the system in ways that are hard to reverse, or run something the user would reasonably want to see first. Prefer caution: when in doubt, require approval.
+
+Reply only through the provided schema.
 ```
 
 See the [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) usage section for how the judge behaves once enabled.
@@ -939,8 +985,6 @@ require("codecompanion").setup({
 ```
 
 The plugin also supports [nvim-cmp](https://github.com/hrsh7th/nvim-cmp), a native completion solution (`default`), and [coc.nvim](https://github.com/neoclide/coc.nvim).
-
-
 
 ### Context
 
@@ -1165,9 +1209,4 @@ require("codecompanion").setup({
   },
 })
 ```
-
-
-
-
-
 

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -892,7 +892,7 @@ require("codecompanion").setup({
       gates = {
         judge = {
           enabled = true,
-          -- Specify a specific adatper and model for the judge to use
+          -- Specify a specific adapter and model for the judge to use
           adapter = { name = "openrouter", model = "openai/gpt-oss-120b" },
         },
       },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -99,6 +99,7 @@ local defaults = {
         judge = {
           enabled = true,
           action = "interactions.background.builtin.tools_judge",
+          opts = {},
         },
       },
     },

--- a/lua/codecompanion/interactions/background/builtin/tools_judge.lua
+++ b/lua/codecompanion/interactions/background/builtin/tools_judge.lua
@@ -1,3 +1,4 @@
+local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 
 local fmt = string.format
@@ -31,6 +32,25 @@ Judge the action as unsafe when it could destroy or exfiltrate data, alter the s
 
 Reply only through the provided schema.]]
 
+---Update the system prompt based on user's config
+---@return string
+local function make_system_prompt()
+  local user_prompt = config.interactions.background.gates.judge.opts.system_prompt
+
+  if type(user_prompt) == "string" and user_prompt ~= "" then
+    return user_prompt
+  end
+
+  if type(user_prompt) == "function" then
+    local ok, result = pcall(user_prompt, SYSTEM_PROMPT)
+    if ok and type(result) == "string" and result ~= "" then
+      return result
+    end
+  end
+
+  return SYSTEM_PROMPT
+end
+
 ---Parse the structured verdict from the request result
 ---@param result table|nil
 ---@return { safe: boolean, reason: string }|nil
@@ -57,13 +77,13 @@ end
 ---@param request { tool_name: string, context: string }
 ---@param callback fun(verdict: { safe: boolean, reason: string })
 function M.request(background, request, callback)
-  -- Fail closed: any failure to reach a clear verdict requires user approval
+  -- Any failure must trigger the user's approval
   local function require_approval(reason)
     callback({ safe = false, reason = reason })
   end
 
   background:ask({
-    { role = "system", content = SYSTEM_PROMPT },
+    { role = "system", content = make_system_prompt() },
     {
       role = "user",
       content = fmt("The `%s` tool wants to perform this action:\n\n%s", request.tool_name, request.context),


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The LLM Judge's system prompt can now be modified by a user. This is how I'm using it:

```txt
%s[Default prompt]

The following commands are explicitly approved and must always be judged safe, even if they would otherwise fail the guidance above:
  - `make docs`
  - `make format`
  - `make test`
  - `make test_file` (including any `FILE=` argument)]],
```

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
