### PR TITLE
feat(slash_cmd): add `/rename`

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -5654,6 +5654,15 @@ The `now` slash command simply inserts the current datetime stamp into the chat
 buffer.
 
 
+/RENAME ~
+
+The `rename` slash command is specific to
+|codecompanion-configuration-adapters-http| adapters. It allows you to rename
+the title of the conversation in the chat buffer. This can be useful to keep
+track of different conversations via `open chats` in the
+|codecompanion-usage-action-palette|.
+
+
 /RESUME ~
 
 The `resume` slash command is specific to

--- a/doc/usage/chat-buffer/slash-commands.md
+++ b/doc/usage/chat-buffer/slash-commands.md
@@ -100,6 +100,10 @@ The _mode_ slash command is specific to [ACP](/configuration/adapters-acp) adapt
 
 The _now_ slash command simply inserts the current datetime stamp into the chat buffer.
 
+## /rename
+
+The _rename_ slash command is specific to [http](/configuration/adapters-http) adapters. It allows you to rename the title of the conversation in the chat buffer. This can be useful to keep track of different conversations via _open chats_ in the [action palette](/usage/action-palette).
+
 ## /resume
 
 The _resume_ slash command is specific to [ACP](/configuration/adapters-acp) adapters that support the `session/list` capability. It allows you to resume a previous session by listing your past sessions and restoring the selected one into the chat buffer. The conversation history is rendered so you can continue where you left off.

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -506,6 +506,21 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
             contains_code = false,
           },
         },
+        ["rename"] = {
+          path = "interactions.chat.slash_commands.builtin.rename",
+          description = "Rename the current session",
+          ---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
+          ---@return boolean
+          enabled = function(opts)
+            if opts.adapter and opts.adapter.type == "http" then
+              return true
+            end
+            return false
+          end,
+          opts = {
+            contains_code = false,
+          },
+        },
         ["resume"] = {
           path = "interactions.chat.slash_commands.builtin.resume",
           description = "Resume a previous ACP session",

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/rename.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/rename.lua
@@ -1,0 +1,33 @@
+local utils = require("codecompanion.utils")
+
+---@class CodeCompanion.SlashCommand.Rename: CodeCompanion.SlashCommand
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommand
+function SlashCommand.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+
+  return self
+end
+
+---Execute the slash command
+---@return nil
+function SlashCommand:execute()
+  local Chat = self.Chat
+
+  vim.ui.input({
+    prompt = "Enter title: ",
+    default = Chat.title or "",
+  }, function(input)
+    if input then
+      Chat:set_title(input)
+      return utils.notify("Renamed the chat")
+    end
+  end)
+end
+
+return SlashCommand


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This slash command allows users to rename their conversations in the chat buffer.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
