### PR TITLE
feat(tools): improve `get_diagnostics`

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/builtin/get_diagnostics.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/get_diagnostics.lua
@@ -1,8 +1,17 @@
 local helpers = require("codecompanion.interactions.chat.tools.builtin.helpers")
+
+local file_utils = require("codecompanion.utils.files")
 local log = require("codecompanion.utils.log")
 
 local api = vim.api
 local fmt = string.format
+
+local CONSTANTS = {
+  MAX_CODE_LINES = 8,
+  MAX_WAIT = 5000,
+  WAIT_AFTER_EACH_CHANGE = 250,
+  WAIT_FOR_FIRST_DIAGNOSTICS = 2000,
+}
 
 local severity_labels = {
   [1] = "ERROR",
@@ -19,113 +28,225 @@ local severity_map = {
   HINT = "HINT",
 }
 
----Get the diagnostics for a given file
----@param action { filepath: string, severity: string|nil }
----@return { status: "success"|"error", data: string }
-local function get_diagnostics(action)
-  local filepath = vim.fs.normalize(action.filepath)
-
-  if not filepath or filepath == "" then
+---Resolve a filepath to a loaded buffer, reading it in the background if it isn't open
+---@param filepath string
+---@return { bufnr: number|nil, error: string|nil, freshly_loaded: boolean }
+local function resolve_buffer(filepath)
+  local bufnr = vim.fn.bufadd(filepath)
+  if bufnr == 0 or not api.nvim_buf_is_valid(bufnr) then
     return {
-      status = "error",
-      data = "filepath parameter is required and cannot be empty",
+      error = fmt("`%s` could not be opened. Check the path points at a file and try again", filepath),
+      freshly_loaded = false,
     }
   end
 
-  local normalized = vim.fn.fnamemodify(filepath, ":p")
-  local bufnr = vim.fn.bufnr(normalized)
+  if api.nvim_buf_is_loaded(bufnr) then
+    return { bufnr = bufnr, freshly_loaded = false }
+  end
 
-  local is_existing_buffer = true
-  if bufnr == -1 then
-    -- Buffer doesn't exist so we need to load it
-    bufnr = vim.fn.bufadd(normalized)
-    vim.fn.bufload(bufnr)
+  local ok, err = pcall(vim.fn.bufload, bufnr)
+  if not ok then
+    return {
+      error = fmt("`%s` could not be read. Neovim failed to open it: %s", filepath, err),
+      freshly_loaded = false,
+    }
+  end
 
-    -- Trigger filetype detection which fires the FileType autocommand.
-    -- LSP auto-attach listens on FileType, so without this the LSP
-    -- never attaches to buffers opened via bufadd/bufload.
-    local ft = vim.filetype.match({ buf = bufnr })
-    if ft then
-      vim.bo[bufnr].filetype = ft
+  -- LSP auto-attach listens on FileType, so cover a config with detection turned off
+  if vim.bo[bufnr].filetype == "" then
+    local filetype = vim.filetype.match({ buf = bufnr })
+    if filetype then
+      vim.bo[bufnr].filetype = filetype
+    end
+  end
+
+  return { bufnr = bufnr, freshly_loaded = true }
+end
+
+---Call back once the buffer's diagnostics have stopped arriving, or the waits elapse
+---@param bufnr number
+---@param opts { freshly_loaded: boolean }
+---@param callback fun()
+---@return nil
+local function on_diagnostics(bufnr, opts, callback)
+  if not opts.freshly_loaded and vim.tbl_isempty(vim.lsp.get_clients({ bufnr = bufnr })) then
+    return callback()
+  end
+
+  local group = api.nvim_create_augroup("codecompanion.get_diagnostics." .. bufnr, { clear = true })
+  local responded = false
+  local scheduled = 0
+
+  local function respond()
+    if responded then
+      return
+    end
+    responded = true
+    pcall(api.nvim_del_augroup_by_id, group)
+    callback()
+  end
+
+  ---Respond once the delay is up, unless a later change schedules a new one first
+  ---@param delay number
+  ---@return nil
+  local function respond_in(delay)
+    scheduled = scheduled + 1
+    local generation = scheduled
+    vim.defer_fn(function()
+      if generation == scheduled then
+        respond()
+      end
+    end, delay)
+  end
+
+  api.nvim_create_autocmd("DiagnosticChanged", {
+    group = group,
+    callback = function(request)
+      if request.buf == bufnr then
+        respond_in(CONSTANTS.WAIT_AFTER_EACH_CHANGE)
+      end
+    end,
+  })
+  api.nvim_create_autocmd("LspAttach", {
+    group = group,
+    callback = function(request)
+      if request.buf == bufnr then
+        respond_in(CONSTANTS.WAIT_FOR_FIRST_DIAGNOSTICS)
+      end
+    end,
+  })
+
+  respond_in(CONSTANTS.WAIT_FOR_FIRST_DIAGNOSTICS)
+  vim.defer_fn(respond, CONSTANTS.MAX_WAIT)
+end
+
+---Format diagnostics as a list of messages followed by the source lines they point at
+---@param args { bufnr: number, diagnostics: table[], display_path: string }
+---@return string
+local function format_diagnostics(args)
+  local bufnr = args.bufnr
+
+  table.sort(args.diagnostics, function(a, b)
+    if a.lnum == b.lnum then
+      return (a.col or 0) < (b.col or 0)
+    end
+    return a.lnum < b.lnum
+  end)
+
+  local last_line = api.nvim_buf_line_count(bufnr) - 1
+  local messages = {}
+  local wanted_lines = {}
+
+  for _, diagnostic in ipairs(args.diagnostics) do
+    local origin = diagnostic.source or ""
+    if diagnostic.code then
+      origin = origin == "" and tostring(diagnostic.code) or fmt("%s[%s]", origin, diagnostic.code)
     end
 
-    is_existing_buffer = false
+    table.insert(
+      messages,
+      fmt(
+        "%d:%d %s %s%s",
+        diagnostic.lnum + 1,
+        (diagnostic.col or 0) + 1,
+        severity_labels[diagnostic.severity] or tostring(diagnostic.severity),
+        origin ~= "" and (origin .. " ") or "",
+        (vim.trim(diagnostic.message):gsub("\n", "\n  "))
+      )
+    )
+
+    -- Diagnostics can outlive the edit that produced them, so their range may now sit beyond the end of the buffer
+    local start_line = math.max(0, diagnostic.lnum)
+    local end_line =
+      math.min(diagnostic.end_lnum or diagnostic.lnum, last_line, start_line + CONSTANTS.MAX_CODE_LINES - 1)
+    for line = start_line, end_line do
+      wanted_lines[line] = true
+    end
   end
 
-  if not api.nvim_buf_is_valid(bufnr) then
-    return {
+  local numbers = vim.tbl_keys(wanted_lines)
+  table.sort(numbers)
+
+  local code = {}
+  for _, line in ipairs(numbers) do
+    table.insert(code, fmt("%d: %s", line + 1, api.nvim_buf_get_lines(bufnr, line, line + 1, false)[1] or ""))
+  end
+
+  return fmt(
+    [[Diagnostics for `%s` (%d found):
+%s
+
+Code:
+````%s
+%s
+````]],
+    args.display_path,
+    #args.diagnostics,
+    table.concat(messages, "\n"),
+    vim.bo[bufnr].filetype or "",
+    table.concat(code, "\n")
+  )
+end
+
+---Get the diagnostics for a given file
+---@param action { filepath: string, severity: string|nil }
+---@param callback fun(msg: { status: "success"|"error", data: string })
+---@return nil
+local function get_diagnostics(action, callback)
+  if not action.filepath or action.filepath == "" then
+    return callback({
       status = "error",
-      data = fmt("Could not resolve a valid buffer for `%s`", filepath),
-    }
+      data = "filepath parameter is required and cannot be empty",
+    })
+  end
+
+  local filepath = file_utils.validate_and_normalize_path(action.filepath)
+  if not filepath or not file_utils.exists(filepath) then
+    return callback({
+      status = "error",
+      data = fmt(
+        "`%s` does not exist. Check the path is correct and relative to the current working directory",
+        action.filepath
+      ),
+    })
+  end
+
+  local display_path = vim.fn.fnamemodify(filepath, ":.")
+  local buffer = resolve_buffer(filepath)
+  local bufnr = buffer.bufnr
+  if not bufnr then
+    return callback({ status = "error", data = buffer.error })
   end
 
   local min_severity = vim.diagnostic.severity.HINT
   if action.severity then
     local key = severity_map[string.upper(action.severity)]
     if key then
-      local mapped = vim.diagnostic.severity[key]
-      if mapped then
-        min_severity = mapped
-      end
+      min_severity = vim.diagnostic.severity[key] or min_severity
     end
   end
 
-  if not is_existing_buffer then
-    -- Wait for LSP to attach to the freshly loaded buffer
-    vim.wait(5000, function()
-      return #vim.lsp.get_clients({ bufnr = bufnr }) > 0
-    end, 50)
-  end
+  on_diagnostics(bufnr, { freshly_loaded = buffer.freshly_loaded }, function()
+    if not api.nvim_buf_is_valid(bufnr) then
+      return callback({
+        status = "error",
+        data = fmt("The buffer for `%s` was closed before its diagnostics could be read", display_path),
+      })
+    end
 
-  -- Wait for diagnostics to be published (LSP may still be processing after edits)
-  if #vim.lsp.get_clients({ bufnr = bufnr }) > 0 then
-    vim.wait(5000, function()
-      return #vim.diagnostic.get(bufnr) > 0
-    end, 50)
-  end
+    local diagnostics = vim.diagnostic.get(bufnr, { severity = { min = min_severity } })
+    if #diagnostics == 0 then
+      return callback({
+        status = "success",
+        data = fmt("No diagnostics found for `%s`", display_path),
+      })
+    end
 
-  local diagnostics = vim.diagnostic.get(bufnr, {
-    severity = { min = min_severity },
-  })
-
-  if #diagnostics == 0 then
-    return {
+    callback({
       status = "success",
-      data = fmt("No diagnostics found for `%s`", filepath),
-    }
-  end
-
-  local filetype = vim.bo[bufnr].filetype or ""
-
-  local formatted = {}
-  for _, diagnostic in ipairs(diagnostics) do
-    local lines = {}
-    for i = diagnostic.lnum, diagnostic.end_lnum do
-      local line_content = vim.trim(table.concat(api.nvim_buf_get_lines(bufnr, i, i + 1, false), ""))
-      table.insert(lines, fmt("%d: %s", i + 1, line_content))
-    end
-
-    table.insert(
-      formatted,
-      fmt(
-        [[Severity: %s
-LSP Message: %s
-Code:
-````%s
-%s
-````]],
-        severity_labels[diagnostic.severity] or tostring(diagnostic.severity),
-        diagnostic.message,
-        filetype,
-        table.concat(lines, "\n")
-      )
-    )
-  end
-
-  return {
-    status = "success",
-    data = fmt("Diagnostics for `%s` (%d found):\n\n%s", filepath, #diagnostics, table.concat(formatted, "\n\n")),
-  }
+      data = format_diagnostics({ bufnr = bufnr, diagnostics = diagnostics, display_path = display_path }),
+    })
+  end)
 end
 
 ---@class CodeCompanion.Tool.GetDiagnostics: CodeCompanion.Tools.Tool
@@ -135,10 +256,10 @@ return {
     ---Execute the diagnostics commands
     ---@param self CodeCompanion.Tool.GetDiagnostics
     ---@param args table The arguments from the LLM's tool call
-    ---@param input? any The output from the previous function call
-    ---@return { status: "success"|"error", data: string }
-    function(self, args, input)
-      return get_diagnostics(args)
+    ---@param opts { input: any, output_cb: fun(msg: table) }
+    ---@return nil
+    function(self, args, opts)
+      get_diagnostics(args, vim.schedule_wrap(opts.output_cb))
     end,
   },
   schema = {

--- a/tests/scripts/get_diagnostics_tool.lua
+++ b/tests/scripts/get_diagnostics_tool.lua
@@ -1,0 +1,52 @@
+--[[
+Manual harness for the get_diagnostics tool.
+NOTE: Debug/eyeball script - not part of the automated Mini.Test suite. It needs a real
+language server attached, which is why it can't live in tests/.
+
+Usage: with CodeCompanion loaded and your LSP running:
+  :luafile tests/scripts/get_diagnostics_tool.lua   runs against FILE, or the current buffer
+  :CCGetDiagnostics lua/codecompanion/init.lua      runs against any path, after sourcing
+
+Prints what the tool hands back to the chat buffer: the inspected { status, data } table,
+then the data on its own so the formatting is readable. Both land in :messages.
+--]]
+
+-- ============================================================================
+-- CONFIG - edit, then :luafile %
+-- ============================================================================
+
+local FILE = "~/Code/Neovim/codecompanion.nvim/feature-a/lua/codecompanion/interactions/chat/context.lua" -- empty runs against the current buffer
+local SEVERITY = "WARNING" -- nil | "ERROR" | "WARNING" | "INFORMATION" | "HINT"
+
+-- ============================================================================
+
+local tool = require("codecompanion.interactions.chat.tools.builtin.get_diagnostics")
+
+local fmt = string.format
+
+---Run the tool against a path and print what it returns
+---@param filepath string
+---@return nil
+local function inspect_diagnostics(filepath)
+  local started = vim.uv.hrtime()
+
+  tool.cmds[1](tool, { filepath = filepath, severity = SEVERITY }, {
+    output_cb = function(msg)
+      local bufnr = vim.fn.bufnr(filepath)
+      local clients = bufnr ~= -1 and #vim.lsp.get_clients({ bufnr = bufnr }) or 0
+
+      print(
+        fmt(
+          "get_diagnostics `%s` returned in %.0fms, %d LSP client(s) attached",
+          filepath,
+          (vim.uv.hrtime() - started) / 1e6,
+          clients
+        )
+      )
+      print(vim.inspect(msg))
+      print(msg.data)
+    end,
+  })
+end
+
+inspect_diagnostics(FILE ~= "" and FILE or vim.api.nvim_buf_get_name(0))


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The prior implementation of `get_diagnostics` was not great. It was slow - built upon delays - waiting for the LSP server. An unloaded buffer and an incorrect path always reported "No diagnostics". And there was no way to test it.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
