### PR TITLE
fix(utils): guard buffers.get_info against invalid buffer ids

### DIFF
--- a/lua/codecompanion/utils/buffers.lua
+++ b/lua/codecompanion/utils/buffers.lua
@@ -59,6 +59,18 @@ end
 ---@param bufnr number
 ---@return table
 function M.get_info(bufnr)
+  if not api.nvim_buf_is_valid(bufnr) then
+    return {
+      bufnr = bufnr,
+      filetype = "",
+      name = "[invalid buffer]",
+      number = bufnr,
+      path = "[invalid buffer]",
+      relative_path = "[invalid buffer]",
+      short_path = "[invalid buffer]",
+    }
+  end
+
   local bufname = api.nvim_buf_get_name(bufnr)
 
   return {

--- a/tests/utils/test_buffers.lua
+++ b/tests/utils/test_buffers.lua
@@ -52,26 +52,4 @@ T["Utils->Buffers"]["add_line_numbers works"] = function()
   h.expect_match(result, "3 |test")
 end
 
-T["Utils->Buffers"]["get_info works for a valid buffer"] = function()
-  local info = child.lua([[
-    return _G.buf_utils.get_info(_G.test_buffer)
-  ]])
-
-  h.eq(info.bufnr, child.lua_get("_G.test_buffer"))
-  h.not_eq(info.path, "[invalid buffer]")
-end
-
-T["Utils->Buffers"]["get_info does not error for a deleted/invalid buffer"] = function()
-  local info = child.lua([[
-    local scratch = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_delete(scratch, { force = true })
-    -- scratch is now an invalid buffer id
-    local ok, result = pcall(_G.buf_utils.get_info, scratch)
-    return { ok = ok, result = result }
-  ]])
-
-  h.is_true(info.ok)
-  h.eq(info.result.path, "[invalid buffer]")
-end
-
 return T

--- a/tests/utils/test_buffers.lua
+++ b/tests/utils/test_buffers.lua
@@ -52,4 +52,26 @@ T["Utils->Buffers"]["add_line_numbers works"] = function()
   h.expect_match(result, "3 |test")
 end
 
+T["Utils->Buffers"]["get_info works for a valid buffer"] = function()
+  local info = child.lua([[
+    return _G.buf_utils.get_info(_G.test_buffer)
+  ]])
+
+  h.eq(info.bufnr, child.lua_get("_G.test_buffer"))
+  h.not_eq(info.path, "[invalid buffer]")
+end
+
+T["Utils->Buffers"]["get_info does not error for a deleted/invalid buffer"] = function()
+  local info = child.lua([[
+    local scratch = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_delete(scratch, { force = true })
+    -- scratch is now an invalid buffer id
+    local ok, result = pcall(_G.buf_utils.get_info, scratch)
+    return { ok = ok, result = result }
+  ]])
+
+  h.is_true(info.ok)
+  h.eq(info.result.path, "[invalid buffer]")
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Chat sessions cache the source buffer's number in `buffer_context.bufnr` when they're created. If that buffer is later closed/wiped, submitting a message that triggers any editor context expansion (`#buffer`, `#buffers`, etc.) crashes with `Invalid buffer id: N`.

`EditorContext.replace` in `interactions/shared/editor_context/buffer.lua` unconditionally calls `buf_utils.get_info(bufnr)` on the cached `bufnr` to build the fallback replacement text for the bare `#{buffer}` pattern, regardless of whether that pattern is present in the message or whether the buffer still exists. `get_info` called `nvim_buf_get_name` with no validity check, so an invalid handle throws instead of degrading gracefully.

`buffers.get_info()` now checks `nvim_buf_is_valid(bufnr)` up front and returns a `"[invalid buffer]"` placeholder table instead of erroring. This is the single call site all `get_info` callers go through, so it fixes the crash regardless of which editor-context tag triggered it.

## Supporting Documentation

N/A

## AI Usage

Used Claude Code to reproduce the crash from a real Neovim config, trace the stack to the root cause in `buffers.lua`, and write the one-line validity guard. Reviewed and understand the change; removed the accompanying test after maintainer feedback that it wasn't needed.

## Related Issue(s)

None filed - found and fixed directly from a user config crash (see reproduction screenshot in comments below).

## Screenshots

See reproduction screenshot in the comments below.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
