### PR TITLE
fix(tools): read the documented `tool_in_progress` icon key

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -42,7 +42,7 @@ local CONSTANTS = {
   STATUS_ERROR = "error",
   STATUS_SUCCESS = "success",
 
-  PROCESSING_MSG = (config.display.chat.icons.tools_in_progress or "⚡") .. " Tools processing ...",
+  PROCESSING_MSG = (config.display.chat.icons.tool_in_progress or "⚡") .. " Tools processing ...",
 }
 
 ---@class CodeCompanion.Tools


### PR DESCRIPTION
### Description

The tools-processing banner reads `config.display.chat.icons.tools_in_progress` (plural `tools_`), but that key does not exist anywhere in the project:

- `config.lua` defines `tool_in_progress` (singular), alongside `tool_pending`, `tool_failure` and `tool_success`.
- `doc/configuration/chat-buffer.md` documents `tool_in_progress` (singular).
- `interactions/chat/ui/icons.lua` reads `tool_in_progress` (singular).

`rg 'tools?_in_progress'` over `main` returns the plural spelling at exactly one site — the line changed here.

The effect is that a user who configures `display.chat.icons.tool_in_progress` sees it applied to the per-tool status extmarks but silently ignored by the "Tools processing ..." banner, which always falls back to the hardcoded `⚡`.

### Reproduction

```lua
require("codecompanion").setup({
  display = { chat = { icons = { tool_in_progress = "🔧 " } } },
})
```

Run any tool from a chat buffer: the per-tool icon becomes 🔧, the processing banner stays ⚡.

### Change

One-line fix to read the documented key. No config or documentation change, since the singular spelling is already the documented and defaulted one.

### Note (not changed here)

`CONSTANTS.PROCESSING_MSG` is evaluated at module require time, so it snapshots the config rather than reading it per use. That is fine given the module is required after `setup()`, but it does mean the value cannot be changed at runtime. Happy to make it lazy in a follow-up if you'd prefer.