### PR TITLE
fix(chat): herdr integration

### DIFF
--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -23,6 +23,7 @@ local PromptBuilder = require("codecompanion.acp.prompt_builder")
 local adapter_utils = require("codecompanion.adapters.utils")
 local async = require("codecompanion.utils.async")
 local config = require("codecompanion.config")
+local integrations = require("codecompanion.integrations")
 local jsonrpc = require("codecompanion.utils.jsonrpc")
 local log = require("codecompanion.utils.log")
 local utils = require("codecompanion.utils")
@@ -435,7 +436,7 @@ function Connection:start_agent_process()
     {
       stdin = true,
       cwd = vim.fn.getcwd(),
-      env = adapter.env_replaced or {},
+      env = vim.tbl_extend("force", adapter.env_replaced or {}, integrations.acp_env()),
       stdout = self.methods.schedule_wrap(function(err, data)
         if err then
           log:error("[acp::start_agent_process::stdout] Error: %s", err)

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -1,5 +1,7 @@
 local log = require("codecompanion.utils.log")
 
+local api = vim.api
+
 local M = {}
 
 local CONSTANTS = {
@@ -10,22 +12,18 @@ local CONSTANTS = {
 local herdr = nil ---@type string|nil
 local last_state = nil ---@type string|nil
 
--- herdr discards any sequence that isn't strictly greater than the last one it
--- saw for our source, remembering across Neovim sessions. Seeding from Lua's
--- built-in time ensures that we'll be safe
+---herdr discards a sequence if it's not greater than the previous one
 local seq = os.time() * 1000
 
----The chat buffers mid-turn, keyed by buffer number
+---Enables multiple chat buffers to affect the pane's state
 ---@type table<string, { state: "working"|"blocked", message?: string }>
-local in_flight = {}
+local in_flight_chats = {}
 
----Store the chat buffers so we know what's listed in herdr
 ---@type table<number, boolean>
 local open_chats = {}
 
----Resolve the herdr path
 ---@return string|nil
-local function resolve_herdr()
+local function resolve_herdr_path()
   if vim.env.HERDR_BIN_PATH and vim.env.HERDR_BIN_PATH ~= "" then
     return vim.env.HERDR_BIN_PATH
   end
@@ -37,18 +35,17 @@ local function resolve_herdr()
   return nil
 end
 
----Check whether Neovim is running inside a herdr pane
 ---@return boolean
-local function is_active()
+local function herdr_active()
   return vim.env.HERDR_ENV == "1" and vim.env.HERDR_PANE_ID ~= nil and herdr ~= nil
 end
 
----Roll everything in flight up into the single state the herdr pane can display
+---Aggregate every in-flight chat's state
 ---@return "idle"|"working"|"blocked" state
 ---@return string|nil message
-local function aggregate()
+local function aggregate_in_flight_chats()
   local is_working = false
-  for _, entry in pairs(in_flight) do
+  for _, entry in pairs(in_flight_chats) do
     if entry.state == "blocked" then
       return "blocked", entry.message
     end
@@ -58,14 +55,14 @@ local function aggregate()
   return is_working and "working" or "idle", nil
 end
 
----herdr requires the sequence to be strictly greater than the last one it saw
 ---@return string
 local function next_seq()
+  -- Must be greater than the previous sequence
   seq = seq + 1
   return string.format("%d", seq)
 end
 
----Hand the pane back to herdr, so it no longer lists CodeCompanion as one of its agents
+---Release CodeCompanion from the pane in herdr
 ---@return nil
 local function release()
   if not last_state then
@@ -100,15 +97,14 @@ local function release()
   end
 end
 
----Report the pane's state to herdr, skipping the call when nothing has changed
+---Sync CodeCompanion's status with herdr
 ---@return nil
-local function sync()
-  -- An idle agent stays listed against the pane, so let go entirely once no chat is left to return to
-  if vim.tbl_isempty(in_flight) and vim.tbl_isempty(open_chats) then
+local function update_herdr()
+  if vim.tbl_isempty(in_flight_chats) and vim.tbl_isempty(open_chats) then
     return release()
   end
 
-  local state, message = aggregate()
+  local state, message = aggregate_in_flight_chats()
   if state == last_state then
     return
   end
@@ -141,29 +137,27 @@ local function sync()
   end)
 end
 
----Record a chat as being mid-turn
+---Track an in-flight track with herdr
 ---@param key string
 ---@param state "working"|"blocked"
 ---@param message? string
 ---@return nil
 local function track(key, state, message)
-  in_flight[key] = { state = state, message = message }
-  sync()
+  in_flight_chats[key] = { state = state, message = message }
+  update_herdr()
 end
 
----Drop a chat, moving the pane to idle once no other chat is mid-turn
 ---@param key string
 ---@return nil
 local function untrack(key)
-  in_flight[key] = nil
-  sync()
+  in_flight_chats[key] = nil
+  update_herdr()
 end
 
----Report CodeCompanion's activity to herdr for the life of the Neovim instance
 ---@return nil
 function M.setup()
-  herdr = resolve_herdr()
-  if not is_active() then
+  herdr = resolve_herdr_path()
+  if not herdr_active() then
     log:trace(
       "[herdr] Not reporting: HERDR_ENV=%s HERDR_PANE_ID=%s herdr=%s",
       tostring(vim.env.HERDR_ENV),
@@ -173,12 +167,12 @@ function M.setup()
     return
   end
 
-  local group = vim.api.nvim_create_augroup("codecompanion.integrations.herdr", { clear = true })
+  local group = api.nvim_create_augroup("codecompanion.integrations.herdr", { clear = true })
 
   ---@param events string[]
   ---@param callback fun(data: table)
   local function on(events, callback)
-    vim.api.nvim_create_autocmd("User", {
+    api.nvim_create_autocmd("User", {
       group = group,
       pattern = events,
       callback = function(args)
@@ -195,7 +189,7 @@ function M.setup()
   -- Opening a chat attaches onto the pane as idle, listing it in herdr
   on({ "CodeCompanionChatCreated" }, function(data)
     open_chats[data.bufnr] = true
-    sync()
+    update_herdr()
   end)
   on({ "CodeCompanionChatDone", "CodeCompanionChatStopped" }, function(data)
     untrack("chat:" .. tostring(data.bufnr))
@@ -213,7 +207,7 @@ function M.setup()
     track("chat:" .. tostring(data.bufnr), "working")
   end)
 
-  vim.api.nvim_create_autocmd("VimLeavePre", {
+  api.nvim_create_autocmd("VimLeavePre", {
     group = group,
     desc = "Release CodeCompanion's authority over the herdr pane",
     callback = release,

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -5,7 +5,7 @@ local api = vim.api
 local M = {}
 
 local CONSTANTS = {
-  AGENT = "codecompanion.nvim",
+  AGENT = "CodeCompanion.nvim",
   SOURCE = "custom:codecompanion.nvim",
 }
 
@@ -152,6 +152,13 @@ end
 local function untrack(key)
   in_flight_chats[key] = nil
   update_herdr()
+end
+
+---Set the environment for ACP adapters
+---@return table<string, string>
+function M.acp_env()
+  -- Ensure that any ACP agents spawned by CodeCompanion don't steal the herdr pane
+  return { HERDR_ENV = "", HERDR_PANE_ID = "" }
 end
 
 ---@return nil

--- a/lua/codecompanion/integrations/init.lua
+++ b/lua/codecompanion/integrations/init.lua
@@ -7,9 +7,10 @@ local INTEGRATIONS = {
   "herdr",
 }
 
----Set up any third-party integrations that are enabled in the user's config
+---Call a function for every integration that's enabled in the user's config
+---@param callback fun(integration: table)
 ---@return nil
-function M.setup()
+local function enabled_integrations(callback)
   for _, name in ipairs(INTEGRATIONS) do
     local integration_config = config.integrations[name]
     if integration_config and integration_config.enabled then
@@ -17,10 +18,29 @@ function M.setup()
       if not ok then
         log:warn("Failed to load integration `%s`: %s", name, integration)
       else
-        integration.setup()
+        callback(integration)
       end
     end
   end
+end
+
+---@return nil
+function M.setup()
+  enabled_integrations(function(integration)
+    integration.setup()
+  end)
+end
+
+---Environment overrides for ACP adapters
+---@return table<string, string>
+function M.acp_env()
+  local env = {}
+  enabled_integrations(function(integration)
+    if integration.acp_env then
+      env = vim.tbl_extend("force", env, integration.acp_env())
+    end
+  end)
+  return env
 end
 
 return M


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

The prior herdr implementation had an issue when a user would initiate anACP chat (e.g. Claude Code) and they had the corresponding herdr integration also installed. The ACP chat would spawn Claude Code which herdr would essentially "snatch", taking over the pane. This meant that CodeCompanion could not show any progress or prompt the user.

The fix was to refactor the integration implementation to modify the ACP environment so herdr could not snatch control.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
