### PR TITLE
fix(chat): don't lose tool results when one tool call is malformed

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -91,6 +91,7 @@ local CONSTANTS = {
   STATUS_SUCCESS = "success",
 
   BLANK_DESC = "[No messages]",
+  INCOMPLETE_TOOL_CALL = "This tool call did not complete and produced no result",
 
   SYSTEM_PROMPT = [[You are an AI programming assistant named "CodeCompanion", working within the Neovim text editor.
 
@@ -1311,10 +1312,6 @@ function Chat:submit(opts)
 
   opts = opts or {}
 
-  -- A tool call left without a result makes providers such as Anthropic reject the
-  -- entire request, so stand in a result before the payload is built
-  self:_complete_orphaned_tool_calls({ reason = "This tool call did not complete and produced no result" })
-
   if opts.callback then
     opts.callback()
   end
@@ -1326,6 +1323,7 @@ function Chat:submit(opts)
 
   -- Differentiate between the user submitting and CodeCompanion automatically doing it
   if opts.auto_submit then
+    self:_complete_orphaned_tool_calls({ reason = CONSTANTS.INCOMPLETE_TOOL_CALL })
     self:_inject_btw()
     self.buffer_diffs:check_for_changes(self)
   else
@@ -1340,6 +1338,8 @@ function Chat:submit(opts)
       log:info("Chat submission prevented by on_before_submit callback")
       return self:restore()
     end
+
+    self:_complete_orphaned_tool_calls({ reason = CONSTANTS.INCOMPLETE_TOOL_CALL })
 
     self.buffer_diffs:check_for_changes(self)
 

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1091,16 +1091,18 @@ function Chat:has_orphaned_tool_calls()
   return next(self:_orphaned_tool_calls()) ~= nil
 end
 
----Prevent any orphaned tool calls by "completing" them with a cancelled message
+---Prevent any orphaned tool calls by "completing" them with a stand-in result
+---@param opts? { reason?: string } The stand-in result sent to the LLM
 ---@return nil
-function Chat:_complete_orphaned_tool_calls()
+function Chat:_complete_orphaned_tool_calls(opts)
   local pending = self:_orphaned_tool_calls()
   if next(pending) == nil then
     return
   end
 
+  local reason = opts and opts.reason or "Cancelled by user"
   for id, call in pairs(pending) do
-    local output = adapters.call_handler(self.adapter, "format_response", call, "Cancelled by user")
+    local output = adapters.call_handler(self.adapter, "format_response", call, reason)
     if output then
       output.opts = vim.tbl_extend("force", output.opts or {}, { visible = false })
       output._meta = {
@@ -1308,6 +1310,10 @@ function Chat:submit(opts)
   end
 
   opts = opts or {}
+
+  -- A tool call left without a result makes providers such as Anthropic reject the
+  -- entire request, so stand in a result before the payload is built
+  self:_complete_orphaned_tool_calls({ reason = "This tool call did not complete and produced no result" })
 
   if opts.callback then
     opts.callback()

--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -275,8 +275,7 @@ function Tools:execute(chat, tools)
       local resolved_tool, error_msg, is_json_error = self:_resolve_and_prepare_tool(tool)
 
       if not resolved_tool then
-        -- A JSON error has already been reported to the LLM; other failures still
-        -- need reporting, and either way the remaining tools must still run
+        -- NOTE: A JSON error has already been reported to the LLM
         if not is_json_error then
           self:_handle_tool_error(tool, error_msg or "Unknown Error occurred")
         end

--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -93,11 +93,10 @@ end
 
 ---Resolve and prepare a tool for execution
 ---@param tool table The tool call from the LLM
----@param id number The execution ID for event firing
 ---@return table|nil The resolved tool or nil if failed
 ---@return string|nil Error message if resolution failed
 ---@return boolean|nil Whether this is a JSON parsing error that needs special handling
-function Tools:_resolve_and_prepare_tool(tool, id)
+function Tools:_resolve_and_prepare_tool(tool)
   local name = tool["function"].name
   local tool_config = self.tools_config[name]
 
@@ -142,7 +141,6 @@ function Tools:_resolve_and_prepare_tool(tool, id)
           ""
         )
         self.status = CONSTANTS.STATUS_ERROR
-        utils.fire("ToolsFinished", { id = id, bufnr = self.bufnr })
         return nil, "JSON parsing failed", true -- Special flag to indicate this was handled
       end
 
@@ -274,15 +272,14 @@ function Tools:execute(chat, tools)
     local orchestrator = Orchestrator.new(self, id)
 
     for _, tool in ipairs(tools) do
-      local resolved_tool, error_msg, is_json_error = self:_resolve_and_prepare_tool(tool, id)
+      local resolved_tool, error_msg, is_json_error = self:_resolve_and_prepare_tool(tool)
 
       if not resolved_tool then
-        if is_json_error then
-          -- JSON error was already handled by _resolve_and_prepare_tool
-          return
+        -- A JSON error has already been reported to the LLM; other failures still
+        -- need reporting, and either way the remaining tools must still run
+        if not is_json_error then
+          self:_handle_tool_error(tool, error_msg or "Unknown Error occurred")
         end
-        -- Report the error to the LLM but continue processing remaining tools
-        self:_handle_tool_error(tool, error_msg or "Unknown Error occurred")
       else
         self.tool = resolved_tool --[[@as CodeCompanion.Tools.Tool]]
         orchestrator.queue:push(resolved_tool)

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -638,6 +638,30 @@ T["Chat"]["submit completes orphaned tool calls before the payload is built"] = 
   h.eq(true, result.stands_in_before_the_user_message)
 end
 
+T["Chat"]["submit leaves orphaned tool calls alone when on_before_submit prevents it"] = function()
+  local result = child.lua([[
+    _G.chat:add_callback("on_before_submit", function()
+      return false
+    end)
+
+    table.insert(_G.chat.messages, {
+      role = "llm",
+      tools = {
+        calls = {
+          { id = "call_1", ["function"] = { name = "read_file", arguments = "{}" } },
+        },
+      },
+    })
+
+    _G.chat:add_buf_message({ role = "user", content = "Carry on" })
+    _G.chat:submit()
+
+    return _G.chat:has_orphaned_tool_calls()
+  ]])
+
+  h.eq(true, result)
+end
+
 T["Chat"]["on_before_submit leaves buffer editable after cancellation"] = function()
   local result = child.lua([[
     local chat = _G.chat

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -602,6 +602,42 @@ T["Chat"]["done with stopped status completes orphaned tool calls"] = function()
   h.eq(false, result)
 end
 
+T["Chat"]["submit completes orphaned tool calls before the payload is built"] = function()
+  local result = child.lua([[
+    table.insert(_G.chat.messages, {
+      role = "llm",
+      tools = {
+        calls = {
+          { id = "call_1", ["function"] = { name = "read_file", arguments = "{}" } },
+        },
+      },
+    })
+
+    _G.chat:add_buf_message({ role = "user", content = "Carry on" })
+    _G.chat:submit()
+
+    local synthesized_index, last_user_index
+    for i, msg in ipairs(_G.chat.messages) do
+      if msg.tools and msg.tools.call_id == "call_1" then
+        synthesized_index = i
+      end
+      if msg.role == "user" then
+        last_user_index = i
+      end
+    end
+
+    return {
+      has_orphans = _G.chat:has_orphaned_tool_calls(),
+      synthesized_content = synthesized_index and _G.chat.messages[synthesized_index].content,
+      stands_in_before_the_user_message = (synthesized_index or 0) < (last_user_index or 0),
+    }
+  ]])
+
+  h.eq(false, result.has_orphans)
+  h.eq("This tool call did not complete and produced no result", result.synthesized_content)
+  h.eq(true, result.stands_in_before_the_user_message)
+end
+
 T["Chat"]["on_before_submit leaves buffer editable after cancellation"] = function()
   local result = child.lua([[
     local chat = _G.chat

--- a/tests/interactions/chat/tools/test_tools.lua
+++ b/tests/interactions/chat/tools/test_tools.lua
@@ -215,6 +215,46 @@ T["Tools"][":execute"]["a malformed response from the LLM is handled"] = functio
   h.expect_starts_with("You made an error in calling the weather tool:", output)
 end
 
+T["Tools"][":execute"]["a malformed tool call doesn't discard the other tool calls"] = function()
+  child.lua([[
+    local tools = {
+      {
+        id = 1,
+        type = "function",
+        ["function"] = {
+          name = "weather",
+          arguments = {
+            location = "London, UK",
+            units = "celsius",
+          },
+        },
+      },
+      {
+        id = 2,
+        type = "function",
+        ["function"] = {
+          name = "weather",
+          -- A truncated call arrives last, so it carries an extra } in the arguments
+          arguments = '{\"location\": \"Paris, FR\", \"units\": \"celsius\"}}'
+        },
+      },
+    }
+
+    _G.tools:execute(_G.chat, tools)
+
+    _G.reported_the_error = false
+    for _, msg in ipairs(_G.chat.messages) do
+      local content = type(msg.content) == "string" and msg.content or ""
+      if content:find("You made an error in calling the weather tool", 1, true) then
+        _G.reported_the_error = true
+      end
+    end
+  ]])
+
+  h.eq("The weather in London, UK is 15° celsius", child.lua_get([[_G.weather_output]]))
+  h.eq(true, child.lua_get([[_G.reported_the_error]]))
+end
+
 T["Tools"][":execute"]["a missing tool is handled"] = function()
   child.lua([[
     local tools = {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->
## Description

`Tools:execute` abandoned every queued tool call as soon as one call's arguments failed to parse.

When `_resolve_and_prepare_tool` hits unparseable arguments it reports the mistake to the LLM and returns a "handled" flag. The caller then did a bare `return` — and that `return` fires *before* `orchestrator:setup_next_tool()`, so it abandoned the orchestrator queue along with the rest of the loop. Any tool call that resolved earlier in the same turn was already sitting in that queue, and now never ran, so it never produced a result.

This matters most when a response is truncated mid-`tool_use` (for example `stop_reason=max_tokens`), because the malformed call is then by construction the *last* block in the response: a turn carrying several tool calls loses the results of all the earlier, valid ones. Anthropic rejects any request whose `tool_use` blocks have no matching `tool_result`, so the chat could no longer submit at all — the session was stuck.

Two changes:

- `Tools:execute` still reports the malformed call, but carries on through the loop so the remaining tools execute and produce their results. The premature `utils.fire("ToolsFinished")` moved out of the prepare step, which lets `ToolsFinished` fire from its normal places instead — the empty-queue branch, or the orchestrator once the queue drains.
- As a backstop, `Chat:submit` completes any tool call still missing a result before the payload is built. This also covers adapter errors and any other path that ends a turn with unmatched calls. It reuses `_complete_orphaned_tool_calls` from #3073, which now takes the stand-in text as an option so cancellation keeps its existing `Cancelled by user` wording.

On placement, in case it saves a review round: `Chat:done` is the wrong home because it runs *before* tools execute, so completing orphans there would cancel every call the LLM had just asked for. `Chat:tools_done` is too late, because the `ToolsFinished` autocmd can auto-submit through `Chat:submit` before `Tools:reset` ever reaches it. `Chat:submit` is the one point that is both early enough to matter and guaranteed to run after tools have finished, since it returns early on `current_request`. The call sits before the user message is appended, so the stand-in results stay adjacent to the `tool_use` they answer.

Testing notes: both new tests were confirmed failing before the fix and passing after — the first failed with `_G.weather_output` still unset, which is the abandoned queue showing itself directly, and the second failed with `has_orphaned_tool_calls()` returning true. The full suite locally is 1226 cases with 3 failures, which are the same 3 that `main` already fails on macOS (all in `tests/interactions/code_review/`, asserting on temp paths and branch-scoped storage). `stylua --check tests/ lua/` is clean.

## Supporting Documentation

Anthropic's [Handle tool calls](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/handle-tool-calls#handling-results-from-client-tools) page, which states that "Tool result blocks must immediately follow their corresponding tool use blocks in the message history" and names the resulting failure: "tool_use ids were found without tool_result blocks immediately after". The same section is why the stand-in results are inserted before the user message rather than after it — within the user turn, `tool_result` blocks must come first and any text must follow them.

## AI Usage

This PR was written with CodeCompanion, using Claude (Anthropic). The model traced the bug from the review question on #3244, proposed the two changes and argued the placement, and wrote both tests. I directed the investigation, chose the approach, and reviewed every diff before it landed.

## Related Issue(s)

Companion to #3244, which stops the Anthropic adapter crashing on the same truncated `tool_use`. The two are independent and touch disjoint files, so they can merge in either order.

This PR is the answer to the orphaned-`tool_call` question @olimorris raised in review on #3244. Short version: the adapter guard there does not orphan the truncated call — the executor already reports a result for it — but the question was well aimed, because the sibling calls in the same turn were being dropped, one layer down and independently of that PR.

## Screenshots

Not applicable.

## Checklist
- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
