### PR TITLE
feat(anthropic): support configurable reasoning effort

### DIFF
--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -168,6 +168,14 @@ return {
         end
       end
 
+      -- Effort controls how many tokens Claude spends across thinking, text, and tool
+      -- calls. It lives at output_config.effort in the request body, not on `thinking`.
+      -- Ref: https://platform.claude.com/docs/en/build-with-claude/effort
+      local supported_efforts = models and models.opts and models.opts.reasoning and models.opts.reasoning.supported
+      if self.temp.effort and supported_efforts and vim.tbl_contains(supported_efforts, self.temp.effort) then
+        params.output_config = vim.tbl_deep_extend("force", params.output_config or {}, { effort = self.temp.effort })
+      end
+
       return params
     end,
 
@@ -772,8 +780,38 @@ return {
       end,
     },
     ---@type CodeCompanion.Schema
-    max_tokens = {
+    effort = {
       order = 5,
+      mapping = "temp",
+      type = "string",
+      optional = true,
+      desc = "Controls how many tokens Claude spends on the response, including thinking and tool calls. Higher effort favours thoroughness; lower effort favours speed and cost.",
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return string
+      default = function(self)
+        local models = adapter_utils.model_choice(self)
+        local supported = models and models.opts and models.opts.reasoning and models.opts.reasoning.supported
+        if supported and vim.tbl_contains(supported, "high") then
+          return "high"
+        end
+        return supported and supported[1] or "high"
+      end,
+      ---@param self CodeCompanion.HTTPAdapter
+      enabled = function(self)
+        local models = adapter_utils.model_choice(self)
+        return not not (models and models.opts and models.opts.reasoning and models.opts.reasoning.supported)
+      end,
+      ---@param self CodeCompanion.HTTPAdapter
+      ---@return string[]
+      choices = function(self)
+        local models = adapter_utils.model_choice(self)
+        local supported = models and models.opts and models.opts.reasoning and models.opts.reasoning.supported
+        return supported or { "low", "medium", "high", "xhigh", "max" }
+      end,
+    },
+    ---@type CodeCompanion.Schema
+    max_tokens = {
+      order = 6,
       mapping = "parameters",
       type = "number",
       optional = true,

--- a/tests/adapters/http/test_anthropic.lua
+++ b/tests/adapters/http/test_anthropic.lua
@@ -988,6 +988,47 @@ T["Anthropic adapter"]["resolves model capabilities on the first request"] = fun
   h.not_eq(nil, adapter.handlers.form_structured_output(adapter, { name = "verdict", schema = {} }))
 end
 
+T["Anthropic adapter"]["form_parameters"] = new_set()
+
+---Point the adapter at a model whose choices carry the given opts, so model_choice resolves them
+local function stub_model(name, opts)
+  adapter.schema.model.default = name
+  adapter.schema.model.choices = { [name] = { opts = opts } }
+end
+
+T["Anthropic adapter"]["form_parameters"]["sets output_config.effort for supported levels"] = function()
+  stub_model(
+    "claude-sonnet-5",
+    { can_reason = true, reasoning = { supported = { "low", "medium", "high", "xhigh", "max" } } }
+  )
+  adapter.temp.effort = "xhigh"
+
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+  h.eq({ effort = "xhigh" }, params.output_config)
+end
+
+T["Anthropic adapter"]["form_parameters"]["drops effort the model does not support"] = function()
+  stub_model("claude-sonnet-4-6", { can_reason = true, reasoning = { supported = { "low", "medium", "high", "max" } } })
+  adapter.temp.effort = "xhigh"
+
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+  h.eq(nil, params.output_config)
+end
+
+T["Anthropic adapter"]["form_parameters"]["leaves output_config unset when no effort is chosen"] = function()
+  stub_model(
+    "claude-sonnet-5",
+    { can_reason = true, reasoning = { supported = { "low", "medium", "high", "xhigh", "max" } } }
+  )
+  adapter.temp.effort = nil
+
+  local params = adapter.handlers.form_parameters(adapter, {}, {})
+
+  h.eq(nil, params.output_config)
+end
+
 T["Anthropic model_transformers"] = new_set()
 
 T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model list"] = function()
@@ -1007,6 +1048,7 @@ T["Anthropic model_transformers"]["from_anthropic() transforms the stubbed model
   h.eq(true, result["claude-sonnet-5"].opts.can_reason)
   h.eq(true, result["claude-sonnet-5"].opts.has_vision)
   h.eq(true, result["claude-sonnet-5"].opts.can_form_structured_outputs)
+  h.eq({ "low", "medium", "high", "xhigh", "max" }, result["claude-sonnet-5"].opts.reasoning.supported)
 
   -- Supports context_management as a whole, including compact_20260112
   h.eq(true, result["claude-sonnet-5"].opts.can_manage_context)


### PR DESCRIPTION
## Description

Anthropic models expose an **effort** level (`low`/`medium`/`high`/`xhigh`/`max`) that controls how many tokens Claude spends across thinking, text and tool calls. It is passed at `output_config.effort` in the request body — not on the `thinking` object. CodeCompanion currently has no way to set it, so every Anthropic request runs at whatever the API defaults to.

This PR adds:

- an `effort` schema entry on the Anthropic adapter, gated on the levels the chosen model actually advertises (parsed from the model capability data into `opts.reasoning.supported`), so it disappears for models that don't support effort;
- the mapping in `form_parameters`, which sets `output_config.effort` only when the selected level is supported by the current model — an unsupported level is dropped rather than sent and rejected.

Because it is an ordinary schema item, it immediately works with everything that already reads the schema: `display.chat.show_settings`, per-adapter `schema` overrides in the user's config, and the debug window.

This is split out of #3225 at your request:

> For now, put the Anthropic adapter changes through in a separate PR as it's distinct.

#3225 retains the chat keymap, which is still an open design question and is not needed for this change. This PR stands alone and the two do not depend on each other.

One note on `order`, since it accounts for the only pre-existing line this PR touches: #3260 removed the `temperature` entry and left a gap at `order = 6`. Here `effort` takes `5` — next to `extended_thinking` and `thinking_budget`, which is where it belongs conceptually — and `max_tokens` moves `5` → `6`, closing that gap. Every other entry keeps its current number.

## Supporting Documentation

- Anthropic, *Effort*: https://platform.claude.com/docs/en/build-with-claude/effort — documents the effort levels and that the field is sent as `output_config.effort`.

## AI Usage

Written with CodeCompanion, using Claude. I directed the work, reviewed every change and ran the test suite locally. The rebase of the original commit onto current `main` (including resolving the conflict left by the `temperature` removal in #3260) and the test coverage were produced in that loop under my review.

## Related Issue(s)

Split out of #3225 — no issue to close.

## Screenshots

N/A, there are no UI changes in this PR.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
