### PR TITLE
feat(chat): better herdr integration

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                 For NVIM v0.11    Last change: 2026 August 18
+                                 For NVIM v0.11    Last change: 2026 August 23
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -6422,6 +6422,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
 - `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
 - `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request
+- `CodeCompanionToolQuestionAsked` - Fired when a tool asks the user a question
+- `CodeCompanionToolQuestionAnswered` - Fired when a user has answered or skipped a question
 - `CodeCompanionToolStarted` - Fired when a tool has started executing
 - `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -46,6 +46,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
 - `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
 - `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request
+- `CodeCompanionToolQuestionAsked` - Fired when a tool asks the user a question
+- `CodeCompanionToolQuestionAnswered` - Fired when a user has answered or skipped a question
 - `CodeCompanionToolStarted` - Fired when a tool has started executing
 - `CodeCompanionToolFinished` - Fired when a tool has finished executing
 - `CodeCompanionToolsStarted` - Fired when the tool system has been initiated

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -214,6 +214,14 @@ function M.setup()
     track("chat:" .. tostring(data.bufnr), "working")
   end)
 
+  -- Show CodeCompanion as blocked when the LLM is waiting on an answer
+  on({ "CodeCompanionToolQuestionAsked" }, function(data)
+    track("chat:" .. tostring(data.bufnr), "blocked", data.header and ("Question: " .. data.header) or "Question")
+  end)
+  on({ "CodeCompanionToolQuestionAnswered" }, function(data)
+    track("chat:" .. tostring(data.bufnr), "working")
+  end)
+
   api.nvim_create_autocmd("VimLeavePre", {
     group = group,
     desc = "Release CodeCompanion's authority over the herdr pane",

--- a/lua/codecompanion/interactions/chat/helpers/question_prompt.lua
+++ b/lua/codecompanion/interactions/chat/helpers/question_prompt.lua
@@ -20,6 +20,9 @@ local CONSTANTS = {
 CONSTANTS.DESC_CUSTOM_ANSWER = CONSTANTS.DESC .. ": write a custom answer"
 CONSTANTS.DESC_SKIP = CONSTANTS.DESC .. ": skip this question"
 
+---Each question gets its own id so the asked and answered events can be paired
+local question_id = 0
+
 ---@class CodeCompanion.Chat.QuestionPrompt
 local M = {}
 
@@ -164,10 +167,22 @@ function M.ask(chat, opts)
     return opts.callback(nil)
   end
 
+  question_id = question_id + 1
+  local id = question_id
+
   local options = opts.question.options or {}
   local last_line = chat:add_buf_message({
     role = config.constants.LLM_ROLE,
     content = table.concat(build_lines(opts), "\n"),
+  })
+
+  utils.fire("ToolQuestionAsked", {
+    bufnr = bufnr,
+    header = opts.question.header,
+    id = id,
+    index = opts.index,
+    question = opts.question.question,
+    total = opts.total,
   })
 
   if config.interactions.chat.tools.opts.notify_on_approval and not ui_utils.buf_is_active(bufnr) then
@@ -189,6 +204,13 @@ function M.ask(chat, opts)
     resolved = true
     overrides:restore()
     add_summary(chat, answer)
+    utils.fire("ToolQuestionAnswered", {
+      answer = answer,
+      bufnr = bufnr,
+      header = opts.question.header,
+      id = id,
+      skipped = answer == nil,
+    })
     opts.callback(answer)
   end
 


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR improves the herdr integration by adding events to the `ask_questions` tool. When a user is required to respond to the questions, herdr is shown as blocked and the user notified.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
