### PR TITLE
fix(rules): can conditionally enable

### DIFF
--- a/doc/configuration/rules.md
+++ b/doc/configuration/rules.md
@@ -58,7 +58,7 @@ require("codecompanion").setup({
       chat = {
         ---@param chat CodeCompanion.Chat
         ---@return boolean
-        condition = function(chat)
+        enabled = function(chat)
           -- In this example, only enable rules for chats
           -- that are using http adapters
           return chat.adapter.type == "http"

--- a/lua/codecompanion/interactions/shared/rules/helpers.lua
+++ b/lua/codecompanion/interactions/shared/rules/helpers.lua
@@ -135,7 +135,8 @@ function M.add_callbacks(args, rules_name)
     return args.callbacks
   end
 
-  -- enabled can be a function that receives the chat as a parameter, so only check at runtime
+  -- `enabled` can be a function that receives the chat as a parameter. So we
+  -- use the chat callbacks to ensure that we have a chat object to send.
   args.callbacks = utils.callbacks_extend(args.callbacks, "on_created", function(chat)
     if not is_enabled(chat) then
       return

--- a/lua/codecompanion/interactions/shared/rules/helpers.lua
+++ b/lua/codecompanion/interactions/shared/rules/helpers.lua
@@ -92,48 +92,69 @@ function M.list(chat)
   return picker_items
 end
 
+---Should rules be loaded into this chat?
+---@param chat CodeCompanion.Chat
+---@return boolean
+local function is_enabled(chat)
+  local rules = config.rules and config.rules.opts and config.rules.opts.chat
+  if not rules then
+    return false
+  end
+
+  local enabled = rules.enabled
+  if type(enabled) == "function" then
+    return enabled(chat)
+  end
+
+  return enabled == true
+end
+
 ---Add callbacks to a chat creation request
 ---@param args table
 ---@param rules_name? string The name of the rules instance to use (if any)
 ---@return table|nil
 function M.add_callbacks(args, rules_name)
   local rules = config.rules and config.rules.opts and config.rules.opts.chat
-  if not rules_name and not (rules and rules.enabled and rules.autoload) then
+  if not rules_name and not (rules and rules.autoload) then
     return args.callbacks
   end
 
   local autoload = rules_name or rules.autoload
-  local memories = {}
+  local groups = {}
   if type(autoload) == "string" then
-    memories = { autoload }
+    groups = { autoload }
   elseif type(autoload) == "table" then
-    memories = vim.deepcopy(autoload)
+    groups = vim.deepcopy(autoload)
   elseif type(autoload) == "function" then
-    memories = autoload()
-    assert(type(memories) == "string" or type(memories) == "table", "autoload must return a string or table of strings")
-    if type(memories) == "string" then
-      memories = { memories }
+    groups = autoload()
+    assert(type(groups) == "string" or type(groups) == "table", "autoload must return a string or table of strings")
+    if type(groups) == "string" then
+      groups = { groups }
     end
   else
     return args.callbacks
   end
 
-  for _, name in ipairs(memories) do
-    local current = config.rules[name]
-    if current then
-      -- Ensure that we extend any existing callbacks
-      args.callbacks = utils.callbacks_extend(args.callbacks, "on_created", function(chat)
+  -- enabled can be a function that receives the chat as a parameter, so only check at runtime
+  args.callbacks = utils.callbacks_extend(args.callbacks, "on_created", function(chat)
+    if not is_enabled(chat) then
+      return
+    end
+
+    for _, name in ipairs(groups) do
+      local group = config.rules[name]
+      if group then
         require("codecompanion.interactions.shared.rules").add_to_chat_from_config(chat, {
           name = name,
-          opts = current.opts,
-          parser = current.parser,
-          files = current.files,
+          opts = group.opts,
+          parser = group.parser,
+          files = group.files,
         })
-      end)
-    else
-      log:warn("Could not find `%s` rules", name)
+      else
+        log:warn("Could not find `%s` rules", name)
+      end
     end
-  end
+  end)
 
   return args.callbacks
 end

--- a/minimal.lua
+++ b/minimal.lua
@@ -15,8 +15,9 @@ load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/ma
 local plugins = {
   {
     "olimorris/codecompanion.nvim",
-    -- Test with local version (delete if not required)
-    -- dir = "~/Code/Neovim/codecompanion.nvim",
+    -- Test with local version (delete if not required):
+    --   dir = "~/Code/Neovim/codecompanion.nvim/fix-a",
+    --   name = "codecompanion",
     dependencies = {
       { "nvim-lua/plenary.nvim" },
       {

--- a/tests/interactions/shared/rules/test_rules.lua
+++ b/tests/interactions/shared/rules/test_rules.lua
@@ -524,4 +524,70 @@ T["Rules:make()"]["file referenced in both rules.files and @include should not b
   h.eq(agents_count, 1)
 end
 
+--- Check the logic for enabling rules
+
+T["opts.chat.enabled"] = new_set({})
+
+---Create a chat with the given `enabled` source and count the rules messages it loaded
+---@param enabled_src string Lua source for `opts.chat.enabled`
+---@return number
+local function count_rules_messages(enabled_src)
+  local tmp = child.lua("return vim.fn.tempname()")
+  child.fn.writefile({ "conditional rules content" }, tmp)
+
+  child.lua(string.format(
+    [[
+    local h = require("tests.helpers")
+    local cc = h.setup_plugin()
+    local config = require("codecompanion.config")
+    local tags = require("codecompanion.interactions.shared.tags")
+
+    config.rules = vim.tbl_deep_extend("force", config.rules or {}, {
+      default = { description = "conditional default", files = { %q }, is_preset = true },
+      parsers = {},
+      opts = {
+        chat = { enabled = %s, autoload = "default" },
+        show_presets = true,
+      },
+    })
+
+    _G.seen_adapter_type = nil
+    local chat = cc.chat()
+    _G.test_rules_count = #vim.tbl_filter(function(message)
+      return message._meta and message._meta.tag == tags.RULES
+    end, chat.messages)
+  ]],
+    tmp,
+    enabled_src
+  ))
+
+  return child.lua_get([[_G.test_rules_count]])
+end
+
+T["opts.chat.enabled"]["boolean true loads rules"] = function()
+  h.eq(count_rules_messages("true"), 1)
+end
+
+T["opts.chat.enabled"]["boolean false blocks rules"] = function()
+  h.eq(count_rules_messages("false"), 0)
+end
+
+T["opts.chat.enabled"]["function returning false blocks rules"] = function()
+  h.eq(count_rules_messages("function(chat) return false end"), 0)
+end
+
+T["opts.chat.enabled"]["function is passed the chat, so it can key off the adapter"] = function()
+  local rules_count = count_rules_messages([[function(chat)
+    _G.seen_adapter_type = chat.adapter.type
+    return chat.adapter.type == "http"
+  end]])
+
+  h.eq(child.lua_get([[_G.seen_adapter_type]]), "http")
+  h.eq(rules_count, 1)
+end
+
+T["opts.chat.enabled"]["function checking for acp blocks an http chat"] = function()
+  h.eq(count_rules_messages([[function(chat) return chat.adapter.type == "acp" end]]), 0)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

As per #3320, it was not possible to conditionally enable rules, despite the docs saying otherwise. I can only assume I missed this off the implementation when I added them.

In the docs I had `condition` but that's been correctly renamed to `enabled`.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code

## Related Issue(s)

#3320

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
