### PR TITLE
fix(action_palette): can work from insert mode

### DIFF
--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -133,15 +133,15 @@ function Interactions:chat()
     return self:workflow()
   end
 
-  local mode = self.buffer_context.mode:lower()
   local prompts = self.selected.prompts
 
-  if type(prompts[mode]) == "function" then
-    return prompts[mode](self.buffer_context)
-  elseif type(prompts[mode]) == "table" then
+  if prompts.n ~= nil or prompts.v ~= nil then
+    local mode = self.buffer_context.is_visual and "v" or "n"
+    if type(prompts[mode]) == "function" then
+      return prompts[mode](self.buffer_context)
+    end
     messages = self.evaluate_prompts(prompts[mode], self.buffer_context)
   else
-    -- No mode specified
     messages = self.evaluate_prompts(prompts, self.buffer_context)
   end
 

--- a/tests/prompt_library/test_prompt_library.lua
+++ b/tests/prompt_library/test_prompt_library.lua
@@ -270,4 +270,86 @@ T["Prompt Library"]["can ignore system prompt"] = function()
   h.eq(false, has_system_tag)
 end
 
+T["Prompt Library"]["malformed message is never formed, even if the current mode doesn't match the prompt's mode"] = function()
+  local has_invalid_role = child.lua([[
+    local Interactions = require("codecompanion.interactions")
+    local config = require("codecompanion.config")
+    local selected = {
+      name = "Visual only",
+      interaction = "chat",
+      opts = {},
+      prompts = {
+        -- Prompt has visual mode only...
+        v = {
+          {
+            role = config.constants.USER_ROLE,
+            content = "visual prompt",
+          },
+        },
+      },
+    }
+    Interactions.new({
+      -- ... but the user is in normal mode
+      buffer_context = { mode = "n", is_visual = false, is_normal = true, filetype = "lua" },
+      selected = selected,
+    }):start("chat")
+
+    local chat = require("codecompanion").last_chat()
+    if not chat then
+      return false
+    end
+
+    local has_invalid_role = false
+    for _, msg in ipairs(chat.messages) do
+      if msg.role == nil or msg.role == "" then
+        has_invalid_role = true
+      end
+    end
+    return has_invalid_role
+  ]])
+
+  h.eq(false, has_invalid_role)
+end
+
+--- Ref: https://github.com/olimorris/codecompanion.nvim/issues/3322
+T["Prompt Library"]["resolves an unsupported mode to normal for n/v keyed prompts"] = function()
+  local has_empty_role = child.lua([[
+    local Interactions = require("codecompanion.interactions")
+    local config = require("codecompanion.config")
+    local selected = {
+      name = "Chat",
+      interaction = "chat",
+      opts = { stop_context_insertion = true },
+      prompts = {
+        -- Prompt has normal and visual mode prompts defined ...
+        n = function()
+          return require("codecompanion").chat()
+        end,
+        v = {
+          {
+            role = config.constants.USER_ROLE,
+            content = "visual prompt",
+          },
+        },
+      },
+    }
+    Interactions.new({
+      -- ... But the user is in insert mode
+      buffer_context = { mode = "i", is_visual = false, is_normal = true, filetype = "lua" },
+      selected = selected,
+    }):start("chat")
+
+    local chat = require("codecompanion").last_chat()
+    local has_empty_role = false
+    for _, msg in ipairs(chat.messages) do
+      if msg.role == "" then
+        has_empty_role = true
+      end
+    end
+    return has_empty_role
+  ]])
+
+  h.eq(false, has_empty_role)
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

This PR fixes two issues:
- A user open a chat from the action palette whilst being in insert mode
- Lua prompt library items that have a prompt defined for `normal` mode, whilst the user activates a chat in`visual` mode

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code + Sonnet

## Related Issue(s)

#3322 and PR #3249

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
