### PR TITLE
fix(ui): diffing with last line

### DIFF
--- a/lua/codecompanion/diff/utils.lua
+++ b/lua/codecompanion/diff/utils.lua
@@ -249,6 +249,16 @@ function M.changed_lines(from_lines, to_lines)
   return count
 end
 
+---Join lines ensuring they have a trailing newline. Fixed #3338
+---@param lines string[]
+---@return string
+local function join_with_newline(lines)
+  if #lines == 0 then
+    return ""
+  end
+  return table.concat(lines, "\n") .. "\n"
+end
+
 ---Generate a unified diff string suitable for inline display
 ---@param from_lines string[]
 ---@param to_lines string[]
@@ -257,10 +267,8 @@ function M.unified(from_lines, to_lines)
   ---@diagnostic disable-next-line: deprecated
   local diff_fn = vim.text.diff or vim.diff
   local result =
-    diff_fn(table.concat(from_lines, "\n"), table.concat(to_lines, "\n"), { result_type = "unified", ctxlen = 3 })
-
-  -- Strip the newline marker
-  result = (result or ""):gsub("\n?\\ No newline at end of file%s*", ""):gsub("\n$", "")
+    diff_fn(join_with_newline(from_lines), join_with_newline(to_lines), { result_type = "unified", ctxlen = 3 })
+  result = (result or ""):gsub("\n$", "")
 
   return result
 end

--- a/tests/test_diff.lua
+++ b/tests/test_diff.lua
@@ -198,6 +198,38 @@ T["Diff"]["Handles multiple hunks"] = function()
   h.eq(2, result.hunk_count, "Should detect 2 separate change hunks")
 end
 
+T["Diff"]["Unified diff keeps the last changed line separate"] = function()
+  local result = child.lua([[
+    return require("codecompanion.diff.utils").unified(
+      { "Lorem", "ipsum", "dolor", "sit" },
+      { "Lorem", "ipsum", "dolor modified", "sit modified" }
+    )
+  ]])
+
+  h.eq({
+    "@@ -1,4 +1,4 @@",
+    " Lorem",
+    " ipsum",
+    "-dolor",
+    "-sit",
+    "+dolor modified",
+    "+sit modified",
+  }, vim.split(result, "\n"), "Should not merge the final deletion into the first addition")
+end
+
+T["Diff"]["Unified diff handles empty sets of lines"] = function()
+  local result = child.lua([[
+    local utils = require("codecompanion.diff.utils")
+    return {
+      created = utils.unified({}, { "one", "two" }),
+      emptied = utils.unified({ "one", "two" }, {}),
+    }
+  ]])
+
+  h.eq("@@ -0,0 +1,2 @@\n+one\n+two", result.created, "Should diff against an empty file")
+  h.eq("@@ -1,2 +0,0 @@\n-one\n-two", result.emptied, "Should diff to an empty file")
+end
+
 T["Diff"]["Integration Test"] = new_set()
 
 T["Diff"]["Integration Test"]["Example 1"] = function()


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fixes an issue whereby a diff would be displayed incorrectly, owing to the last line of a buffer not containing a newline, like:

```diff
@@ -1,4 +1,4 @@
 Lorem
 ipsum
-dolor
-sit+dolor modified
+sit modified
```

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code

## Related Issue(s)

#3338

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
