### PR TITLE
refactor(tools): standardise `path` in get_diagnostics

### DIFF
--- a/lua/codecompanion/interactions/chat/tools/builtin/get_diagnostics.lua
+++ b/lua/codecompanion/interactions/chat/tools/builtin/get_diagnostics.lua
@@ -28,14 +28,14 @@ local severity_map = {
   HINT = "HINT",
 }
 
----Resolve a filepath to a loaded buffer, reading it in the background if it isn't open
----@param filepath string
+---Resolve a path to a loaded buffer, reading it in the background if it isn't open
+---@param path string
 ---@return { bufnr: number|nil, error: string|nil, freshly_loaded: boolean }
-local function resolve_buffer(filepath)
-  local bufnr = vim.fn.bufadd(filepath)
+local function resolve_buffer(path)
+  local bufnr = vim.fn.bufadd(path)
   if bufnr == 0 or not api.nvim_buf_is_valid(bufnr) then
     return {
-      error = fmt("`%s` could not be opened. Check the path points at a file and try again", filepath),
+      error = fmt("`%s` could not be opened. Check the path points at a file and try again", path),
       freshly_loaded = false,
     }
   end
@@ -47,7 +47,7 @@ local function resolve_buffer(filepath)
   local ok, err = pcall(vim.fn.bufload, bufnr)
   if not ok then
     return {
-      error = fmt("`%s` could not be read. Neovim failed to open it: %s", filepath, err),
+      error = fmt("`%s` could not be read. Neovim failed to open it: %s", path, err),
       freshly_loaded = false,
     }
   end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

CodeCompanion follows Vim's standard of using `path` throughout the plugin. Where this deviates is when working with an LLM where we typically use `filepath`. However, internally, always making sure `path` is dominant.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

None

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ ] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
