### PR TITLE
fix(ui): reuse window when cycling or creating chats

### DIFF
--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -629,12 +629,13 @@ function Chat.new(args)
     name = "Chat " .. vim.tbl_count(chats),
     description = CONSTANTS.BLANK_DESC,
     interaction = "chat",
-    open = function()
-      Chat.close_last_chat()
-      self.ui:open()
+    open = function(opts)
+      opts = opts or {}
+      opts.ui = self.ui
+      Chat.open_or_reuse(opts)
     end,
-    hide = function()
-      self.ui:hide()
+    hide = function(opts)
+      self.ui:hide(opts)
     end,
   })
 
@@ -656,8 +657,7 @@ function Chat.new(args)
   end
 
   if not self.hidden then
-    self.close_last_chat()
-    self.ui:open():render(self.buffer_context, self.messages, {
+    Chat.open_or_reuse({ ui = self.ui }):render(self.buffer_context, self.messages, {
       stop_context_insertion = args.stop_context_insertion,
       auto_submit = args.auto_submit,
       from_prompt_library = args.from_prompt_library,
@@ -2172,17 +2172,48 @@ function Chat.last_chat()
 end
 
 ---Close the last chat buffer
----@return nil
-function Chat.close_last_chat()
+---@param opts? { keep_window?: boolean }
+---@return number|nil
+function Chat.close_last_chat(opts)
+  opts = opts or {}
   if last_chat and not vim.tbl_isempty(last_chat) then
     if last_chat.ui:is_visible() then
       -- pertab: leave chats visible in other tabs alone
       if config.display.chat.window.pertab and last_chat.ui:is_visible_non_curtab() then
-        return
+        return nil
+      end
+      -- Never reuse a window from another tab
+      if opts.keep_window and not last_chat.ui:is_visible_non_curtab() then
+        local winnr = last_chat.ui.winnr
+        last_chat.ui:hide({ keep_window = true })
+        return winnr
       end
       last_chat.ui:hide()
     end
   end
+  return nil
+end
+
+---Open a chat UI in an existing window when possible
+---@param opts { ui: CodeCompanion.Chat.UI, winnr?: number, toggled?: boolean, window_opts?: table }
+---@return CodeCompanion.Chat.UI
+function Chat.open_or_reuse(opts)
+  opts = opts or {}
+  local ui = opts.ui
+  if opts.winnr and api.nvim_win_is_valid(opts.winnr) then
+    return ui:show_in_win(opts)
+  end
+
+  local winnr = Chat.close_last_chat({ keep_window = true })
+  if winnr and api.nvim_win_is_valid(winnr) then
+    return ui:show_in_win({
+      winnr = winnr,
+      toggled = opts.toggled,
+      window_opts = opts.window_opts,
+    })
+  end
+
+  return ui:open(opts)
 end
 
 ---Check if the last chat is currently visible
@@ -2244,16 +2275,11 @@ function Chat.toggle(args)
   chat.buffer_context = args.context or chat.buffer_context
 
   -- At this point, the chat exists but is not visible in the current tab
-
-  -- Close the chat window (if it's open elsewhere)
-  Chat.close_last_chat()
-
-  -- Reopen the chat in the current tab with the toggled flag
-  local opts = { toggled = true }
+  local opts = { ui = chat.ui, toggled = true }
   if window_opts then
     opts.window_opts = window_opts
   end
-  chat.ui:open(opts)
+  Chat.open_or_reuse(opts)
 end
 
 return Chat

--- a/lua/codecompanion/interactions/chat/keymaps/init.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/init.lua
@@ -335,14 +335,18 @@ end
 
 M.close = {
   callback = function(chat)
+    local winnr
+    if chat.ui:is_visible() and not chat.ui:is_visible_non_curtab() then
+      winnr = chat.ui.winnr
+    end
+    local window_opts = chat.ui.window_opts or { default = true }
+
     chat:close()
 
     local chats = require("codecompanion").buf_get_chat()
     if vim.tbl_count(chats) == 0 then
       return
     end
-
-    local window_opts = chat.ui.window_opts or { default = true }
 
     local target = chats[1]
 
@@ -357,7 +361,11 @@ M.close = {
       end
     end
 
-    target.chat.ui:open({ window_opts = window_opts })
+    require("codecompanion.interactions.chat").open_or_reuse({
+      ui = target.chat.ui,
+      winnr = winnr,
+      window_opts = window_opts,
+    })
   end,
 }
 

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -229,17 +229,65 @@ function UI:open(opts)
   return self
 end
 
----Hide the chat buffer from view
----@return nil
-function UI:hide()
-  local layout
-  if self.window_opts then
-    layout = vim.tbl_deep_extend("force", {}, config.display.chat.window, self.window_opts).layout
-  else
-    layout = config.display.chat.window.layout
+---Show this chat buffer in an existing window (preserves layout/size)
+---@param opts { winnr: number, toggled?: boolean, window_opts?: table }
+---@return CodeCompanion.Chat.UI
+function UI:show_in_win(opts)
+  opts = opts or {}
+  local winnr = opts.winnr
+
+  if opts.window_opts then
+    if opts.window_opts.default then
+      self.window_opts = nil
+    else
+      self.window_opts = opts.window_opts
+    end
   end
 
-  shared_ui.hide(self.winnr, self.chat_bufnr, layout)
+  api.nvim_win_set_buf(winnr, self.chat_bufnr)
+  self.winnr = winnr
+  -- Filetype is set in shared_ui.open; set it here too when skipping that path
+  api.nvim_set_option_value("filetype", "codecompanion", { buf = self.chat_bufnr })
+  vim.bo[self.chat_bufnr].textwidth = 0
+
+  if config.display.chat.start_in_insert_mode then
+    vim.schedule(function()
+      vim.cmd("startinsert")
+    end)
+  end
+
+  if not opts.toggled then
+    if self.cursor.moved_by_user and self.cursor.pos then
+      vim.schedule(function()
+        if self:is_visible() then
+          pcall(api.nvim_win_set_cursor, self.winnr, self.cursor.pos)
+        end
+      end)
+    else
+      self:follow()
+    end
+  end
+
+  self.folds:setup(self.winnr)
+  log:trace("Chat opened in existing window with ID %d", self.chat_id)
+  utils.fire("ChatOpened", { bufnr = self.chat_bufnr, id = self.chat_id })
+  return self
+end
+
+---Hide the chat buffer from view
+---@param opts? { keep_window?: boolean }
+---@return nil
+function UI:hide(opts)
+  opts = opts or {}
+  if not opts.keep_window then
+    local layout
+    if self.window_opts then
+      layout = vim.tbl_deep_extend("force", {}, config.display.chat.window, self.window_opts).layout
+    else
+      layout = config.display.chat.window.layout
+    end
+    shared_ui.hide(self.winnr, self.chat_bufnr, layout)
+  end
 
   utils.fire("ChatHidden", { bufnr = self.chat_bufnr, id = self.chat_id })
 end

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -162,6 +162,38 @@ function UI.new(args)
   return self
 end
 
+---Apply shared post-open setup once the chat is visible in a window
+---@param opts? { toggled?: boolean }
+---@return CodeCompanion.Chat.UI
+function UI:_finish_open(opts)
+  opts = opts or {}
+  vim.bo[self.chat_bufnr].textwidth = 0
+
+  if config.display.chat.start_in_insert_mode then
+    -- Delay entering insert mode until after Telescope picker fully closes,
+    -- since Telescope resets to normal mode on close.
+    vim.schedule(function()
+      vim.cmd("startinsert")
+    end)
+  end
+
+  if not opts.toggled then
+    if self.cursor.moved_by_user and self.cursor.pos then
+      vim.schedule(function()
+        if self:is_visible() then
+          pcall(api.nvim_win_set_cursor, self.winnr, self.cursor.pos)
+        end
+      end)
+    else
+      self:follow()
+    end
+  end
+
+  self.folds:setup(self.winnr)
+  utils.fire("ChatOpened", { bufnr = self.chat_bufnr, id = self.chat_id })
+  return self
+end
+
 ---Open/create the chat window
 ---@param opts? table
 ---@return CodeCompanion.Chat.UI|nil
@@ -173,13 +205,6 @@ function UI:open(opts)
       api.nvim_set_current_tabpage(api.nvim_win_get_tabpage(self.winnr))
     end
     return
-  end
-  if config.display.chat.start_in_insert_mode then
-    -- Delay entering insert mode until after Telescope picker fully closes,
-    -- since Telescope resets to normal mode on close.
-    vim.schedule(function()
-      vim.cmd("startinsert")
-    end)
   end
 
   if opts.window_opts then
@@ -206,27 +231,8 @@ function UI:open(opts)
     filetype = "codecompanion",
   })
 
-  vim.bo[self.chat_bufnr].textwidth = 0
-
-  if not opts.toggled then
-    -- Put the cursor back in the original position
-    if self.cursor.moved_by_user and self.cursor.pos then
-      vim.schedule(function()
-        if self:is_visible() then
-          pcall(api.nvim_win_set_cursor, self.winnr, self.cursor.pos)
-        end
-      end)
-    else
-      self:follow()
-    end
-  end
-
-  self.folds:setup(self.winnr)
-
   log:trace("Chat opened with ID %d", self.chat_id)
-  utils.fire("ChatOpened", { bufnr = self.chat_bufnr, id = self.chat_id })
-
-  return self
+  return self:_finish_open(opts)
 end
 
 ---Show this chat buffer in an existing window (preserves layout/size)
@@ -234,7 +240,6 @@ end
 ---@return CodeCompanion.Chat.UI
 function UI:show_in_win(opts)
   opts = opts or {}
-  local winnr = opts.winnr
 
   if opts.window_opts then
     if opts.window_opts.default then
@@ -244,34 +249,13 @@ function UI:show_in_win(opts)
     end
   end
 
-  api.nvim_win_set_buf(winnr, self.chat_bufnr)
-  self.winnr = winnr
+  api.nvim_win_set_buf(opts.winnr, self.chat_bufnr)
+  self.winnr = opts.winnr
   -- Filetype is set in shared_ui.open; set it here too when skipping that path
   api.nvim_set_option_value("filetype", "codecompanion", { buf = self.chat_bufnr })
-  vim.bo[self.chat_bufnr].textwidth = 0
 
-  if config.display.chat.start_in_insert_mode then
-    vim.schedule(function()
-      vim.cmd("startinsert")
-    end)
-  end
-
-  if not opts.toggled then
-    if self.cursor.moved_by_user and self.cursor.pos then
-      vim.schedule(function()
-        if self:is_visible() then
-          pcall(api.nvim_win_set_cursor, self.winnr, self.cursor.pos)
-        end
-      end)
-    else
-      self:follow()
-    end
-  end
-
-  self.folds:setup(self.winnr)
   log:trace("Chat opened in existing window with ID %d", self.chat_id)
-  utils.fire("ChatOpened", { bufnr = self.chat_bufnr, id = self.chat_id })
-  return self
+  return self:_finish_open(opts)
 end
 
 ---Hide the chat buffer from view

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -9,6 +9,7 @@ local markdown = require("codecompanion.utils.markdown")
 local schema = require("codecompanion.schema")
 local shared_ui = require("codecompanion.interactions.shared.ui")
 local tags = require("codecompanion.interactions.shared.tags")
+local ui_utils = require("codecompanion.utils.ui")
 local utils = require("codecompanion.utils")
 local yaml = require("codecompanion.utils.yaml")
 
@@ -253,6 +254,16 @@ function UI:show_in_win(opts)
   self.winnr = opts.winnr
   -- Filetype is set in shared_ui.open; set it here too when skipping that path
   api.nvim_set_option_value("filetype", "codecompanion", { buf = self.chat_bufnr })
+
+  local window
+  if self.window_opts then
+    window = vim.tbl_deep_extend("force", {}, config.display.chat.window, self.window_opts)
+  else
+    window = config.display.chat.window
+  end
+  if window.opts and not vim.tbl_isempty(window.opts) then
+    ui_utils.set_win_options(self.winnr, window.opts)
+  end
 
   log:trace("Chat opened in existing window with ID %d", self.chat_id)
   return self:_finish_open(opts)

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -259,9 +259,7 @@ function UI:show_in_win(opts)
   else
     window = config.display.chat.window
   end
-  if window.opts and not vim.tbl_isempty(window.opts) then
-    ui_utils.set_win_options(self.winnr, window.opts)
-  end
+  ui_utils.apply_win_options(self.winnr, window.opts)
 
   log:trace("Chat opened in existing window with ID %d", self.chat_id)
   return self:_finish_open(opts)

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -163,7 +163,6 @@ function UI.new(args)
   return self
 end
 
----Apply shared post-open setup once the chat is visible in a window
 ---@param opts? { toggled?: boolean }
 ---@return CodeCompanion.Chat.UI
 function UI:_finish_open(opts)
@@ -196,7 +195,7 @@ function UI:_finish_open(opts)
 end
 
 ---Open/create the chat window
----@param opts? table
+---@param opts? { toggled?: boolean, window_opts?: table }
 ---@return CodeCompanion.Chat.UI|nil
 function UI:open(opts)
   opts = opts or {}
@@ -236,7 +235,6 @@ function UI:open(opts)
   return self:_finish_open(opts)
 end
 
----Show this chat buffer in an existing window (preserves layout/size)
 ---@param opts { winnr: number, toggled?: boolean, window_opts?: table }
 ---@return CodeCompanion.Chat.UI
 function UI:show_in_win(opts)

--- a/lua/codecompanion/interactions/cli/init.lua
+++ b/lua/codecompanion/interactions/cli/init.lua
@@ -168,11 +168,16 @@ function CLI.create(args)
     name = agent_name,
     description = agent.description or "CLI agent",
     interaction = "cli",
-    open = function()
+    open = function(opts)
+      opts = opts or {}
+      if opts.winnr then
+        self.ui:show_in_win(opts)
+        return
+      end
       self.ui:open()
     end,
-    hide = function()
-      self.ui:hide()
+    hide = function(opts)
+      self.ui:hide(opts)
     end,
   })
 

--- a/lua/codecompanion/interactions/cli/ui.lua
+++ b/lua/codecompanion/interactions/cli/ui.lua
@@ -1,6 +1,7 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local shared_ui = require("codecompanion.interactions.shared.ui")
+local ui_utils = require("codecompanion.utils.ui")
 local utils = require("codecompanion.utils")
 
 ---@class CodeCompanion.CLI.UI
@@ -65,6 +66,12 @@ function UI:show_in_win(opts)
   opts = opts or {}
   vim.api.nvim_win_set_buf(opts.winnr, self.bufnr)
   self.winnr = opts.winnr
+
+  local window = resolve_window_config()
+  if window.opts and not vim.tbl_isempty(window.opts) then
+    ui_utils.set_win_options(self.winnr, window.opts)
+  end
+
   log:trace("CLI opened in existing window")
   utils.fire("CLIOpened", { bufnr = self.bufnr })
   return self

--- a/lua/codecompanion/interactions/cli/ui.lua
+++ b/lua/codecompanion/interactions/cli/ui.lua
@@ -58,11 +58,27 @@ function UI:open(opts)
   return self
 end
 
+---Show this CLI buffer in an existing window (preserves layout/size)
+---@param opts { winnr: number }
+---@return CodeCompanion.CLI.UI
+function UI:show_in_win(opts)
+  opts = opts or {}
+  vim.api.nvim_win_set_buf(opts.winnr, self.bufnr)
+  self.winnr = opts.winnr
+  log:trace("CLI opened in existing window")
+  utils.fire("CLIOpened", { bufnr = self.bufnr })
+  return self
+end
+
 ---Hide the CLI window (does not kill the terminal process)
+---@param opts? { keep_window?: boolean }
 ---@return nil
-function UI:hide()
-  local window = resolve_window_config()
-  shared_ui.hide(self.winnr, self.bufnr, window.layout)
+function UI:hide(opts)
+  opts = opts or {}
+  if not opts.keep_window then
+    local window = resolve_window_config()
+    shared_ui.hide(self.winnr, self.bufnr, window.layout)
+  end
 
   utils.fire("CLIHidden", { bufnr = self.bufnr })
 end

--- a/lua/codecompanion/interactions/cli/ui.lua
+++ b/lua/codecompanion/interactions/cli/ui.lua
@@ -67,9 +67,7 @@ function UI:show_in_win(opts)
   self.winnr = opts.winnr
 
   local window = resolve_window_config()
-  if window.opts and not vim.tbl_isempty(window.opts) then
-    ui_utils.set_win_options(self.winnr, window.opts)
-  end
+  ui_utils.apply_win_options(self.winnr, window.opts)
 
   log:trace("CLI opened in existing window")
   utils.fire("CLIOpened", { bufnr = self.bufnr })

--- a/lua/codecompanion/interactions/cli/ui.lua
+++ b/lua/codecompanion/interactions/cli/ui.lua
@@ -59,7 +59,6 @@ function UI:open(opts)
   return self
 end
 
----Show this CLI buffer in an existing window (preserves layout/size)
 ---@param opts { winnr: number }
 ---@return CodeCompanion.CLI.UI
 function UI:show_in_win(opts)

--- a/lua/codecompanion/interactions/shared/registry.lua
+++ b/lua/codecompanion/interactions/shared/registry.lua
@@ -3,10 +3,13 @@
 ---@field description string
 ---@field interaction string
 ---@field bufnr number
----@field open fun()
----@field hide fun()
+---@field open fun(opts?: { winnr?: number })
+---@field hide fun(opts?: { keep_window?: boolean })
 
 local M = {}
+
+local api = vim.api
+local ui_utils = require("codecompanion.utils.ui")
 
 ---@type table<number, CodeCompanion.Registry.Entry>
 local entries = {}
@@ -94,8 +97,14 @@ function M.move(current_bufnr, direction, opts)
   local current = sorted[idx]
   local next_entry = sorted[next_idx]
 
-  current.hide()
-  next_entry.open()
+  local winnr = ui_utils.buf_get_win(current_bufnr)
+  if winnr and api.nvim_win_is_valid(winnr) then
+    current.hide({ keep_window = true })
+    next_entry.open({ winnr = winnr })
+  else
+    current.hide()
+    next_entry.open()
+  end
 
   return next_entry
 end

--- a/lua/codecompanion/utils/ui.lua
+++ b/lua/codecompanion/utils/ui.lua
@@ -404,6 +404,29 @@ function M.set_win_options(winnr, opts)
   end
 end
 
+---Apply destination window opts on reuse, resetting other interaction-managed keys to global
+---@param winnr number
+---@param opts? table
+---@return nil
+function M.apply_win_options(winnr, opts)
+  opts = opts or {}
+  local config = require("codecompanion.config")
+  local managed = vim.tbl_extend(
+    "force",
+    {},
+    (config.display.chat.window and config.display.chat.window.opts) or {},
+    (config.display.cli and config.display.cli.window and config.display.cli.window.opts) or {}
+  )
+
+  for k, _ in pairs(managed) do
+    local value = opts[k]
+    if value == nil then
+      value = api.nvim_get_option_value(k, { scope = "global" })
+    end
+    api.nvim_set_option_value(k, value, { scope = "local", win = winnr })
+  end
+end
+
 --- Jump to an existing tab if the file is already opened.
 --- Otherwise, open it in a new tab.
 --- Returns the window ID after the jump.

--- a/tests/interactions/chat/test_window_reuse.lua
+++ b/tests/interactions/chat/test_window_reuse.lua
@@ -1,0 +1,171 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+  hooks = {
+    pre_once = function()
+      h.child_start(child)
+      child.lua([[
+        h = require("tests.helpers")
+        local config = require("codecompanion.config")
+        config.rules.opts.chat.enabled = false
+        h.setup_plugin(config)
+      ]])
+    end,
+    pre_case = function()
+      child.lua([[
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+          local name = vim.api.nvim_buf_get_name(bufnr)
+          if name:find("%[CodeCompanion%]") then
+            pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+          end
+        end
+        local wins = vim.api.nvim_list_wins()
+        for i = 2, #wins do
+          pcall(vim.api.nvim_win_close, wins[i], true)
+        end
+        package.loaded["codecompanion.interactions.chat"] = nil
+        package.loaded["codecompanion.interactions.shared.registry"] = nil
+        package.loaded["codecompanion"] = nil
+        h = require("tests.helpers")
+        local config = require("codecompanion.config")
+        config.rules.opts.chat.enabled = false
+        h.setup_plugin(config)
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["Window reuse"] = new_set()
+
+T["Window reuse"]["cycling chats in a sole window does not error"] = function()
+  local result = child.lua([[
+    vim.cmd("CodeCompanionChat")
+    vim.cmd("CodeCompanionChat")
+
+    local chat = require("codecompanion").last_chat()
+    vim.api.nvim_set_current_win(chat.ui.winnr)
+    vim.cmd("only")
+
+    local winnr_before = vim.api.nvim_get_current_win()
+    local bufnr_before = vim.api.nvim_get_current_buf()
+    local ok, err = pcall(function()
+      require("codecompanion.interactions.chat.keymaps").next_chat.callback(chat)
+    end)
+
+    local chat_after = require("codecompanion").last_chat()
+    return {
+      ok = ok,
+      err = ok and vim.NIL or tostring(err),
+      same_win = vim.api.nvim_get_current_win() == winnr_before,
+      buf_changed = vim.api.nvim_get_current_buf() ~= bufnr_before,
+      filetype = vim.bo[vim.api.nvim_get_current_buf()].filetype,
+      visible = chat_after.ui:is_visible(),
+    }
+  ]])
+
+  h.eq(true, result.ok)
+  h.eq(vim.NIL, result.err)
+  h.eq(true, result.same_win)
+  h.eq(true, result.buf_changed)
+  h.eq("codecompanion", result.filetype)
+  h.eq(true, result.visible)
+end
+
+T["Window reuse"]["cycling preserves layout and size"] = function()
+  local result = child.lua([[
+    vim.cmd("CodeCompanionChat")
+    local chat1 = require("codecompanion").last_chat()
+    local winnr = chat1.ui.winnr
+    vim.api.nvim_set_current_win(winnr)
+    vim.cmd("wincmd K")
+    winnr = vim.api.nvim_get_current_win()
+    chat1.ui.winnr = winnr
+    vim.api.nvim_win_set_height(winnr, 12)
+
+    local height_before = vim.api.nvim_win_get_height(winnr)
+    local layout_before = vim.fn.winlayout()
+
+    vim.cmd("CodeCompanionChat")
+    local chat2 = require("codecompanion").last_chat()
+    local ok, err = pcall(function()
+      require("codecompanion.interactions.chat.keymaps").previous_chat.callback(chat2)
+    end)
+
+    local chat_after = require("codecompanion").last_chat()
+    return {
+      ok = ok,
+      err = ok and vim.NIL or tostring(err),
+      same_win = chat_after.ui.winnr == winnr,
+      height_before = height_before,
+      height_after = vim.api.nvim_win_get_height(winnr),
+      layout_same = vim.deep_equal(layout_before, vim.fn.winlayout()),
+    }
+  ]])
+
+  h.eq(true, result.ok)
+  h.eq(vim.NIL, result.err)
+  h.eq(true, result.same_win)
+  h.eq(true, result.layout_same)
+  h.eq(result.height_before, result.height_after)
+end
+
+T["Window reuse"]["new chat reuses window and sets filetype"] = function()
+  local result = child.lua([[
+    vim.cmd("CodeCompanionChat")
+    local chat1 = require("codecompanion").last_chat()
+    local winnr = chat1.ui.winnr
+    vim.api.nvim_set_current_win(winnr)
+    vim.cmd("wincmd K")
+    winnr = vim.api.nvim_get_current_win()
+    chat1.ui.winnr = winnr
+    local height_before = vim.api.nvim_win_get_height(winnr)
+    local layout_before = vim.fn.winlayout()
+
+    vim.cmd("CodeCompanionChat")
+    local chat2 = require("codecompanion").last_chat()
+
+    return {
+      same_win = chat2.ui.winnr == winnr,
+      filetype = vim.bo[chat2.bufnr].filetype,
+      height_before = height_before,
+      height_after = vim.api.nvim_win_get_height(winnr),
+      layout_same = vim.deep_equal(layout_before, vim.fn.winlayout()),
+      different_chat = chat1.bufnr ~= chat2.bufnr,
+    }
+  ]])
+
+  h.eq(true, result.same_win)
+  h.eq("codecompanion", result.filetype)
+  h.eq(true, result.different_chat)
+  h.eq(true, result.layout_same)
+  h.eq(result.height_before, result.height_after)
+end
+
+T["Window reuse"]["show_in_win sets filetype without shared_ui.open"] = function()
+  local result = child.lua([[
+    local chat = require("codecompanion").chat({ hidden = true })
+    local filetype_before = vim.bo[chat.bufnr].filetype
+
+    vim.cmd("vsplit")
+    local winnr = vim.api.nvim_get_current_win()
+    chat.ui:show_in_win({ winnr = winnr })
+
+    return {
+      filetype_before = filetype_before,
+      filetype_after = vim.bo[chat.bufnr].filetype,
+      visible = chat.ui:is_visible(),
+      winnr = chat.ui.winnr == winnr,
+    }
+  ]])
+
+  h.eq("", result.filetype_before)
+  h.eq("codecompanion", result.filetype_after)
+  h.eq(true, result.visible)
+  h.eq(true, result.winnr)
+end
+
+return T

--- a/tests/interactions/chat/test_window_reuse.lua
+++ b/tests/interactions/chat/test_window_reuse.lua
@@ -168,6 +168,35 @@ T["Window reuse"]["show_in_win sets filetype without shared_ui.open"] = function
   h.eq(true, result.winnr)
 end
 
+T["Window reuse"]["closing a chat in a sole window reuses it for the next chat"] = function()
+  local result = child.lua([[
+    vim.cmd("CodeCompanionChat")
+    vim.cmd("CodeCompanionChat")
+
+    local chat = require("codecompanion").last_chat()
+    vim.api.nvim_set_current_win(chat.ui.winnr)
+    vim.cmd("only")
+
+    local winnr_before = vim.api.nvim_get_current_win()
+    local layout_before = vim.fn.winlayout()
+
+    require("codecompanion.interactions.chat.keymaps").close.callback(chat)
+
+    local chat_after = require("codecompanion").last_chat()
+    return {
+      same_win = vim.api.nvim_get_current_win() == winnr_before,
+      layout_same = vim.deep_equal(layout_before, vim.fn.winlayout()),
+      visible = chat_after.ui:is_visible(),
+      filetype = vim.bo[vim.api.nvim_get_current_buf()].filetype,
+    }
+  ]])
+
+  h.eq(true, result.same_win)
+  h.eq(true, result.layout_same)
+  h.eq(true, result.visible)
+  h.eq("codecompanion", result.filetype)
+end
+
 T["Window reuse"]["show_in_win applies destination window opts"] = function()
   local result = child.lua([[
     local chat = require("codecompanion").chat({ hidden = true })

--- a/tests/interactions/chat/test_window_reuse.lua
+++ b/tests/interactions/chat/test_window_reuse.lua
@@ -168,4 +168,24 @@ T["Window reuse"]["show_in_win sets filetype without shared_ui.open"] = function
   h.eq(true, result.winnr)
 end
 
+T["Window reuse"]["show_in_win applies destination window opts"] = function()
+  local result = child.lua([[
+    local chat = require("codecompanion").chat({ hidden = true })
+    vim.cmd("vsplit")
+    local winnr = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_option_value("wrap", false, { scope = "local", win = winnr })
+    vim.api.nvim_set_option_value("linebreak", false, { scope = "local", win = winnr })
+
+    chat.ui:show_in_win({ winnr = winnr })
+
+    return {
+      wrap = vim.api.nvim_get_option_value("wrap", { scope = "local", win = winnr }),
+      linebreak = vim.api.nvim_get_option_value("linebreak", { scope = "local", win = winnr }),
+    }
+  ]])
+
+  h.eq(true, result.wrap)
+  h.eq(true, result.linebreak)
+end
+
 return T

--- a/tests/interactions/chat/test_window_reuse.lua
+++ b/tests/interactions/chat/test_window_reuse.lua
@@ -217,4 +217,24 @@ T["Chat"]["applies window opts when shown in an existing window"] = function()
   h.eq(true, result.linebreak)
 end
 
+T["Chat"]["clears source-only window opts when reusing"] = function()
+  local result = child.lua([[
+    local chat = require("codecompanion").chat({ hidden = true })
+    vim.cmd("vsplit")
+    local winnr = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_option_value("list", true, { scope = "global" })
+    vim.api.nvim_set_option_value("list", false, { scope = "local", win = winnr })
+
+    chat.ui:show_in_win({ winnr = winnr })
+
+    return {
+      list = vim.api.nvim_get_option_value("list", { scope = "local", win = winnr }),
+      wrap = vim.api.nvim_get_option_value("wrap", { scope = "local", win = winnr }),
+    }
+  ]])
+
+  h.eq(true, result.list)
+  h.eq(true, result.wrap)
+end
+
 return T

--- a/tests/interactions/chat/test_window_reuse.lua
+++ b/tests/interactions/chat/test_window_reuse.lua
@@ -39,9 +39,9 @@ local T = new_set({
   },
 })
 
-T["Window reuse"] = new_set()
+T["Chat"] = new_set()
 
-T["Window reuse"]["cycling chats in a sole window does not error"] = function()
+T["Chat"]["can cycle in a sole window"] = function()
   local result = child.lua([[
     vim.cmd("CodeCompanionChat")
     vim.cmd("CodeCompanionChat")
@@ -75,7 +75,7 @@ T["Window reuse"]["cycling chats in a sole window does not error"] = function()
   h.eq(true, result.visible)
 end
 
-T["Window reuse"]["cycling preserves layout and size"] = function()
+T["Chat"]["keeps layout and size when cycling"] = function()
   local result = child.lua([[
     vim.cmd("CodeCompanionChat")
     local chat1 = require("codecompanion").last_chat()
@@ -113,7 +113,7 @@ T["Window reuse"]["cycling preserves layout and size"] = function()
   h.eq(result.height_before, result.height_after)
 end
 
-T["Window reuse"]["new chat reuses window and sets filetype"] = function()
+T["Chat"]["reuses window when creating a chat"] = function()
   local result = child.lua([[
     vim.cmd("CodeCompanionChat")
     local chat1 = require("codecompanion").last_chat()
@@ -145,7 +145,7 @@ T["Window reuse"]["new chat reuses window and sets filetype"] = function()
   h.eq(result.height_before, result.height_after)
 end
 
-T["Window reuse"]["show_in_win sets filetype without shared_ui.open"] = function()
+T["Chat"]["sets filetype when shown in an existing window"] = function()
   local result = child.lua([[
     local chat = require("codecompanion").chat({ hidden = true })
     local filetype_before = vim.bo[chat.bufnr].filetype
@@ -168,7 +168,7 @@ T["Window reuse"]["show_in_win sets filetype without shared_ui.open"] = function
   h.eq(true, result.winnr)
 end
 
-T["Window reuse"]["closing a chat in a sole window reuses it for the next chat"] = function()
+T["Chat"]["reuses window when closing to the next chat"] = function()
   local result = child.lua([[
     vim.cmd("CodeCompanionChat")
     vim.cmd("CodeCompanionChat")
@@ -197,7 +197,7 @@ T["Window reuse"]["closing a chat in a sole window reuses it for the next chat"]
   h.eq("codecompanion", result.filetype)
 end
 
-T["Window reuse"]["show_in_win applies destination window opts"] = function()
+T["Chat"]["applies window opts when shown in an existing window"] = function()
   local result = child.lua([[
     local chat = require("codecompanion").chat({ hidden = true })
     vim.cmd("vsplit")


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When cycling chats or creating a new one, CodeCompanion hid the window then reopened it. That triggers E444 if the chat is the sole window, and resets user-adjusted split orientation and size from config.

This reuses the existing window via `nvim_win_set_buf`, preserves layout/size across cycle and new-chat, and still sets `filetype=codecompanion` on the reuse path. The same pattern applies to CLI interactions via the shared registry.

So this makes possible to:
- leave only codecompanion's chat buffer in a window and freely switch the codecompanion's chats w/o the need to open some other buffer (to avoid E444)
- change codecompanion's chat buffer split to horizontal, adjust split width/height and freely switch the codecompanion chats w/o resetting that layout to default vertical split.

In other words, I can use neovim instance like a simple llm-chat, where i can _also_ open/review/edit the code when i need to.

## Supporting Documentation

N/A — UI window lifecycle fix; no ACP/MCP/LLM protocol changes.

## AI Usage

Used Cursor (Composer) to explore the chat/CLI UI and registry paths, draft the in-place window reuse, write regression tests, and refactor shared post-open setup between `UI:open` and `UI:show_in_win`. I reviewed the approach against discussion #3333, dogfooded cycle/new-chat in Neovim, and ran the full test suite.

## Related Issue(s)

- Relates to https://github.com/olimorris/codecompanion.nvim/discussions/3333

## Screenshots

N/A — behavior is layout/window lifecycle; covered by Mini.Test cases and manual dogfood.

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages