### PR TITLE
refactor: control when to display CodeCompanion rules

### DIFF
--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1111,8 +1111,7 @@ The user is working on a %s machine. Please respond with system specific command
       parser = "claude",
       ---@return boolean
       enabled = function()
-        -- Don't show this to users who aren't working on CodeCompanion itself
-        return vim.fn.getcwd():find("codecompanion", 1, true) ~= nil
+        return vim.fn.isdirectory(vim.fs.joinpath(vim.fn.getcwd(), ".codecompanion")) == 1
       end,
       files = {
         ["adapters"] = {


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

That was pretty perfect. Ensure that CodeCompanion rules are shown to users when they're working on CodeCompanion itself and a work tree might be in some other place on the file system. We do this by checking for a `.codecompanion` directory. 

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Sonnet 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
