### PR TITLE
refactor: move `resolve` functions to utils

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                 For NVIM v0.11    Last change: 2026 August 29
+                                 For NVIM v0.11    Last change: 2026 August 30
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -276,7 +276,7 @@ require("codecompanion").setup({
 require("codecompanion").setup({
   context = {
     formatters = {
-      -- The path to any module which returns a table with a `format` function.
+      -- The path to any module, or file, which returns a table with a `format` function.
       sqlite = "my_plugin.context.formatters.sqlite",
     },
   },

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -1077,7 +1077,7 @@ The user is working on a %s machine. Please respond with system specific command
     ---Format file and buffer content before sharing it with an LLM, keyed by file extension.
     ---@type table<string, string|fun(raw: string, path: string): string|nil>
     formatters = {
-      ipynb = "codecompanion.context.formatters.builtin.jupyter_notebook",
+      ipynb = "context.formatters.builtin.jupyter_notebook",
     },
   },
   -- PROMPT LIBRARIES ---------------------------------------------------------
@@ -1179,10 +1179,10 @@ The user is working on a %s machine. Please respond with system specific command
       is_preset = true,
     },
     parsers = {
-      claude = "claude", -- Parser for CLAUDE.md files
-      cli = "cli", -- Parser for CLI interactions (file paths only, no content)
-      codecompanion = "codecompanion", -- Parser for CodeCompanion specific rules files
-      none = "none", -- No parsing, just raw text
+      claude = "interactions.shared.rules.parsers.claude", -- Parser for CLAUDE.md files
+      cli = "interactions.shared.rules.parsers.cli", -- Parser for CLI interactions (file paths only, no content)
+      codecompanion = "interactions.shared.rules.parsers.codecompanion", -- Parser for CodeCompanion specific rules files
+      none = "interactions.shared.rules.parsers.none", -- No parsing, just raw text
     },
     opts = {
       chat = {

--- a/lua/codecompanion/context/formatters/init.lua
+++ b/lua/codecompanion/context/formatters/init.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local M = {}
 
@@ -19,9 +20,12 @@ local function resolve(value)
     return resolved[value]
   end
 
-  local ok, module = pcall(require, value)
-  if not ok or type(module) ~= "table" or type(module.format) ~= "function" then
-    log:error("[Formatters] Could not resolve `%s`", value)
+  local module = utils.resolve({ value = value, source = "Formatters" })
+  if not module then
+    return nil
+  end
+  if type(module) ~= "table" or type(module.format) ~= "function" then
+    log:error("[Formatters] `%s` does not expose a `format` function", value)
     return nil
   end
 

--- a/lua/codecompanion/interactions/background/callbacks.lua
+++ b/lua/codecompanion/interactions/background/callbacks.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local M = {}
 
@@ -7,24 +8,7 @@ local M = {}
 ---@param path string The path to the module
 ---@return table|nil The loaded action module or nil on failure
 function M.resolve(path)
-  local ok, action = pcall(require, "codecompanion." .. path)
-  if ok then
-    return action
-  end
-
-  -- Load the tool from the user's config using a module path
-  ok, action = pcall(require, path)
-  if ok then
-    return action
-  end
-
-  -- Try loading the tool from the user's config using a file path
-  local chunk, err = loadfile(vim.fs.normalize(path))
-  if err or not chunk then
-    return
-  end
-
-  return chunk()
+  return utils.resolve({ value = path, source = "background::callbacks" })
 end
 
 ---Execute an action

--- a/lua/codecompanion/interactions/chat/slash_commands/init.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/init.lua
@@ -2,6 +2,7 @@ local buf_utils = require("codecompanion.utils.buffers")
 local config = require("codecompanion.config")
 local interactions = require("codecompanion.interactions")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local api = vim.api
 
@@ -25,30 +26,7 @@ end
 ---@param path string The module or file path
 ---@return table|nil
 local function resolve(path)
-  local ok, slash_command = pcall(require, "codecompanion." .. path)
-  if ok then
-    log:debug("Calling slash command: %s", path)
-    return slash_command
-  end
-
-  -- Try loading from the user's config using a module path
-  ok, slash_command = pcall(require, path)
-  if ok then
-    log:debug("Calling slash command using a module path: %s", path)
-    return slash_command
-  end
-
-  -- Try loading from the user's config using a file path
-  local err
-  slash_command, err = loadfile(vim.fs.normalize(path))
-  if err then
-    return log:error("Could not load the slash command: %s", path)
-  end
-
-  if slash_command then
-    log:debug("Calling slash command from a file path: %s", path)
-    return slash_command()
-  end
+  return utils.resolve({ value = path, source = "Slash Commands" })
 end
 
 ---@class CodeCompanion.SlashCommands

--- a/lua/codecompanion/interactions/chat/tools/init.lua
+++ b/lua/codecompanion/interactions/chat/tools/init.lua
@@ -444,32 +444,7 @@ end
 ---@param path string The module path or file path
 ---@return CodeCompanion.Tools.Unresolved|nil
 local function resolve_path(path)
-  local ok, module = pcall(require, "codecompanion." .. path)
-  if ok then
-    log:debug("[Tools] %s identified", path)
-    return module
-  end
-
-  -- Try loading from the user's config using a module path
-  ok, module = pcall(require, path)
-  if ok then
-    log:debug("[Tools] %s identified", path)
-    return module
-  end
-
-  -- Try loading from the user's config using a file path
-  local err
-  module, err = loadfile(vim.fs.normalize(path))
-  if err then
-    return log:error("[Tools] Failed to load tool from %s: %s", path, err)
-  end
-
-  if module then
-    log:debug("[Tools] %s identified", path)
-    return module()
-  end
-
-  return nil
+  return utils.resolve({ value = path, source = "Tools" })
 end
 
 ---Resolve a tool from the config

--- a/lua/codecompanion/interactions/cli/providers/init.lua
+++ b/lua/codecompanion/interactions/cli/providers/init.lua
@@ -1,5 +1,5 @@
 local config = require("codecompanion.config")
-local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 local M = {}
 
@@ -7,27 +7,7 @@ local M = {}
 ---@param path string The module or file path
 ---@return table|nil
 local function _resolve(path)
-  local ok, provider = pcall(require, "codecompanion." .. path)
-  if ok then
-    return provider
-  end
-
-  -- Try loading from the user's config using a module path
-  ok, provider = pcall(require, path)
-  if ok then
-    return provider
-  end
-
-  -- Try loading from the user's config using a file path
-  local err
-  provider, err = loadfile(vim.fs.normalize(path))
-  if err then
-    return log:error("Could not load CLI provider: %s", path)
-  end
-
-  if provider then
-    return provider()
-  end
+  return utils.resolve({ value = path, source = "CLI Providers" })
 end
 
 ---Create a provider based on the agent's configured provider

--- a/lua/codecompanion/interactions/inline/editor_context/init.lua
+++ b/lua/codecompanion/interactions/inline/editor_context/init.lua
@@ -14,6 +14,7 @@ local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local regex = require("codecompanion.utils.regex")
 local triggers = require("codecompanion.triggers")
+local utils = require("codecompanion.utils")
 
 local CONSTANTS = {
   PREFIX = triggers.mappings.editor_context,
@@ -89,32 +90,15 @@ function EditorContext:output()
       goto skip
     end
 
-    -- Resolve them and add them to the outputs
-    local path = ec_config.path
-    local ok, module = pcall(require, "codecompanion." .. path)
-    if ok then
-      ec_output = module --[[@type CodeCompanion.Inline.EditorContext]]
-      goto append
-    end
-
-    do
-      local err
-      module, err = loadfile(vim.fs.normalize(path))
-      if err then
-        log:error("[EditorContext] %s could not be resolved", item)
-        goto skip
-      end
-      if module then
-        ec_output = module() --[[@type CodeCompanion.Inline.EditorContext]]
-      end
+    ec_output = utils.resolve({ value = ec_config.path, source = "EditorContext" })
+    if not ec_output then
+      goto skip
     end
 
     if (ec_config.opts and ec_config.opts.contains_code) and not config.can_send_code() then
       log:warn("Sending of code has been disabled")
       goto skip
     end
-
-    ::append::
 
     local output = ec_output.new({ context = self.inline.buffer_context }):output()
     if output then

--- a/lua/codecompanion/interactions/shared/editor_context/init.lua
+++ b/lua/codecompanion/interactions/shared/editor_context/init.lua
@@ -3,6 +3,7 @@ local triggers = require("codecompanion.triggers")
 
 local log = require("codecompanion.utils.log")
 local regex = require("codecompanion.utils.regex")
+local utils = require("codecompanion.utils")
 
 local CONSTANTS = {
   PREFIX = triggers.mappings.editor_context,
@@ -31,15 +32,9 @@ end
 
 ---Require an editor context module by its dot-separated path
 ---@param path string
----@return table
+---@return table|nil
 local function require_module(path)
-  -- Try as a built-in module first, then as a user-provided path
-  local ok, module = pcall(require, "codecompanion." .. path)
-  if ok then
-    return module
-  end
-
-  return require(path)
+  return utils.resolve({ value = path, source = "EditorContext" })
 end
 
 ---Create an editor context module instance
@@ -62,7 +57,11 @@ local function create_module(interaction, ctx_config, params, target, interactio
 
   if ctx_config.path then
     log:trace("Calling editor context: %s", ctx_config.path)
-    return require_module(ctx_config.path).new(init)
+    local module = require_module(ctx_config.path)
+    if not module then
+      error(string.format("Could not resolve the `%s` editor context", ctx_config.path))
+    end
+    return module.new(init)
   end
 
   -- No path means a user-defined callback
@@ -212,8 +211,8 @@ function EditorContext:replace(message, bufnr)
     local ctx_config = self.editor_context[ctx]
     -- Delegate to the module's replace method if it has one
     if ctx_config.path then
-      local ok, module = pcall(require_module, ctx_config.path)
-      if ok and module.replace then
+      local module = require_module(ctx_config.path)
+      if module and module.replace then
         message = module.replace(CONSTANTS.PREFIX, message, bufnr)
         goto continue
       end

--- a/lua/codecompanion/interactions/shared/rules/parsers/init.lua
+++ b/lua/codecompanion/interactions/shared/rules/parsers/init.lua
@@ -1,6 +1,6 @@
 local config = require("codecompanion.config")
-local file_utils = require("codecompanion.utils.files")
 local log = require("codecompanion.utils.log")
+local utils = require("codecompanion.utils")
 
 ---@class CodeCompanion.Chat.Rules.Parser
 ---@field content string The content of the rules file
@@ -16,55 +16,25 @@ function M.resolve(parser)
     return nil
   end
 
-  local ok, err, resolved
-
   assert(type(parser) == "string", "Parser must be a string")
   assert(
     config and config.rules and config.rules.parsers and config.rules.parsers[parser],
     "Couldn't find the " .. parser .. " parser in the config"
   )
 
-  parser = config.rules.parsers[parser]
+  local value = config.rules.parsers[parser]
+  local resolved = utils.resolve({ value = value, source = "Rules" })
 
-  -- If the config entry is a function that returns a parser table, call it.
-  if type(parser) == "function" then
-    ok, resolved = pcall(parser)
+  -- A parser module is itself a function, so only a function in the config is a factory
+  if type(value) == "function" then
+    local ok, output = pcall(resolved)
     if not ok then
-      log:error("[Rules] Parser factory error: %s", resolved)
-      return nil
+      return log:error("[Rules] Parser factory error: %s", output)
     end
-    return resolved
+    return output
   end
 
-  if type(parser) == "string" then
-    -- The parser might be a CodeCompanion default one ...
-    ok, resolved = pcall(require, "codecompanion.interactions.shared.rules.parsers." .. parser)
-    if ok then
-      return resolved
-    end
-
-    -- Or one that exists on the user's disk
-    parser = vim.fs.normalize(parser)
-    if not file_utils.exists(parser) then
-      return log:error("[Rules] Could not find the file %s", parser)
-    end
-
-    ok, resolved = pcall(require, parser)
-    if ok then
-      return resolved
-    end
-
-    resolved, err = loadfile(parser)
-    if err then
-      return log:error("[Rules] %s", err)
-    end
-
-    if resolved then
-      return resolved()
-    end
-  end
-
-  return nil
+  return resolved
 end
 
 ---Parse the content through the parser and return it

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -1,3 +1,5 @@
+local log = require("codecompanion.utils.log")
+
 local api = vim.api
 
 local M = {}
@@ -250,6 +252,37 @@ function M.callbacks_extend(callbacks, event, fn)
     table.insert(existing, fn)
   end
   return callbacks
+end
+
+---Resolve a config value into the module, table or function it points at
+---@param args { value: string|function, source?: string }
+---@return any|nil
+function M.resolve(args)
+  local value = args.value
+  if type(value) == "function" then
+    return value
+  end
+  if type(value) ~= "string" then
+    return nil
+  end
+
+  local ok, resolved = pcall(require, "codecompanion." .. value)
+  if ok then
+    return resolved
+  end
+
+  ok, resolved = pcall(require, value)
+  if ok then
+    return resolved
+  end
+
+  local chunk, err = loadfile(vim.fs.normalize(value))
+  if err or not chunk then
+    log:error("[%s] Could not resolve `%s`", args.source or "CodeCompanion", value)
+    return nil
+  end
+
+  return chunk()
 end
 
 ---Resolve a nested table value using a dot-separated path string

--- a/lua/codecompanion/utils/init.lua
+++ b/lua/codecompanion/utils/init.lua
@@ -266,19 +266,22 @@ function M.resolve(args)
     return nil
   end
 
-  local ok, resolved = pcall(require, "codecompanion." .. value)
-  if ok then
-    return resolved
-  end
+  local source = args.source or "CodeCompanion"
 
-  ok, resolved = pcall(require, value)
-  if ok then
-    return resolved
+  for _, name in ipairs({ "codecompanion." .. value, value }) do
+    local ok, resolved = pcall(require, name)
+    if ok then
+      return resolved
+    end
+    -- A module that is on the runtimepath but fails to load must surface its own error
+    if not tostring(resolved):match("module '" .. vim.pesc(name) .. "' not found") then
+      return log:error("[%s] `%s` could not be loaded: %s", source, name, resolved)
+    end
   end
 
   local chunk, err = loadfile(vim.fs.normalize(value))
   if err or not chunk then
-    log:error("[%s] Could not resolve `%s`", args.source or "CodeCompanion", value)
+    log:error("[%s] Could not resolve `%s`", source, value)
     return nil
   end
 

--- a/tests/interactions/shared/rules/parsers/test_parsers.lua
+++ b/tests/interactions/shared/rules/parsers/test_parsers.lua
@@ -42,7 +42,7 @@ T["parsers.resolve()"]["supports builtin module name and file-based parser"] = f
       content = function(p) return "BUILTIN:" .. (p.content or "") end
     }
     package.loaded['codecompanion.config'] = {
-      rules = { parsers = { builtin_parser = "builtinmod" } }
+      rules = { parsers = { builtin_parser = "interactions.shared.rules.parsers.builtinmod" } }
     }
   ]])
 

--- a/tests/interactions/shared/slash_commands/test_rules.lua
+++ b/tests/interactions/shared/slash_commands/test_rules.lua
@@ -36,7 +36,7 @@ T["cli_render returns rules file paths and @-referenced files"] = function()
 
     package.loaded["codecompanion.config"] = {
       rules = {
-        parsers = { cli = "cli" },
+        parsers = { cli = "interactions.shared.rules.parsers.cli" },
         test_group = {
           description = "Test rules",
           files = { %q },


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Long overdue moving of the `resolve` function from various modules to `utils/init.lua`.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code and Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
