### PR TITLE
feat(chat): add message and tool context protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,9 @@ This is a Neovim plugin written in Lua, which allows developers to code with LLM
 - **Don't narrate every change:** the maintainer is an expert who knows this codebase. Do NOT add a comment to explain routine code (`-- Clear the modified flag`, `-- Loop over the messages`, `-- Return early`). Default to no comment. Reserve comments for genuinely non-obvious *why* — a subtle API quirk, a workaround, an ordering constraint — the kind of thing that would trip up even a reader who knows the codebase
 - **Function params:** prefer a single table argument over positional args
 - **Error handling:** `pcall` + `log:error()`, return nil on failure
-- **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise — one description line, params should be self-explanatory without inline comments
-- **Function descriptions:** exactly one line. No multi-paragraph rationale, no usage examples, no "why we cache this" essays — that belongs in commit messages or a single inline `--` comment at the relevant line. If you can't summarise the function in one line, the function is doing too much
+- **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise - params should be self-explanatory without inline comments
+- **Function descriptions:** omit them when the name and the annotations already say it. `truncate_tool_output(opts: { adapter, content }): string` needs no prose above it; `tool_output_limit` does, because "limit" alone doesn't say it's the most a *single* tool result may contribute. Write the description only when it adds what the signature can't
+- **When you do write one:** exactly one line. No multi-paragraph rationale, no usage examples, no "why we cache this" essays - that belongs in commit messages or a single inline `--` comment at the relevant line. If you can't summarise the function in one line, the function is doing too much
 - **Functions:** keep under 50 lines
 - **Globals:** avoid; use module-local state
 - **Code blocks:** use four backticks with language spec unless in a markdown file
@@ -47,6 +48,8 @@ Core: `lua/codecompanion/`
 
 - When running `make test_file` tests, do not append `| tail -12` or similar to filter the output. This prevents the user's rules governing what can be auto-accepted, from applying
 - Chat buffer cursor position, scrolling and folds are verified by hand in real use. Don't add test cases for them, even alongside a fix. Ask first
+- Test the behaviour, not the obvious. A case that only proves a guard clause returns `false`, or that a value passes through a shared utility unchanged, earns nothing - cut it and keep the cases where the outcome could genuinely go either way
+- Name a case for the behaviour it pins down, and lean on contrast so a pair reads as a pair: `DOES NOT truncate a tool that is INSIDE the limit` / `truncates a tool that is OUTSIDE the limit`
 
 ## Important instructions
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                 For NVIM v0.11    Last change: 2026 August 29
+                                 For NVIM v0.11    Last change: 2026 August 31
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -2787,6 +2787,20 @@ chat buffers:
 opts = { default_tools = { "my_tool", "my_tool_group" } }, } } } })`
 
 This also works for |codecompanion-configuration-extensions|.
+
+
+LIMITING TOOL OUTPUT
+
+To prevent the output from a tool exceeding the context window of a model,
+CodeCompanion will look to use the lower of a specified `max_output_tokens`
+limit or a model's own prompt limit. Should the tool exceed the limit,
+CodeCompanion will truncate the output and notify the LLM in the response.
+
+The limit can be configured with:
+
+`lua {6} require("codecompanion").setup({ interactions = { chat = { tools = {
+opts = { max_output_tokens = 30000, -- Truncate a tool's output above this many
+tokens }, } } } })`
 
 
 LLM JUDGE

--- a/doc/configuration/chat-buffer.md
+++ b/doc/configuration/chat-buffer.md
@@ -957,6 +957,26 @@ require("codecompanion").setup({
 
 This also works for [extensions](/configuration/extensions).
 
+### Limiting Tool Output
+
+To prevent the output from a tool exceeding the context window of a model, CodeCompanion will look to use the lower of a specified `max_output_tokens` limit or a model's own prompt limit. Should the tool exceed the limit, CodeCompanion will truncate the output and notify the LLM in the response.
+
+The limit can be configured with:
+
+```lua {6}
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      tools = {
+        opts = {
+          max_output_tokens = 30000, -- Truncate a tool's output above this many tokens
+        },
+      }
+    }
+  }
+})
+```
+
 ### LLM Judge
 
 When [YOLO mode](/usage/chat-buffer/agents-tools#yolo-mode) is on, tools are auto-approved. Some tools (such as `run_command` and `delete_file`), by default, will always ask you first, owing to their destructive nature. The judge offers a middle ground: a background LLM judges the specific action and only interrupts you when it is judged to be unsafe.

--- a/lua/codecompanion/adapters/http/anthropic.lua
+++ b/lua/codecompanion/adapters/http/anthropic.lua
@@ -375,7 +375,7 @@ return {
 
       local context_management = nil
       if self.opts.can_manage_context then
-        local helpers = require("codecompanion.interactions.chat.helpers")
+        local helpers = require("codecompanion.interactions.chat.helpers.context")
         local editing_trigger = helpers.trigger_context_management(self, { operation = "editing" })
 
         context_management = {

--- a/lua/codecompanion/adapters/http/copilot/get_models.lua
+++ b/lua/codecompanion/adapters/http/copilot/get_models.lua
@@ -6,6 +6,7 @@ local M = {}
 ---@class CopilotModels
 ---@field formatted_name string
 ---@field vendor? string
+---@field meta? { context_window: number }
 ---@field opts { can_stream: boolean, can_use_tools: boolean, has_vision: boolean }
 
 ---Resolve the Copilot token to authenticate the models request with
@@ -50,6 +51,7 @@ local models_source = {
 ---@type CopilotModels
 local auto_model = {
   formatted_name = "Auto",
+  meta = { context_window = 12288 },
   opts = {
     can_stream = true,
     can_use_tools = true,

--- a/lua/codecompanion/adapters/http/openai_responses.lua
+++ b/lua/codecompanion/adapters/http/openai_responses.lua
@@ -274,7 +274,7 @@ return {
 
         local context_management = nil
         if self.opts.can_manage_context then
-          local helpers = require("codecompanion.interactions.chat.helpers")
+          local helpers = require("codecompanion.interactions.chat.helpers.context")
 
           context_management = {
             {

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -34,12 +34,25 @@ function M.apply_extend(adapter, opts)
   return adapter
 end
 
----Resolve the context window for the current model
+---Read a field from an adapter's meta data
 ---@param adapter CodeCompanion.HTTPAdapter
+---@param fields string[]
 ---@return number|nil
-function M.context_window(adapter)
-  if adapter.model and adapter.model.meta and adapter.model.meta.context_window then
-    return adapter.model.meta.context_window
+local function from_model_meta(adapter, fields)
+  local function pick(meta)
+    if type(meta) ~= "table" then
+      return nil
+    end
+    for _, field in ipairs(fields) do
+      if meta[field] then
+        return meta[field]
+      end
+    end
+  end
+
+  local value = adapter.model and pick(adapter.model.meta)
+  if value then
+    return value
   end
 
   local model = adapter.schema and adapter.schema.model and adapter.schema.model.default
@@ -62,11 +75,25 @@ function M.context_window(adapter)
     choices = resolved
   end
 
-  if type(choices) == "table" and model and choices[model] and choices[model].meta then
-    return choices[model].meta.context_window
+  if type(choices) == "table" and model and choices[model] then
+    return pick(choices[model].meta)
   end
 
   return nil
+end
+
+---Resolve the context window for the current model
+---@param adapter CodeCompanion.HTTPAdapter
+---@return number|nil
+function M.context_window(adapter)
+  return from_model_meta(adapter, { "context_window" })
+end
+
+---Resolve the largest prompt the current model will accept
+---@param adapter CodeCompanion.HTTPAdapter
+---@return number|nil
+function M.input_limit(adapter)
+  return from_model_meta(adapter, { "max_prompt_tokens", "context_window" })
 end
 
 ---Whether the provider compacts its own context server-side for the current model

--- a/lua/codecompanion/adapters/utils/models/transform.lua
+++ b/lua/codecompanion/adapters/utils/models/transform.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---@class CodeCompanion.Adapter.ModelChoice
 ---@field formatted_name string
----@field meta? { context_window?: number, max_tokens?: number }
+---@field meta? { context_window?: number, max_tokens?: number, max_output_tokens?: number, max_prompt_tokens?: number }
 ---@field opts table
 
 ---Ref: https://platform.claude.com/docs/en/api/models-list
@@ -76,7 +76,7 @@ function M.from_copilot(model)
   end
 
   local opts = {}
-  local limits = {}
+  local meta = {}
   local billing = {}
 
   local supports = capabilities.supports or {}
@@ -85,11 +85,11 @@ function M.from_copilot(model)
   opts.can_use_tools = supports.tool_calls or nil
   opts.has_vision = supports.vision or nil
 
-  local capability_limits = capabilities.limits
-  if capability_limits then
-    limits.max_output_tokens = capability_limits.max_output_tokens
-    limits.max_prompt_tokens = capability_limits.max_prompt_tokens
-    limits.context_window = capability_limits.max_context_window_tokens
+  local limits = capabilities.limits
+  if limits then
+    meta.context_window = limits.max_context_window_tokens
+    meta.max_output_tokens = limits.max_output_tokens
+    meta.max_prompt_tokens = limits.max_prompt_tokens
   end
 
   if model.billing then
@@ -105,8 +105,7 @@ function M.from_copilot(model)
       description = description,
       endpoint = endpoint,
       formatted_name = model.name,
-      limits = limits,
-      meta = limits.context_window and { context_window = limits.context_window } or nil,
+      meta = not vim.tbl_isempty(meta) and meta or nil,
       opts = opts,
       vendor = model.vendor,
     }

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -325,6 +325,7 @@ The user is working on a %s machine. Please respond with system specific command
         opts = {
           auto_submit_errors = true, -- Send any errors to the LLM automatically?
           auto_submit_success = true, -- Send any successful output to the LLM automatically?
+          max_output_tokens = 30000, -- Truncate a tool's output above this many tokens, or the model's limit if lower
           notify_on_approval = true, -- Notify the user when a tool requires approval?,
 
           folds = {

--- a/lua/codecompanion/interactions/chat/context_management/compaction.lua
+++ b/lua/codecompanion/interactions/chat/context_management/compaction.lua
@@ -293,7 +293,7 @@ local function apply_summary(chat, retained, content)
   chat:add_buf_message({ role = config.constants.USER_ROLE, content = summary })
   chat._compacting = false
   chat:ready_for_input()
-  chat:submit({ auto_submit = true }) -- Don't re-parse the chat buffer
+  chat:submit({ auto_submit = true, after_compaction = true }) -- Don't re-parse the chat buffer
   utils.notify("Chat compacted")
 end
 

--- a/lua/codecompanion/interactions/chat/context_management/init.lua
+++ b/lua/codecompanion/interactions/chat/context_management/init.lua
@@ -1,5 +1,5 @@
 local config = require("codecompanion.config")
-local helpers = require("codecompanion.interactions.chat.helpers")
+local helpers = require("codecompanion.interactions.chat.helpers.context")
 local log = require("codecompanion.utils.log")
 local tokens = require("codecompanion.utils.tokens")
 

--- a/lua/codecompanion/interactions/chat/helpers/context.lua
+++ b/lua/codecompanion/interactions/chat/helpers/context.lua
@@ -1,5 +1,6 @@
 local config = require("codecompanion.config")
 
+local log = require("codecompanion.utils.log")
 local tags = require("codecompanion.interactions.shared.tags")
 local tokens = require("codecompanion.utils.tokens")
 
@@ -73,6 +74,33 @@ function M.truncate_tool_output(opts)
   local keep = math.floor(#opts.content * (budget / token_count))
 
   return opts.content:sub(1, keep) .. notice
+end
+
+---Returns the number of tokens that trigger context management for a given operation
+---@param adapter CodeCompanion.HTTPAdapter
+---@param opts? { operation?: "editing"|"compaction" } defaults to "compaction"
+---@return number
+function M.trigger_context_management(adapter, opts)
+  opts = opts or {}
+  local operation = opts.operation or "compaction"
+
+  local context_management = config.interactions.chat.opts.context_management
+  local settings = context_management and context_management[operation]
+  local trigger = settings and settings.trigger
+  if trigger == nil then
+    return 0
+  end
+
+  if trigger < 1 then
+    local context_window = require("codecompanion.adapters.shared").context_window(adapter)
+    if not context_window then
+      log:debug("[Context Window] No context window for `%s` adapter, skipping %s trigger", adapter.name, operation)
+      return 0
+    end
+    trigger = math.floor(trigger * context_window)
+  end
+
+  return trigger
 end
 
 return M

--- a/lua/codecompanion/interactions/chat/helpers/context.lua
+++ b/lua/codecompanion/interactions/chat/helpers/context.lua
@@ -1,0 +1,78 @@
+local config = require("codecompanion.config")
+
+local tags = require("codecompanion.interactions.shared.tags")
+local tokens = require("codecompanion.utils.tokens")
+
+local M = {}
+
+local fmt = string.format
+
+---@param messages CodeCompanion.Chat.Messages
+---@return number
+function M.estimate_tokens(messages)
+  local count = 0
+  for _, message in ipairs(messages) do
+    local meta = message._meta or {}
+    if meta.tag ~= tags.IMAGE then
+      count = count + (meta.estimated_tokens or tokens.calculate(message.content))
+    end
+  end
+
+  return count
+end
+
+---@param opts { adapter: CodeCompanion.HTTPAdapter, messages: CodeCompanion.Chat.Messages }
+---@return { exceeded: boolean, token_count?: number, input_limit?: number }
+function M.exceeds_input_limit(opts)
+  local shared = require("codecompanion.adapters.shared")
+  if shared.manages_own_context(opts.adapter) then
+    return { exceeded = false }
+  end
+
+  local input_limit = shared.input_limit(opts.adapter)
+  if not input_limit then
+    return { exceeded = false }
+  end
+
+  local token_count = M.estimate_tokens(opts.messages)
+
+  return { exceeded = token_count >= input_limit, token_count = token_count, input_limit = input_limit }
+end
+
+---The most tokens a single tool result may contribute to the message history
+---@param adapter CodeCompanion.HTTPAdapter
+---@return number
+local function tool_output_limit(adapter)
+  local limit = config.interactions.chat.tools.opts.max_output_tokens
+  local input_limit = require("codecompanion.adapters.shared").input_limit(adapter)
+
+  return input_limit and math.min(limit, input_limit) or limit
+end
+
+---@param opts { adapter: CodeCompanion.HTTPAdapter, content: string }
+---@return string
+function M.truncate_tool_output(opts)
+  if type(opts.content) ~= "string" or opts.content == "" then
+    return opts.content
+  end
+
+  local token_count = tokens.calculate(opts.content)
+  local limit = tool_output_limit(opts.adapter)
+  if token_count <= limit then
+    return opts.content
+  end
+
+  local notice = fmt(
+    "\n\n[Tool output truncated: it was around %d tokens, which is over the %d token limit for a single tool result. Re-run the tool with a narrower scope to see the rest.]",
+    token_count,
+    limit
+  )
+
+  -- The notice has to fit inside the limit too, otherwise trimming puts us back over it
+  local budget = math.max(limit - tokens.calculate(notice), 0)
+  local keep = math.floor(#opts.content * (budget / token_count))
+
+  return opts.content:sub(1, keep) .. notice
+end
+
+return M

--- a/lua/codecompanion/interactions/chat/helpers/init.lua
+++ b/lua/codecompanion/interactions/chat/helpers/init.lua
@@ -416,31 +416,4 @@ function M.format_viewport_for_llm(buf_lines)
   return table.concat(formatted, "\n\n")
 end
 
----Returns the number of tokens that trigger context management for a given operation
----@param adapter CodeCompanion.HTTPAdapter
----@param opts? { operation?: "editing"|"compaction" } defaults to "compaction"
----@return number
-function M.trigger_context_management(adapter, opts)
-  opts = opts or {}
-  local operation = opts.operation or "compaction"
-
-  local context_management = config.interactions.chat.opts.context_management
-  local settings = context_management and context_management[operation]
-  local trigger = settings and settings.trigger
-  if trigger == nil then
-    return 0
-  end
-
-  if trigger < 1 then
-    local context_window = require("codecompanion.adapters.shared").context_window(adapter)
-    if not context_window then
-      log:debug("[Context Window] No context window for `%s` adapter, skipping %s trigger", adapter.name, operation)
-      return 0
-    end
-    trigger = math.floor(trigger * context_window)
-  end
-
-  return trigger
-end
-
 return M

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1364,6 +1364,11 @@ function Chat:submit(opts)
   if opts.auto_submit then
     self:_complete_orphaned_tool_calls({ reason = CONSTANTS.INCOMPLETE_TOOL_CALL })
     self:_inject_btw()
+
+    -- A compaction request re-submits the chat itself, post summarisation
+    if not opts.after_compaction and require("codecompanion.interactions.chat.context_management").apply(self) then
+      return
+    end
   else
     local message_to_submit = parser.messages(self, self.header_line)
     if not message_to_submit and not helpers.has_user_messages(self.messages) then
@@ -1389,6 +1394,19 @@ function Chat:submit(opts)
       sync_all_buffer_content(self)
     end
 
+    -- Check if the user has manually overridden the adapter
+    if vim.g.codecompanion_adapter and self.adapter.name ~= vim.g.codecompanion_adapter then
+      self.adapter = adapters.resolve(config.adapters[vim.g.codecompanion_adapter])
+      safe_adapter = adapters.make_safe(self.adapter)
+    end
+
+    -- Decorate the prompt before checking size
+    local chat_opts = config.interactions.chat.opts
+    if not opts.regenerate and message_to_submit and message_to_submit.content and chat_opts.prompt_decorator then
+      message_to_submit.content =
+        chat_opts.prompt_decorator(message_to_submit.content, safe_adapter, self.buffer_context)
+    end
+
     if self:message_too_big(message_to_submit) then
       return self:restore()
     end
@@ -1399,20 +1417,10 @@ function Chat:submit(opts)
 
     -- Add the user message after any context so the LLM sees context first
     if not opts.regenerate then
-      local chat_opts = config.interactions.chat.opts
-      if message_to_submit and message_to_submit.content and chat_opts and chat_opts.prompt_decorator then
-        message_to_submit.content =
-          chat_opts.prompt_decorator(message_to_submit.content, safe_adapter, self.buffer_context)
-      end
       self:add_message({
         role = config.constants.USER_ROLE,
         content = (message_to_submit and message_to_submit.content or config.interactions.chat.opts.blank_prompt),
       })
-    end
-
-    -- Check if the user has manually overridden the adapter
-    if vim.g.codecompanion_adapter and self.adapter.name ~= vim.g.codecompanion_adapter then
-      self.adapter = adapters.resolve(config.adapters[vim.g.codecompanion_adapter])
     end
 
     if not config.display.chat.auto_scroll then

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -68,6 +68,7 @@
 local adapters = require("codecompanion.adapters")
 local approvals = require("codecompanion.interactions.chat.tools.approvals")
 local config = require("codecompanion.config")
+local context_helpers = require("codecompanion.interactions.chat.helpers.context")
 local helpers = require("codecompanion.interactions.chat.helpers")
 local parser = require("codecompanion.interactions.chat.parser")
 local schema = require("codecompanion.schema")
@@ -1302,6 +1303,42 @@ function Chat:_submit_acp(payload)
   self.current_request = acp_handler:submit(payload)
 end
 
+---Determine if a message is too big to send to the LLM
+---@param message? { content: string }
+---@return boolean
+function Chat:message_too_big(message)
+  local messages = vim.list_extend({}, self.messages)
+  if message then
+    table.insert(messages, message)
+  end
+
+  local check = context_helpers.exceeds_input_limit({ adapter = self.adapter, messages = messages })
+  local exceeded_limit = check.exceeded
+  if not exceeded_limit then
+    return false
+  end
+
+  -- Compacting the history is no help when the message is singularly too big
+  local message_tokens = message and tokens.calculate(message.content) or 0
+  local fix = message_tokens >= check.input_limit and "Shorten it, or edit it from the debug window"
+    or "Run /compact to summarise the chat history"
+
+  utils.notify(
+    fmt(
+      [[Message not sent.
+Message is around %d tokens, which is over %s's %d token limit.
+%s]],
+      check.token_count,
+      self.adapter.formatted_name,
+      check.input_limit,
+      fix
+    ),
+    vim.log.levels.WARN
+  )
+
+  return true
+end
+
 ---Submit the chat buffer's contents to the LLM
 ---@param opts? table
 ---@return nil
@@ -1348,9 +1385,16 @@ function Chat:submit(opts)
     if message_to_submit then
       message_to_submit = self.context:remove(message_to_submit)
       self:replace_user_inputs(message_to_submit)
-      self:check_images(message_to_submit)
       self:check_context()
       sync_all_buffer_content(self)
+    end
+
+    if self:message_too_big(message_to_submit) then
+      return self:restore()
+    end
+
+    if message_to_submit then
+      self:check_images(message_to_submit)
     end
 
     -- Add the user message after any context so the LLM sees context first
@@ -1890,9 +1934,16 @@ function Chat:add_tool_output(tool, for_llm, for_user)
     else
       existing.content = output.content
     end
+    output = existing
   else
     table.insert(self.messages, output)
   end
+
+  -- Truncate after merging so that a tool emitting many small chunks is caught too
+  output.content = context_helpers.truncate_tool_output({ adapter = self.adapter, content = output.content })
+  output._meta = vim.tbl_extend("force", output._meta or {}, {
+    estimated_tokens = tokens.calculate(output.content),
+  })
 
   -- Allow tools to pass in an empty string to not write any output to the buffer
   if for_user ~= "" then

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -1318,20 +1318,14 @@ function Chat:message_too_big(message)
     return false
   end
 
-  -- Compacting the history is no help when the message is singularly too big
-  local message_tokens = message and tokens.calculate(message.content) or 0
-  local fix = message_tokens >= check.input_limit and "Shorten it, or edit it from the debug window"
-    or "Run /compact to summarise the chat history"
-
   utils.notify(
     fmt(
       [[Message not sent.
 Message is around %d tokens, which is over %s's %d token limit.
-%s]],
+Shorten it, or edit it from the debug window]],
       check.token_count,
       self.adapter.formatted_name,
-      check.input_limit,
-      fix
+      check.input_limit
     ),
     vim.log.levels.WARN
   )

--- a/tests/adapters/http/copilot/test_models.lua
+++ b/tests/adapters/http/copilot/test_models.lua
@@ -88,6 +88,7 @@ T["copilot.models"]["choices() synchronous returns expected models"] = function(
   local expected = {
     auto = {
       formatted_name = "Auto",
+      meta = { context_window = 12288 },
       opts = { can_stream = true, can_use_tools = true, has_vision = true },
     },
     model1 = {
@@ -95,8 +96,7 @@ T["copilot.models"]["choices() synchronous returns expected models"] = function(
       description = "Model One",
       endpoint = "completions",
       formatted_name = "Model One",
-      limits = { context_window = 200000, max_output_tokens = 64000 },
-      meta = { context_window = 200000 },
+      meta = { context_window = 200000, max_output_tokens = 64000 },
       opts = { can_stream = true, can_use_tools = true, has_vision = true },
       vendor = "copilot",
     },
@@ -105,7 +105,6 @@ T["copilot.models"]["choices() synchronous returns expected models"] = function(
       description = "Model Two",
       endpoint = "completions",
       formatted_name = "Model Two",
-      limits = {},
       opts = {},
       vendor = "copilot",
     },
@@ -178,6 +177,7 @@ T["copilot.models"]["choices() async populates cache and returns later"] = funct
   local expected = {
     auto = {
       formatted_name = "Auto",
+      meta = { context_window = 12288 },
       opts = { can_stream = true, can_use_tools = true, has_vision = true },
     },
     model1 = {
@@ -185,8 +185,7 @@ T["copilot.models"]["choices() async populates cache and returns later"] = funct
       description = "Model One",
       endpoint = "completions",
       formatted_name = "Model One",
-      limits = { context_window = 200000, max_output_tokens = 64000 },
-      meta = { context_window = 200000 },
+      meta = { context_window = 200000, max_output_tokens = 64000 },
       opts = { can_stream = true, can_use_tools = true, has_vision = true },
       vendor = "copilot",
     },
@@ -195,7 +194,6 @@ T["copilot.models"]["choices() async populates cache and returns later"] = funct
       description = "Model Two",
       endpoint = "completions",
       formatted_name = "Model Two",
-      limits = {},
       opts = {},
       vendor = "copilot",
     },

--- a/tests/interactions/chat/context_management/test_init.lua
+++ b/tests/interactions/chat/context_management/test_init.lua
@@ -364,4 +364,49 @@ T["apply"]["does nothing when the token count is below all thresholds"] = functi
   h.eq(child.lua_get("_G.before"), child.lua_get("_G.chat.messages"))
 end
 
+T["auto submit"] = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child.lua([==[
+        _G.summarised = false
+        package.loaded["codecompanion.interactions.background"] = {
+          new = function()
+            return {
+              ask = function(_, _, opts)
+                _G.summarised = true
+                opts.on_done({ output = { content = "Summary" } })
+              end,
+            }
+          end,
+        }
+
+        require("codecompanion.config").interactions.chat.opts.context_management = {
+          enabled = true,
+          editing = { trigger = 999999, exclude_tools = {}, keep_cycles = 3 },
+          compaction = { trigger = 10, min_token_savings = 1 },
+        }
+
+        local big_chunk = string.rep("payload ", 3000)
+        _G.chat.cycle = 3
+        _G.chat.messages = {
+          { role = "user", content = big_chunk, _meta = { cycle = 1, id = 1 }, opts = { visible = true } },
+          { role = "llm", content = big_chunk, _meta = { cycle = 1, id = 2 }, opts = { visible = true } },
+        }
+      ]==])
+    end,
+  },
+})
+
+T["auto submit"]["compacts when a tool loop pushes the chat over the threshold"] = function()
+  child.lua([[_G.chat:submit({ auto_submit = true })]])
+
+  h.is_true(child.lua_get("_G.summarised"))
+end
+
+T["auto submit"]["DOES NOT compact when compaction itself resubmits"] = function()
+  child.lua([[_G.chat:submit({ auto_submit = true, after_compaction = true })]])
+
+  h.eq(false, child.lua_get("_G.summarised"))
+end
+
 return T

--- a/tests/interactions/chat/helpers/test_context.lua
+++ b/tests/interactions/chat/helpers/test_context.lua
@@ -1,0 +1,156 @@
+local h = require("tests.helpers")
+
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+
+      child.lua([[
+        _G.helpers = require("codecompanion.interactions.chat.helpers.context")
+        require("codecompanion").setup(require("tests.config"))
+      ]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["exceeds_input_limit"] = new_set()
+
+T["exceeds_input_limit"]["returns true when the messages exceed the limit"] = function()
+  local result = child.lua([[
+    return _G.helpers.exceeds_input_limit({
+      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 50 } } } } } },
+      messages = {
+        { role = "user", content = "hello", _meta = { estimated_tokens = 40 } },
+        { role = "user", content = string.rep("word ", 200) },
+      },
+    })
+  ]])
+
+  h.eq(true, result.exceeded)
+  h.eq(50, result.input_limit)
+  h.expect_truthy(result.token_count > 50)
+end
+
+T["exceeds_input_limit"]["returns false when the messages are within the limit"] = function()
+  local result = child.lua([[
+    return _G.helpers.exceeds_input_limit({
+      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 100000 } } } } } },
+      messages = { { role = "user", content = "hello", _meta = { estimated_tokens = 5 } } },
+    })
+  ]])
+
+  h.eq(false, result.exceeded)
+end
+
+T["exceeds_input_limit"]["prefers the model's prompt limit over its context window"] = function()
+  local result = child.lua([[
+    return _G.helpers.exceeds_input_limit({
+      adapter = {
+        schema = {
+          model = {
+            default = "m",
+            choices = { m = { meta = { context_window = 100000, max_prompt_tokens = 50 } } },
+          },
+        },
+      },
+      messages = { { role = "user", content = "hello", _meta = { estimated_tokens = 60 } } },
+    })
+  ]])
+
+  h.eq(true, result.exceeded)
+  h.eq(50, result.input_limit)
+end
+
+T["estimate_tokens"] = new_set()
+
+T["estimate_tokens"]["trusts stored estimates rather than recomputing from content"] = function()
+  local result = child.lua([[
+    return _G.helpers.estimate_tokens({ { role = "user", content = "hi", _meta = { estimated_tokens = 90 } } })
+  ]])
+
+  h.eq(90, result)
+end
+
+T["estimate_tokens"]["calculates for messages that have no stored estimate"] = function()
+  local result = child.lua([[
+    return _G.helpers.estimate_tokens({ { role = "user", content = string.rep("word ", 200) } })
+  ]])
+
+  h.expect_truthy(result > 0)
+end
+
+T["estimate_tokens"]["ignores images"] = function()
+  local result = child.lua([[
+    local tags = require("codecompanion.interactions.shared.tags")
+
+    return _G.helpers.estimate_tokens({
+      { role = "user", content = "hello", _meta = { estimated_tokens = 10 } },
+      { role = "user", content = string.rep("A", 100000), _meta = { tag = tags.IMAGE, estimated_tokens = 20000 } },
+    })
+  ]])
+
+  h.eq(10, result)
+end
+
+T["truncate_tool_output"] = new_set()
+
+T["truncate_tool_output"]["DOES NOT truncate a tool that is INSIDE the limit"] = function()
+  local result = child.lua([[
+    return _G.helpers.truncate_tool_output({
+      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 100000 } } } } } },
+      content = "a short tool result",
+    })
+  ]])
+
+  h.eq("a short tool result", result)
+end
+
+T["truncate_tool_output"]["truncates a tool that is OUTSIDE the limit"] = function()
+  local result = child.lua([[
+    return _G.helpers.truncate_tool_output({
+      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 50 } } } } } },
+      content = string.rep("word ", 5000),
+    })
+  ]])
+
+  h.expect_match(result, "^word word")
+  h.expect_match(result, "Tool output truncated")
+  h.expect_truthy(#result < #string.rep("word ", 5000))
+end
+
+T["truncate_tool_output"]["caps at the configured limit when the model's is larger"] = function()
+  local result = child.lua([[
+    local config = require("codecompanion.config")
+    config.interactions.chat.tools.opts.max_output_tokens = 10
+
+    return _G.helpers.truncate_tool_output({
+      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 100000 } } } } } },
+      content = string.rep("word ", 500),
+    })
+  ]])
+
+  h.expect_match(result, "Tool output truncated")
+  h.expect_match(result, "over the 10 token limit")
+end
+
+T["truncate_tool_output"]["keeps the truncated output and notification under the limit"] = function()
+  local result = child.lua([[
+    local config = require("codecompanion.config")
+    config.interactions.chat.tools.opts.max_output_tokens = 100
+
+    local content = _G.helpers.truncate_tool_output({
+      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 100000 } } } } } },
+      content = string.rep("word ", 5000),
+    })
+
+    return require("codecompanion.utils.tokens").calculate(content)
+  ]])
+
+  h.expect_truthy(result <= 100)
+end
+
+return T

--- a/tests/interactions/chat/helpers/test_context.lua
+++ b/tests/interactions/chat/helpers/test_context.lua
@@ -35,17 +35,6 @@ T["exceeds_input_limit"]["returns true when the messages exceed the limit"] = fu
   h.expect_truthy(result.token_count > 50)
 end
 
-T["exceeds_input_limit"]["returns false when the messages are within the limit"] = function()
-  local result = child.lua([[
-    return _G.helpers.exceeds_input_limit({
-      adapter = { schema = { model = { default = "m", choices = { m = { meta = { context_window = 100000 } } } } } },
-      messages = { { role = "user", content = "hello", _meta = { estimated_tokens = 5 } } },
-    })
-  ]])
-
-  h.eq(false, result.exceeded)
-end
-
 T["exceeds_input_limit"]["prefers the model's prompt limit over its context window"] = function()
   local result = child.lua([[
     return _G.helpers.exceeds_input_limit({


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

For a while, it's always been possible for a rogue tool call to breach an LLM's context limit.

Whilst CodeCompanion has added [context management](https://codecompanion.olimorris.dev/configuration/chat-buffer#context-management) support, there was no feature to truncate tool calls or stop the user from sending their own super large message. This would prevent the need for any context editing or compaction.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code + Opus 5

## Related Issue(s)

#2756 - Token grenades

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
