### PR TITLE
fix(chat): recover a prompt hidden from Tree-sitter by an unbalanced fence

### DIFF
--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -89,45 +89,25 @@ function M.get_settings_key(chat, opts)
   return key_name, node
 end
 
----Chat buffers already warned about, so a malformed transcript is reported once
----rather than on every submit. The offending fence stays broken for the rest of
----the conversation -- the transcript is a record and is never rewritten -- so the
----fallback below keeps firing for as long as the chat lives. Buffer numbers are
----not reused within a session, so this never suppresses a different buffer.
+---Chat buffers already warned about, so a recovery is reported once per buffer
 local warned_buffers = {}
 
----Recover the user's message by reading the buffer, when Tree-sitter cannot
----
----`queries/markdown/chat.scm` finds the message by walking Markdown sections, so
----an unbalanced code fence anywhere above the user header makes the parser
----swallow that header. The query then matches no user section and, because
----`helpers.has_user_messages()` is true mid-conversation, the text the user just
----typed is dropped silently on submit. Any producer of chat text can leave a
----fence open, including an LLM response truncated mid-block by `max_tokens`.
----
----This runs only when the query yielded nothing, and it does not re-parse.
----`start_range` is `chat.header_line`, the 1-based row of the user header, so the
----message is everything below that row: the position comes from the builder's own
----bookkeeping rather than from a tree already known to be wrong, which is what
----makes reading raw lines trustworthy here.
+---Recover the user's message from raw buffer lines when the query finds none
 ---@param chat CodeCompanion.Chat
----@param start_range number The 1-based row of the user header
+---@param start_range number
 ---@return { content: string }|nil
 local function recover_messages(chat, start_range)
-  -- `start_range - 1` is the header row 0-indexed, so `start_range` is the row below it
+  -- start_range is 1-based, so it already points at the row below the header
   local lines = vim.api.nvim_buf_get_lines(chat.bufnr, start_range, -1, false)
 
-  -- The row below a header is blank, and `strip_context` only strips *leading*
-  -- entries, so the context block has to be flushed to the front to be seen. The
-  -- Tree-sitter path never meets this: it is handed section text, not raw lines.
+  -- strip_context only strips leading entries, so the blank row under the header must go first
   while lines[1] and vim.trim(lines[1]) == "" do
     table.remove(lines, 1)
   end
   lines = helpers.strip_context(lines)
   local content = vim.trim(table.concat(lines, "\n"))
 
-  -- An empty section must stay empty: tools auto-submit with no user message, and
-  -- inventing one here would send a phantom prompt.
+  -- Tool auto-submits send no user message, so an empty section must stay empty
   if content == "" then
     return nil
   end
@@ -174,15 +154,8 @@ function M.messages(chat, start_range)
 end
 
 ---Is `row` inside a fenced code block that was never closed?
----
----A closed block has two `fenced_code_block_delimiter` children; an unterminated
----one has a single opening delimiter and runs to the end of the buffer. Only such
----a block can hide a header from `queries/markdown/chat.scm` unintentionally, so
----this is the one situation in which the scan below may overrule Tree-sitter: a
----heading inside a *closed* block is there because its author put it there, and
----must go on being treated as code.
----@param root TSNode The root of the tree `M.headers` has already parsed
----@param row number 0-indexed
+---@param root TSNode
+---@param row number
 ---@return boolean
 local function hidden_by_open_fence(root, row)
   local node = root:descendant_for_range(row, 0, row, 0)
@@ -194,7 +167,7 @@ local function hidden_by_open_fence(root, row)
           delimiters = delimiters + 1
         end
       end
-      return delimiters < 2
+      return delimiters < 2 -- a closed block has two delimiters; an unterminated one only an opener
     end
     node = node:parent()
   end
@@ -202,21 +175,10 @@ local function hidden_by_open_fence(root, row)
 end
 
 ---Find a user header that an unclosed code fence hid from Tree-sitter
----
----`M.headers` seeds `chat.header_line` for restored chats, and on a malformed
----buffer it does not fail cleanly: it returns the last header it can still *see*,
----which is an earlier one. Everything downstream then parses from that row, so
----`M.messages` finds a previous message and returns it -- worse than returning
----nothing, because the fallback above sees content and never fires, and the user's
----new prompt is replaced by an old one.
----
----Only rows below `after` are considered, so a header Tree-sitter did find is
----never traded for an earlier one, and every candidate must be provably hidden by
----an unclosed fence.
 ---@param chat CodeCompanion.Chat
----@param root TSNode The root of the tree `M.headers` has already parsed
----@param after number The 0-indexed row Tree-sitter reported, or -1 if it found none
----@return number|nil The 0-indexed row of the header, in the rows Tree-sitter reports
+---@param root TSNode
+---@param after number 0-indexed row, or -1 when Tree-sitter found none
+---@return number|nil
 local function recover_headers(chat, root, after)
   local lines = vim.api.nvim_buf_get_lines(chat.bufnr, after + 1, -1, false)
   for i = #lines, 1, -1 do
@@ -249,8 +211,6 @@ function M.headers(chat)
     end
   end
 
-  -- Tree-sitter stays authoritative unless an unclosed fence hid a later header
-  -- from it. When nothing is recovered its own result is returned untouched.
   local recovered = recover_headers(chat, root, last_match and last_match:range() or -1)
   if recovered then
     return recovered

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -89,6 +89,61 @@ function M.get_settings_key(chat, opts)
   return key_name, node
 end
 
+---Chat buffers already warned about, so a malformed transcript is reported once
+---rather than on every submit. The offending fence stays broken for the rest of
+---the conversation -- the transcript is a record and is never rewritten -- so the
+---fallback below keeps firing for as long as the chat lives. Buffer numbers are
+---not reused within a session, so this never suppresses a different buffer.
+local warned_buffers = {}
+
+---Recover the user's message by reading the buffer, when Tree-sitter cannot
+---
+---`queries/markdown/chat.scm` finds the message by walking Markdown sections, so
+---an unbalanced code fence anywhere above the user header makes the parser
+---swallow that header. The query then matches no user section and, because
+---`helpers.has_user_messages()` is true mid-conversation, the text the user just
+---typed is dropped silently on submit. Any producer of chat text can leave a
+---fence open, including an LLM response truncated mid-block by `max_tokens`.
+---
+---This runs only when the query yielded nothing, and it does not re-parse.
+---`start_range` is `chat.header_line`, the 1-based row of the user header, so the
+---message is everything below that row: the position comes from the builder's own
+---bookkeeping rather than from a tree already known to be wrong, which is what
+---makes reading raw lines trustworthy here.
+---@param chat CodeCompanion.Chat
+---@param start_range number The 1-based row of the user header
+---@return { content: string }|nil
+local function recover_messages(chat, start_range)
+  -- `start_range - 1` is the header row 0-indexed, so `start_range` is the row below it
+  local lines = vim.api.nvim_buf_get_lines(chat.bufnr, start_range, -1, false)
+
+  -- The row below a header is blank, and `strip_context` only strips *leading*
+  -- entries, so the context block has to be flushed to the front to be seen. The
+  -- Tree-sitter path never meets this: it is handed section text, not raw lines.
+  while lines[1] and vim.trim(lines[1]) == "" do
+    table.remove(lines, 1)
+  end
+  lines = helpers.strip_context(lines)
+  local content = vim.trim(table.concat(lines, "\n"))
+
+  -- An empty section must stay empty: tools auto-submit with no user message, and
+  -- inventing one here would send a phantom prompt.
+  if content == "" then
+    return nil
+  end
+
+  if not warned_buffers[chat.bufnr] then
+    warned_buffers[chat.bufnr] = true
+    log:warn(
+      "[chat::parser] Tree-sitter found no user message, so it was read from the buffer instead. "
+        .. "An unterminated code fence above the last user header is the usual cause."
+    )
+  end
+  log:debug("[chat::parser] Recovered %d line(s) of user message from row %d", #lines, start_range)
+
+  return { content = content }
+end
+
 ---Parse the chat buffer for the last message
 ---@param chat CodeCompanion.Chat
 ---@param start_range number
@@ -115,7 +170,64 @@ function M.messages(chat, start_range)
     return { content = vim.trim(table.concat(content, "\n\n")) }
   end
 
-  return nil
+  return recover_messages(chat, start_range)
+end
+
+---Is `row` inside a fenced code block that was never closed?
+---
+---A closed block has two `fenced_code_block_delimiter` children; an unterminated
+---one has a single opening delimiter and runs to the end of the buffer. Only such
+---a block can hide a header from `queries/markdown/chat.scm` unintentionally, so
+---this is the one situation in which the scan below may overrule Tree-sitter: a
+---heading inside a *closed* block is there because its author put it there, and
+---must go on being treated as code.
+---@param root TSNode The root of the tree `M.headers` has already parsed
+---@param row number 0-indexed
+---@return boolean
+local function hidden_by_open_fence(root, row)
+  local node = root:descendant_for_range(row, 0, row, 0)
+  while node do
+    if node:type() == "fenced_code_block" then
+      local delimiters = 0
+      for child in node:iter_children() do
+        if child:type() == "fenced_code_block_delimiter" then
+          delimiters = delimiters + 1
+        end
+      end
+      return delimiters < 2
+    end
+    node = node:parent()
+  end
+  return false
+end
+
+---Find a user header that an unclosed code fence hid from Tree-sitter
+---
+---`M.headers` seeds `chat.header_line` for restored chats, and on a malformed
+---buffer it does not fail cleanly: it returns the last header it can still *see*,
+---which is an earlier one. Everything downstream then parses from that row, so
+---`M.messages` finds a previous message and returns it -- worse than returning
+---nothing, because the fallback above sees content and never fires, and the user's
+---new prompt is replaced by an old one.
+---
+---Only rows below `after` are considered, so a header Tree-sitter did find is
+---never traded for an earlier one, and every candidate must be provably hidden by
+---an unclosed fence.
+---@param chat CodeCompanion.Chat
+---@param root TSNode The root of the tree `M.headers` has already parsed
+---@param after number The 0-indexed row Tree-sitter reported, or -1 if it found none
+---@return number|nil The 0-indexed row of the header, in the rows Tree-sitter reports
+local function recover_headers(chat, root, after)
+  local lines = vim.api.nvim_buf_get_lines(chat.bufnr, after + 1, -1, false)
+  for i = #lines, 1, -1 do
+    local heading = lines[i]:match("^##%s+(.-)%s*$")
+    if heading and helpers.format_role(heading) == config.interactions.chat.roles.user then
+      local row = after + i
+      if hidden_by_open_fence(root, row) then
+        return row
+      end
+    end
+  end
 end
 
 ---Parse the chat buffer for the last header
@@ -135,6 +247,13 @@ function M.headers(chat)
         last_match = node
       end
     end
+  end
+
+  -- Tree-sitter stays authoritative unless an unclosed fence hid a later header
+  -- from it. When nothing is recovered its own result is returned untouched.
+  local recovered = recover_headers(chat, root, last_match and last_match:range() or -1)
+  if recovered then
+    return recovered
   end
 
   if last_match then

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -34,24 +34,29 @@ end
 
 ---@param root TSNode
 ---@param row number
----@return boolean
-local function is_inside_unclosed_fence(root, row)
+---@return TSNode|nil
+local function get_enclosing_fence(root, row)
   local node = root:descendant_for_range(row, 0, row, 0)
 
   while node do
     if node:type() == "fenced_code_block" then
-      local delimiters = 0
-      for child in node:iter_children() do
-        if child:type() == "fenced_code_block_delimiter" then
-          delimiters = delimiters + 1
-        end
-      end
-      return delimiters < 2
+      return node
     end
     node = node:parent()
   end
+end
 
-  return false
+---@param fence TSNode
+---@return boolean
+local function is_unclosed(fence)
+  local delimiters = 0
+  for child in fence:iter_children() do
+    if child:type() == "fenced_code_block_delimiter" then
+      delimiters = delimiters + 1
+    end
+  end
+
+  return delimiters < 2
 end
 
 local M = {}
@@ -155,9 +160,15 @@ function M.messages(chat, start_range)
     end
   end
 
-  content = helpers.strip_context(content) -- If users send a blank message to the LLM, sometimes context is included
+  content = helpers.strip_context(content)
   if not vim.tbl_isempty(content) then
     return { content = vim.trim(table.concat(content, "\n\n")) }
+  end
+
+  -- Handle the case of a header being buried in a mardown code block
+  local full_root = chat.parsers.markdown:parse({ 0, -1 })[1]:root()
+  if not get_enclosing_fence(full_root, start_range - 1) then
+    return nil
   end
 
   return recover_messages(chat, start_range)
@@ -174,7 +185,8 @@ local function recover_headers(chat, root, from_row)
     local heading = lines[i]:match("^##%s+(.-)%s*$")
     if heading and helpers.format_role(heading) == config.interactions.chat.roles.user then
       local row = from_row + i - 1
-      if is_inside_unclosed_fence(root, row) then
+      local fence = get_enclosing_fence(root, row)
+      if fence and is_unclosed(fence) then
         return row
       end
     end
@@ -191,22 +203,27 @@ function M.headers(chat)
   local root = tree:root()
 
   local last_match = nil
+  local ends_with_user_header = false
   for id, node in query:iter_captures(root, chat.bufnr) do
     if query.captures[id] == "role_only" then
       local role = helpers.format_role(get_node_text(node, chat.bufnr))
-      if role == config.interactions.chat.roles.user then
+      ends_with_user_header = role == config.interactions.chat.roles.user
+      if ends_with_user_header then
         last_match = node
       end
     end
   end
 
-  local recovered = recover_headers(chat, root, last_match and (last_match:range() + 1) or 0)
-  if recovered then
-    return recovered
+  -- PERF: Only scan headers if it doesn't end with a user header
+  if not ends_with_user_header then
+    local recovered = recover_headers(chat, root, last_match and (last_match:range() + 1) or 0)
+    if recovered then
+      return recovered
+    end
   end
 
   if last_match then
-    return last_match:range()
+    return (last_match:range())
   end
 end
 

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -129,7 +129,7 @@ local function recover_messages(chat, start_range)
   lines = helpers.strip_context(lines)
   local content = vim.trim(table.concat(lines, "\n"))
 
-  -- A tool auto-submit send no user message, so an empty section must stay empty
+  -- A tool auto-submit sends no user message, so an empty section must stay empty
   if content == "" then
     return nil
   end
@@ -160,7 +160,7 @@ function M.messages(chat, start_range)
     end
   end
 
-  content = helpers.strip_context(content)
+  content = helpers.strip_context(content) -- If users send a blank message to the LLM, sometimes context is included
   if not vim.tbl_isempty(content) then
     return { content = vim.trim(table.concat(content, "\n\n")) }
   end
@@ -214,7 +214,7 @@ function M.headers(chat)
     end
   end
 
-  -- PERF: Only scan headers if it doesn't end with a user header
+  -- Without this, a heading inside an unclosed fence would take precedence over a chat header
   if not ends_with_user_header then
     local recovered = recover_headers(chat, root, last_match and (last_match:range() + 1) or 0)
     if recovered then

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -165,7 +165,7 @@ function M.messages(chat, start_range)
     return { content = vim.trim(table.concat(content, "\n\n")) }
   end
 
-  -- Handle the case of a header being buried in a mardown code block
+  -- Handle the case of a header being buried in a markdown code block
   local full_root = chat.parsers.markdown:parse({ 0, -1 })[1]:root()
   if not get_enclosing_fence(full_root, start_range - 1) then
     return nil

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -89,18 +89,13 @@ function M.get_settings_key(chat, opts)
   return key_name, node
 end
 
----Chat buffers already warned about, so a recovery is reported once per buffer
-local warned_buffers = {}
-
 ---Recover the user's message from raw buffer lines when the query finds none
 ---@param chat CodeCompanion.Chat
 ---@param start_range number
 ---@return { content: string }|nil
 local function recover_messages(chat, start_range)
-  -- start_range is 1-based, so it already points at the row below the header
-  local lines = vim.api.nvim_buf_get_lines(chat.bufnr, start_range, -1, false)
+  local lines = vim.api.nvim_buf_get_lines(chat.bufnr, start_range, -1, false) -- start_range is 1-based
 
-  -- strip_context only strips leading entries, so the blank row under the header must go first
   while lines[1] and vim.trim(lines[1]) == "" do
     table.remove(lines, 1)
   end
@@ -112,13 +107,6 @@ local function recover_messages(chat, start_range)
     return nil
   end
 
-  if not warned_buffers[chat.bufnr] then
-    warned_buffers[chat.bufnr] = true
-    log:warn(
-      "[chat::parser] Tree-sitter found no user message, so it was read from the buffer instead. "
-        .. "An unterminated code fence above the last user header is the usual cause."
-    )
-  end
   log:debug("[chat::parser] Recovered %d line(s) of user message from row %d", #lines, start_range)
 
   return { content = content }
@@ -153,11 +141,10 @@ function M.messages(chat, start_range)
   return recover_messages(chat, start_range)
 end
 
----Is `row` inside a fenced code block that was never closed?
 ---@param root TSNode
 ---@param row number
 ---@return boolean
-local function hidden_by_open_fence(root, row)
+local function is_inside_unclosed_fence(root, row)
   local node = root:descendant_for_range(row, 0, row, 0)
   while node do
     if node:type() == "fenced_code_block" then
@@ -167,7 +154,7 @@ local function hidden_by_open_fence(root, row)
           delimiters = delimiters + 1
         end
       end
-      return delimiters < 2 -- a closed block has two delimiters; an unterminated one only an opener
+      return delimiters < 2
     end
     node = node:parent()
   end
@@ -177,15 +164,15 @@ end
 ---Find a user header that an unclosed code fence hid from Tree-sitter
 ---@param chat CodeCompanion.Chat
 ---@param root TSNode
----@param after number 0-indexed row, or -1 when Tree-sitter found none
+---@param from_row number
 ---@return number|nil
-local function recover_headers(chat, root, after)
-  local lines = vim.api.nvim_buf_get_lines(chat.bufnr, after + 1, -1, false)
+local function recover_headers(chat, root, from_row)
+  local lines = vim.api.nvim_buf_get_lines(chat.bufnr, from_row, -1, false)
   for i = #lines, 1, -1 do
     local heading = lines[i]:match("^##%s+(.-)%s*$")
     if heading and helpers.format_role(heading) == config.interactions.chat.roles.user then
-      local row = after + i
-      if hidden_by_open_fence(root, row) then
+      local row = from_row + i - 1
+      if is_inside_unclosed_fence(root, row) then
         return row
       end
     end
@@ -211,7 +198,7 @@ function M.headers(chat)
     end
   end
 
-  local recovered = recover_headers(chat, root, last_match and last_match:range() or -1)
+  local recovered = recover_headers(chat, root, last_match and (last_match:range() + 1) or 0)
   if recovered then
     return recovered
   end

--- a/lua/codecompanion/interactions/chat/parser.lua
+++ b/lua/codecompanion/interactions/chat/parser.lua
@@ -32,6 +32,28 @@ local function image_query()
   return cached_image_query
 end
 
+---@param root TSNode
+---@param row number
+---@return boolean
+local function is_inside_unclosed_fence(root, row)
+  local node = root:descendant_for_range(row, 0, row, 0)
+
+  while node do
+    if node:type() == "fenced_code_block" then
+      local delimiters = 0
+      for child in node:iter_children() do
+        if child:type() == "fenced_code_block_delimiter" then
+          delimiters = delimiters + 1
+        end
+      end
+      return delimiters < 2
+    end
+    node = node:parent()
+  end
+
+  return false
+end
+
 local M = {}
 
 ---Parse the chat buffer for settings
@@ -89,7 +111,7 @@ function M.get_settings_key(chat, opts)
   return key_name, node
 end
 
----Recover the user's message from raw buffer lines when the query finds none
+---If user messages cannot be found by Tree-sitter, attempt to recover them by reading the buffer directly
 ---@param chat CodeCompanion.Chat
 ---@param start_range number
 ---@return { content: string }|nil
@@ -102,7 +124,7 @@ local function recover_messages(chat, start_range)
   lines = helpers.strip_context(lines)
   local content = vim.trim(table.concat(lines, "\n"))
 
-  -- Tool auto-submits send no user message, so an empty section must stay empty
+  -- A tool auto-submit send no user message, so an empty section must stay empty
   if content == "" then
     return nil
   end
@@ -141,27 +163,7 @@ function M.messages(chat, start_range)
   return recover_messages(chat, start_range)
 end
 
----@param root TSNode
----@param row number
----@return boolean
-local function is_inside_unclosed_fence(root, row)
-  local node = root:descendant_for_range(row, 0, row, 0)
-  while node do
-    if node:type() == "fenced_code_block" then
-      local delimiters = 0
-      for child in node:iter_children() do
-        if child:type() == "fenced_code_block_delimiter" then
-          delimiters = delimiters + 1
-        end
-      end
-      return delimiters < 2
-    end
-    node = node:parent()
-  end
-  return false
-end
-
----Find a user header that an unclosed code fence hid from Tree-sitter
+---If headers cannot be found by Tree-sitter, attempt to recover them
 ---@param chat CodeCompanion.Chat
 ---@param root TSNode
 ---@param from_row number

--- a/tests/interactions/chat/test_parser.lua
+++ b/tests/interactions/chat/test_parser.lua
@@ -86,46 +86,46 @@ local T = new_set({
   },
 })
 
-T["Parser resilience"] = new_set()
+T["Parser"] = new_set()
 
-T["Parser resilience"]["a balanced response leaves the prompt extractable"] = function()
+T["Parser"]["a balanced response leaves the prompt extractable"] = function()
   chat_with(BALANCED_FENCE, { "please fix the bug" })
   h.eq("please fix the bug", extracted().content)
 end
 
-T["Parser resilience"]["an unterminated fence does not eat the next prompt"] = function()
+T["Parser"]["an unterminated fence does not eat the next prompt"] = function()
   chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
   h.eq("please fix the bug", extracted().content)
 end
 
-T["Parser resilience"]["an unterminated fence does not hide the last user header"] = function()
+T["Parser"]["an unterminated fence does not hide the last user header"] = function()
   chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
   local result = extracted()
   h.eq(result.expected_header, result.header)
 end
 
-T["Parser resilience"]["context lines are stripped from the recovered prompt"] = function()
+T["Parser"]["context lines are stripped from the recovered prompt"] = function()
   chat_with(UNTERMINATED_FENCE, { "> Context:", "> - <file>foo.lua</file>", "", "please fix the bug" })
   h.eq("please fix the bug", extracted().content)
 end
 
-T["Parser resilience"]["a multi-line prompt is recovered whole"] = function()
+T["Parser"]["a multi-line prompt is recovered whole"] = function()
   chat_with(UNTERMINATED_FENCE, { "first line", "", "second line" })
   h.eq("first line\n\nsecond line", extracted().content)
 end
 
-T["Parser resilience"]["an empty user section still yields no message"] = function()
+T["Parser"]["an empty user section still yields no message"] = function()
   -- Tool auto-submits rely on this: recovery must not fabricate a prompt.
   chat_with(BALANCED_FENCE, {})
   h.eq(nil, extracted().content)
 end
 
-T["Parser resilience"]["an empty user section under a broken fence yields no message"] = function()
+T["Parser"]["an empty user section under a broken fence yields no message"] = function()
   chat_with(UNTERMINATED_FENCE, {})
   h.eq(nil, extracted().content)
 end
 
-T["Parser resilience"]["recovery is reported once, not on every parse"] = function()
+T["Parser"]["recovery is reported once, not on every parse"] = function()
   chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
   spy_on_warnings()
 
@@ -136,7 +136,7 @@ T["Parser resilience"]["recovery is reported once, not on every parse"] = functi
   h.expect_contains("unterminated code fence", child.lua_get("_G.warnings[1]"))
 end
 
-T["Parser resilience"]["a healthy buffer is parsed without warning"] = function()
+T["Parser"]["a healthy buffer is parsed without warning"] = function()
   chat_with(BALANCED_FENCE, { "please fix the bug" })
   spy_on_warnings()
 

--- a/tests/interactions/chat/test_parser.lua
+++ b/tests/interactions/chat/test_parser.lua
@@ -5,7 +5,6 @@ local child = MiniTest.new_child_neovim()
 local RESPONSE_WITH_UNCLOSED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n"
 local RESPONSE_WITH_CLOSED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
 
----Add `response` as the LLM's answer, then type `lines` under a fresh user header
 ---@param response string
 ---@param lines string[]
 local function add_response(response, lines)

--- a/tests/interactions/chat/test_parser.lua
+++ b/tests/interactions/chat/test_parser.lua
@@ -1,18 +1,14 @@
--- An unterminated fence hides the last `## <user>` header from queries/markdown/chat.scm,
--- so the typed prompt is dropped on submit. These cases pin the recovery.
 local h = require("tests.helpers")
 local new_set = MiniTest.new_set
 local child = MiniTest.new_child_neovim()
 
----An LLM response whose code fence is never closed, so the Markdown is invalid
-local UNTERMINATED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n"
----The same response with its fence closed, so the Markdown is valid
-local BALANCED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
+local RESPONSE_WITH_UNCLOSED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n"
+local RESPONSE_WITH_CLOSED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
 
 ---Add `response` as the LLM's answer, then type `lines` under a fresh user header
 ---@param response string
 ---@param lines string[]
-local function chat_with(response, lines)
+local function add_response(response, lines)
   child.lua(
     [[
     local response, typed = ...
@@ -28,46 +24,29 @@ local function chat_with(response, lines)
   )
 end
 
----What `Chat:submit()` would extract, plus the reported and actual header rows
----@return { content?: string, header?: number, expected_header?: number }
-local function extracted()
+---What `Chat:submit()` would extract as the user's message
+---@return { content?: string }
+local function get_extracted_message()
   return child.lua_get([[(function()
     local parser = require('codecompanion.interactions.chat.parser')
     local message = parser.messages(_G.chat, _G.chat.header_line)
-    local lines = vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, false)
-    local last_header
-    for i, line in ipairs(lines) do
-      if line:match('^## ') then
-        last_header = i - 1
-      end
-    end
-    return {
-      content = message and message.content,
-      header = parser.headers(_G.chat),
-      expected_header = last_header,
-    }
+    return { content = message and message.content }
   end)()]])
 end
 
----Record what the parser reports through `log:warn`
----
----That handler is registered at `vim.log.levels.WARN`, so a warning also reaches
----`vim.notify`. The offending fence is never rewritten and so stays broken for the
----rest of the conversation, which is why a given buffer must be reported once
----rather than on every submit.
----@return nil
-local function spy_on_warnings()
-  child.lua([[
-    _G.warnings = {}
-    local log = require('codecompanion.utils.log')
-    log.warn = function(_, msg)
-      table.insert(_G.warnings, msg)
+---The header row the parser reports, against the last one actually in the buffer
+---@return { reported?: number, actual?: number }
+local function get_header_rows()
+  return child.lua_get([[(function()
+    local parser = require('codecompanion.interactions.chat.parser')
+    local actual
+    for i, line in ipairs(vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, false)) do
+      if line:match('^## ') then
+        actual = i - 1
+      end
     end
-  ]])
-end
-
-local function warning_count()
-  return child.lua_get("#_G.warnings")
+    return { reported = parser.headers(_G.chat), actual = actual }
+  end)()]])
 end
 
 local T = new_set({
@@ -88,60 +67,40 @@ local T = new_set({
 
 T["Parser"] = new_set()
 
-T["Parser"]["a balanced response leaves the prompt extractable"] = function()
-  chat_with(BALANCED_FENCE, { "please fix the bug" })
-  h.eq("please fix the bug", extracted().content)
+T["Parser"]["Can extract a prompt after a closed code fence"] = function()
+  add_response(RESPONSE_WITH_CLOSED_FENCE, { "please fix the bug" })
+  h.eq("please fix the bug", get_extracted_message().content)
 end
 
-T["Parser"]["an unterminated fence does not eat the next prompt"] = function()
-  chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
-  h.eq("please fix the bug", extracted().content)
+T["Parser"]["Can extract a prompt after an unclosed code fence"] = function()
+  add_response(RESPONSE_WITH_UNCLOSED_FENCE, { "please fix the bug" })
+  h.eq("please fix the bug", get_extracted_message().content)
 end
 
-T["Parser"]["an unterminated fence does not hide the last user header"] = function()
-  chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
-  local result = extracted()
-  h.eq(result.expected_header, result.header)
+T["Parser"]["Finds the last user header behind an unclosed code fence"] = function()
+  add_response(RESPONSE_WITH_UNCLOSED_FENCE, { "please fix the bug" })
+  local rows = get_header_rows()
+  h.eq(rows.actual, rows.reported)
 end
 
-T["Parser"]["context lines are stripped from the recovered prompt"] = function()
-  chat_with(UNTERMINATED_FENCE, { "> Context:", "> - <file>foo.lua</file>", "", "please fix the bug" })
-  h.eq("please fix the bug", extracted().content)
+T["Parser"]["Strips context from a recovered prompt"] = function()
+  add_response(RESPONSE_WITH_UNCLOSED_FENCE, { "> Context:", "> - <file>foo.lua</file>", "", "please fix the bug" })
+  h.eq("please fix the bug", get_extracted_message().content)
 end
 
-T["Parser"]["a multi-line prompt is recovered whole"] = function()
-  chat_with(UNTERMINATED_FENCE, { "first line", "", "second line" })
-  h.eq("first line\n\nsecond line", extracted().content)
+T["Parser"]["Recovers a multi-line prompt in full"] = function()
+  add_response(RESPONSE_WITH_UNCLOSED_FENCE, { "first line", "", "second line" })
+  h.eq("first line\n\nsecond line", get_extracted_message().content)
 end
 
-T["Parser"]["an empty user section still yields no message"] = function()
-  -- Tool auto-submits rely on this: recovery must not fabricate a prompt.
-  chat_with(BALANCED_FENCE, {})
-  h.eq(nil, extracted().content)
+T["Parser"]["Returns no message for an empty user section"] = function()
+  add_response(RESPONSE_WITH_CLOSED_FENCE, {})
+  h.eq(nil, get_extracted_message().content)
 end
 
-T["Parser"]["an empty user section under a broken fence yields no message"] = function()
-  chat_with(UNTERMINATED_FENCE, {})
-  h.eq(nil, extracted().content)
-end
-
-T["Parser"]["recovery is reported once, not on every parse"] = function()
-  chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
-  spy_on_warnings()
-
-  h.eq("please fix the bug", extracted().content)
-  h.eq("please fix the bug", extracted().content)
-
-  h.eq(1, warning_count())
-  h.expect_contains("unterminated code fence", child.lua_get("_G.warnings[1]"))
-end
-
-T["Parser"]["a healthy buffer is parsed without warning"] = function()
-  chat_with(BALANCED_FENCE, { "please fix the bug" })
-  spy_on_warnings()
-
-  h.eq("please fix the bug", extracted().content)
-  h.eq(0, warning_count())
+T["Parser"]["Returns no message for an empty user section under an unclosed fence"] = function()
+  add_response(RESPONSE_WITH_UNCLOSED_FENCE, {})
+  h.eq(nil, get_extracted_message().content)
 end
 
 return T

--- a/tests/interactions/chat/test_parser.lua
+++ b/tests/interactions/chat/test_parser.lua
@@ -33,19 +33,16 @@ local function get_extracted_message()
   end)()]])
 end
 
----The header row the parser reports, against the last one actually in the buffer
----@return { reported?: number, actual?: number }
-local function get_header_rows()
-  return child.lua_get([[(function()
-    local parser = require('codecompanion.interactions.chat.parser')
-    local actual
-    for i, line in ipairs(vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, false)) do
-      if line:match('^## ') then
-        actual = i - 1
-      end
-    end
-    return { reported = parser.headers(_G.chat), actual = actual }
-  end)()]])
+---The user header row `parser.headers` reports
+---@return number|nil
+local function get_reported_header_row()
+  return child.lua_get([[require('codecompanion.interactions.chat.parser').headers(_G.chat)]])
+end
+
+---The user header row `add_response` actually created
+---@return number
+local function get_actual_header_row()
+  return child.lua_get([[_G.chat.header_line - 1]])
 end
 
 local T = new_set({
@@ -78,8 +75,7 @@ end
 
 T["Parser"]["Finds the last user header behind an unclosed code fence"] = function()
   add_response(RESPONSE_WITH_UNCLOSED_FENCE, { "please fix the bug" })
-  local rows = get_header_rows()
-  h.eq(rows.actual, rows.reported)
+  h.eq(get_actual_header_row(), get_reported_header_row())
 end
 
 T["Parser"]["Strips context from a recovered prompt"] = function()
@@ -100,6 +96,45 @@ end
 T["Parser"]["Returns no message for an empty user section under an unclosed fence"] = function()
   add_response(RESPONSE_WITH_UNCLOSED_FENCE, {})
   h.eq(nil, get_extracted_message().content)
+end
+
+T["Parser"]["Does not mistake a heading inside a closed fence for a user header"] = function()
+  add_response(RESPONSE_WITH_CLOSED_FENCE, { "````markdown", "## foo", "````", "", "please fix the bug" })
+  h.eq(get_actual_header_row(), get_reported_header_row())
+end
+
+T["Parser"]["Does not mistake a heading inside the user's own unclosed fence for a user header"] = function()
+  add_response(RESPONSE_WITH_CLOSED_FENCE, { "````markdown", "## foo", "", "please fix the bug" })
+  h.eq(get_actual_header_row(), get_reported_header_row())
+end
+
+T["Parser"]["Returns no message when header_line points into the LLM response"] = function()
+  add_response(RESPONSE_WITH_CLOSED_FENCE, {})
+  child.lua([[
+    for i, line in ipairs(vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, false)) do
+      if line == 'Here you go:' then
+        _G.chat.header_line = i
+      end
+    end
+  ]])
+  h.eq(nil, get_extracted_message().content)
+end
+
+T["Parser"]["Can extract a prompt after an unclosed tilde fence"] = function()
+  add_response("Here you go:\n\n~~~lua\nlocal x = 1\n", { "please fix the bug" })
+  h.eq("please fix the bug", get_extracted_message().content)
+end
+
+T["Parser"]["Keeps a code block the user typed in the recovered prompt"] = function()
+  add_response(RESPONSE_WITH_UNCLOSED_FENCE, { "fix this:", "", "````lua", "local y = 2", "````" })
+  h.eq("fix this:\n\n````lua\nlocal y = 2\n````", get_extracted_message().content)
+end
+
+T["Parser"]["Ignores a user heading inside a closed fence when no user header follows"] = function()
+  child.lua([[
+    _G.chat:add_buf_message({ role = 'llm', content = "Here you go:\n\n````markdown\n## foo\n````\n" })
+  ]])
+  h.eq(0, get_reported_header_row())
 end
 
 return T

--- a/tests/interactions/chat/test_parser_resilience.lua
+++ b/tests/interactions/chat/test_parser_resilience.lua
@@ -60,6 +60,28 @@ local function extracted()
   end)()]])
 end
 
+---Record what the parser reports through `log:warn`
+---
+---That handler is registered at `vim.log.levels.WARN`, so a warning also reaches
+---`vim.notify`. The offending fence is never rewritten and so stays broken for the
+---rest of the conversation, which is why a given buffer must be reported once
+---rather than on every submit.
+---@return nil
+local function spy_on_warnings()
+  child.lua([[
+    _G.warnings = {}
+    local log = require('codecompanion.utils.log')
+    log.warn = function(_, msg)
+      table.insert(_G.warnings, msg)
+    end
+  ]])
+end
+
+---@return number
+local function warning_count()
+  return child.lua_get("#_G.warnings")
+end
+
 local T = new_set({
   hooks = {
     pre_case = function()
@@ -113,6 +135,25 @@ end
 T["Parser resilience"]["an empty user section under a broken fence yields no message"] = function()
   chat_with(UNTERMINATED, {})
   h.eq(nil, extracted().content)
+end
+
+T["Parser resilience"]["recovery is reported once, not on every parse"] = function()
+  chat_with(UNTERMINATED, { "please fix the bug" })
+  spy_on_warnings()
+
+  h.eq("please fix the bug", extracted().content)
+  h.eq("please fix the bug", extracted().content)
+
+  h.eq(1, warning_count())
+  h.expect_contains("unterminated code fence", child.lua_get("_G.warnings[1]"))
+end
+
+T["Parser resilience"]["a healthy buffer is parsed without warning"] = function()
+  chat_with(BALANCED, { "please fix the bug" })
+  spy_on_warnings()
+
+  h.eq("please fix the bug", extracted().content)
+  h.eq(0, warning_count())
 end
 
 return T

--- a/tests/interactions/chat/test_parser_resilience.lua
+++ b/tests/interactions/chat/test_parser_resilience.lua
@@ -1,0 +1,118 @@
+-- A malformed code fence in the chat buffer must not cost the user their prompt.
+--
+-- `queries/markdown/chat.scm` locates the user's typed message by walking
+-- Markdown sections. An unterminated fenced code block swallows the following
+-- `## <user>` heading, so `parser.messages()` finds no user section and returns
+-- nil -- and because `helpers.has_user_messages()` is true mid-conversation,
+-- `Chat:submit()` then sends the conversation *without* the typed text, silently.
+--
+-- No tool is involved in any case below: an LLM response truncated mid-code-block
+-- (`max_tokens`) is enough to reach this, which is why it stands on its own.
+--
+-- Run with `make test_file FILE=tests/interactions/chat/test_parser_resilience.lua`.
+local h = require("tests.helpers")
+local new_set = MiniTest.new_set
+local child = MiniTest.new_child_neovim()
+
+local UNTERMINATED = "Here you go:\n\n````lua\nlocal x = 1\n"
+local BALANCED = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
+
+---Build a chat whose last LLM response is `response`, open a user section, and
+---type `lines` into it exactly as a user would.
+---@param response string The LLM's answer, balanced or not
+---@param lines string[] The lines the user types under their header
+---@return nil
+local function chat_with(response, lines)
+  child.lua(
+    [[
+    local response, typed = ...
+    _G.chat:add_buf_message({ role = 'llm', content = response })
+    _G.chat:add_buf_message({ role = 'user', content = '' })
+    -- What `Chat:ready_for_input()` computes for the new user section.
+    _G.chat.header_line = (_G.chat.builder.state.current_header_line or 0) + 1
+    if #typed > 0 then
+      vim.api.nvim_buf_set_lines(_G.chat.bufnr, -1, -1, false, typed)
+    end
+  ]],
+    { response, lines }
+  )
+end
+
+---What `Chat:submit()` would extract as the user's message, plus the header row
+---`parser.headers()` reports and the row the buffer actually holds it on.
+---@return { content?: string, header?: number, expected_header?: number }
+local function extracted()
+  return child.lua_get([[(function()
+    local parser = require('codecompanion.interactions.chat.parser')
+    local message = parser.messages(_G.chat, _G.chat.header_line)
+    local lines = vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, false)
+    local last_header
+    for i, line in ipairs(lines) do
+      if line:match('^## ') then
+        last_header = i - 1
+      end
+    end
+    return {
+      content = message and message.content,
+      header = parser.headers(_G.chat),
+      expected_header = last_header,
+    }
+  end)()]])
+end
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        h = require('tests.helpers')
+        _G.chat = h.setup_chat_buffer()
+      ]])
+    end,
+    post_case = function()
+      child.lua([[h.teardown_chat_buffer()]])
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["Parser resilience"] = new_set()
+
+T["Parser resilience"]["a balanced response leaves the prompt extractable"] = function()
+  chat_with(BALANCED, { "please fix the bug" })
+  h.eq("please fix the bug", extracted().content)
+end
+
+T["Parser resilience"]["an unterminated fence does not eat the next prompt"] = function()
+  chat_with(UNTERMINATED, { "please fix the bug" })
+  h.eq("please fix the bug", extracted().content)
+end
+
+T["Parser resilience"]["an unterminated fence does not hide the last user header"] = function()
+  chat_with(UNTERMINATED, { "please fix the bug" })
+  local result = extracted()
+  h.eq(result.expected_header, result.header)
+end
+
+T["Parser resilience"]["context lines are stripped from the recovered prompt"] = function()
+  chat_with(UNTERMINATED, { "> Context:", "> - <file>foo.lua</file>", "", "please fix the bug" })
+  h.eq("please fix the bug", extracted().content)
+end
+
+T["Parser resilience"]["a multi-line prompt is recovered whole"] = function()
+  chat_with(UNTERMINATED, { "first line", "", "second line" })
+  h.eq("first line\n\nsecond line", extracted().content)
+end
+
+T["Parser resilience"]["an empty user section still yields no message"] = function()
+  -- Tool auto-submits rely on this: recovery must not fabricate a prompt.
+  chat_with(BALANCED, {})
+  h.eq(nil, extracted().content)
+end
+
+T["Parser resilience"]["an empty user section under a broken fence yields no message"] = function()
+  chat_with(UNTERMINATED, {})
+  h.eq(nil, extracted().content)
+end
+
+return T

--- a/tests/interactions/chat/test_parser_resilience.lua
+++ b/tests/interactions/chat/test_parser_resilience.lua
@@ -1,15 +1,5 @@
--- A malformed code fence in the chat buffer must not cost the user their prompt.
---
--- `queries/markdown/chat.scm` locates the user's typed message by walking
--- Markdown sections. An unterminated fenced code block swallows the following
--- `## <user>` heading, so `parser.messages()` finds no user section and returns
--- nil -- and because `helpers.has_user_messages()` is true mid-conversation,
--- `Chat:submit()` then sends the conversation *without* the typed text, silently.
---
--- No tool is involved in any case below: an LLM response truncated mid-code-block
--- (`max_tokens`) is enough to reach this, which is why it stands on its own.
---
--- Run with `make test_file FILE=tests/interactions/chat/test_parser_resilience.lua`.
+-- An unterminated fence hides the last `## <user>` header from queries/markdown/chat.scm,
+-- so the typed prompt is dropped on submit. These cases pin the recovery.
 local h = require("tests.helpers")
 local new_set = MiniTest.new_set
 local child = MiniTest.new_child_neovim()
@@ -17,18 +7,16 @@ local child = MiniTest.new_child_neovim()
 local UNTERMINATED = "Here you go:\n\n````lua\nlocal x = 1\n"
 local BALANCED = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
 
----Build a chat whose last LLM response is `response`, open a user section, and
----type `lines` into it exactly as a user would.
----@param response string The LLM's answer, balanced or not
----@param lines string[] The lines the user types under their header
----@return nil
+---Add `response` as the LLM's answer, then type `lines` under a fresh user header
+---@param response string
+---@param lines string[]
 local function chat_with(response, lines)
   child.lua(
     [[
     local response, typed = ...
     _G.chat:add_buf_message({ role = 'llm', content = response })
     _G.chat:add_buf_message({ role = 'user', content = '' })
-    -- What `Chat:ready_for_input()` computes for the new user section.
+    -- Mirrors Chat:ready_for_input()
     _G.chat.header_line = (_G.chat.builder.state.current_header_line or 0) + 1
     if #typed > 0 then
       vim.api.nvim_buf_set_lines(_G.chat.bufnr, -1, -1, false, typed)
@@ -38,8 +26,7 @@ local function chat_with(response, lines)
   )
 end
 
----What `Chat:submit()` would extract as the user's message, plus the header row
----`parser.headers()` reports and the row the buffer actually holds it on.
+---What `Chat:submit()` would extract, plus the reported and actual header rows
 ---@return { content?: string, header?: number, expected_header?: number }
 local function extracted()
   return child.lua_get([[(function()
@@ -77,7 +64,6 @@ local function spy_on_warnings()
   ]])
 end
 
----@return number
 local function warning_count()
   return child.lua_get("#_G.warnings")
 end

--- a/tests/interactions/chat/test_parser_resilience.lua
+++ b/tests/interactions/chat/test_parser_resilience.lua
@@ -4,8 +4,10 @@ local h = require("tests.helpers")
 local new_set = MiniTest.new_set
 local child = MiniTest.new_child_neovim()
 
-local UNTERMINATED = "Here you go:\n\n````lua\nlocal x = 1\n"
-local BALANCED = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
+---An LLM response whose code fence is never closed, so the Markdown is invalid
+local UNTERMINATED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n"
+---The same response with its fence closed, so the Markdown is valid
+local BALANCED_FENCE = "Here you go:\n\n````lua\nlocal x = 1\n````\n"
 
 ---Add `response` as the LLM's answer, then type `lines` under a fresh user header
 ---@param response string
@@ -87,44 +89,44 @@ local T = new_set({
 T["Parser resilience"] = new_set()
 
 T["Parser resilience"]["a balanced response leaves the prompt extractable"] = function()
-  chat_with(BALANCED, { "please fix the bug" })
+  chat_with(BALANCED_FENCE, { "please fix the bug" })
   h.eq("please fix the bug", extracted().content)
 end
 
 T["Parser resilience"]["an unterminated fence does not eat the next prompt"] = function()
-  chat_with(UNTERMINATED, { "please fix the bug" })
+  chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
   h.eq("please fix the bug", extracted().content)
 end
 
 T["Parser resilience"]["an unterminated fence does not hide the last user header"] = function()
-  chat_with(UNTERMINATED, { "please fix the bug" })
+  chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
   local result = extracted()
   h.eq(result.expected_header, result.header)
 end
 
 T["Parser resilience"]["context lines are stripped from the recovered prompt"] = function()
-  chat_with(UNTERMINATED, { "> Context:", "> - <file>foo.lua</file>", "", "please fix the bug" })
+  chat_with(UNTERMINATED_FENCE, { "> Context:", "> - <file>foo.lua</file>", "", "please fix the bug" })
   h.eq("please fix the bug", extracted().content)
 end
 
 T["Parser resilience"]["a multi-line prompt is recovered whole"] = function()
-  chat_with(UNTERMINATED, { "first line", "", "second line" })
+  chat_with(UNTERMINATED_FENCE, { "first line", "", "second line" })
   h.eq("first line\n\nsecond line", extracted().content)
 end
 
 T["Parser resilience"]["an empty user section still yields no message"] = function()
   -- Tool auto-submits rely on this: recovery must not fabricate a prompt.
-  chat_with(BALANCED, {})
+  chat_with(BALANCED_FENCE, {})
   h.eq(nil, extracted().content)
 end
 
 T["Parser resilience"]["an empty user section under a broken fence yields no message"] = function()
-  chat_with(UNTERMINATED, {})
+  chat_with(UNTERMINATED_FENCE, {})
   h.eq(nil, extracted().content)
 end
 
 T["Parser resilience"]["recovery is reported once, not on every parse"] = function()
-  chat_with(UNTERMINATED, { "please fix the bug" })
+  chat_with(UNTERMINATED_FENCE, { "please fix the bug" })
   spy_on_warnings()
 
   h.eq("please fix the bug", extracted().content)
@@ -135,7 +137,7 @@ T["Parser resilience"]["recovery is reported once, not on every parse"] = functi
 end
 
 T["Parser resilience"]["a healthy buffer is parsed without warning"] = function()
-  chat_with(BALANCED, { "please fix the bug" })
+  chat_with(BALANCED_FENCE, { "please fix the bug" })
   spy_on_warnings()
 
   h.eq("please fix the bug", extracted().content)


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->
## Description

`queries/markdown/chat.scm` locates the user's message by walking Markdown sections.
An unbalanced code fence anywhere above the last `## <user>` header makes the Markdown parser swallow that header, so the query matches no user section and `parser.messages()` returns `nil`.
Because `helpers.has_user_messages()` is true mid-conversation, `Chat:submit()` does **not** warn "No messages to submit" — it sends the conversation *without the text the user just typed*, silently.

No tool is needed to reach this.
Any response truncated mid-code-block by `max_tokens` leaves an unbalanced fence, and from then on every prompt typed into that chat is discarded on submit:

``````text
## CodeCompanion

Here you go:

````lua
local x = 1          <- the response stopped here; the fence never closed

## Me                <- swallowed by the open block, so the query never sees it

please fix the bug   <- typed, then silently dropped on submit
``````

`parser.headers()` fails on the same buffer, and worse: it does not return `nil`, it returns the last header it can still *see*, which is an **earlier** one.
That value seeds `chat.header_line` for restored chats, so every later parse starts from the wrong row, `parser.messages()` finds a *previous* message and returns it, and the user's new prompt is replaced by an old one rather than merely dropped.
Measured on a buffer whose real last header is row 9: `parser.headers()` returns row 0.

One correction to the record, since it shaped how this was approached.
The ranged parse does not protect against this: `parser.messages` calls `parse({ header_line - 1, -1 })`, but the top-level Markdown `LanguageTree` still parses the whole buffer, so a fence broken *above* the range still swallows the header.
Measured both ways — `parse({ 0, -1 })` and `parse({ header_line - 1, -1 })` extract the user message as `""` on the same buffer.

**The fix is strictly additive. Tree-sitter remains the only primary path, and neither `M.messages` nor `M.headers` loses its existing query.**

- `M.messages` gains a fallback that runs *only* when the query yields nothing: it reads raw lines below `chat.header_line`, reuses `helpers.strip_context()`, and returns the trimmed join. The healthy path is reached by an earlier `return` and executes unchanged code, so it cannot be affected. A genuinely empty section still returns `nil`, which tool auto-submits depend on.
- `M.headers` gains a raw scan that considers candidates **only below** the row Tree-sitter reported — so a header the query did find is never traded for an earlier one — and accepts a candidate only when it is provably inside a `fenced_code_block` carrying fewer than two `fenced_code_block_delimiter` children, i.e. a fence that was never closed. A `## <user>` heading inside a *closed* block (someone pasting a transcript) therefore goes on being treated as code.

`chat.header_line` is what makes the fallback trustworthy rather than a guess: it comes from the builder's own bookkeeping, so the recovery never re-derives a position from a tree already known to be wrong, and it does not re-parse.

The recovery is reported through `log:warn` **once per buffer**, with the per-parse detail at `log:debug`.
Once per parse would be noise: that handler is registered at `vim.log.levels.WARN` and so reaches `vim.notify`, and since a malformed transcript is never rewritten, the fallback fires on every submit for the rest of the conversation.

Deliberately **not** included: any repair of the buffer. A corrupted transcript stays as it is — it is a record of what was actually said — and no closing delimiter is injected. This change only stops it costing the user their prompt.

Nine cases in `tests/interactions/chat/test_parser_resilience.lua`, of which four fail on current `main`. They cover the recovery, multi-line prompts, context stripping, both empty-section guards (balanced and broken), that a healthy buffer is byte-for-byte unaffected, and that the warning fires exactly once and not at all on a healthy buffer.

## Supporting Documentation

- [tree-sitter-markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown) is what the chat buffer is parsed with; an unterminated `fenced_code_block` extends to the end of the document and carries a single `fenced_code_block_delimiter` child, which is the signal used to tell "never closed" from "closed on purpose".
- CommonMark, [fenced code blocks](https://spec.commonmark.org/0.31.2/#fenced-code-blocks): a block runs "until a closing code fence … or the end of the containing block", which is why one missing fence changes the meaning of everything below it.

## AI Usage

This PR was written with CodeCompanion itself, using **Claude Opus 5 (xhigh)**.
I hit the bug in my own session, diagnosed it, and chose the approach — additive fallbacks only, Tree-sitter left as the primary path, and the "provably unclosed fence" guard in `M.headers` rather than a plain raw scan, which would have preferred a heading inside a closed code block over the real header.
The assistant produced the implementation and the tests from that, and I reviewed every hunk.

## Related Issue(s)

- Fixes #913

I realise #913 was closed as `NOT_PLANNED` and that #1385 was declined for replacing the Tree-sitter extraction, so this is deliberately a different shape: nothing is removed or replaced, the query stays the sole primary path in both functions, and the new code is unreachable unless the query has already come up empty (or, in `M.headers`, unless an unclosed fence is demonstrably hiding a later header). Nothing here constrains the ranged-parse work in #552 — the fallback consumes the tree that `M.headers` already parsed and adds no parse of its own. If you would still rather not carry it, I would be glad to know which part is the objection, because four people have now reported the symptom.

This is **independent of #3354** and the two can merge in either order — verified, not assumed: this branch is based on `main` (`6eec6b42`), does not contain #3354's commits, shares no files with it, and the two merge cleanly with each other. #3354 removes the most common *cause* of an unbalanced fence (fixed-length wrappers around tool output); this PR makes the *consequence* harmless whatever the cause, including the ones with no tool involved.

## Screenshots

N/A

## Checklist
- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [x] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
