### PR TITLE
chore: add style guide

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,158 @@
+{
+  "rules": [
+    {
+      "id": "comment-restates-code",
+      "rule": "Flag any comment that restates what the line below it already says, or that explains a self-evident guard, early return, loop, or assignment. Comments must record a non-obvious 'why' (an API quirk, an indexing convention, an ordering constraint, a deliberate limitation). Examples to flag: '-- Clear the modified flag', '-- Loop over the messages', '-- Return early if there is no buffer'.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "comment-density",
+      "rule": "Comment density must match the surrounding codebase, which averages fewer than one inline comment per 50 lines of Lua. Flag any new or modified Lua function that introduces more than roughly one inline comment per 20 lines of added code, and say which comments should be deleted.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "multi-line-rationale",
+      "rule": "A LuaCATS doc block description must be exactly one line. Flag any doc block whose description runs to two or more lines, or that contains rationale, usage examples, or background - that belongs in the commit message or PR description. Flag block comments used as file headers or section dividers in new files.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "empty-annotations",
+      "rule": "Flag LuaCATS annotations that carry no information: a '---@return nil' on a function that returns nothing, a description line that only restates the function name, and inline explanations appended to '---@param' lines (rename the param instead).",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "commented-out-code",
+      "rule": "Flag any commented-out code left in the diff. It must be deleted.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "naming-case",
+      "rule": "Naming conventions: snake_case for files, functions, locals and table keys; PascalCase for classes and LuaCATS type names; a leading underscore for private functions; SCREAMING_SNAKE_CASE only for module-level constants, never for a local declared inside a function.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "explicit-names",
+      "rule": "Names must be explicit and domain-specific. Flag abbreviations ('pat' for 'pattern', 'res', 'tmp', 'obj') and generic placeholder names ('ctx', 'data', 'val', 'item', 'after') where a domain word applies ('permission', 'request', 'source', 'adapter', 'chat', 'from_row'). Suggest the concrete replacement.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "function-names-are-verbs",
+      "rule": "Function names must start with a verb ('get_message', 'add_response', 'recover_headers'). Flag function names that are bare nouns, past participles ('extracted'), or prepositional phrases ('chat_with'). Boolean-returning helpers read as a question or state: has_*, is_*, should_*, can_*. Flag clever or poetic predicate names in favour of literal ones.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "function-length",
+      "rule": "Functions must not exceed 50 lines.",
+      "scope": [
+        "**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "table-argument",
+      "rule": "Functions take an `opts` table rather than a list of positional parameters. The shape used throughout the codebase is one positional argument for the subject the function acts on and an `opts` table for everything else (Chat:add_message(data, opts), Client:send(payload, opts)); where there is no natural subject, `opts` is the only parameter. Flag any new or modified function declaring more than two positional parameters, or declaring two where neither is the subject, and suggest the `opts` signature. An optional table is normalised on the first line with `opts = opts or {}`, or `vim.tbl_extend(\"force\", opts or {}, { ... })` when defaults are layered over it - flag an `opts` parameter that is read without being normalised. The shape is annotated inline on the @param, for example `---@param opts? { auto_submit?: boolean }`.",
+      "scope": [
+        "lua/**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "no-globals",
+      "rule": "No module-level globals in plugin source. Use module-local state. (_G is expected inside tests running in a child Neovim process.)",
+      "scope": [
+        "lua/**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "error-handling",
+      "rule": "Fallible calls are wrapped in pcall, logged with log:error(), and return nil on failure.",
+      "scope": [
+        "lua/**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "no-defensive-padding",
+      "rule": "Flag defensive code for conditions that cannot occur: validating a parameter every caller in the repo already supplies, nil-guarding a value the type annotation says is required, or adding a fallback path with no test that reaches it. This is a common LLM-generated pattern and it hides the real contract.",
+      "scope": [
+        "lua/**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "file-path-helpers",
+      "rule": "Filesystem work must use the helpers in lua/codecompanion/utils/files.lua, and paths must be joined with vim.fs.joinpath - never string concatenation or a hardcoded '/' or '\\' separator.",
+      "scope": [
+        "lua/**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "test-file-location",
+      "rule": "Test files mirror the source tree and are named test_<module>.lua: lua/codecompanion/interactions/chat/parser.lua is tested by tests/interactions/chat/test_parser.lua. Flag a new test file that adds a descriptive suffix for a subset of a module's behaviour (for example test_parser_resilience.lua) - those cases belong in the module's existing test file.",
+      "scope": [
+        "tests/**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "test-naming",
+      "rule": "Test case names follow T[\"<Subject>\"][\"<what it does>\"], where Subject is the capitalised module or feature (\"Chat\", \"Context\", \"Keymaps\", \"Parser\") and the case name is a short behavioural phrase completing 'it ...' - for example \"can load default tools\", \"system prompt is added first\", \"Cannot be added twice with the same id\". Flag narrative or prose-style case names such as \"an unterminated fence does not eat the next prompt\" and suggest a name matching the existing suite.",
+      "scope": [
+        "tests/**/*.lua"
+      ],
+      "severity": "high"
+    },
+    {
+      "id": "test-substance",
+      "rule": "Flag tests that assert nothing meaningful: a schema compared against a mirror of itself, a shared utility's error simply passed through, or a case whose assertions pass whether or not the change under review is applied. Comprehensive-looking tests that never exercise the edge case are worse than none.",
+      "scope": [
+        "tests/**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "no-ui-position-tests",
+      "rule": "Do not add tests for chat buffer cursor position, scrolling, or folds. These are verified by hand.",
+      "scope": [
+        "tests/**/*.lua"
+      ],
+      "severity": "medium"
+    },
+    {
+      "id": "scope-creep",
+      "rule": "Flag changes outside the stated scope of the PR: unrelated reformatting, renames, or 'tidying' of code the change does not otherwise touch, and new files where the code could live in an existing one. Flag new documentation files that the PR description does not call for.",
+      "severity": "medium"
+    },
+    {
+      "id": "plain-language",
+      "rule": "Plain English in code, comments and commit messages. Flag jargon shortcuts such as 'no-op' in favour of saying what happens ('returns unchanged', 'does nothing', 'skipped because it was already handled'). Flag em dashes; use a plain dash.",
+      "severity": "low"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,21 @@
+{
+  "files": [
+    {
+      "path": "STYLE.md",
+      "description": "The style contract for this repository: comments, naming, functions, type annotations, tests, scope. Cite the relevant section when raising a style comment."
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "description": "What is accepted here and why, including the project's stance on AI-assisted contributions and the red flags to look for."
+    },
+    {
+      "path": "AGENTS.md",
+      "description": "Repository conventions and architecture map, also loaded by coding agents working in this repo."
+    },
+    {
+      "path": ".codecompanion/tests/mini_test_testing.md",
+      "description": "How Mini.Test is used here, with the child Neovim process setup",
+      "scope": ["tests/**"]
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,23 +4,27 @@ This is a Neovim plugin written in Lua, which allows developers to code with LLM
 
 ## Commands
 
-- `make format` — StyLua (120 cols, 2 spaces). Run before committing.
-- `make test` — full test suite (Mini.Test)
-- `make test_file FILE=path` — targeted tests
-- `make docs` — regenerate vimdoc. Run this after changing any docs pages
+- `make format` - StyLua (120 cols, 2 spaces). Run before committing.
+- `make test` - full test suite (Mini.Test)
+- `make test_file FILE=path` - targeted tests
+- `make docs` - regenerate vimdoc. Run this after changing any docs pages
 
 ## Code conventions
 
+The full style guide, with worked examples:
+
+@STYLE.md
+
 - **Naming:** snake_case for files/functions, PascalCase for classes, underscore prefix for private functions
 - **Explicit names:** `pattern` not `pat`, `should_include` not `include_ok`
-- **Readable code:** names, variables, and control flow should read like clean English. Avoid generic names like `ctx` — use domain-specific names (`permission`, `request`, `source`)
-- **Plain language:** avoid jargon shortcuts in code, comments, commit messages, and chat. Don't say "no-op" — say what the code actually does ("returns unchanged", "does nothing", "skipped because already edited")
+- **Readable code:** names, variables, and control flow should read like clean English. Avoid generic names like `ctx` - use domain-specific names (`permission`, `request`, `source`)
+- **Plain language:** avoid jargon shortcuts in code, comments, commit messages, and chat. Don't say "no-op" - say what the code actually does ("returns unchanged", "does nothing", "skipped because already edited")
 - **Comments earn their place:** don't restate what a readable line of code already says. If a guard like `if type(x) ~= "number" then return end` is self-evident, a comment explaining it is noise. Comment the *why* that isn't in the code (e.g. `-- NOTE: Not handling token tables yet`), not the *what*
-- **Don't narrate every change:** the maintainer is an expert who knows this codebase. Do NOT add a comment to explain routine code (`-- Clear the modified flag`, `-- Loop over the messages`, `-- Return early`). Default to no comment. Reserve comments for genuinely non-obvious *why* — a subtle API quirk, a workaround, an ordering constraint — the kind of thing that would trip up even a reader who knows the codebase
-- **Function params:** prefer a single table argument over positional args
+- **Don't narrate every change:** the maintainer is an expert who knows this codebase. Do NOT add a comment to explain routine code (`-- Clear the modified flag`, `-- Loop over the messages`, `-- Return early`). Default to no comment. Reserve comments for genuinely non-obvious *why* - a subtle API quirk, a workaround, an ordering constraint - the kind of thing that would trip up even a reader who knows the codebase
+- **Function params:** take an `opts` table, not a list of positional args - a new parameter then costs one edit instead of every call site. One positional for the subject the function acts on, `opts` for everything else (`Chat:add_message(data, opts)`); `opts` alone where there's no subject. Normalise it on the first line with `opts = opts or {}` and annotate the shape inline: `---@param opts? { auto_submit?: boolean }`
 - **Error handling:** `pcall` + `log:error()`, return nil on failure
-- **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise — one description line, params should be self-explanatory without inline comments
-- **Function descriptions:** exactly one line. No multi-paragraph rationale, no usage examples, no "why we cache this" essays — that belongs in commit messages or a single inline `--` comment at the relevant line. If you can't summarise the function in one line, the function is doing too much
+- **Type annotations:** LuaCATS for public APIs. Keep doc blocks concise - one description line, params should be self-explanatory without inline comments
+- **Function descriptions:** exactly one line. No multi-paragraph rationale, no usage examples, no "why we cache this" essays - that belongs in commit messages or a single inline `--` comment at the relevant line. If you can't summarise the function in one line, the function is doing too much
 - **Functions:** keep under 50 lines
 - **Globals:** avoid; use module-local state
 - **Code blocks:** use four backticks with language spec unless in a markdown file
@@ -34,13 +38,13 @@ Core: `lua/codecompanion/`
 - **Tools** (`interactions/chat/tools/builtin/`): `ask_questions`, `run_command`, `read_file`, `create_file`, `delete_file`, `insert_edit_into_file/`, `grep_search`, `file_search`, `web_search`, `fetch_webpage`, `memory`, `get_changed_files`, `get_diagnostics`, `cmd_tool` (factory for custom command tools)
 - **Slash Commands** (`interactions/chat/slash_commands/builtin/`): `/buffer`, `/command`, `/compact`, `/fetch`, `/file`, `/help`, `/image`, `/mcp`, `/mode`, `/now`, `/rules`, `/symbols`
 - **Editor Context** (`interactions/chat/editor_context/`): `buffer`, `buffers`, `diagnostics`, `diff`, `messages`, `quickfix`, `selection`, `terminal`, `viewport`
-- **Config:** `config.lua` — tool groups (`agent`, `files`), adapter defaults, all settings
+- **Config:** `config.lua` - tool groups (`agent`, `files`), adapter defaults, all settings
 - **Entry point:** `plugin/codecompanion.lua` → `lua/codecompanion/init.lua`
 
 ## General rules
 
 - Don't over-explore the codebase with excessive grep/read calls. If you haven't converged on an approach after 3-4 searches, pause and share what you've found so far rather than continuing to search.
-- When the user asks to fix tests, fix the tests — not the source code — unless explicitly asked otherwise.
+- When the user asks to fix tests, fix the tests - not the source code - unless explicitly asked otherwise.
 - If you're working with directories or files, utilise the functions in `codecompanion/utils/files.lua` ensuring you join paths with `vim.fs.joinpath`
 
 ### Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,8 @@ It can also be useful to share an example [test file](https://github.com/olimorr
 
 ## Code Style and Conventions
 
+**Read the [style guide](STYLE.md) before opening a PR.** It's the contract for comments, naming, type annotations and test conventions in this repository, and it's what the automated reviewer checks against.
+
 - Use [stylua](https://github.com/JohnnyMorganz/StyLua) for formatting Lua code
 - Configuration is in `stylua.toml`
 - Run `make format` to format the code before submitting a PR

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,196 @@
+# CodeCompanion Style Guide
+
+This is the style contract for code in this repository. It applies to every PR, whether written by a human, an LLM, or both.
+
+It exists because the most common reason a PR needs rework is not that the logic is wrong - it's that the code doesn't read like the rest of the codebase. Verbose comments, invented naming schemes, and test names that don't match the existing suite all cost review time and make the plugin harder to maintain long-term.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) first for what to contribute. This file covers how to write it.
+
+## 1. Formatting
+
+- Formatting is StyLua's job, not yours. Run `make format` before committing
+- 120 column width, 2 space indent, double quotes, Unix line endings (`stylua.toml`)
+- `make test` must pass. `make docs` must be run if you touched anything in `doc/`
+
+## 2. Comments
+
+**The rule: comment the *why*, never the *what*. Default to no comment.**
+
+Read the code around you before you write one. `lua/codecompanion/interactions/chat/parser.lua` is 216 lines and carries 4 inline comments. `lua/codecompanion/utils/files.lua` is 546 lines and carries 9. That is the density to aim for.
+
+Names and control flow carry the narrative. A comment earns its place only when an experienced reader would be confused without it.
+
+**Delete a comment that restates the code:**
+
+```lua
+-- ❌ The name already says this
+-- Clear the modified flag
+self.modified = false
+
+-- ❌ Explains what any Lua reader can see
+-- Loop over the messages
+for _, message in ipairs(messages) do
+```
+
+**Delete a comment that explains a self-evident guard:**
+
+```lua
+-- ❌
+-- Return early if there's no buffer
+if not bufnr then
+  return
+end
+```
+
+**Keep a comment that records a constraint the code cannot show:**
+
+```lua
+-- ✅ A Tree-sitter indexing quirk the reader would otherwise trip on
+-- Account for the two YAML lines and the fact Tree-sitter is 0-indexed
+end_line = vim.tbl_count(adapter.schema) + 2 - 1
+
+-- ✅ Records a deliberate limitation
+-- NOTE: Not handling token tables yet
+```
+
+**Single line, always.** If your reasoning needs a paragraph, it belongs in the commit message, the PR description, or an issue. Not in the source.
+
+```lua
+-- ❌ Five lines of rationale above a test helper
+---Record what the parser reports through `log:warn`
+---
+---That handler is registered at `vim.log.levels.WARN`, so a warning also reaches
+---`vim.notify`. The offending fence is never rewritten and so stays broken for the
+---rest of the conversation, which is why a given buffer must be reported once
+---rather than on every submit.
+local function spy_on_warnings()
+
+-- ✅
+---Capture the warnings the parser emits
+local function capture_warnings()
+```
+
+**Don't add banner or section-divider comments** to new files, and don't add a prose header block explaining the bug a file was written for. The tests themselves are the record.
+
+**Commented-out code does not get merged.** Delete it.
+
+## 3. Naming
+
+- `snake_case` for files, functions, locals, and table keys
+- `PascalCase` for classes and LuaCATS type names
+- `SCREAMING_SNAKE_CASE` only for module-level constant tables and values, never for a local inside a function
+- `_leading_underscore` for private functions
+
+**Names must be explicit and domain-specific.** Write `pattern` not `pat`, `should_include` not `include_ok`. Avoid generic placeholder names like `ctx`, `data`, `obj`, `tmp`, `res` - reach for the domain word instead: `permission`, `request`, `source`, `adapter`, `chat`.
+
+```lua
+-- ❌ Vague - after what? measured how?
+local function recover_headers(chat, root, after)
+
+-- ✅ Says what the number is
+local function recover_headers(chat, root, from_row)
+```
+
+**Functions are named with a verb.** A past participle or a bare noun reads as a value, not a call.
+
+```lua
+-- ❌ Reads like a variable
+local function extracted()
+local function chat_with(response, lines)
+
+-- ✅
+local function get_extracted_message()
+local function add_response(response, lines)
+```
+
+**Boolean-returning helpers read as a question or a state:** `has_user_messages`, `is_visible`, `should_include`. Don't invent poetic predicates - `hidden_by_open_fence` is cleverer than it is clear; `is_inside_unclosed_fence` is not.
+
+## 4. Functions and type annotations
+
+- **Keep functions under 50 lines.** If it's longer, it's doing too much
+- **No module-level globals.** Use module-local state
+
+### Take an `opts` table, not a list of positional arguments
+
+Positional parameters don't scale. Adding one means touching the signature, every call site, and every annotation. An `opts` table absorbs the new parameter in a single place, and call sites that don't care about it stay as they are.
+
+The shape used throughout the codebase is one positional argument for the subject the function acts on, and an `opts` table for everything else - `Chat:add_message(data, opts)`, `Client:send(payload, opts)`, `M.get_settings_key(chat, opts)`. Where there is no natural subject, `opts` is the only parameter.
+
+```lua
+-- ❌ Three positionals, and a fourth means editing every caller
+function add_header(name, start_from, contents)
+
+-- ✅
+---@param opts? { name?: string, start_from?: number, contents?: string[] }
+function add_header(opts)
+  opts = opts or {}
+```
+
+Normalise an optional table on the first line with `opts = opts or {}`, or with `vim.tbl_extend("force", opts or {}, { ... })` when you're layering defaults over it. Annotate the shape inline on the `@param` - `---@param opts? { auto_submit?: boolean }` - so callers can see the keys without opening the function.
+
+LuaCATS annotations are expected on public APIs.
+
+**A function description is exactly one line.** No multi-paragraph rationale, no usage examples, no "why we cache this" essays. If you can't summarise the function in one line, split the function.
+
+**Drop the description entirely when the name already says it,** and drop annotations that carry no information.
+
+```lua
+-- ❌ Description restates the name; the return annotation says nothing
+---Get the chat buffer number
+---@param chat CodeCompanion.Chat
+---@return nil
+local function get_bufnr(chat)
+
+-- ✅
+---@param chat CodeCompanion.Chat
+---@return number
+local function get_bufnr(chat)
+```
+
+Don't annotate params with inline explanations - if a param needs explaining, rename it.
+
+## 5. Tests
+
+Tests use [Mini.Test](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-test.md) with child Neovim processes. Read an existing test file before writing one - `tests/adapters/test_openai.lua` and `tests/interactions/chat/test_chat.lua` are good models. There are roughly 800 tests and they act as a second source of documentation.
+
+**File layout mirrors the source tree.** `lua/codecompanion/interactions/chat/parser.lua` is tested by `tests/interactions/chat/test_parser.lua`. Don't invent a suffix like `test_parser_resilience.lua` for a subset of a module's behaviour - add cases to the module's existing test file.
+
+**Test names follow the existing suite.** The pattern is `T["<Subject>"]["<what it does>"]`, where the subject is the capitalised module or feature (`T["Chat"]`, `T["Context"]`, `T["Keymaps"]`) and the case name completes the sentence "it ...". Keep them short and behavioural.
+
+```lua
+-- ✅ Matches the suite
+T["Chat"]["can load default tools"] = function()
+T["Chat"]["system prompt is added first"] = function()
+T["Context"]["Cannot be added twice with the same id"] = function()
+
+-- ❌ Narrative prose that reads nothing like its neighbours
+T["Parser"]["an unterminated fence does not eat the next prompt"] = function()
+T["Parser"]["a balanced response leaves the prompt extractable"] = function()
+```
+
+**Test what the change actually does.** Comprehensive-looking tests that never exercise the edge case are worse than no tests. Don't test a schema mirroring itself, and don't test that a shared utility passes its errors through.
+
+**Don't write tests for chat buffer cursor position, scrolling, or folds.** These are verified by hand in real use. Ask first if you think a case is warranted.
+
+**Use an LLM for the feature or the tests. Not both.**
+
+## 6. Error handling and defensive code
+
+- Wrap fallible calls in `pcall`, log with `log:error()`, return `nil` on failure
+- **Don't add defensive guards for conditions that cannot occur.** Validating a param that every caller in the repo already supplies is noise, and it hides the real contract
+- Don't add a fallback path "just in case". If the primary path can fail, show the failing case in a test; if it can't, delete the fallback
+
+## 7. Files and paths
+
+Use the helpers in `lua/codecompanion/utils/files.lua` for anything touching the filesystem, and join paths with `vim.fs.joinpath` rather than string concatenation or hardcoded separators.
+
+## 8. Scope
+
+- Do what the PR says it does, nothing more
+- Don't create new files unless there is no reasonable place for the code to live. Prefer editing an existing file
+- Don't add documentation files that weren't asked for
+- Don't reformat, rename, or "tidy" code your change doesn't touch - it buries the actual diff
+
+## 9. Language
+
+Plain English, in code, comments, commit messages and PR descriptions. Say what actually happens rather than reaching for jargon: "returns unchanged", "does nothing", "skipped because it was already handled" - not "no-op". Never use an em dash; use a plain dash.


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

With a growing number of PRs, I'm keen to ensure that CodeCompanion's style is unified.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code and Opus - Under my direction to analyse the code base and create a STYLE.md

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
