### PR TITLE
fix(chat): don't show system prompts for ACP

### DIFF
--- a/lua/codecompanion/interactions/chat/debug.lua
+++ b/lua/codecompanion/interactions/chat/debug.lua
@@ -287,9 +287,25 @@ function Debug:render()
   -- Add messages
   if vim.tbl_count(self.chat.messages) > 0 then
     table.insert(lines, "")
+
+    local display_messages = self.chat.messages
+    if adapter.type == "acp" then
+      display_messages, self.excluded_messages = {}, {}
+      for _, msg in ipairs(self.chat.messages) do
+        if msg.role == config.constants.SYSTEM_ROLE then
+          table.insert(self.excluded_messages, msg)
+        else
+          table.insert(display_messages, msg)
+        end
+      end
+      if #self.excluded_messages > 0 then
+        table.insert(lines, "-- NOTE: ACP doesn't accept a system prompt, so they're not sent")
+      end
+    end
+
     table.insert(lines, "local messages = ")
 
-    local messages = vim.inspect(self.chat.messages)
+    local messages = vim.inspect(display_messages)
     for line in messages:gmatch("[^\r\n]+") do
       table.insert(lines, line)
     end
@@ -411,6 +427,11 @@ function Debug:save()
     helpers.apply_settings_and_model(self.chat, settings)
   end
   if messages then
+    -- The debug window hides ACP-excluded system messages, so splice them back in
+    -- by their original index rather than letting an unrelated save drop them
+    for _, msg in ipairs(self.excluded_messages or {}) do
+      table.insert(messages, math.min(msg._meta and msg._meta.index or 1, #messages + 1), msg)
+    end
     self.chat.messages = messages
   end
   if session_id then

--- a/lua/codecompanion/interactions/chat/debug.lua
+++ b/lua/codecompanion/interactions/chat/debug.lua
@@ -427,8 +427,6 @@ function Debug:save()
     helpers.apply_settings_and_model(self.chat, settings)
   end
   if messages then
-    -- The debug window hides ACP-excluded system messages, so splice them back in
-    -- by their original index rather than letting an unrelated save drop them
     for _, msg in ipairs(self.excluded_messages or {}) do
       table.insert(messages, math.min(msg._meta and msg._meta.index or 1, #messages + 1), msg)
     end


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Rightly raised by a user, that ACP adapters never send system prompts yet the debug window didn't display this.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Sonnet 5

## Related Issue(s)

#3348

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
