### PR TITLE
fix(code_review): capture ALL edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Core: `lua/codecompanion/`
 
 ### Testing
 
+- `make test_file FILE=` takes a single file (`tests/interactions/code_review/test_ui.lua`), never a directory. Run one file per invocation
 - When running `make test_file` tests, do not append `| tail -12` or similar to filter the output. This prevents the user's rules governing what can be auto-accepted, from applying
 - Chat buffer cursor position, scrolling and folds are verified by hand in real use. Don't add test cases for them, even alongside a fix. Ask first
 

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                                 For NVIM v0.11    Last change: 2026 August 30
+                              For NVIM v0.11    Last change: 2026 September 04
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -6231,6 +6231,10 @@ When you start a review, the diff between that baseline and the repo's files is
 produced. As the baseline lives in git and the review comments are persisted to
 disk, your progress is stored across sessions and Neovim instances.
 
+That snapshot is taken on the **first prompt of a round**. Prompt again before
+you've reviewed and the baseline stays where it is, so a round of work can't
+slip past you - it accumulates until you approve it or send your comments.
+
 
   [!IMPORTANT] Snapshots are produced against an index owned by CodeCompanion, so
   `git add` never runs against the user's index. This means a user's staged
@@ -6247,9 +6251,9 @@ COMMANDS ~
   :CodeCompanionCodeReview Accept     Accept the current hunk, keeping it
                                       out of future reviews
 
-  :CodeCompanionCodeReview All        As above, but include every change
-                                      since the baseline - accepted hunks
-                                      and files beyond the agent's
+  :CodeCompanionCodeReview All        As above, but also include the
+                                      hunks you've accepted and the files
+                                      you've ignored
 
   :CodeCompanionCodeReview Approve    Approve everything up to now,
                                       advancing the baseline
@@ -6363,16 +6367,17 @@ of the next review by itself.
 
 SCOPING
 
-By default a review only covers the files an agent edited **through
-CodeCompanion's tools**. Append `All` to widen it to every change since the
-baseline:
+A review covers **every change since the baseline**, whoever made it and
+however it was made. An agent that edits with a shell command, or hands the
+work to a sub-agent, is reviewed the same as one using CodeCompanion's own
+tools.
+
+Accepted hunks and ignored files are the only things held back. Append `All` to
+bring them in too:
 
 >
     :CodeCompanionCodeReview All
 <
-
-That includes your own edits, edits from outside of Neovim, hunks you've
-accepted and files you've ignored.
 
 
 DIFFING ~
@@ -6425,7 +6430,7 @@ running in a separate terminal:
 
 1. `:CodeCompanionCodeReview Start` before the agent begins
 2. Let the agent work
-3. `:CodeCompanionCodeReview All` to review everything since the baseline
+3. `:CodeCompanionCodeReview` to review everything since the baseline
 4. Leave comments with `:CodeCompanionCodeReview Comment`, as normal
 5. `:CodeCompanionCodeReview Share` to begin sharing with the agent. Your comments move to a `review.md` file, the baseline advances, and the file's path is copied to your clipboard
 6. Paste the path into the agent:
@@ -6433,9 +6438,6 @@ running in a separate terminal:
 >
     Please action my code review: /path/to/review.md
 <
-
-`All` is required because CodeCompanion can only attribute a change to an agent
-when it goes through CodeCompanion's own tools or interactions.
 
 
   [!TIP] The `review.md` path is static at a repository level. Therefore, in a

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                              For NVIM v0.11    Last change: 2026 September 04
+                              For NVIM v0.11    Last change: 2026 September 05
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -6231,9 +6231,10 @@ When you start a review, the diff between that baseline and the repo's files is
 produced. As the baseline lives in git and the review comments are persisted to
 disk, your progress is stored across sessions and Neovim instances.
 
-That snapshot is taken on the **first prompt of a round**. Prompt again before
-you've reviewed and the baseline stays where it is, so a round of work can't
-slip past you - it accumulates until you approve it or send your comments.
+That snapshot is taken on the first prompt in any editing round. If you prompt
+again before reviewing the code then the baseline stays at the exact same point
+it was at, prior. The result of this is that you never lose sight of what's
+been edited by an agent as the edits accumulate.
 
 
   [!IMPORTANT] Snapshots are produced against an index owned by CodeCompanion, so

--- a/doc/usage/code-review.md
+++ b/doc/usage/code-review.md
@@ -47,6 +47,8 @@ sequenceDiagram
 
 When an agent begins working in a git repository, CodeCompanion snapshots the worktree to a _baseline_ (a commit at `refs/worktree/codecompanion/baseline`). When you start a review, the diff between that baseline and the repo's files is produced. As the baseline lives in git and the review comments are persisted to disk, your progress is stored across sessions and Neovim instances.
 
+That snapshot is taken on the **first prompt of a round**. Prompt again before you've reviewed and the baseline stays where it is, so a round of work can't slip past you - it accumulates until you approve it or send your comments.
+
 > [!IMPORTANT]
 > Snapshots are produced against an index owned by CodeCompanion, so `git add` never runs against the user's index. This means a user's staged changes and anything that's pushed are unaffected by a code review
 
@@ -56,7 +58,7 @@ When an agent begins working in a git repository, CodeCompanion snapshots the wo
 | --- | --- |
 | `:CodeCompanionCodeReview` | Open the agent's changes in the quickfix list, one entry per hunk |
 | `:CodeCompanionCodeReview Accept` | Accept the current hunk, keeping it out of future reviews |
-| `:CodeCompanionCodeReview All` | As above, but include every change since the baseline - accepted hunks and files beyond the agent's |
+| `:CodeCompanionCodeReview All` | As above, but also include the hunks you've accepted and the files you've ignored |
 | `:CodeCompanionCodeReview Approve` | Approve everything up to now, advancing the baseline |
 | `:CodeCompanionCodeReview Comment` | Comment on the current line or visual selection, or edit the comment already there |
 | `:CodeCompanionCodeReview Comments` | Open the pending comments file for editing |
@@ -129,13 +131,13 @@ To reject a hunk outright, diff it with `d` and use Vim's native `do` (`:h do`) 
 
 ### Scoping
 
-By default a review only covers the files an agent edited **through CodeCompanion's tools**. Append `All` to widen it to every change since the baseline:
+A review covers **every change since the baseline**, whoever made it and however it was made. An agent that edits with a shell command, or hands the work to a sub-agent, is reviewed the same as one using CodeCompanion's own tools.
+
+Accepted hunks and ignored files are the only things held back. Append `All` to bring them in too:
 
 ```
 :CodeCompanionCodeReview All
 ```
-
-That includes your own edits, edits from outside of Neovim, hunks you've accepted and files you've ignored.
 
 ## Diffing
 
@@ -172,7 +174,7 @@ The baseline sees every change in your worktree, no matter who made it - so you 
 
 1. `:CodeCompanionCodeReview Start` before the agent begins
 2. Let the agent work
-3. `:CodeCompanionCodeReview All` to review everything since the baseline
+3. `:CodeCompanionCodeReview` to review everything since the baseline
 4. Leave comments with `:CodeCompanionCodeReview Comment`, as normal
 5. `:CodeCompanionCodeReview Share` to begin sharing with the agent. Your comments move to a `review.md` file, the baseline advances, and the file's path is copied to your clipboard
 6. Paste the path into the agent:
@@ -180,8 +182,6 @@ The baseline sees every change in your worktree, no matter who made it - so you 
 ```
 Please action my code review: /path/to/review.md
 ```
-
-`All` is required because CodeCompanion can only attribute a change to an agent when it goes through CodeCompanion's own tools or interactions.
 
 > [!TIP]
 > The `review.md` path is static at a repository level. Therefore, in a `CLAUDE.md` or `AGENTS.md` file you can reference this file, only needing to do `:CodeCompanionCodeReview Share` to advance the baseline.

--- a/doc/usage/code-review.md
+++ b/doc/usage/code-review.md
@@ -47,7 +47,7 @@ sequenceDiagram
 
 When an agent begins working in a git repository, CodeCompanion snapshots the worktree to a _baseline_ (a commit at `refs/worktree/codecompanion/baseline`). When you start a review, the diff between that baseline and the repo's files is produced. As the baseline lives in git and the review comments are persisted to disk, your progress is stored across sessions and Neovim instances.
 
-That snapshot is taken on the **first prompt of a round**. Prompt again before you've reviewed and the baseline stays where it is, so a round of work can't slip past you - it accumulates until you approve it or send your comments.
+That snapshot is taken on the first prompt in any editing round. If you prompt again before reviewing the code then the baseline stays at the exact same point it was at, prior. The result of this is that you never lose sight of what's been edited by an agent as the edits accumulate.
 
 > [!IMPORTANT]
 > Snapshots are produced against an index owned by CodeCompanion, so `git add` never runs against the user's index. This means a user's staged changes and anything that's pushed are unaffected by a code review

--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -11,6 +11,7 @@ local watch = require("codecompanion.interactions.shared.watch")
 ---@field output table Standard output message from the Agent
 ---@field reasoning table Reasoning output from the Agent
 ---@field tools table<string, table> Cache of tool calls by their ID
+---@field edits table<string, { path: string, line?: number }[]> Files each tool call has edited, by tool call ID
 ---@field ui_state table<string, table> Cache of tool call UI states (line_number, icon_id) by tool call ID
 ---@field _permission { queue: CodeCompanion.Queue, active: boolean, respond: function|nil } Internal state for managing permission requests
 local ACPHandler = {}
@@ -23,6 +24,7 @@ function ACPHandler.new(chat)
     output = {},
     reasoning = {},
     tools = {},
+    edits = {},
     ui_state = {},
     _permission = {
       active = false,
@@ -48,30 +50,22 @@ local function merge_tool_call(existing, incoming)
   return out
 end
 
----If a file has been edited, fire an event
----@param tool_call table The merged tool call
----@param adapter_name string
----@return nil
-local function file_edited(tool_call, adapter_name)
-  local fired = {}
-
-  -- Fire an event but only once per file
-  local function fire(path, line)
-    if type(path) ~= "string" or path == "" or fired[path] then
-      return
-    end
-    fired[path] = true
-    utils.fire("FileEdited", { path = path, tool = adapter_name, line = line })
-  end
+---The files a tool call update edits, alongside locations and diffs
+---@param tool_call table
+---@return { path: string, line?: number }[]
+local function touched_files(tool_call)
+  local touched = {}
 
   for _, location in ipairs(tool_call.locations or {}) do
-    fire(location.path, location.line)
+    table.insert(touched, { path = location.path, line = location.line })
   end
   for _, content in ipairs(tool_call.content or {}) do
     if content.type == "diff" then
-      fire(content.path)
+      table.insert(touched, { path = content.path })
     end
   end
+
+  return touched
 end
 
 ---Submit payload to ACP and handle streaming response
@@ -258,6 +252,49 @@ function ACPHandler:handle_thought_chunk(content)
   end
 end
 
+---Remember the files a tool call names, as a later update can arrive without them
+---@param id string
+---@param tool_call table
+---@return nil
+function ACPHandler:track_edits(id, tool_call)
+  local edits = self.edits[id] or {}
+
+  for _, file in ipairs(touched_files(tool_call)) do
+    local existing = vim.iter(edits):find(function(edit)
+      return edit.path == file.path
+    end)
+
+    if existing then
+      existing.line = existing.line or file.line
+    elseif type(file.path) == "string" and file.path ~= "" then
+      table.insert(edits, file)
+    end
+  end
+
+  self.edits[id] = edits
+end
+
+---Release a finished tool call's files, firing an event for each one it edited
+---@param id string
+---@param tool_call table
+---@return nil
+function ACPHandler:flush_edits(id, tool_call)
+  if tool_call.status ~= "completed" and tool_call.status ~= "failed" then
+    return
+  end
+
+  local edits = self.edits[id]
+  self.edits[id] = nil
+
+  if tool_call.status == "failed" or tool_call.kind ~= "edit" then
+    return
+  end
+
+  for _, file in ipairs(edits or {}) do
+    utils.fire("FileEdited", { path = file.path, tool = self.chat.adapter.name, line = file.line })
+  end
+end
+
 ---Output tool call to the chat
 ---@param tool_call table
 ---@return nil
@@ -267,6 +304,8 @@ function ACPHandler:process_tool_call(tool_call)
   local merged = merge_tool_call(self.tools[id], tool_call)
   tool_call = merged
 
+  self:track_edits(id, tool_call)
+
   -- Cache or cleanup
   if tool_call.status == "completed" then
     self.tools[id] = nil
@@ -274,9 +313,7 @@ function ACPHandler:process_tool_call(tool_call)
     self.tools[id] = merged
   end
 
-  if tool_call.status == "completed" and tool_call.kind == "edit" then
-    file_edited(tool_call, self.chat.adapter.name)
-  end
+  self:flush_edits(id, tool_call)
 
   -- Pending tool calls are awaiting approval or streaming input, so hold them
   -- back from the buffer until the agent moves them out of the pending state

--- a/lua/codecompanion/interactions/code_review/baseline.lua
+++ b/lua/codecompanion/interactions/code_review/baseline.lua
@@ -335,6 +335,18 @@ function M.snapshot(root)
   return commit
 end
 
+---Is the worktree identical to the baseline?
+---@param root string
+---@return boolean
+function M.worktree_matches(root)
+  local tree = git(root, { "rev-parse", "--quiet", "--verify", ref_for(root) .. "^{tree}" })
+  if not tree or tree == "" then
+    return false
+  end
+
+  return write_worktree(root) == tree
+end
+
 ---Diff the current worktree against the baseline, one entry per hunk
 ---@param root string
 ---@return CodeCompanion.CodeReview.Hunk[]|nil hunks Nil when the worktree couldn't be read

--- a/lua/codecompanion/interactions/code_review/baseline.lua
+++ b/lua/codecompanion/interactions/code_review/baseline.lua
@@ -337,9 +337,8 @@ end
 
 ---Diff the current worktree against the baseline, one entry per hunk
 ---@param root string
----@param paths? string[] Limit the diff to these paths, relative to the root
 ---@return CodeCompanion.CodeReview.Hunk[]|nil hunks Nil when the worktree couldn't be read
-function M.diff(root, paths)
+function M.diff(root)
   local worktree = write_worktree(root)
   if not worktree then
     return nil
@@ -348,12 +347,7 @@ function M.diff(root, paths)
   local ref = ref_for(root)
   sync_alias(root, ref)
 
-  local args = { "diff", "--no-color", "--no-ext-diff", "--unified=0", ref, worktree, "--" }
-  if paths then
-    vim.list_extend(args, paths)
-  end
-
-  local output = git(root, args)
+  local output = git(root, { "diff", "--no-color", "--no-ext-diff", "--unified=0", ref, worktree })
   if not output or output == "" then
     return {}
   end

--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -140,7 +140,7 @@ local function advance_baseline(root)
     )
     return false
   end
-  store.clear_edited(root)
+  store.clear_round(root)
   store.clear_accepted(root)
   store.clear_ignored(root)
   keymaps.restore()
@@ -151,7 +151,7 @@ end
 ---@param root string
 ---@return boolean
 local function awaiting_review(root)
-  return #store.edited(root) > 0 or #store.comments(root) > 0
+  return store.round_open(root) or #store.comments(root) > 0
 end
 
 ---Replace the review quickfix list, keeping the cursor on a nearby entry
@@ -267,22 +267,12 @@ function M.open(opts)
     return
   end
 
-  local paths = nil
-  if opts.scope ~= "all" then
-    paths = store.edited(root)
-    if #paths == 0 then
-      return notify(
-        "No edits to review. Use `:CodeCompanionCodeReview All` to review everything since the baseline",
-        vim.log.levels.WARN
-      )
-    end
-  end
-
-  local hunks = baseline.diff(root, paths)
+  local hunks = baseline.diff(root)
   if not hunks then
     return notify("Could not read the worktree", vim.log.levels.ERROR)
   end
 
+  local changed = #hunks
   if opts.scope ~= "all" then
     local accepted = store.accepted(root)
     local ignored = store.ignored(root)
@@ -292,6 +282,9 @@ function M.open(opts)
   end
 
   if #hunks == 0 then
+    if changed > 0 then
+      return notify("No edits left to review. Use `:CodeCompanionCodeReview All` to include what you've set aside")
+    end
     return notify("No edits to review")
   end
 
@@ -401,22 +394,18 @@ function M.setup()
     group = group,
     pattern = { "CodeCompanionChatSubmitted", "CodeCompanionCLISent" },
     callback = function()
-      -- Only take a snapshot if the user hasn't finished a review
       local root = baseline.get_root()
-      if root and not awaiting_review(root) then
+      if not root then
+        return
+      end
+
+      -- Only take a snapshot if the user has finished reviewing the last round
+      if not awaiting_review(root) then
         baseline.snapshot(root)
       end
-    end,
-  })
 
-  api.nvim_create_autocmd("User", {
-    desc = "Track the files an agent edits for review",
-    group = group,
-    pattern = "CodeCompanionFileEdited",
-    callback = function(args)
-      local root = baseline.get_root()
-      if root and args.data and args.data.path then
-        store.track(root, args.data.path)
+      if baseline.get(root) then
+        store.begin_round(root)
       end
     end,
   })

--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -410,6 +410,18 @@ function M.setup()
     end,
   })
 
+  api.nvim_create_autocmd("User", {
+    desc = "Close a round the agent left the worktree untouched in",
+    group = group,
+    pattern = "CodeCompanionChatDone",
+    callback = function()
+      local root = baseline.get_root()
+      if root and store.round_open(root) and baseline.worktree_matches(root) then
+        store.clear_round(root)
+      end
+    end,
+  })
+
   ui.refresh()
 end
 

--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -411,7 +411,7 @@ function M.setup()
   })
 
   api.nvim_create_autocmd("User", {
-    desc = "Close a round the agent left the worktree untouched in",
+    desc = "Re-baseline on the next prompt when the agent changed no files",
     group = group,
     pattern = "CodeCompanionChatDone",
     callback = function()

--- a/lua/codecompanion/interactions/code_review/store.lua
+++ b/lua/codecompanion/interactions/code_review/store.lua
@@ -227,39 +227,27 @@ function M.submit(root)
   return M.review_path(root)
 end
 
-local edited_files_path = branch_file("edited_files.txt")
+local round_path = branch_file("round")
 
----Return the files an agent has edited since the baseline, relative to the root
----@param root string
----@return string[]
-function M.edited(root)
-  return read_lines(edited_files_path(root))
-end
-
----Record a file an agent has edited, ignoring paths outside the repo
----@param root string
----@param filepath string An absolute path
----@return nil
-function M.track(root, filepath)
-  local relative = vim.fs.relpath(root, filepath)
-  if not relative then
-    return
-  end
-
-  local edited = M.edited(root)
-  if vim.list_contains(edited, relative) then
-    return
-  end
-
-  table.insert(edited, relative)
-  files.write_to_path(edited_files_path(root), table.concat(edited, "\n") .. "\n")
-end
-
----Forget the edited files for a repo
+---Mark a round of agent work as begun, so the baseline holds until it's reviewed
 ---@param root string
 ---@return nil
-function M.clear_edited(root)
-  delete(edited_files_path(root))
+function M.begin_round(root)
+  files.write_to_path(round_path(root), "")
+end
+
+---Has a round of agent work begun since the baseline was last advanced?
+---@param root string
+---@return boolean
+function M.round_open(root)
+  return files.exists(round_path(root))
+end
+
+---Close the round, so the next submission re-baselines
+---@param root string
+---@return nil
+function M.clear_round(root)
+  delete(round_path(root))
 end
 
 local accepted_path = branch_file("accepted.txt")

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -660,6 +660,58 @@ T["ACPHandler"]["Edited Files"]["fires FileEdited when an edit tool call complet
   h.eq("test_acp", result.tool)
 end
 
+T["ACPHandler"]["Edited Files"]["fires FileEdited when a later update empties the locations"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+    chat.add_buf_message = function() end
+
+    local events = {}
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "CodeCompanionFileEdited",
+      callback = function(args)
+        table.insert(events, args.data)
+      end,
+    })
+
+    local id = "toolu_emptied"
+    handler:process_tool_call({
+      toolCallId = id,
+      sessionUpdate = "tool_call",
+      status = "in_progress",
+      kind = "edit",
+      locations = { { path = "/tmp/kept.lua", line = 12 } },
+    })
+    -- The completing update carries empty arrays, which would otherwise stand for the real ones
+    handler:process_tool_call({
+      toolCallId = id,
+      sessionUpdate = "tool_call_update",
+      status = "completed",
+      content = {},
+      locations = {},
+    })
+
+    return {
+      event_count = #events,
+      path = events[1] and events[1].path,
+      line = events[1] and events[1].line,
+    }
+  ]])
+
+  h.eq(1, result.event_count)
+  h.eq("/tmp/kept.lua", result.path)
+  h.eq(12, result.line)
+end
+
 T["ACPHandler"]["Edited Files"]["falls back to diff content when locations are absent"] = function()
   local result = child.lua([[
     local chat = h.setup_chat_buffer({}, {

--- a/tests/interactions/code_review/test_baseline.lua
+++ b/tests/interactions/code_review/test_baseline.lua
@@ -134,20 +134,6 @@ T["Baseline"]["a removed line that reads like a diff header stays inside its hun
   h.is_true(child.lua_get("hunks[1].id ~= hunks[2].id"))
 end
 
-T["Baseline"]["diff scopes to the given paths"] = function()
-  child.lua([[
-    write("a.lua", { "local a = 1" })
-    write("b.lua", { "local b = 2" })
-    baseline.snapshot(repo)
-    write("a.lua", { "local a = 10" })
-    write("b.lua", { "local b = 20" })
-  ]])
-
-  local hunks = child.lua_get([[baseline.diff(repo, { "a.lua" })]])
-  h.eq(1, #hunks)
-  h.eq("a.lua", hunks[1].path)
-end
-
 T["Baseline"]["a nested repo with no commits doesn't block the review"] = function()
   child.lua([[
     write("a.lua", { "local a = 1" })

--- a/tests/interactions/code_review/test_code_review.lua
+++ b/tests/interactions/code_review/test_code_review.lua
@@ -170,8 +170,7 @@ end
 T["Review"]["consume drains the comments and advances the baseline"] = function()
   child.lua([[
     write("a.lua", { "local a = 1" })
-    baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
+    submit()
     write("a.lua", { "local a = 100" })
     store.add_comment(repo, { comment = "Why 100?", code = "local a = 100", filetype = "lua", path = "a.lua", start_line = 1, end_line = 1 })
 
@@ -181,7 +180,7 @@ T["Review"]["consume drains the comments and advances the baseline"] = function(
   h.eq(1, child.lua_get("#consumed"))
   h.eq("Why 100?", child.lua_get("consumed[1].comment"))
   h.eq(0, child.lua_get("#review.pending()"))
-  h.eq(0, child.lua_get("#store.edited(repo)"))
+  h.is_false(child.lua_get("store.round_open(repo)"))
   h.eq(0, child.lua_get("#baseline.diff(repo)")) -- The commented change is now part of the baseline, so nothing is left to review
 end
 
@@ -241,7 +240,7 @@ T["Review"]["open leaves the quickfix alone when there is no baseline"] = functi
   h.is_false(child.lua_get("review_owns_quickfix()"))
 end
 
-T["Review"]["open leaves the quickfix alone when the agent has not edited anything"] = function()
+T["Review"]["open leaves the quickfix alone when nothing has changed since the baseline"] = function()
   child.lua([[
     write("a.lua", { "local a = 1" })
     baseline.snapshot(repo)
@@ -256,7 +255,6 @@ T["Review"]["open leaves the quickfix alone when the worktree can't be read"] = 
   child.lua([[
     write("a.lua", { "local a = 1" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
     write("a.lua", { "local a = 100" })
 
     -- A lock another Neovim holds, so the diff can't be trusted and must not be read as "no edits"
@@ -273,85 +271,71 @@ T["Review"]["open leaves the quickfix alone when the worktree can't be read"] = 
   h.is_false(child.lua_get("review_owns_quickfix()"))
 end
 
-T["Review"]["open lists a quickfix entry per hunk in the agent's files"] = function()
+T["Review"]["open lists a quickfix entry per hunk, however the change was made"] = function()
   child.lua([[
     write("a.lua", { "local a = 1", "local b = 2", "local c = 3" })
     write("b.lua", { "local d = 4" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
+
+    -- The agent's tools report a.lua, but the b.lua edit it made with a shell command is reported by nothing
     write("a.lua", { "local a = 1", "local b = 20", "local c = 3" })
-    write("b.lua", { "local d = 40" }) -- the user's own edit, not the agent's
+    write("b.lua", { "local d = 40" })
 
     own_quickfix()
     review.open()
   ]])
 
   local qf = child.lua_get("vim.fn.getqflist()")
-  h.eq(1, #qf)
+  h.eq(2, #qf)
   h.eq(2, qf[1].lnum)
   h.is_true(child.lua_get("vim.endswith(vim.fn.bufname(vim.fn.getqflist()[1].bufnr), 'a.lua')"))
+  h.is_true(child.lua_get("vim.endswith(vim.fn.bufname(vim.fn.getqflist()[2].bufnr), 'b.lua')"))
   -- Anchors the cases asserting a review *didn't* take the quickfix over
   h.is_true(child.lua_get("review_owns_quickfix()"))
 end
 
-T["Review"]["a new round re-baselines, so only the agent's edits are left to review"] = function()
+T["Review"]["the first submission after a review re-baselines, dropping the user's own work"] = function()
   child.lua([[
     write("a.lua", { "local a = 1" })
-    write("b.lua", { "local b = 2" })
     submit()
+    write("a.lua", { "local a = 1", "-- from the agent" })
+    review.approve()
 
     -- A pull brings work of its own, and the user edits a file by hand
-    write("a.lua", { "local a = 1", "-- from upstream" })
-    write("b.lua", { "local b = 2", "-- typed by hand" })
+    write("b.lua", { "-- from upstream" })
+    write("a.lua", { "local a = 1", "-- from the agent", "-- typed by hand" })
     submit()
 
-    -- Only now does the agent edit anything
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
-    write("a.lua", { "local a = 1", "-- from upstream", "-- from the agent" })
-
-    -- Scoped to everything, so nothing is merely being filtered out by file
-    review.open({ scope = "all" })
+    write("a.lua", { "local a = 1", "-- from the agent", "-- typed by hand", "-- from the next round" })
+    review.open()
   ]])
 
   h.eq(1, child.lua_get("#vim.fn.getqflist()"))
-  h.eq("+1 -0 -- from the agent", child.lua_get("vim.fn.getqflist()[1].text"))
+  h.eq("+1 -0 -- from the next round", child.lua_get("vim.fn.getqflist()[1].text"))
 end
 
 T["Review"]["a round still to be reviewed keeps its baseline"] = function()
   child.lua([[
     write("a.lua", { "local a = 1" })
-    baseline.snapshot(repo)
+    submit()
     before = baseline.get(repo)
-    write("a.lua", { "local a = 10" })
 
     -- An edit the user hasn't reviewed yet
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
+    write("a.lua", { "local a = 10" })
     submit()
     after_edit = baseline.get(repo)
 
+    review.approve()
+    approved = baseline.get(repo)
+
     -- A comment they haven't sent yet
-    store.clear_edited(repo)
     store.add_comment(repo, { comment = "Why 10?", code = "local a = 10", filetype = "lua", path = "a.lua", start_line = 1, end_line = 1 })
     submit()
     after_comment = baseline.get(repo)
   ]])
 
   h.eq(child.lua_get("before"), child.lua_get("after_edit"))
-  h.eq(child.lua_get("before"), child.lua_get("after_comment"))
-end
-
-T["Review"]["open with scope all includes changes outside the agent's files"] = function()
-  child.lua([[
-    write("a.lua", { "local a = 1" })
-    write("b.lua", { "local b = 2" })
-    baseline.snapshot(repo)
-    write("a.lua", { "local a = 10" })
-    write("b.lua", { "local b = 20" })
-
-    review.open({ scope = "all" })
-  ]])
-
-  h.eq(2, child.lua_get("#vim.fn.getqflist()"))
+  h.eq(child.lua_get("approved"), child.lua_get("after_comment"))
 end
 
 T["Review"]["accept keeps the hunk out of later reviews, until the baseline advances"] = function()
@@ -359,8 +343,6 @@ T["Review"]["accept keeps the hunk out of later reviews, until the baseline adva
     write("a.lua", { "local a = 1" })
     write("b.lua", { "local b = 2" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
-    store.track(repo, vim.fs.joinpath(repo, "b.lua"))
     write("a.lua", { "local a = 10" })
     write("b.lua", { "local b = 20" })
 
@@ -386,7 +368,6 @@ T["Review"]["an accepted hunk returns when the change changes"] = function()
   child.lua([[
     write("a.lua", { "local a = 1" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
     write("a.lua", { "local a = 10" })
 
     review.open()
@@ -412,8 +393,6 @@ T["Review"]["ignore drops every hunk in the file, until the baseline advances"] 
     write("a.lua", { "local a = 1", "local b = 2", "local c = 3" })
     write("b.lua", { "local d = 4" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
-    store.track(repo, vim.fs.joinpath(repo, "b.lua"))
     write("a.lua", { "local a = 10", "local b = 2", "local c = 30" })
     write("b.lua", { "local d = 40" })
 
@@ -440,7 +419,6 @@ T["Review"]["comment from the quickfix list targets the hunk"] = function()
     stub_input("Why 10?")
     write("a.lua", { "local a = 1" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
     write("a.lua", { "local a = 10" })
 
     review.open()
@@ -468,8 +446,6 @@ T["Review"]["accepting or ignoring a hunk closes the diff it was being read in"]
     write("notes", { "local a = 1" })
     write("other", { "local b = 2" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "notes"))
-    store.track(repo, vim.fs.joinpath(repo, "other"))
     write("notes", { "local a = 10" })
     write("other", { "local b = 20" })
 
@@ -498,7 +474,6 @@ T["Review"]["open_diff hands the hunk under the cursor to the configured provide
     end
     write("a.lua", { "local a = 1" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
     write("a.lua", { "local a = 10" })
 
     review.open()
@@ -531,7 +506,6 @@ T["Review"]["the review keymaps take the quickfix window, and give it back to an
 
     write("a.lua", { "local a = 1" })
     baseline.snapshot(repo)
-    store.track(repo, vim.fs.joinpath(repo, "a.lua"))
     write("a.lua", { "local a = 10" })
 
     all_keymaps = vim.tbl_keys(config.interactions.code_review.keymaps)

--- a/tests/interactions/code_review/test_code_review.lua
+++ b/tests/interactions/code_review/test_code_review.lua
@@ -29,6 +29,10 @@ T = new_set({
           vim.api.nvim_exec_autocmds("User", { pattern = "CodeCompanionChatSubmitted" })
         end
 
+        done = function()
+          vim.api.nvim_exec_autocmds("User", { pattern = "CodeCompanionChatDone" })
+        end
+
         -- Stub the input popup so `comment` submits immediately
         stub_input = function(comment)
           package.loaded["codecompanion.interactions.shared.input"].open = function(opts)
@@ -312,6 +316,40 @@ T["Review"]["the first submission after a review re-baselines, dropping the user
 
   h.eq(1, child.lua_get("#vim.fn.getqflist()"))
   h.eq("+1 -0 -- from the next round", child.lua_get("vim.fn.getqflist()[1].text"))
+end
+
+T["Review"]["a round the agent changed nothing in closes, so the next one re-baselines"] = function()
+  child.lua([[
+    write("a.lua", { "local a = 1" })
+    submit()
+
+    -- The agent only answered a question, so there is nothing to hold the baseline for
+    done()
+    closed = store.round_open(repo)
+
+    -- A pull brings work of its own, and the user edits a file by hand
+    write("b.lua", { "-- from upstream" })
+    write("a.lua", { "local a = 1", "-- typed by hand" })
+    submit()
+
+    write("a.lua", { "local a = 1", "-- typed by hand", "-- from the agent" })
+    review.open()
+  ]])
+
+  h.is_false(child.lua_get("closed"))
+  h.eq(1, child.lua_get("#vim.fn.getqflist()"))
+  h.eq("+1 -0 -- from the agent", child.lua_get("vim.fn.getqflist()[1].text"))
+end
+
+T["Review"]["a round the agent edited in stays open"] = function()
+  child.lua([[
+    write("a.lua", { "local a = 1" })
+    submit()
+    write("a.lua", { "local a = 10" })
+    done()
+  ]])
+
+  h.is_true(child.lua_get("store.round_open(repo)"))
 end
 
 T["Review"]["a round still to be reviewed keeps its baseline"] = function()

--- a/tests/interactions/code_review/test_store.lua
+++ b/tests/interactions/code_review/test_store.lua
@@ -147,26 +147,6 @@ T["Store"]["clear_comments empties the store"] = function()
   h.eq(0, child.lua_get("#store.comments(repo)"))
 end
 
-T["Store"]["tracks edited files once, relative to the root"] = function()
-  child.lua([[
-    store.track(repo, vim.fs.joinpath(repo, "lua/foo.lua"))
-    store.track(repo, vim.fs.joinpath(repo, "lua/foo.lua"))
-    store.track(repo, vim.fs.joinpath(repo, "lua/bar.lua"))
-    store.track(repo, "/somewhere/else/baz.lua")
-  ]])
-
-  h.eq({ "lua/foo.lua", "lua/bar.lua" }, child.lua_get("store.edited(repo)"))
-end
-
-T["Store"]["clear_edited forgets the edited files"] = function()
-  child.lua([[
-    store.track(repo, vim.fs.joinpath(repo, "lua/foo.lua"))
-    store.clear_edited(repo)
-  ]])
-
-  h.eq(0, child.lua_get("#store.edited(repo)"))
-end
-
 T["Store"]["comments are scoped per branch"] = function()
   child.lua([[
     commit("init")


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Tools like Claude Code in bypass mode will not always use the edit tool. So with the prior code review iteration, these edits wouldn't always be captured. This PR addresses this by making git the sole source of truth. Therefore, the review shows every change since the baseline, regardless of how it was made. The downside of this is it will also capture user edits.

To handle this, `a` accepts a hunk and `x` ignores a file. This remains until the next baseline. So anything you dismiss stays dismissed. An accepted hunk only returns if the agent rewrites that same code.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code and Opus 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
