### PR TITLE
feat: add hooks for CLI agents

### DIFF
--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3129,6 +3129,33 @@ You can define multiple agents and switch between them:
 Then use `:CodeCompanionCLI agent=codex <prompt>` to use a specific agent.
 
 
+HOOK INTEGRATION ~
+
+CLI interactions can integrate with agents that support hooks, enabling the
+CodeCompanion event system to react to the agent. Without this, features that
+need to know where a turn starts and ends, such as the
+|codecompanion-usage-code-review|, are limited.
+
+CodeCompanion sets `CODECOMPANION_CLI_BUFNR` in the agent's environment, and
+Neovim sets `$NVIM` to its own server address, so a hook can call back into the
+session that started it.
+
+
+CLAUDE CODE HOOKS
+
+To connect Claude Code <https://code.claude.com/docs/en/hooks>, add this to
+`.claude/settings.json`
+
+`json [.claude/settings.json] { "hooks": { "UserPromptSubmit": [ { "hooks": [ {
+"type": "command", "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim
+--server \"$NVIM\" --remote-expr
+\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
+'event': 'submitted'})\" || true" } ] } ], "Stop": [ { "hooks": [ { "type":
+"command", "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server
+\"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr':
+$CODECOMPANION_CLI_BUFNR, 'event': 'done'})\" || true" } ] } ] } }`
+
+
 PROVIDERS ~
 
 Providers determine how the CLI agent is run. The built-in `terminal` provider
@@ -6539,6 +6566,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLIClosed` - Fired after a CLI buffer has been closed
 - `CodeCompanionCLIHidden` - Fired after a CLI buffer has been hidden
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
+- `CodeCompanionCLISubmitted` - Fired when a CLI agent accepts a prompt, however it was typed. Requires |codecompanion-configuration-cli-reporting-turns-with-hooks|
+- `CodeCompanionCLIDone` - Fired when a CLI agent finishes a turn. Requires |codecompanion-configuration-cli-reporting-turns-with-hooks|
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                              For NVIM v0.11    Last change: 2026 September 05
+                              For NVIM v0.11    Last change: 2026 September 06
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -528,6 +528,7 @@ The plugin has five core commands:
 - `CodeCompanion` - Open the inline interaction
 - `CodeCompanionChat` - Open a chat buffer
 - `CodeCompanionCLI` - Open a CLI interaction
+- `CodeCompanionCLI Install` - Write CodeCompanion's hooks into your CLI agents' settings
 - `CodeCompanionCmd` - Generate a command in the command-line
 - `CodeCompanionActions` - Open the `Action Palette`
 
@@ -3136,62 +3137,20 @@ CodeCompanion event system to react to the agent in realtime. Without this,
 features that need to know where a turn starts and ends, such as the
 |codecompanion-usage-code-review|, are limited.
 
-CodeCompanion sets `CODECOMPANION_CLI_BUFNR` in the agent's environment, and
-Neovim sets `$NVIM` to its own server address, so a hook can call back into the
-session that started it.
+Currently, CodeCompanion only supports Claude Code
+<https://code.claude.com/docs/en/hooks>.
 
 
-CLAUDE CODE
+INSTALLING
 
-To integrate Claude Code <https://code.claude.com/docs/en/hooks>, add this to
-`.claude/settings.json`
+In order to integrate CodeCompanion with the supported coding agents, inside
+Neovim, run:
 
-`json [.claude/settings.json] { "hooks": { "Notification": [ { "hooks": [ {
-"type": "command", "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim
---server \"$NVIM\" --remote-expr
-\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
-'event': 'blocked', 'message': 'Waiting for you'})\" || true" } ] } ],
-"PermissionRequest": [ { "hooks": [ { "type": "command", "command": "[ -z
-\"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr
-\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
-'event': 'blocked', 'message': 'Permission needed'})\" || true" } ] } ],
-"PostToolUse": [ { "hooks": [ { "type": "command", "command": "[ -z
-\"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr
-\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
-'event': 'working'})\" || true" } ] } ], "Stop": [ { "hooks": [ { "type":
-"command", "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server
-\"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr':
-$CODECOMPANION_CLI_BUFNR, 'event': 'done'})\" || true" } ] } ],
-"UserPromptSubmit": [ { "hooks": [ { "type": "command", "command": "[ -z
-\"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr
-\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
-'event': 'submitted'})\" || true" } ] } ] } }`
+>
+    :CodeCompanionCLI Install
+<
 
-  ------------------------------------------------------------------------------
-  Claude Code hook        event                   CodeCompanion event
-  ----------------------- ----------------------- ------------------------------
-  Notification            blocked                 CodeCompanionCLIBlocked
-
-  PermissionRequest       blocked                 CodeCompanionCLIBlocked
-
-  PostToolUse             working                 CodeCompanionCLIWorking
-
-  Stop                    done                    CodeCompanionCLIDone, plus
-                                                  CodeCompanionRequestFinished
-
-  UserPromptSubmit        submitted               CodeCompanionCLISubmitted,
-                                                  plus
-                                                  CodeCompanionRequestStarted
-  ------------------------------------------------------------------------------
-`UserPromptSubmit` and `Stop` are the pair that marks out a turn. The rest are
-optional and separate `the agent is thinking` from `the agent is waiting on
-you`, which is what a statusline or herdr <https://herdr.dev> needs to show you
-that a pane wants attention. `PostToolUse` is what returns the agent to working
-once you've answered, so take it if you take `Notification` or
-`PermissionRequest`. It runs on every tool call, which costs a process spawn
-each time.
-
-`message` is free text and reaches listeners on the event's data payload.
+- In the case of Claude Code, hooks are added to `~/.claude/settings.json`
 
 
 PROVIDERS ~
@@ -6606,8 +6565,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
 - `CodeCompanionCLISubmitted` - Fired when a CLI agent accepts a prompt, however it was typed. Requires |codecompanion-configuration-cli-hooks|
 - `CodeCompanionCLIDone` - Fired when a CLI agent finishes a turn. Requires |codecompanion-configuration-cli-hooks|
-- `CodeCompanionCLIBlocked` - Fired when a CLI agent is waiting on the user, with a `message` in the data payload. Requires |codecompanion-configuration-cli-hooks|
-- `CodeCompanionCLIWorking` - Fired when a CLI agent resumes after waiting. Requires |codecompanion-configuration-cli-hooks|
+- `CodeCompanionCLIApprovalRequested` - Fired when a CLI agent is waiting on the user, with a `message` in the data payload. Requires |codecompanion-configuration-cli-hooks|
+- `CodeCompanionCLIApprovalFinished` - Fired when a CLI agent resumes after waiting. Requires |codecompanion-configuration-cli-hooks|
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -3129,11 +3129,11 @@ You can define multiple agents and switch between them:
 Then use `:CodeCompanionCLI agent=codex <prompt>` to use a specific agent.
 
 
-HOOK INTEGRATION ~
+HOOKS ~
 
 CLI interactions can integrate with agents that support hooks, enabling the
-CodeCompanion event system to react to the agent. Without this, features that
-need to know where a turn starts and ends, such as the
+CodeCompanion event system to react to the agent in realtime. Without this,
+features that need to know where a turn starts and ends, such as the
 |codecompanion-usage-code-review|, are limited.
 
 CodeCompanion sets `CODECOMPANION_CLI_BUFNR` in the agent's environment, and
@@ -3141,19 +3141,57 @@ Neovim sets `$NVIM` to its own server address, so a hook can call back into the
 session that started it.
 
 
-CLAUDE CODE HOOKS
+CLAUDE CODE
 
-To connect Claude Code <https://code.claude.com/docs/en/hooks>, add this to
+To integrate Claude Code <https://code.claude.com/docs/en/hooks>, add this to
 `.claude/settings.json`
 
-`json [.claude/settings.json] { "hooks": { "UserPromptSubmit": [ { "hooks": [ {
+`json [.claude/settings.json] { "hooks": { "Notification": [ { "hooks": [ {
 "type": "command", "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim
 --server \"$NVIM\" --remote-expr
 \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
-'event': 'submitted'})\" || true" } ] } ], "Stop": [ { "hooks": [ { "type":
+'event': 'blocked', 'message': 'Waiting for you'})\" || true" } ] } ],
+"PermissionRequest": [ { "hooks": [ { "type": "command", "command": "[ -z
+\"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr
+\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
+'event': 'blocked', 'message': 'Permission needed'})\" || true" } ] } ],
+"PostToolUse": [ { "hooks": [ { "type": "command", "command": "[ -z
+\"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr
+\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
+'event': 'working'})\" || true" } ] } ], "Stop": [ { "hooks": [ { "type":
 "command", "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server
 \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr':
-$CODECOMPANION_CLI_BUFNR, 'event': 'done'})\" || true" } ] } ] } }`
+$CODECOMPANION_CLI_BUFNR, 'event': 'done'})\" || true" } ] } ],
+"UserPromptSubmit": [ { "hooks": [ { "type": "command", "command": "[ -z
+\"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr
+\"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR,
+'event': 'submitted'})\" || true" } ] } ] } }`
+
+  ------------------------------------------------------------------------------
+  Claude Code hook        event                   CodeCompanion event
+  ----------------------- ----------------------- ------------------------------
+  Notification            blocked                 CodeCompanionCLIBlocked
+
+  PermissionRequest       blocked                 CodeCompanionCLIBlocked
+
+  PostToolUse             working                 CodeCompanionCLIWorking
+
+  Stop                    done                    CodeCompanionCLIDone, plus
+                                                  CodeCompanionRequestFinished
+
+  UserPromptSubmit        submitted               CodeCompanionCLISubmitted,
+                                                  plus
+                                                  CodeCompanionRequestStarted
+  ------------------------------------------------------------------------------
+`UserPromptSubmit` and `Stop` are the pair that marks out a turn. The rest are
+optional and separate `the agent is thinking` from `the agent is waiting on
+you`, which is what a statusline or herdr <https://herdr.dev> needs to show you
+that a pane wants attention. `PostToolUse` is what returns the agent to working
+once you've answered, so take it if you take `Notification` or
+`PermissionRequest`. It runs on every tool call, which costs a process spawn
+each time.
+
+`message` is free text and reaches listeners on the event's data payload.
 
 
 PROVIDERS ~
@@ -6566,8 +6604,10 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLIClosed` - Fired after a CLI buffer has been closed
 - `CodeCompanionCLIHidden` - Fired after a CLI buffer has been hidden
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
-- `CodeCompanionCLISubmitted` - Fired when a CLI agent accepts a prompt, however it was typed. Requires |codecompanion-configuration-cli-reporting-turns-with-hooks|
-- `CodeCompanionCLIDone` - Fired when a CLI agent finishes a turn. Requires |codecompanion-configuration-cli-reporting-turns-with-hooks|
+- `CodeCompanionCLISubmitted` - Fired when a CLI agent accepts a prompt, however it was typed. Requires |codecompanion-configuration-cli-hooks|
+- `CodeCompanionCLIDone` - Fired when a CLI agent finishes a turn. Requires |codecompanion-configuration-cli-hooks|
+- `CodeCompanionCLIBlocked` - Fired when a CLI agent is waiting on the user, with a `message` in the data payload. Requires |codecompanion-configuration-cli-hooks|
+- `CodeCompanionCLIWorking` - Fired when a CLI agent resumes after waiting. Requires |codecompanion-configuration-cli-hooks|
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction
@@ -6576,9 +6616,9 @@ The events that are fired from within the plugin are:
 - `CodeCompanionMCPServerReady` - Fired when an MCP server is ready for requests
 - `CodeCompanionMCPServerClosed` - Fired when an MCP server is closed
 - `CodeCompanionMCPServerToolsLoaded` - Fired when tools are loaded for an MCP server
-- `CodeCompanionRequestStarted` - Fired at the start of any API request
+- `CodeCompanionRequestStarted` - Fired at the start of any API request, and at the start of a CLI agent's turn when |codecompanion-configuration-cli-hooks| are wired up
 - `CodeCompanionRequestStreaming` - Fired at the start of a streaming API request
-- `CodeCompanionRequestFinished` - Fired at the end of any API request
+- `CodeCompanionRequestFinished` - Fired at the end of any API request, and at the end of a CLI agent's turn when |codecompanion-configuration-cli-hooks| are wired up
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
 - `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
 - `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request

--- a/doc/configuration/cli.md
+++ b/doc/configuration/cli.md
@@ -67,6 +67,43 @@ require("codecompanion").setup({
 
 Then use `:CodeCompanionCLI agent=codex <prompt>` to use a specific agent.
 
+## Hook Integration
+
+CLI interactions can integrate with agents that support hooks, enabling the CodeCompanion event system to react to the agent. Without this, features that need to know where a turn starts and ends, such as the [code review](/usage/code-review), are limited.
+
+CodeCompanion sets `CODECOMPANION_CLI_BUFNR` in the agent's environment, and Neovim sets `$NVIM` to its own server address, so a hook can call back into the session that started it.
+
+### Claude Code Hooks
+
+To connect [Claude Code](https://code.claude.com/docs/en/hooks), add this to `.claude/settings.json`
+
+````json [.claude/settings.json]
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'submitted'})\" || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'done'})\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}
+````
+
 ## Providers
 
 Providers determine how the CLI agent is run. The built-in `terminal` provider uses a Neovim terminal buffer with `jobstart()`:

--- a/doc/configuration/cli.md
+++ b/doc/configuration/cli.md
@@ -67,25 +67,45 @@ require("codecompanion").setup({
 
 Then use `:CodeCompanionCLI agent=codex <prompt>` to use a specific agent.
 
-## Hook Integration
+## Hooks
 
-CLI interactions can integrate with agents that support hooks, enabling the CodeCompanion event system to react to the agent. Without this, features that need to know where a turn starts and ends, such as the [code review](/usage/code-review), are limited.
+CLI interactions can integrate with agents that support hooks, enabling the CodeCompanion event system to react to the agent in realtime. Without this, features that need to know where a turn starts and ends, such as the [code review](/usage/code-review), are limited.
 
 CodeCompanion sets `CODECOMPANION_CLI_BUFNR` in the agent's environment, and Neovim sets `$NVIM` to its own server address, so a hook can call back into the session that started it.
 
-### Claude Code Hooks
+### Claude Code
 
-To connect [Claude Code](https://code.claude.com/docs/en/hooks), add this to `.claude/settings.json`
+To integrate [Claude Code](https://code.claude.com/docs/en/hooks), add this to `.claude/settings.json`
 
 ````json [.claude/settings.json]
 {
   "hooks": {
-    "UserPromptSubmit": [
+    "Notification": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'submitted'})\" || true"
+            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'blocked', 'message': 'Waiting for you'})\" || true"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'blocked', 'message': 'Permission needed'})\" || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'working'})\" || true"
           }
         ]
       }
@@ -99,10 +119,32 @@ To connect [Claude Code](https://code.claude.com/docs/en/hooks), add this to `.c
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'submitted'})\" || true"
+          }
+        ]
+      }
     ]
   }
 }
 ````
+
+| Claude Code hook | `event` | CodeCompanion event |
+|---|---|---|
+| `Notification` | `blocked` | `CodeCompanionCLIBlocked` |
+| `PermissionRequest` | `blocked` | `CodeCompanionCLIBlocked` |
+| `PostToolUse` | `working` | `CodeCompanionCLIWorking` |
+| `Stop` | `done` | `CodeCompanionCLIDone`, plus `CodeCompanionRequestFinished` |
+| `UserPromptSubmit` | `submitted` | `CodeCompanionCLISubmitted`, plus `CodeCompanionRequestStarted` |
+
+`UserPromptSubmit` and `Stop` are the pair that marks out a turn. The rest are optional and separate _the agent is thinking_ from _the agent is waiting on you_, which is what a statusline or [herdr](https://herdr.dev) needs to show you that a pane wants attention. `PostToolUse` is what returns the agent to working once you've answered, so take it if you take `Notification` or `PermissionRequest`. It runs on every tool call, which costs a process spawn each time.
+
+`message` is free text and reaches listeners on the event's data payload.
 
 ## Providers
 

--- a/doc/configuration/cli.md
+++ b/doc/configuration/cli.md
@@ -71,80 +71,17 @@ Then use `:CodeCompanionCLI agent=codex <prompt>` to use a specific agent.
 
 CLI interactions can integrate with agents that support hooks, enabling the CodeCompanion event system to react to the agent in realtime. Without this, features that need to know where a turn starts and ends, such as the [code review](/usage/code-review), are limited.
 
-CodeCompanion sets `CODECOMPANION_CLI_BUFNR` in the agent's environment, and Neovim sets `$NVIM` to its own server address, so a hook can call back into the session that started it.
+Currently, CodeCompanion only supports [Claude Code](https://code.claude.com/docs/en/hooks).
 
-### Claude Code
+### Installing
 
-To integrate [Claude Code](https://code.claude.com/docs/en/hooks), add this to `.claude/settings.json`
+In order to integrate CodeCompanion with the supported coding agents, inside Neovim, run:
 
-````json [.claude/settings.json]
-{
-  "hooks": {
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'blocked', 'message': 'Waiting for you'})\" || true"
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'blocked', 'message': 'Permission needed'})\" || true"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'working'})\" || true"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'done'})\" || true"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -z \"$CODECOMPANION_CLI_BUFNR\" ] || nvim --server \"$NVIM\" --remote-expr \"v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': 'submitted'})\" || true"
-          }
-        ]
-      }
-    ]
-  }
-}
-````
+```
+:CodeCompanionCLI Install
+```
 
-| Claude Code hook | `event` | CodeCompanion event |
-|---|---|---|
-| `Notification` | `blocked` | `CodeCompanionCLIBlocked` |
-| `PermissionRequest` | `blocked` | `CodeCompanionCLIBlocked` |
-| `PostToolUse` | `working` | `CodeCompanionCLIWorking` |
-| `Stop` | `done` | `CodeCompanionCLIDone`, plus `CodeCompanionRequestFinished` |
-| `UserPromptSubmit` | `submitted` | `CodeCompanionCLISubmitted`, plus `CodeCompanionRequestStarted` |
-
-`UserPromptSubmit` and `Stop` are the pair that marks out a turn. The rest are optional and separate _the agent is thinking_ from _the agent is waiting on you_, which is what a statusline or [herdr](https://herdr.dev) needs to show you that a pane wants attention. `PostToolUse` is what returns the agent to working once you've answered, so take it if you take `Notification` or `PermissionRequest`. It runs on every tool call, which costs a process spawn each time.
-
-`message` is free text and reaches listeners on the event's data payload.
+- In the case of Claude Code, hooks are added to `~/.claude/settings.json`
 
 ## Providers
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -246,6 +246,7 @@ The plugin has five core commands:
 - `CodeCompanion` - Open the inline interaction
 - `CodeCompanionChat` - Open a chat buffer
 - `CodeCompanionCLI` - Open a CLI interaction
+- `CodeCompanionCLI Install` - Write CodeCompanion's hooks into your CLI agents' settings
 - `CodeCompanionCmd` - Generate a command in the command-line
 - `CodeCompanionActions` - Open the _Action Palette_
 

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -34,8 +34,8 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
 - `CodeCompanionCLISubmitted` - Fired when a CLI agent accepts a prompt, however it was typed. Requires [agent hooks](/configuration/cli#hooks)
 - `CodeCompanionCLIDone` - Fired when a CLI agent finishes a turn. Requires [agent hooks](/configuration/cli#hooks)
-- `CodeCompanionCLIBlocked` - Fired when a CLI agent is waiting on the user, with a `message` in the data payload. Requires [agent hooks](/configuration/cli#hooks)
-- `CodeCompanionCLIWorking` - Fired when a CLI agent resumes after waiting. Requires [agent hooks](/configuration/cli#hooks)
+- `CodeCompanionCLIApprovalRequested` - Fired when a CLI agent is waiting on the user, with a `message` in the data payload. Requires [agent hooks](/configuration/cli#hooks)
+- `CodeCompanionCLIApprovalFinished` - Fired when a CLI agent resumes after waiting. Requires [agent hooks](/configuration/cli#hooks)
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction

--- a/doc/usage/events.md
+++ b/doc/usage/events.md
@@ -32,6 +32,10 @@ The events that are fired from within the plugin are:
 - `CodeCompanionCLIClosed` - Fired after a CLI buffer has been closed
 - `CodeCompanionCLIHidden` - Fired after a CLI buffer has been hidden
 - `CodeCompanionCLISent` - Fired after data has been sent to a CLI buffer
+- `CodeCompanionCLISubmitted` - Fired when a CLI agent accepts a prompt, however it was typed. Requires [agent hooks](/configuration/cli#hooks)
+- `CodeCompanionCLIDone` - Fired when a CLI agent finishes a turn. Requires [agent hooks](/configuration/cli#hooks)
+- `CodeCompanionCLIBlocked` - Fired when a CLI agent is waiting on the user, with a `message` in the data payload. Requires [agent hooks](/configuration/cli#hooks)
+- `CodeCompanionCLIWorking` - Fired when a CLI agent resumes after waiting. Requires [agent hooks](/configuration/cli#hooks)
 - `CodeCompanionContextChanged` - Fired when the context that a chat buffer follows, changes
 - `CodeCompanionFileEdited` - Fired after the LLM has edited or created a file; the data payload includes the `path` and what made the change (`tool`)
 - `CodeCompanionInlineStarted` - Fired at the start of the Inline interaction
@@ -40,9 +44,9 @@ The events that are fired from within the plugin are:
 - `CodeCompanionMCPServerReady` - Fired when an MCP server is ready for requests
 - `CodeCompanionMCPServerClosed` - Fired when an MCP server is closed
 - `CodeCompanionMCPServerToolsLoaded` - Fired when tools are loaded for an MCP server
-- `CodeCompanionRequestStarted` - Fired at the start of any API request
+- `CodeCompanionRequestStarted` - Fired at the start of any API request, and at the start of a CLI agent's turn when [hooks](/configuration/cli#hooks) are wired up
 - `CodeCompanionRequestStreaming` - Fired at the start of a streaming API request
-- `CodeCompanionRequestFinished` - Fired at the end of any API request
+- `CodeCompanionRequestFinished` - Fired at the end of any API request, and at the end of a CLI agent's turn when [hooks](/configuration/cli#hooks) are wired up
 - `CodeCompanionToolAdded` - Fired when a tool has been added to a chat
 - `CodeCompanionToolApprovalRequested` - Fired when a tool is requesting approval to run
 - `CodeCompanionToolApprovalFinished` - Fired when a user has actioned an approval request

--- a/lua/codecompanion/acp/init.lua
+++ b/lua/codecompanion/acp/init.lua
@@ -436,7 +436,7 @@ function Connection:start_agent_process()
     {
       stdin = true,
       cwd = vim.fn.getcwd(),
-      env = vim.tbl_extend("force", adapter.env_replaced or {}, integrations.acp_env()),
+      env = vim.tbl_extend("force", adapter.env_replaced or {}, integrations.agent_env()),
       stdout = self.methods.schedule_wrap(function(err, data)
         if err then
           log:error("[acp::start_agent_process::stdout] Error: %s", err)

--- a/lua/codecompanion/commands/init.lua
+++ b/lua/codecompanion/commands/init.lua
@@ -336,6 +336,10 @@ return {
         cli_opts.agent = params.agent
       end
 
+      if prompt == "Install" then
+        return require("codecompanion.interactions.cli.hooks").install()
+      end
+
       -- :CodeCompanionCLI Ask — open prompt input buffer
       if prompt == "Ask" then
         cli_opts.prompt = true
@@ -374,7 +378,7 @@ return {
         end
 
         if cmdline:match("^['<,'>]*CodeCompanionCLI[!]*%s+$") or arg_lead == "" then
-          local completions = { "Ask", "agent=" }
+          local completions = { "Ask", "Install", "agent=" }
           return vim
             .iter(completions)
             :filter(function(key)

--- a/lua/codecompanion/init.lua
+++ b/lua/codecompanion/init.lua
@@ -422,6 +422,13 @@ CodeCompanion.cli = function(prompt_or_opts, opts)
   _last_toggle = "cli"
 end
 
+---Report a turn event from a CLI agent's hook system
+---@param opts { bufnr: number, event: "submitted"|"done" }
+---@return string
+CodeCompanion.cli_hook = function(opts)
+  return require("codecompanion.interactions.cli").hook(opts)
+end
+
 ---Toggle the CLI terminal buffer
 ---@param args? { agent?: string }
 ---@return nil

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -215,6 +215,8 @@ end
 ---Environment for agents CodeCompanion spawns, so they never claim the pane themselves
 ---@return table<string, string>
 function M.agent_env()
+  -- HERDR_ENV is herdr's master switch, so a spawned agent stops at its first guard and
+  -- CodeCompanion never has to track the rest of herdr's variables to stay ahead of it
   return { HERDR_ENV = "", HERDR_PANE_ID = "" }
 end
 

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -208,10 +208,9 @@ local function untrack(args)
   update_herdr()
 end
 
----Set the environment for ACP adapters
+---Environment for agents CodeCompanion spawns, so they never claim the pane themselves
 ---@return table<string, string>
-function M.acp_env()
-  -- Ensure that any ACP agents spawned by CodeCompanion don't steal the herdr pane
+function M.agent_env()
   return { HERDR_ENV = "", HERDR_PANE_ID = "" }
 end
 
@@ -259,18 +258,23 @@ function M.setup()
     })
   end
 
-  on({ "CodeCompanionChatSubmitted", "CodeCompanionChatCompacting", "CodeCompanionToolsStarted" }, function(data)
+  on({
+    "CodeCompanionChatSubmitted",
+    "CodeCompanionChatCompacting",
+    "CodeCompanionCLISubmitted",
+    "CodeCompanionToolsStarted",
+  }, function(data)
     track({ bufnr = data.bufnr, state = "working" })
   end)
 
-  on({ "CodeCompanionChatCreated" }, function(data)
+  on({ "CodeCompanionChatCreated", "CodeCompanionCLICreated" }, function(data)
     open_chats[data.bufnr] = true
     update_herdr()
   end)
-  on({ "CodeCompanionChatDone", "CodeCompanionChatStopped" }, function(data)
+  on({ "CodeCompanionChatDone", "CodeCompanionChatStopped", "CodeCompanionCLIDone" }, function(data)
     untrack({ bufnr = data.bufnr })
   end)
-  on({ "CodeCompanionChatClosed" }, function(data)
+  on({ "CodeCompanionChatClosed", "CodeCompanionCLIClosed" }, function(data)
     open_chats[data.bufnr] = nil
     untrack({ bufnr = data.bufnr })
   end)
@@ -279,6 +283,13 @@ function M.setup()
     track({ bufnr = data.bufnr, state = "blocked", message = data.name and ("Approval needed: " .. data.name) or nil })
   end)
   on({ "CodeCompanionToolApprovalFinished" }, function(data)
+    resume({ bufnr = data.bufnr })
+  end)
+
+  on({ "CodeCompanionCLIBlocked" }, function(data)
+    track({ bufnr = data.bufnr, state = "blocked", message = data.message })
+  end)
+  on({ "CodeCompanionCLIWorking" }, function(data)
     resume({ bufnr = data.bufnr })
   end)
 

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -152,7 +152,7 @@ local function update_herdr()
     return release()
   end
 
-  -- A blocked pane can change what it is waiting on, so the message decides this too
+  -- A blocked pane can change what it is waiting on so make sure we capture this
   local state, message = aggregate_in_flight_chats()
   if state == last_state and message == last_message then
     return
@@ -212,11 +212,11 @@ local function untrack(args)
   update_herdr()
 end
 
----Environment for agents CodeCompanion spawns, so they never claim the pane themselves
+---Environment for the agents that CodeCompanion spawns
 ---@return table<string, string>
 function M.agent_env()
-  -- HERDR_ENV is herdr's master switch, so a spawned agent stops at its first guard and
-  -- CodeCompanion never has to track the rest of herdr's variables to stay ahead of it
+  -- Empty so a spawned agent can't report against Neovim's pane
+  -- NOTE: HERDR_ENV is the guard any hooks check first
   return { HERDR_ENV = "", HERDR_PANE_ID = "" }
 end
 

--- a/lua/codecompanion/integrations/herdr.lua
+++ b/lua/codecompanion/integrations/herdr.lua
@@ -39,6 +39,7 @@ local CONSTANTS = {
 }
 
 local herdr = nil ---@type string|nil
+local last_message = nil ---@type string|nil
 local last_state = nil ---@type string|nil
 
 ---herdr discards a sequence if it's not greater than the previous one
@@ -97,6 +98,7 @@ local function release()
   if not last_state then
     return
   end
+  last_message = nil
   last_state = nil
 
   -- Carries a sequence so herdr discards any report still in flight, which would re-attach the agent
@@ -150,11 +152,13 @@ local function update_herdr()
     return release()
   end
 
+  -- A blocked pane can change what it is waiting on, so the message decides this too
   local state, message = aggregate_in_flight_chats()
-  if state == last_state then
+  if state == last_state and message == last_message then
     return
   end
   last_state = state
+  last_message = message
 
   local args = {
     herdr,
@@ -286,10 +290,10 @@ function M.setup()
     resume({ bufnr = data.bufnr })
   end)
 
-  on({ "CodeCompanionCLIBlocked" }, function(data)
+  on({ "CodeCompanionCLIApprovalRequested" }, function(data)
     track({ bufnr = data.bufnr, state = "blocked", message = data.message })
   end)
-  on({ "CodeCompanionCLIWorking" }, function(data)
+  on({ "CodeCompanionCLIApprovalFinished" }, function(data)
     resume({ bufnr = data.bufnr })
   end)
 

--- a/lua/codecompanion/integrations/init.lua
+++ b/lua/codecompanion/integrations/init.lua
@@ -31,13 +31,13 @@ function M.setup()
   end)
 end
 
----Environment overrides for ACP adapters
+---Environment overrides for agent processes that CodeCompanion spawns
 ---@return table<string, string>
-function M.acp_env()
+function M.agent_env()
   local env = {}
   enabled_integrations(function(integration)
-    if integration.acp_env then
-      env = vim.tbl_extend("force", env, integration.acp_env())
+    if integration.agent_env then
+      env = vim.tbl_extend("force", env, integration.agent_env())
     end
   end)
   return env

--- a/lua/codecompanion/interactions/cli/hooks.lua
+++ b/lua/codecompanion/interactions/cli/hooks.lua
@@ -6,167 +6,30 @@ local api = vim.api
 
 local M = {}
 
-local CONSTANTS = {
-  MARKER = "$CODECOMPANION_HOOK",
-}
-
----@class CodeCompanion.CLI.Hooks.Integration
+---@class CodeCompanion.CLI.Integration
 ---@field name string
----@field hooks table<string, string> The agent's hook events, mapped to the script's actions
----@field settings string The agent's settings file, relative to the home directory
 ---@field script string Filename beneath `interactions/cli/integrations/`
+---@field get_settings_path fun(): string
+---@field install fun(): boolean, string|nil
 
----@type table<string, CodeCompanion.CLI.Hooks.Integration>
-local INTEGRATIONS = {
-  claude = {
-    name = "Claude Code",
-    hooks = {
-      Notification = "approval_requested",
-      PermissionRequest = "approval_requested",
-      PostToolUse = "approval_finished",
-      Stop = "done",
-      UserPromptSubmit = "submitted",
-    },
-    settings = ".claude/settings.json",
-    script = "claude.sh",
-  },
-}
-
----The script an agent's hooks call
+---An agent's integration, which is named after the command that starts it
 ---@param cmd string
----@return string|nil
-function M.script_for(cmd)
-  local integration = INTEGRATIONS[vim.fs.basename(cmd)]
-  if not integration then
-    return nil
-  end
-
-  local path = vim.fs.joinpath("lua", "codecompanion", "interactions", "cli", "integrations", integration.script)
-  return api.nvim_get_runtime_file(path, false)[1]
-end
-
----@param value any
----@param indent string
----@return string
-local function encode(value, indent)
-  if type(value) ~= "table" then
-    return vim.json.encode(value)
-  end
-
-  local child = indent .. "  "
-
-  if vim.islist(value) then
-    if vim.tbl_isempty(value) then
-      return "[]"
-    end
-    local items = vim.tbl_map(function(item)
-      return child .. encode(item, child)
-    end, value)
-    return "[\n" .. table.concat(items, ",\n") .. "\n" .. indent .. "]"
-  end
-
-  if vim.tbl_isempty(value) then
-    return "{}"
-  end
-
-  -- Decoding loses the original key order, so sort to keep repeat writes stable
-  local keys = vim.tbl_keys(value)
-  table.sort(keys)
-
-  local pairs_out = vim.tbl_map(function(key)
-    return string.format("%s%s: %s", child, vim.json.encode(key), encode(value[key], child))
-  end, keys)
-
-  return "{\n" .. table.concat(pairs_out, ",\n") .. "\n" .. indent .. "}"
-end
-
----@param path string
----@return table|nil settings Nil when the file could not be read or parsed
-local function read_settings(path)
-  local ok, lines = pcall(vim.fn.readfile, path)
+---@return CodeCompanion.CLI.Integration|nil
+local function get_integration(cmd)
+  local ok, integration = pcall(require, "codecompanion.interactions.cli.integrations." .. vim.fs.basename(cmd))
   if not ok then
     return nil
   end
 
-  local contents = table.concat(lines, "\n")
-  if vim.trim(contents) == "" then
-    return {}
-  end
-
-  local ok, decoded = pcall(vim.json.decode, contents, { luanil = { object = true, array = true } })
-  if not ok or type(decoded) ~= "table" then
-    return nil
-  end
-
-  return decoded
+  return integration
 end
 
----Drop the entries a previous install wrote, leaving the user's own hooks in place
----@param entries table[]
----@return table[]
-local function remove_our_entries(entries)
-  return vim.tbl_filter(function(entry)
-    for _, hook in ipairs(entry.hooks or {}) do
-      if type(hook.command) == "string" and hook.command:find(CONSTANTS.MARKER, 1, true) then
-        return false
-      end
-    end
-    return true
-  end, entries)
-end
-
----@param action string
----@return table
-local function build_entry(action)
-  return {
-    hooks = {
-      {
-        type = "command",
-        command = string.format('[ -z "%s" ] || "%s" %s', CONSTANTS.MARKER, CONSTANTS.MARKER, action),
-      },
-    },
-  }
-end
-
----@param integration CodeCompanion.CLI.Hooks.Integration
----@return string
-local function get_settings_path(integration)
-  return vim.fs.joinpath(vim.fn.expand("~"), integration.settings)
-end
-
----@param integration CodeCompanion.CLI.Hooks.Integration
----@return boolean
-local function install(integration)
-  local path = get_settings_path(integration)
-
-  local settings = read_settings(path)
-  if not settings then
-    utils.notify(string.format("Could not read or parse %s, so it has been left alone", path), vim.log.levels.ERROR)
-    return false
-  end
-
-  settings.hooks = settings.hooks or {}
-  for event, action in pairs(integration.hooks) do
-    local entries = remove_our_entries(settings.hooks[event] or {})
-    table.insert(entries, build_entry(action))
-    settings.hooks[event] = entries
-  end
-
-  local ok, err = pcall(files.write_to_path, path, encode(settings, "") .. "\n")
-  if not ok then
-    utils.notify(string.format("Could not write %s: %s", path, err), vim.log.levels.ERROR)
-    return false
-  end
-
-  return true
-end
-
----@return CodeCompanion.CLI.Hooks.Integration[]
+---@return CodeCompanion.CLI.Integration[]
 local function get_configured_integrations()
   local found = {}
 
   for _, agent in pairs(config.interactions.cli.agents or {}) do
-    local integration = agent.cmd and INTEGRATIONS[vim.fs.basename(agent.cmd)]
+    local integration = agent.cmd and get_integration(agent.cmd)
     if integration and not vim.tbl_contains(found, integration) then
       table.insert(found, integration)
     end
@@ -183,14 +46,13 @@ function M.install()
     return utils.notify("None of your CLI agents have an integration", vim.log.levels.WARN)
   end
 
-  -- An agent that has never run has no settings to merge into, and writing its config for it
-  -- would leave a file the agent itself has never validated
+  -- An agent that has never run has no settings to merge into, so check for this
   local ready = vim.tbl_filter(function(integration)
-    if files.exists(get_settings_path(integration)) then
+    if files.exists(integration.get_settings_path()) then
       return true
     end
     utils.notify(
-      string.format("%s was not found, so run %s once first", get_settings_path(integration), integration.name),
+      string.format("%s was not found, so run %s once first", integration.get_settings_path(), integration.name),
       vim.log.levels.WARN
     )
     return false
@@ -200,17 +62,36 @@ function M.install()
     return
   end
 
-  local targets = vim.tbl_map(get_settings_path, ready)
+  local targets = vim.tbl_map(function(integration)
+    return integration.get_settings_path()
+  end, ready)
+
   local prompt = string.format("Add CodeCompanion's hooks to:\n%s", table.concat(targets, "\n"))
   if vim.fn.confirm(prompt, "&Install\n&Cancel", 2) ~= 1 then
     return
   end
 
   for _, integration in ipairs(ready) do
-    if install(integration) then
+    local ok, err = integration.install()
+    if ok then
       utils.notify(string.format("Installed the %s hooks", integration.name))
+    else
+      utils.notify(err, vim.log.levels.ERROR)
     end
   end
+end
+
+---The script an agent's hooks call
+---@param cmd string
+---@return string|nil
+function M.script_for_agent(cmd)
+  local integration = get_integration(cmd)
+  if not integration then
+    return nil
+  end
+
+  local path = vim.fs.joinpath("lua", "codecompanion", "interactions", "cli", "integrations", integration.script)
+  return api.nvim_get_runtime_file(path, false)[1]
 end
 
 return M

--- a/lua/codecompanion/interactions/cli/hooks.lua
+++ b/lua/codecompanion/interactions/cli/hooks.lua
@@ -81,9 +81,14 @@ local function encode(value, indent)
 end
 
 ---@param path string
----@return table|nil settings Nil when the file could not be parsed
+---@return table|nil settings Nil when the file could not be read or parsed
 local function read_settings(path)
-  local contents = table.concat(vim.fn.readfile(path), "\n")
+  local ok, lines = pcall(vim.fn.readfile, path)
+  if not ok then
+    return nil
+  end
+
+  local contents = table.concat(lines, "\n")
   if vim.trim(contents) == "" then
     return {}
   end
@@ -99,7 +104,7 @@ end
 ---Drop the entries a previous install wrote, leaving the user's own hooks in place
 ---@param entries table[]
 ---@return table[]
-local function without_ours(entries)
+local function remove_our_entries(entries)
   return vim.tbl_filter(function(entry)
     for _, hook in ipairs(entry.hooks or {}) do
       if type(hook.command) == "string" and hook.command:find(CONSTANTS.MARKER, 1, true) then
@@ -125,24 +130,24 @@ end
 
 ---@param integration CodeCompanion.CLI.Hooks.Integration
 ---@return string
-local function settings_path(integration)
+local function get_settings_path(integration)
   return vim.fs.joinpath(vim.fn.expand("~"), integration.settings)
 end
 
 ---@param integration CodeCompanion.CLI.Hooks.Integration
 ---@return boolean
 local function install(integration)
-  local path = settings_path(integration)
+  local path = get_settings_path(integration)
 
   local settings = read_settings(path)
   if not settings then
-    utils.notify(string.format("Could not parse %s, so it has been left alone", path), vim.log.levels.ERROR)
+    utils.notify(string.format("Could not read or parse %s, so it has been left alone", path), vim.log.levels.ERROR)
     return false
   end
 
   settings.hooks = settings.hooks or {}
   for event, action in pairs(integration.hooks) do
-    local entries = without_ours(settings.hooks[event] or {})
+    local entries = remove_our_entries(settings.hooks[event] or {})
     table.insert(entries, build_entry(action))
     settings.hooks[event] = entries
   end
@@ -157,7 +162,7 @@ local function install(integration)
 end
 
 ---@return CodeCompanion.CLI.Hooks.Integration[]
-local function configured_integrations()
+local function get_configured_integrations()
   local found = {}
 
   for _, agent in pairs(config.interactions.cli.agents or {}) do
@@ -173,7 +178,7 @@ end
 ---Write the hooks each configured CLI agent needs in order to report its turns
 ---@return nil
 function M.install()
-  local integrations = configured_integrations()
+  local integrations = get_configured_integrations()
   if vim.tbl_isempty(integrations) then
     return utils.notify("None of your CLI agents have an integration", vim.log.levels.WARN)
   end
@@ -181,11 +186,11 @@ function M.install()
   -- An agent that has never run has no settings to merge into, and writing its config for it
   -- would leave a file the agent itself has never validated
   local ready = vim.tbl_filter(function(integration)
-    if files.exists(settings_path(integration)) then
+    if files.exists(get_settings_path(integration)) then
       return true
     end
     utils.notify(
-      string.format("%s was not found, so run %s once first", settings_path(integration), integration.name),
+      string.format("%s was not found, so run %s once first", get_settings_path(integration), integration.name),
       vim.log.levels.WARN
     )
     return false
@@ -195,7 +200,7 @@ function M.install()
     return
   end
 
-  local targets = vim.tbl_map(settings_path, ready)
+  local targets = vim.tbl_map(get_settings_path, ready)
   local prompt = string.format("Add CodeCompanion's hooks to:\n%s", table.concat(targets, "\n"))
   if vim.fn.confirm(prompt, "&Install\n&Cancel", 2) ~= 1 then
     return

--- a/lua/codecompanion/interactions/cli/hooks.lua
+++ b/lua/codecompanion/interactions/cli/hooks.lua
@@ -1,0 +1,211 @@
+local config = require("codecompanion.config")
+local files = require("codecompanion.utils.files")
+local utils = require("codecompanion.utils")
+
+local api = vim.api
+
+local M = {}
+
+local CONSTANTS = {
+  MARKER = "$CODECOMPANION_HOOK",
+}
+
+---@class CodeCompanion.CLI.Hooks.Integration
+---@field name string
+---@field hooks table<string, string> The agent's hook events, mapped to the script's actions
+---@field settings string The agent's settings file, relative to the home directory
+---@field script string Filename beneath `interactions/cli/integrations/`
+
+---@type table<string, CodeCompanion.CLI.Hooks.Integration>
+local INTEGRATIONS = {
+  claude = {
+    name = "Claude Code",
+    hooks = {
+      Notification = "approval_requested",
+      PermissionRequest = "approval_requested",
+      PostToolUse = "approval_finished",
+      Stop = "done",
+      UserPromptSubmit = "submitted",
+    },
+    settings = ".claude/settings.json",
+    script = "claude.sh",
+  },
+}
+
+---The script an agent's hooks call
+---@param cmd string
+---@return string|nil
+function M.script_for(cmd)
+  local integration = INTEGRATIONS[vim.fs.basename(cmd)]
+  if not integration then
+    return nil
+  end
+
+  local path = vim.fs.joinpath("lua", "codecompanion", "interactions", "cli", "integrations", integration.script)
+  return api.nvim_get_runtime_file(path, false)[1]
+end
+
+---@param value any
+---@param indent string
+---@return string
+local function encode(value, indent)
+  if type(value) ~= "table" then
+    return vim.json.encode(value)
+  end
+
+  local child = indent .. "  "
+
+  if vim.islist(value) then
+    if vim.tbl_isempty(value) then
+      return "[]"
+    end
+    local items = vim.tbl_map(function(item)
+      return child .. encode(item, child)
+    end, value)
+    return "[\n" .. table.concat(items, ",\n") .. "\n" .. indent .. "]"
+  end
+
+  if vim.tbl_isempty(value) then
+    return "{}"
+  end
+
+  -- Decoding loses the original key order, so sort to keep repeat writes stable
+  local keys = vim.tbl_keys(value)
+  table.sort(keys)
+
+  local pairs_out = vim.tbl_map(function(key)
+    return string.format("%s%s: %s", child, vim.json.encode(key), encode(value[key], child))
+  end, keys)
+
+  return "{\n" .. table.concat(pairs_out, ",\n") .. "\n" .. indent .. "}"
+end
+
+---@param path string
+---@return table|nil settings Nil when the file could not be parsed
+local function read_settings(path)
+  local contents = table.concat(vim.fn.readfile(path), "\n")
+  if vim.trim(contents) == "" then
+    return {}
+  end
+
+  local ok, decoded = pcall(vim.json.decode, contents, { luanil = { object = true, array = true } })
+  if not ok or type(decoded) ~= "table" then
+    return nil
+  end
+
+  return decoded
+end
+
+---Drop the entries a previous install wrote, leaving the user's own hooks in place
+---@param entries table[]
+---@return table[]
+local function without_ours(entries)
+  return vim.tbl_filter(function(entry)
+    for _, hook in ipairs(entry.hooks or {}) do
+      if type(hook.command) == "string" and hook.command:find(CONSTANTS.MARKER, 1, true) then
+        return false
+      end
+    end
+    return true
+  end, entries)
+end
+
+---@param action string
+---@return table
+local function build_entry(action)
+  return {
+    hooks = {
+      {
+        type = "command",
+        command = string.format('[ -z "%s" ] || "%s" %s', CONSTANTS.MARKER, CONSTANTS.MARKER, action),
+      },
+    },
+  }
+end
+
+---@param integration CodeCompanion.CLI.Hooks.Integration
+---@return string
+local function settings_path(integration)
+  return vim.fs.joinpath(vim.fn.expand("~"), integration.settings)
+end
+
+---@param integration CodeCompanion.CLI.Hooks.Integration
+---@return boolean
+local function install(integration)
+  local path = settings_path(integration)
+
+  local settings = read_settings(path)
+  if not settings then
+    utils.notify(string.format("Could not parse %s, so it has been left alone", path), vim.log.levels.ERROR)
+    return false
+  end
+
+  settings.hooks = settings.hooks or {}
+  for event, action in pairs(integration.hooks) do
+    local entries = without_ours(settings.hooks[event] or {})
+    table.insert(entries, build_entry(action))
+    settings.hooks[event] = entries
+  end
+
+  local ok, err = pcall(files.write_to_path, path, encode(settings, "") .. "\n")
+  if not ok then
+    utils.notify(string.format("Could not write %s: %s", path, err), vim.log.levels.ERROR)
+    return false
+  end
+
+  return true
+end
+
+---@return CodeCompanion.CLI.Hooks.Integration[]
+local function configured_integrations()
+  local found = {}
+
+  for _, agent in pairs(config.interactions.cli.agents or {}) do
+    local integration = agent.cmd and INTEGRATIONS[vim.fs.basename(agent.cmd)]
+    if integration and not vim.tbl_contains(found, integration) then
+      table.insert(found, integration)
+    end
+  end
+
+  return found
+end
+
+---Write the hooks each configured CLI agent needs in order to report its turns
+---@return nil
+function M.install()
+  local integrations = configured_integrations()
+  if vim.tbl_isempty(integrations) then
+    return utils.notify("None of your CLI agents have an integration", vim.log.levels.WARN)
+  end
+
+  -- An agent that has never run has no settings to merge into, and writing its config for it
+  -- would leave a file the agent itself has never validated
+  local ready = vim.tbl_filter(function(integration)
+    if files.exists(settings_path(integration)) then
+      return true
+    end
+    utils.notify(
+      string.format("%s was not found, so run %s once first", settings_path(integration), integration.name),
+      vim.log.levels.WARN
+    )
+    return false
+  end, integrations)
+
+  if vim.tbl_isempty(ready) then
+    return
+  end
+
+  local targets = vim.tbl_map(settings_path, ready)
+  local prompt = string.format("Add CodeCompanion's hooks to:\n%s", table.concat(targets, "\n"))
+  if vim.fn.confirm(prompt, "&Install\n&Cancel", 2) ~= 1 then
+    return
+  end
+
+  for _, integration in ipairs(ready) do
+    if install(integration) then
+      utils.notify(string.format("Installed the %s hooks", integration.name))
+    end
+  end
+end
+
+return M

--- a/lua/codecompanion/interactions/cli/init.lua
+++ b/lua/codecompanion/interactions/cli/init.lua
@@ -17,11 +17,54 @@ _G.codecompanion_cli_metadata = {}
 ---@field bufnr number
 ---@field id number
 ---@field provider CodeCompanion.CLI.Provider
+---@field request_id string|nil
 ---@field ui CodeCompanion.CLI.UI
 local CLI = {}
 
 local clis = {} ---@type table<number, CodeCompanion.CLI>
 local last_cli = nil ---@type CodeCompanion.CLI|nil
+
+local HOOK_EVENTS = {
+  approval_finished = "CLIApprovalFinished",
+  approval_requested = "CLIApprovalRequested",
+  done = "CLIDone",
+  submitted = "CLISubmitted",
+}
+
+---@param cli CodeCompanion.CLI
+---@return table
+local function request_payload(cli)
+  return {
+    id = cli.request_id,
+    bufnr = cli.bufnr,
+    interaction = "cli",
+    adapter = {
+      name = cli.agent_name,
+      formatted_name = cli.agent.description or cli.agent_name,
+      type = "cli",
+    },
+  }
+end
+
+---Open the request that statusline integrations pair with, so a CLI turn shows as in flight
+---@param cli CodeCompanion.CLI
+---@return nil
+local function start_request(cli)
+  cli.request_id = tostring(math.random(10000000))
+  utils.fire("RequestStarted", request_payload(cli))
+end
+
+---@param cli CodeCompanion.CLI
+---@param status "success"|"cancelled"
+---@return nil
+local function finish_request(cli, status)
+  if not cli.request_id then
+    return
+  end
+
+  utils.fire("RequestFinished", vim.tbl_extend("force", request_payload(cli), { status = status }))
+  cli.request_id = nil
+end
 
 ---Keymap callbacks for the CLI buffer
 local keymap_callbacks = {
@@ -236,6 +279,7 @@ end
 ---@return nil
 function CLI:close()
   self.provider:stop()
+  finish_request(self, "cancelled")
 
   pcall(api.nvim_del_augroup_by_id, self.aug)
 
@@ -274,6 +318,30 @@ end
 ---@return boolean
 function CLI.is_visible()
   return CLI.get_visible() ~= nil
+end
+
+---Hook into a CLI agent
+---@param opts { bufnr: number, event: "submitted"|"done"|"approval_requested"|"approval_finished", message?: string }
+---@return string
+function CLI.hook(opts)
+  local event = HOOK_EVENTS[opts.event]
+  if not event or not clis[opts.bufnr] then
+    return ""
+  end
+
+  -- The agent blocks on this call, so let it return before the listeners run
+  vim.schedule(function()
+    utils.fire(event, { bufnr = opts.bufnr, message = opts.message })
+
+    -- A turn stays in flight while the agent waits on the user, so only its ends move the request
+    if opts.event == "submitted" then
+      start_request(clis[opts.bufnr])
+    elseif opts.event == "done" then
+      finish_request(clis[opts.bufnr], "success")
+    end
+  end)
+
+  return ""
 end
 
 ---Toggle the CLI terminal buffer

--- a/lua/codecompanion/interactions/cli/init.lua
+++ b/lua/codecompanion/interactions/cli/init.lua
@@ -33,7 +33,7 @@ local HOOK_EVENTS = {
 
 ---@param cli CodeCompanion.CLI
 ---@return table
-local function request_payload(cli)
+local function build_request_payload(cli)
   return {
     id = cli.request_id,
     bufnr = cli.bufnr,
@@ -51,7 +51,7 @@ end
 ---@return nil
 local function start_request(cli)
   cli.request_id = tostring(math.random(10000000))
-  utils.fire("RequestStarted", request_payload(cli))
+  utils.fire("RequestStarted", build_request_payload(cli))
 end
 
 ---@param cli CodeCompanion.CLI
@@ -62,7 +62,7 @@ local function finish_request(cli, status)
     return
   end
 
-  utils.fire("RequestFinished", vim.tbl_extend("force", request_payload(cli), { status = status }))
+  utils.fire("RequestFinished", vim.tbl_extend("force", build_request_payload(cli), { status = status }))
   cli.request_id = nil
 end
 
@@ -331,13 +331,18 @@ function CLI.hook(opts)
 
   -- The agent blocks on this call, so let it return before the listeners run
   vim.schedule(function()
+    local cli = clis[opts.bufnr]
+    if not cli then
+      return
+    end
+
     utils.fire(event, { bufnr = opts.bufnr, message = opts.message })
 
     -- A turn stays in flight while the agent waits on the user, so only its ends move the request
     if opts.event == "submitted" then
-      start_request(clis[opts.bufnr])
+      start_request(cli)
     elseif opts.event == "done" then
-      finish_request(clis[opts.bufnr], "success")
+      finish_request(cli, "success")
     end
   end)
 

--- a/lua/codecompanion/interactions/cli/integrations/claude.lua
+++ b/lua/codecompanion/interactions/cli/integrations/claude.lua
@@ -1,0 +1,136 @@
+local files = require("codecompanion.utils.files")
+
+local M = {}
+
+M.name = "Claude Code"
+M.script = "claude.sh"
+
+-- `claude.sh` reads the same variable, so the pair owns the name between them
+local MARKER = "$CODECOMPANION_HOOK"
+
+---Claude Code's hook events, mapped to the actions `claude.sh` reports
+local HOOKS = {
+  Notification = "approval_requested",
+  PermissionRequest = "approval_requested",
+  PostToolUse = "approval_finished",
+  Stop = "done",
+  UserPromptSubmit = "submitted",
+}
+
+---@param value any
+---@param indent? string Carried through the recursion, not for callers
+---@return string
+local function encode(value, indent)
+  indent = indent or ""
+
+  if type(value) ~= "table" then
+    return vim.json.encode(value)
+  end
+
+  local child = indent .. "  "
+
+  if vim.islist(value) then
+    if vim.tbl_isempty(value) then
+      return "[]"
+    end
+    local items = vim.tbl_map(function(item)
+      return child .. encode(item, child)
+    end, value)
+    return "[\n" .. table.concat(items, ",\n") .. "\n" .. indent .. "]"
+  end
+
+  if vim.tbl_isempty(value) then
+    return "{}"
+  end
+
+  -- Decoding loses the original key order, so sort to keep repeat writes stable
+  local keys = vim.tbl_keys(value)
+  table.sort(keys)
+
+  local pairs_out = vim.tbl_map(function(key)
+    return string.format("%s%s: %s", child, vim.json.encode(key), encode(value[key], child))
+  end, keys)
+
+  return "{\n" .. table.concat(pairs_out, ",\n") .. "\n" .. indent .. "}"
+end
+
+---@param path string
+---@return table|nil settings Nil when the file could not be read or parsed
+local function read_settings(path)
+  local read_ok, lines = pcall(vim.fn.readfile, path)
+  if not read_ok then
+    return nil
+  end
+
+  local contents = table.concat(lines, "\n")
+  if vim.trim(contents) == "" then
+    return {}
+  end
+
+  local decode_ok, decoded = pcall(vim.json.decode, contents, { luanil = { object = true, array = true } })
+  if not decode_ok or type(decoded) ~= "table" then
+    return nil
+  end
+
+  return decoded
+end
+
+---Remove previous writes that CodeCompanion made to Claude Code's settings
+---@param entries table[]
+---@return table[]
+local function delete_entries(entries)
+  return vim.tbl_filter(function(entry)
+    for _, hook in ipairs(entry.hooks or {}) do
+      if type(hook.command) == "string" and hook.command:find(MARKER, 1, true) then
+        return false
+      end
+    end
+    return true
+  end, entries)
+end
+
+---@param action string
+---@return table
+local function build_entry(action)
+  return {
+    hooks = {
+      {
+        type = "command",
+        command = string.format('[ -z "%s" ] || "%s" %s', MARKER, MARKER, action),
+      },
+    },
+  }
+end
+
+---@return string
+function M.get_settings_path()
+  return vim.fs.joinpath(vim.fn.expand("~"), ".claude", "settings.json")
+end
+
+---Merge CodeCompanion's hooks into Claude Code's settings
+---@return boolean ok
+---@return string|nil err
+function M.install()
+  local path = M.get_settings_path()
+
+  local settings = read_settings(path)
+  if not settings then
+    return false, string.format("Could not read or parse %s, so it has been left alone", path)
+  end
+
+  settings.hooks = settings.hooks or {}
+  for event, action in pairs(HOOKS) do
+    local entries = delete_entries(settings.hooks[event] or {})
+    table.insert(entries, build_entry(action))
+    settings.hooks[event] = entries
+  end
+
+  local ok, err = pcall(files.write_to_path, path, encode(settings) .. "\n")
+  if not ok then
+    return false, string.format("Could not write %s: %s", path, err)
+  end
+
+  return true
+end
+
+return M

--- a/lua/codecompanion/interactions/cli/integrations/claude.sh
+++ b/lua/codecompanion/interactions/cli/integrations/claude.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Reports Claude Code's turn events back to the Neovim instance that started it.
+#
+# CodeCompanion sets CODECOMPANION_HOOK to this path in the agent's environment, so
+# `.claude/settings.json` calls it without knowing where the plugin is installed. Both
+# guards below make the script do nothing when Claude Code runs anywhere else.
+
+set -u
+
+action="${1:-}"
+
+[ -n "${CODECOMPANION_CLI_BUFNR:-}" ] || exit 0
+[ -n "${NVIM:-}" ] || exit 0
+
+# The socket's basename carries Neovim's pid, so this stays unique without forking a subshell
+marker="${TMPDIR:-/tmp}/codecompanion-approval-${NVIM##*/}-$CODECOMPANION_CLI_BUFNR"
+message=""
+
+case "$action" in
+  submitted | done)
+    rm -f "$marker"
+    ;;
+  approval_requested)
+    : >"$marker"
+    message="Waiting for you"
+    # Only PermissionRequest names a tool, so Notification keeps the message above
+    if command -v jq >/dev/null 2>&1; then
+      tool="$(jq -r '.tool_name // empty' 2>/dev/null)"
+      if [ -n "$tool" ]; then
+        message="Permission: $tool"
+      fi
+    fi
+    ;;
+  approval_finished)
+    # Runs after every tool call, so cost nothing unless an approval is outstanding
+    if [ ! -f "$marker" ]; then
+      exit 0
+    fi
+    rm -f "$marker"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+expression="v:lua.require'codecompanion'.cli_hook({'bufnr': $CODECOMPANION_CLI_BUFNR, 'event': '$action'"
+if [ -n "$message" ]; then
+  expression="$expression, 'message': '$(printf '%s' "$message" | tr -d "'")'"
+fi
+expression="$expression})"
+
+# A closed Neovim must not fail the hook, because a non-zero UserPromptSubmit blocks the prompt
+nvim --server "$NVIM" --remote-expr "$expression" >/dev/null 2>&1 || true
+
+exit 0

--- a/lua/codecompanion/interactions/cli/providers/terminal.lua
+++ b/lua/codecompanion/interactions/cli/providers/terminal.lua
@@ -49,7 +49,7 @@ end
 local function build_hook_env(opts)
   local env = { CODECOMPANION_CLI_BUFNR = tostring(opts.bufnr) }
 
-  local script = hooks.script_for(opts.cmd)
+  local script = hooks.script_for_agent(opts.cmd)
   if script then
     env.CODECOMPANION_HOOK = script
   end

--- a/lua/codecompanion/interactions/cli/providers/terminal.lua
+++ b/lua/codecompanion/interactions/cli/providers/terminal.lua
@@ -44,13 +44,12 @@ function Terminal.new(args)
 end
 
 ---Environment that lets an agent's hooks report back to this buffer via `$NVIM`
----@param bufnr number
----@param cmd string
+---@param opts { bufnr: number, cmd: string }
 ---@return table<string, string>
-local function hook_env(bufnr, cmd)
-  local env = { CODECOMPANION_CLI_BUFNR = tostring(bufnr) }
+local function build_hook_env(opts)
+  local env = { CODECOMPANION_CLI_BUFNR = tostring(opts.bufnr) }
 
-  local script = hooks.script_for(cmd)
+  local script = hooks.script_for(opts.cmd)
   if script then
     env.CODECOMPANION_HOOK = script
   end
@@ -69,7 +68,11 @@ function Terminal:start()
       self.chan = vim.fn.jobstart(cmd, {
         term = true,
         cwd = vim.fn.getcwd(),
-        env = vim.tbl_extend("force", hook_env(self.bufnr, self.agent.cmd), integrations.agent_env()),
+        env = vim.tbl_extend(
+          "force",
+          build_hook_env({ bufnr = self.bufnr, cmd = self.agent.cmd }),
+          integrations.agent_env()
+        ),
         on_exit = function(_, exit_code, _)
           log:debug("CLI agent exited with code %d", exit_code)
           self.chan = nil

--- a/lua/codecompanion/interactions/cli/providers/terminal.lua
+++ b/lua/codecompanion/interactions/cli/providers/terminal.lua
@@ -2,6 +2,8 @@
 -- https://github.com/folke/sidekick.nvim
 
 local Queue = require("codecompanion.utils.queue")
+local hooks = require("codecompanion.interactions.cli.hooks")
+local integrations = require("codecompanion.integrations")
 local log = require("codecompanion.utils.log")
 
 local api = vim.api
@@ -41,6 +43,21 @@ function Terminal.new(args)
   return self
 end
 
+---Environment that lets an agent's hooks report back to this buffer via `$NVIM`
+---@param bufnr number
+---@param cmd string
+---@return table<string, string>
+local function hook_env(bufnr, cmd)
+  local env = { CODECOMPANION_CLI_BUFNR = tostring(bufnr) }
+
+  local script = hooks.script_for(cmd)
+  if script then
+    env.CODECOMPANION_HOOK = script
+  end
+
+  return env
+end
+
 ---Start the terminal process and begin polling for readiness
 ---@return boolean
 function Terminal:start()
@@ -52,6 +69,7 @@ function Terminal:start()
       self.chan = vim.fn.jobstart(cmd, {
         term = true,
         cwd = vim.fn.getcwd(),
+        env = vim.tbl_extend("force", hook_env(self.bufnr, self.agent.cmd), integrations.agent_env()),
         on_exit = function(_, exit_code, _)
           log:debug("CLI agent exited with code %d", exit_code)
           self.chan = nil

--- a/lua/codecompanion/interactions/code_review/init.lua
+++ b/lua/codecompanion/interactions/code_review/init.lua
@@ -392,7 +392,7 @@ function M.setup()
   api.nvim_create_autocmd("User", {
     desc = "Snapshot the review baseline at the start of an agent's edits",
     group = group,
-    pattern = { "CodeCompanionChatSubmitted", "CodeCompanionCLISent" },
+    pattern = { "CodeCompanionChatSubmitted", "CodeCompanionCLISent", "CodeCompanionCLISubmitted" },
     callback = function()
       local root = baseline.get_root()
       if not root then
@@ -413,7 +413,7 @@ function M.setup()
   api.nvim_create_autocmd("User", {
     desc = "Re-baseline on the next prompt when the agent changed no files",
     group = group,
-    pattern = "CodeCompanionChatDone",
+    pattern = { "CodeCompanionChatDone", "CodeCompanionCLIDone" },
     callback = function()
       local root = baseline.get_root()
       if root and store.round_open(root) and baseline.worktree_matches(root) then


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Hook into CLI agents (Claude Code for now) to allow for tighter Neovim integration.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code and Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
