### PR TITLE
fix(ui): auto scrolling when the last line is in a fold

### DIFF
--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -283,10 +283,10 @@ function UI:is_following()
     return true
   end
 
-  -- Or if the last line is folded away and the cursor sits on that fold's header line.
-  -- Trailing blank lines are trimmed under the cursor, and when the tail of the
-  -- buffer is a closed tool fold, the clamp displaces the cursor to the fold's
-  -- header rather than the last line (e.g. multi-line MCP tool output)
+  -- Or if the very last lines are folded and the cursor sits on them.
+  --
+  -- In this case, the cursor is visually at the bottom of the chat, but programmatically
+  -- it's on the header line of the fold.
   if line_count > 0 then
     local ok_fold, fold_start = pcall(api.nvim_win_call, self.winnr, function()
       return vim.fn.foldclosed(line_count)

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -283,10 +283,7 @@ function UI:is_following()
     return true
   end
 
-  -- Or if the very last lines are folded and the cursor sits on them.
-  --
-  -- In this case, the cursor is visually at the bottom of the chat, but programmatically
-  -- it's on the header line of the fold.
+  -- Or if the very last lines are folded and the cursor sits on them
   if line_count > 0 then
     local ok_fold, fold_start = pcall(api.nvim_win_call, self.winnr, function()
       return vim.fn.foldclosed(line_count)

--- a/lua/codecompanion/interactions/chat/ui/init.lua
+++ b/lua/codecompanion/interactions/chat/ui/init.lua
@@ -279,7 +279,24 @@ function UI:is_following()
 
   -- Or if it's still where we last placed it, with the buffer having grown beneath it
   local followed_to = self.cursor.followed_to
-  return followed_to ~= nil and followed_to[1] == cursor[1] and followed_to[2] == cursor[2]
+  if followed_to ~= nil and followed_to[1] == cursor[1] and followed_to[2] == cursor[2] then
+    return true
+  end
+
+  -- Or if the last line is folded away and the cursor sits on that fold's header line.
+  -- Trailing blank lines are trimmed under the cursor, and when the tail of the
+  -- buffer is a closed tool fold, the clamp displaces the cursor to the fold's
+  -- header rather than the last line (e.g. multi-line MCP tool output)
+  if line_count > 0 then
+    local ok_fold, fold_start = pcall(api.nvim_win_call, self.winnr, function()
+      return vim.fn.foldclosed(line_count)
+    end)
+    if ok_fold and fold_start ~= -1 and fold_start == cursor[1] then
+      return true
+    end
+  end
+
+  return false
 end
 
 ---Determine if the current chat buffer is active


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

<!--
  Please provide a clear and concise description of your changes:
  - What does this PR do?
  - Why is this change needed?
  - If this is a feature request, describe how it will benefit other CodeCompanion users.
-->

Usually when the cursor is on the last line in the chat buffer, the buffer automatically scrolls down. But on the main branch there was a bug: if the last line is in a folded fold, it wouldn't scroll.

When a tool outputs multiple lines and marks them not for users, the lines will be automatically folded, and triggers this bug. This is typical for my MCP tools: they always output multiple lines, and the scrolling never works.

The root cause is: when a cursor is on a folded fold, it was on the fold's header line, rather than it's last line.

This PR simply modifies the "at last line" criteria, and treats "the very last lines are folded and the cursor is on a header line of a folded fold" equivalent as "the cursor is on the last line".

I installed the modified code and the bug has gone.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

N/A

## AI Usage

<!--
  CodeCompanion actively encourages PRs and the use of CodeCompanion to help write them.
  If you used AI assistance to help with this PR, please describe how you used it and the models you used.
-->

This code is developed by CodeCompanion with GLM-5.3. The PR message is written by me.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

N/A

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

N/A

## Checklist

- [X] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code. **See "Notes" below**.
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages

## Notes

I ran `StyLua` but I got some difficulties: my StyLua 2.5.2 rejects the repo's syntax = "Lua52". Everything else in `make all` runs fine.
