### PR TITLE
refactor(adapters): extract model resolve logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ Core: `lua/codecompanion/`
 - Don't over-explore the codebase with excessive grep/read calls. If you haven't converged on an approach after 3-4 searches, pause and share what you've found so far rather than continuing to search.
 - When the user asks to fix tests, fix the tests - not the source code - unless explicitly asked otherwise.
 - If you're working with directories or files, utilise the functions in `codecompanion/utils/files.lua` ensuring you join paths with `vim.fs.joinpath`
+- Never read `adapter.schema.model.default` directly - it holds a function on Ollama and any `openai_compatible` adapter. `adapter_utils.model(adapter)` gives the model as a string without ever calling that function; `adapter_utils.resolve_model(adapter)` calls it for the places that need the value and can afford the HTTP round-trip it may cost. Both return `string|nil`
+- To change an adapter's model, `adapters.set_model({ adapter = adapter, model = "gpt-4o" })`, or `adapters.resolve(name, { model = "gpt-4o" })` when starting from an adapter name. Don't assign the schema yourself
 
 ### Testing
 

--- a/lua/codecompanion/adapters/http/init.lua
+++ b/lua/codecompanion/adapters/http/init.lua
@@ -274,7 +274,7 @@ function Adapter.extend(adapter, opts)
 end
 
 ---Set the model name and options on the adapter for convenience
----@param args { adapter: CodeCompanion.HTTPAdapter }
+---@param args { adapter: CodeCompanion.HTTPAdapter, model?: string }
 ---@return CodeCompanion.HTTPAdapter
 function Adapter.set_model(args)
   local adapter = args.adapter
@@ -284,6 +284,10 @@ function Adapter.set_model(args)
   -- requests to obtain a list of available models. This is expensive, so
   -- we don't execute them here. Instead, let the user decide when to.
   if adapter.schema and adapter.schema.model then
+    if args.model then
+      adapter.schema.model.default = args.model
+    end
+
     adapter.model = {}
     local model = adapter.schema.model.default
     local choices = adapter.schema.model.choices

--- a/lua/codecompanion/adapters/shared.lua
+++ b/lua/codecompanion/adapters/shared.lua
@@ -55,15 +55,7 @@ local function from_model_meta(adapter, fields)
     return value
   end
 
-  local model = adapter.schema and adapter.schema.model and adapter.schema.model.default
-  if type(model) == "function" then
-    local ok, resolved = pcall(model, adapter)
-    if not ok then
-      log:debug("[Context Window] Failed to resolve model name for `%s` adapter: %s", adapter.name, resolved)
-      return nil
-    end
-    model = resolved
-  end
+  local model = adapter_utils.resolve_model(adapter)
 
   local choices = adapter.schema and adapter.schema.model and adapter.schema.model.choices
   if type(choices) == "function" then

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -409,6 +409,7 @@ function M.map_roles(roles, messages)
       message.role = roles[message.role:lower()] or message.role
     end
   end
+
   return messages
 end
 
@@ -437,9 +438,10 @@ function M.resolve_model(adapter, opts)
 
   local ok, resolved = pcall(default, adapter, opts)
   if not ok then
-    log:debug("[adapters::utils::resolve_model] Could not resolve a model for `%s`: %s", adapter.name, resolved)
+    log:error("[adapters::utils::resolve_model] Could not resolve model for `%s`: %s", adapter.name, resolved)
     return nil
   end
+
   return type(resolved) == "string" and resolved or nil
 end
 
@@ -455,6 +457,7 @@ function M.model_choice(adapter, opts)
   if type(choices) ~= "table" then
     return nil
   end
+
   return choices[M.resolve_model(adapter, opts)]
 end
 

--- a/lua/codecompanion/adapters/utils/init.lua
+++ b/lua/codecompanion/adapters/utils/init.lua
@@ -412,11 +412,35 @@ function M.map_roles(roles, messages)
   return messages
 end
 
----Helper function to return the default model
+---Obtain the model from the given adapter's schema
 ---@param adapter CodeCompanion.HTTPAdapter
----@return string
+---@return string|nil
 function M.model(adapter)
-  return adapter.schema.model.default
+  local default = adapter.schema and adapter.schema.model and adapter.schema.model.default
+  return type(default) == "string" and default or nil
+end
+
+---Resolve the model from the given adapter
+---@param adapter CodeCompanion.HTTPAdapter
+---@param opts? { async?: boolean }
+---@return string|nil
+function M.resolve_model(adapter, opts)
+  local model = M.model(adapter)
+  if model then
+    return model
+  end
+
+  local default = adapter.schema and adapter.schema.model and adapter.schema.model.default
+  if type(default) ~= "function" then
+    return nil
+  end
+
+  local ok, resolved = pcall(default, adapter, opts)
+  if not ok then
+    log:debug("[adapters::utils::resolve_model] Could not resolve a model for `%s`: %s", adapter.name, resolved)
+    return nil
+  end
+  return type(resolved) == "string" and resolved or nil
 end
 
 ---Helper function to return the model from the choices
@@ -431,7 +455,7 @@ function M.model_choice(adapter, opts)
   if type(choices) ~= "table" then
     return nil
   end
-  return choices[M.model(adapter)]
+  return choices[M.resolve_model(adapter, opts)]
 end
 
 return M

--- a/lua/codecompanion/http.lua
+++ b/lua/codecompanion/http.lua
@@ -169,11 +169,10 @@ end
 ---@param adapter CodeCompanion.HTTPAdapter
 ---@return table
 local function adapter_event_data(adapter)
-  local model = adapter.schema.model.default
   return {
     name = adapter.name,
     formatted_name = adapter.formatted_name,
-    model = type(model) == "function" and model(adapter) or model or "",
+    model = adapter_utils.resolve_model(adapter) or "",
   }
 end
 

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -65,6 +65,7 @@
 ---@field window_opts? table Window configuration options for the chat buffer
 ---@field yolo_mode? boolean Automatically approve all tool calls
 
+local adapter_utils = require("codecompanion.adapters.utils")
 local adapters = require("codecompanion.adapters")
 local approvals = require("codecompanion.interactions.chat.tools.approvals")
 local config = require("codecompanion.config")
@@ -417,7 +418,7 @@ local function init_adapter(chat, args)
     adapter = adapters.make_safe(chat.adapter),
     bufnr = chat.bufnr,
     id = chat.id,
-    model = chat.adapter.schema and chat.adapter.schema.model.default,
+    model = adapter_utils.resolve_model(chat.adapter),
   })
 
   if chat.adapter.type == "http" then
@@ -830,7 +831,6 @@ function Chat:change_model(args)
 
   if self.adapter.type == "http" then
     self.settings.model = args.model
-    self.adapter.schema.model.default = args.model
     self.adapter = apply()
 
     self:set_system_prompt()
@@ -2050,7 +2050,7 @@ function Chat:update_metadata()
   local config_options
 
   if self.adapter.type == "http" then
-    model = self.adapter.schema and self.adapter.schema.model and self.adapter.schema.model.default
+    model = adapter_utils.model(self.adapter)
   elseif self.adapter.type == "acp" and self.acp_connection then
     local acp_models = self.acp_connection:get_models()
     model = acp_models and acp_models.currentModelId or "default"

--- a/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
+++ b/lua/codecompanion/interactions/chat/keymaps/change_adapter.lua
@@ -1,3 +1,4 @@
+local adapter_utils = require("codecompanion.adapters.utils")
 local config = require("codecompanion.config")
 local log = require("codecompanion.utils.log")
 local utils = require("codecompanion.utils")
@@ -72,10 +73,7 @@ function M.list_http_models(adapter)
     return nil
   end
 
-  local current_model_id = adapter.schema.model.default
-  if type(current_model_id) == "function" then
-    current_model_id = current_model_id(adapter)
-  end
+  local current_model_id = adapter_utils.resolve_model(adapter)
 
   local current_model = nil
 

--- a/lua/codecompanion/interactions/chat/sessions/serializer.lua
+++ b/lua/codecompanion/interactions/chat/sessions/serializer.lua
@@ -9,6 +9,7 @@
 --]]
 
 local ToolRegistry = require("codecompanion.interactions.chat.tool_registry")
+local adapter_utils = require("codecompanion.adapters.utils")
 local adapters = require("codecompanion.adapters")
 local config = require("codecompanion.config")
 local utils = require("codecompanion.utils")
@@ -59,20 +60,6 @@ local function encode_tools(registry)
   }
 end
 
----The model as a plain string, or nil when the adapter has yet to settle on one
----@param adapter CodeCompanion.HTTPAdapter
----@return string|nil
-local function get_model(adapter)
-  local name = adapter and adapter.model and adapter.model.name
-  if type(name) == "string" then
-    return name
-  end
-
-  -- Adapters like Ollama make `default` a function that fetches the model list over HTTP
-  local default = adapter and adapter.schema and adapter.schema.model and adapter.schema.model.default
-  return type(default) == "string" and default or nil
-end
-
 ---@param chat CodeCompanion.Chat
 ---@return string
 local function get_cwd(chat)
@@ -93,7 +80,7 @@ function M.to_session(chat, opts)
       context_items = vim.deepcopy(chat.context_items or {}),
       cycle = chat.cycle,
       messages = encode_messages(chat.messages),
-      model = get_model(adapter),
+      model = adapter and adapter_utils.model(adapter),
       schema_version = M.SCHEMA_VERSION,
       settings = chat.settings and vim.deepcopy(chat.settings) or nil,
       tools = encode_tools(chat.tool_registry),
@@ -114,7 +101,6 @@ end
 local function resolve_adapter(saved_chat)
   local name = saved_chat.adapter
   if name and config.adapters.http and config.adapters.http[name] then
-    -- The model has to be passed through `resolve`; `set_model` reads the adapter's own default
     return adapters.resolve(name, { model = saved_chat.model })
   end
 

--- a/tests/adapters/test_adapters.lua
+++ b/tests/adapters/test_adapters.lua
@@ -356,6 +356,20 @@ T["HTTP Adapter"]["can update a model on the adapter"] = function()
   }, result)
 end
 
+T["HTTP Adapter"]["set_model applies the model it is given"] = function()
+  local result = child.lua([[
+    local adapters = require("codecompanion.adapters")
+    local adapter = adapters.set_model({
+      adapter = adapters.resolve(test_adapter),
+      model = "gpt-4-1106-preview",
+    })
+    return { name = adapter.model.name, default = adapter.schema.model.default }
+  ]])
+
+  h.eq("gpt-4-1106-preview", result.name)
+  h.eq("gpt-4-1106-preview", result.default)
+end
+
 T["HTTP Adapter"]["can update schema"] = function()
   local adapter = require("codecompanion.adapters").extend("openai", {
     schema = {
@@ -797,6 +811,51 @@ T["Adapter"]["utils"]["can consolidate system messages"] = function()
     { role = "assistant", content = "Bar" },
     { role = "user", content = "Baz" },
   }, child.lua_get([[utils.merge_system_messages(messages)]]))
+end
+
+T["Adapter"]["utils"]["model DOES NOT call a function default"] = function()
+  local result = child.lua([[
+    _G.called = false
+    local adapter = {
+      name = "test",
+      schema = { model = { default = function()
+        _G.called = true
+        return "fetched-over-http"
+      end } },
+    }
+    return { model = tostring(utils.model(adapter)), called = _G.called }
+  ]])
+
+  h.eq("nil", result.model)
+  h.eq(false, result.called)
+end
+
+T["Adapter"]["utils"]["resolve_model calls a function default"] = function()
+  local result = child.lua([[
+    local adapter = {
+      name = "test",
+      schema = { model = { default = function()
+        return "fetched-over-http"
+      end } },
+    }
+    return utils.resolve_model(adapter)
+  ]])
+
+  h.eq("fetched-over-http", result)
+end
+
+T["Adapter"]["utils"]["resolve_model returns nil when the function default errors"] = function()
+  local result = child.lua([[
+    local adapter = {
+      name = "test",
+      schema = { model = { default = function()
+        error("no connection")
+      end } },
+    }
+    return utils.resolve_model(adapter)
+  ]])
+
+  h.eq(vim.NIL, result)
 end
 
 T["Adapter"]["call_handler"] = new_set()

--- a/tests/interactions/chat/test_chat.lua
+++ b/tests/interactions/chat/test_chat.lua
@@ -64,6 +64,14 @@ T["Chat"]["buffer editor context is handled"] = function()
   h.eq(tags.EDITOR_CONTEXT, last_message_tag)
 end
 
+T["Chat"]["can change the model"] = function()
+  child.lua([[_G.chat:change_model({ model = "gpt-4o" })]])
+
+  h.eq("gpt-4o", child.lua_get([[_G.chat.adapter.schema.model.default]]))
+  h.eq("gpt-4o", child.lua_get([[_G.chat.adapter.model.name]]))
+  h.eq("gpt-4o", child.lua_get([[_G.chat.settings.model]]))
+end
+
 T["Chat"]["system prompt can be ignored"] = function()
   child.lua([[_G.new_chat = require("codecompanion.interactions.chat").new({
     ignore_system_prompt = true,


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Extract adapter resolution logic into a utilities file, making it easier for features to leverage in the future, without being weighed down by a complex pattern.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code + Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
