### PR TITLE
fix(ui): tool output with newlines

### DIFF
--- a/lua/codecompanion/interactions/chat/ui/builder.lua
+++ b/lua/codecompanion/interactions/chat/ui/builder.lua
@@ -61,7 +61,7 @@ end
 
 ---@param text string
 ---@return string
-local function to_single_line(text)
+local function collapse_to_single_line(text)
   -- Ensure text doesn't span multiple lines as this causes extmark/icon challenges
   return vim.trim((text:gsub("%s*\r?\n%s*", " ")))
 end
@@ -132,7 +132,7 @@ function Builder:add_message(data, opts)
 
   local content = data.content
   if content and opts.status then
-    content = to_single_line(content)
+    content = collapse_to_single_line(content)
   end
 
   -- If the role has changed (user <-> LLM) then start a new line
@@ -299,14 +299,14 @@ function Builder:_apply_icon(insert_line, opts, content_start)
 end
 
 ---Update a specific line in the chat buffer
----@param line_number number The line number to update (1-based)
----@param content string The new content for the line
+---@param line_number number The
+---@param content string
 ---@param opts? { status?: string, icon_id?: number, priority?: number, virt_text_pos?: string }
----@return boolean success Whether the update was successful
----@return number|nil icon_id The new icon extmark ID, if an icon was placed
+---@return boolean
+---@return number|nil
 function Builder:update_line(line_number, content, opts)
   opts = opts or {}
-  content = to_single_line(content)
+  content = collapse_to_single_line(content)
 
   if line_number < 1 then
     return false

--- a/lua/codecompanion/interactions/chat/ui/builder.lua
+++ b/lua/codecompanion/interactions/chat/ui/builder.lua
@@ -62,7 +62,6 @@ end
 ---@param text string
 ---@return string
 local function collapse_to_single_line(text)
-  -- Ensure text doesn't span multiple lines as this causes extmark/icon challenges
   return vim.trim((text:gsub("%s*\r?\n%s*", " ")))
 end
 

--- a/lua/codecompanion/interactions/chat/ui/builder.lua
+++ b/lua/codecompanion/interactions/chat/ui/builder.lua
@@ -59,6 +59,13 @@ local function separator(prev, new)
   return (row and row[new]) or {}
 end
 
+---@param text string
+---@return string
+local function to_single_line(text)
+  -- Ensure text doesn't span multiple lines as this causes extmark/icon challenges
+  return vim.trim((text:gsub("%s*\r?\n%s*", " ")))
+end
+
 ---@class CodeCompanion.Chat.UI.BuilderState
 ---@field last_role? string The role of the section currently being rendered
 ---@field block_type? string The `BLOCK` type of the open block; nil after a header
@@ -124,6 +131,10 @@ function Builder:add_message(data, opts)
   local role_changed = self:_needs_header(data, opts)
 
   local content = data.content
+  if content and opts.status then
+    content = to_single_line(content)
+  end
+
   -- If the role has changed (user <-> LLM) then start a new line
   local has_content = content ~= nil and (content ~= "" or role_changed)
 
@@ -295,6 +306,7 @@ end
 ---@return number|nil icon_id The new icon extmark ID, if an icon was placed
 function Builder:update_line(line_number, content, opts)
   opts = opts or {}
+  content = to_single_line(content)
 
   if line_number < 1 then
     return false

--- a/tests/interactions/chat/ui/test_builder_state.lua
+++ b/tests/interactions/chat/ui/test_builder_state.lua
@@ -110,4 +110,49 @@ T["Builder state"]["tool fold is placed on the content line when the tool messag
   h.eq(res.fold.type, "tool")
 end
 
+T["Builder"] = new_set()
+
+T["Builder"]["a status write is collapsed onto a single line"] = function()
+  child.lua([[
+    _G.chat:add_buf_message(
+      { role = "llm", content = "Execute: run tests\n\n  make test\n" },
+      { type = _G.MT.TOOL_MESSAGE, status = "in_progress" }
+    )
+  ]])
+  local lines = child.lua_get([[vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, true)]])
+  h.eq(lines[#lines], "Execute: run tests make test")
+end
+
+T["Builder"]["a tool write WITHOUT a status keeps its line breaks"] = function()
+  child.lua([[
+    _G.chat:add_buf_message({ role = "llm", content = "tool line 1\nline 2" }, { type = _G.MT.TOOL_MESSAGE })
+  ]])
+  local lines = child.lua_get([[vim.api.nvim_buf_get_lines(_G.chat.bufnr, 0, -1, true)]])
+  h.eq(lines[#lines - 1], "tool line 1")
+  h.eq(lines[#lines], "line 2")
+end
+
+T["Builder"]["update_line collapses a multi-line replacement rather than losing the write"] = function()
+  local line_number = child.lua([[
+    local line = _G.chat:add_buf_message(
+      { role = "llm", content = "run_command: ls" },
+      { type = _G.MT.TOOL_MESSAGE, status = "in_progress" }
+    )
+    return line
+  ]])
+  local before = child.lua_get([[vim.api.nvim_buf_line_count(_G.chat.bufnr)]])
+
+  local updated = child.lua(
+    [[return _G.chat:update_buf_line(...,  "run_command: ls -la \\\n  --color", { status = "success" })]],
+    { line_number }
+  )
+
+  h.eq(updated, true)
+  h.eq(child.lua_get([[vim.api.nvim_buf_line_count(_G.chat.bufnr)]]), before)
+  h.eq(
+    child.lua_get([[vim.api.nvim_buf_get_lines(_G.chat.bufnr, ... - 1, ..., true)]], { line_number }),
+    { "run_command: ls -la \\ --color" }
+  )
+end
+
 return T


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Tool output can sometimes comprise new lines. This causes issues in the Neovim UI where extmarks would not be applied across all lines. This PR addresses that. 

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code + Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
