### PR TITLE
fix(cli): approval requests in herdr

### DIFF
--- a/lua/codecompanion/interactions/cli/init.lua
+++ b/lua/codecompanion/interactions/cli/init.lua
@@ -334,6 +334,11 @@ function CLI.hook(opts)
       return
     end
 
+    -- Claude Code notifies when its prompt sits idle, which arrives after the turn ended and would show as blocked
+    if opts.event == "approval_requested" and not cli.request_id then
+      return
+    end
+
     utils.fire(event, { bufnr = opts.bufnr, message = opts.message })
 
     -- A turn stays in flight while the agent waits on the user, so only its ends move the request


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Fixes an issue where Claude Code in the CLI would always notify herdr that approval was required, 60 seconds after no response from the user.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code + Opus

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
