### PR TITLE
fix(acp): linebreak code blocks

### DIFF
--- a/lua/codecompanion/interactions/chat/acp/handler.lua
+++ b/lua/codecompanion/interactions/chat/acp/handler.lua
@@ -480,7 +480,7 @@ function ACPHandler:handle_error(error)
   log:error("[ACP::Handler] %s", error)
 
   self.chat:add_buf_message(
-    { role = config.constants.LLM_ROLE, content = markdown.form_codeblock(error, { ft = "txt" }) },
+    { role = config.constants.LLM_ROLE, content = "\n" .. markdown.form_codeblock(error, { ft = "txt" }) },
     { type = self.chat.MESSAGE_TYPES.LLM_MESSAGE }
   )
 

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -278,39 +278,6 @@ T["ACPHandler"]["handles connection errors"] = function()
   h.eq(nil, result.request_returned)
 end
 
-T["ACPHandler"]["starts the error codeblock on its own line"] = function()
-  local result = child.lua([[
-    local chat = h.setup_chat_buffer({}, {
-      name = "test_acp",
-      config = {
-        name = "test_acp",
-        type = "acp",
-        handlers = { form_messages = function(a, m) return m end }
-      }
-    })
-
-    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
-    local handler = ACPHandler.new(chat)
-
-    local buffer_messages = {}
-    chat.add_buf_message = function(self, data, opts)
-      table.insert(buffer_messages, { data = data, opts = opts })
-    end
-    chat.done = function() end
-
-    -- A preceding message chunk that doesn't end in a newline is what
-    -- previously left the fence glued to the end of that line
-    handler:handle_message_chunk("You've hit your session limit")
-    handler:handle_error("Internal error: You've hit your session limit")
-
-    return {
-      error_content = buffer_messages[2].data.content,
-    }
-  ]])
-
-  h.eq(true, result.error_content:sub(1, 1) == "\n")
-end
-
 T["ACPHandler"]["integrates with chat submit flow"] = function()
   local result = child.lua([[
     -- Create chat with ACP adapter

--- a/tests/interactions/chat/acp/test_handler.lua
+++ b/tests/interactions/chat/acp/test_handler.lua
@@ -278,6 +278,39 @@ T["ACPHandler"]["handles connection errors"] = function()
   h.eq(nil, result.request_returned)
 end
 
+T["ACPHandler"]["starts the error codeblock on its own line"] = function()
+  local result = child.lua([[
+    local chat = h.setup_chat_buffer({}, {
+      name = "test_acp",
+      config = {
+        name = "test_acp",
+        type = "acp",
+        handlers = { form_messages = function(a, m) return m end }
+      }
+    })
+
+    local ACPHandler = require("codecompanion.interactions.chat.acp.handler")
+    local handler = ACPHandler.new(chat)
+
+    local buffer_messages = {}
+    chat.add_buf_message = function(self, data, opts)
+      table.insert(buffer_messages, { data = data, opts = opts })
+    end
+    chat.done = function() end
+
+    -- A preceding message chunk that doesn't end in a newline is what
+    -- previously left the fence glued to the end of that line
+    handler:handle_message_chunk("You've hit your session limit")
+    handler:handle_error("Internal error: You've hit your session limit")
+
+    return {
+      error_content = buffer_messages[2].data.content,
+    }
+  ]])
+
+  h.eq(true, result.error_content:sub(1, 1) == "\n")
+end
+
 T["ACPHandler"]["integrates with chat submit flow"] = function()
   local result = child.lua([[
     -- Create chat with ACP adapter


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

When you hit your Claude Code usage limit, the error message was never properly formatted.

## Supporting Documentation

<!--
  Share any links to supporting documentation, such as:
  - Agent Client Protocol (ACP) documentation
  - Model Context Protocol (MCP) documentation
  - Any relevant LLM or agent documentation
-->

## AI Usage

Claude Code + Sonnet 5

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
