### PR TITLE
feat: add skills support

### DIFF
--- a/doc/.vitepress/config.mjs
+++ b/doc/.vitepress/config.mjs
@@ -193,6 +193,7 @@ export default withMermaid(
             { text: "MCP", link: "/configuration/mcp" },
             { text: "Prompt Library", link: "/configuration/prompt-library" },
             { text: "Rules", link: "/configuration/rules" },
+            { text: "Skills", link: "/configuration/skills" },
             { text: "System Prompt", link: "/configuration/system-prompt" },
             { text: "Others", link: "/configuration/others" },
           ],
@@ -217,6 +218,7 @@ export default withMermaid(
                   link: "/usage/chat-buffer/editor-context",
                 },
                 { text: "Rules", link: "/usage/chat-buffer/rules" },
+                { text: "Skills", link: "/usage/chat-buffer/skills" },
                 {
                   text: "Slash Commands",
                   link: "/usage/chat-buffer/slash-commands",

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -4001,7 +4001,6 @@ Set skills to `none` to start a prompt with no skills at all, overriding
 `autoload`:
 
 
-
 PROMPT LIBRARY                    *codecompanion-configuration-prompt-library*
 
 CodeCompanion enables you to leverage prompt templates to quickly interact with
@@ -5878,8 +5877,15 @@ The |codecompanion-usage-chat-buffer-slash-commands-skills-group| slash command
 lists your configured |codecompanion-configuration-skills-groups| and adds all
 of their skills to the chat buffer.
 
-Both commands use whichever picker you've set for them. The `default` provider
-is `vim.ui.select`, which only selects one item at a time:
+CodeCompanion detects whether you have telescope
+<https://github.com/nvim-telescope/telescope.nvim>, fzf_lua
+<https://github.com/ibhagwan/fzf-lua>, mini_pick
+<https://github.com/echasnovski/mini.pick> or snacks.nvim
+<https://github.com/folke/snacks.nvim> installed and picks one for you. Failing
+that, it falls back to the `default` provider, `vim.ui.select`, which is the
+only one that can't select more than one skill at a time.
+
+Each command is configured separately:
 
 >lua
     require("codecompanion").setup({
@@ -5889,6 +5895,11 @@ is `vim.ui.select`, which only selects one item at a time:
             ["skills"] = {
               opts = {
                 provider = "snacks", -- Can be "default", "telescope", "fzf_lua", "mini_pick" or "snacks"
+              },
+            },
+            ["skills-group"] = {
+              opts = {
+                provider = "snacks",
               },
             },
           },

--- a/doc/codecompanion.txt
+++ b/doc/codecompanion.txt
@@ -1,5 +1,5 @@
 *codecompanion.txt*
-                              For NVIM v0.11    Last change: 2026 September 08
+                              For NVIM v0.11    Last change: 2026 September 11
 
 ==============================================================================
 Table of Contents                            *codecompanion-table-of-contents*
@@ -44,6 +44,7 @@ Table of Contents                            *codecompanion-table-of-contents*
   - Inline Interaction        |codecompanion-configuration-inline-interaction|
   - MCP Servers                      |codecompanion-configuration-mcp-servers|
   - Rules                                  |codecompanion-configuration-rules|
+  - Skills                                |codecompanion-configuration-skills|
   - Prompt Library                |codecompanion-configuration-prompt-library|
   - System Prompts                |codecompanion-configuration-system-prompts|
   - Extensions                        |codecompanion-configuration-extensions|
@@ -55,6 +56,7 @@ Table of Contents                            *codecompanion-table-of-contents*
   - Agents and Tools                    |codecompanion-usage-agents-and-tools|
   - Editor Context                        |codecompanion-usage-editor-context|
   - Rules                                          |codecompanion-usage-rules|
+  - Skills                                        |codecompanion-usage-skills|
   - Slash Commands                        |codecompanion-usage-slash-commands|
   - Command-Line Interface (CLI)|codecompanion-usage-command-line-interface-(cli)|
   - Code Reviews                            |codecompanion-usage-code-reviews|
@@ -3891,6 +3893,115 @@ to have more granular control.
 
 
 
+SKILLS                                    *codecompanion-configuration-skills*
+
+Skills are reusable, filesystem-based resources that give LLMs domain-specific
+expertise (source
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview>).
+In CodeCompanion, skills are folders of repeatable instructions that your LLM
+reads when it needs them.
+
+At initialisation, the LLM only receives the skills name and description.
+During a conversation, if the LLM deduces that the skill is required, then it
+reads the skill fully. This is known as progressive disclosure and it's what
+allows many skills to be present in the chat without consuming significant
+context.
+
+CodeCompanion uses the same `SKILL.md` format as Claude
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work>.
+
+
+ENABLING AND DISABLING SKILLS ~
+
+Skills are enabled by default. To disable them:
+
+>lua
+    require("codecompanion").setup({
+      skills = {
+        opts = {
+          chat = {
+            enabled = false,
+          },
+        },
+      },
+    })
+<
+
+
+DIRECTORIES ~
+
+By passing in a list of directories, CodeCompanion will search for skills in
+each of them. They can be customised with:
+
+>lua
+    require("codecompanion").setup({
+      skills = {
+        dirs = {
+          "~/.config/codecompanion/skills", -- Personal skills
+          ".codecompanion/skills",          -- Project skills
+          "~/.claude/skills",               -- Claude Code's personal skills
+          ".claude/skills",                 -- Claude Code's project skills
+        },
+      },
+    })
+<
+
+The directories are searched in order and skills are keyed on the `name` in
+their frontmatter. This results in a directory further down the list taking
+precedence if skills of the same name clash. This also means that if you
+symlink one skills directory to another and list both, you get one entry per
+skill rather than two.
+
+CodeCompanion never caches skills so they can be added throughout the Neovim
+session without restarting.
+
+
+GROUPS ~
+
+Groups allow you to group collective skills together under a single name for
+use in the chat buffer. They can be customised with:
+
+>lua
+    require("codecompanion").setup({
+      skills = {
+        ["Senior Engineer"] = {
+          description = "How I want code written and reviewed",
+          skills = { "lua-developer", "code-review", "tdd" },
+        },
+        ["Technical Writer"] = {
+          description = "How I want the docs written",
+          skills = { "docs-voice", "changelog" },
+        },
+      },
+    })
+<
+
+The skills in a group must reference the name of the skill as per its
+frontmatter and not the path to the skill. This means that the skill must exist
+in one of the directories listed in `dirs`.
+
+
+AUTOLOAD ~
+
+Skills and groups can be autoloaded into the chat buffer on startup. This is
+configured with:
+
+
+
+PROMPT LIBRARY ~
+
+Skills can also be referenced in |codecompanion-configuration-prompt-library|
+items, ensuring that they are loaded in the chat buffer when the prompt is
+used.
+
+
+  [!NOTE] The prompt library skills takes priority over `autoload`
+
+Set skills to `none` to start a prompt with no skills at all, overriding
+`autoload`:
+
+
+
 PROMPT LIBRARY                    *codecompanion-configuration-prompt-library*
 
 CodeCompanion enables you to leverage prompt templates to quickly interact with
@@ -5727,6 +5838,131 @@ Rules can also be cleared from a chat buffer via the `gR` keymap. Although
 note, this will remove `ALL` context that's been designated as `rules`.
 
 
+SKILLS                                            *codecompanion-usage-skills*
+
+
+  [!IMPORTANT] Skills are only available for
+  |codecompanion-configuration-adapters-http| adapters.
+  |codecompanion-configuration-adapters-acp| agents `may` have skills implemented
+  which can be accessed via the `\` trigger. See
+  |codecompanion-usage-chat-buffer-skills-acp-adapters| for more information.
+Ensure that you have read the |codecompanion-configuration-skills| section to
+understand how to configure skill directories and groups.
+
+
+WHAT YOUR LLM SEES ~
+
+Adding a skill to a chat buffer shares the skill's metadata (the YAML
+frontmatter in `SKILL.md`) with the LLM:
+
+>
+    The `lua-developer` skill is available: The Lua conventions for this project. Use when writing or reviewing Lua.
+    Read `/Users/Oli/.config/codecompanion/skills/lua-developer/SKILL.md` when the skill applies and follow its instructions.
+<
+
+By only loading the metadata, the context in the chat buffer is kept small.
+
+To read the skill in full, CodeCompanion attaches the `read_file` and
+`run_command` |codecompanion-usage-chat-buffer-agents-tools| to the chat. As a
+result, you'll need to use an LLM which has function calling capability.
+
+
+ADDING SKILLS ~
+
+The |codecompanion-usage-chat-buffer-slash-commands-skills| slash command lists
+every skill found in the |codecompanion-configuration-skills-directories|.
+Multiple skills can be added at once depending on the picker you've defined in
+the config.
+
+The |codecompanion-usage-chat-buffer-slash-commands-skills-group| slash command
+lists your configured |codecompanion-configuration-skills-groups| and adds all
+of their skills to the chat buffer.
+
+Both commands use whichever picker you've set for them. The `default` provider
+is `vim.ui.select`, which only selects one item at a time:
+
+>lua
+    require("codecompanion").setup({
+      interactions = {
+        chat = {
+          slash_commands = {
+            ["skills"] = {
+              opts = {
+                provider = "snacks", -- Can be "default", "telescope", "fzf_lua", "mini_pick" or "snacks"
+              },
+            },
+          },
+        },
+      },
+    })
+<
+
+
+ACP ADAPTERS ~
+
+Everything above applies to |codecompanion-configuration-adapters-http|
+adapters. On an |codecompanion-configuration-adapters-acp| adapter such as
+Claude Code, the agent runs its own skills, so `/skills` and `/skills-group`
+are hidden.
+
+Reach the agent's skills with the `\` trigger instead, which lists the
+|codecompanion-usage-chat-buffer--completion| the agent has discovered for
+itself. A skill in `~/.claude/skills` is therefore available either way:
+through `/skills` when you're on an http adapter, and through `\` when Claude
+Code is driving.
+
+
+CREATING A SKILL ~
+
+A skill is a directory containing a `SKILL.md`, in one of your configured
+|codecompanion-configuration-skills-directories|:
+
+>
+    lua-developer/
+    ├── SKILL.md          # Required
+    ├── REFERENCE.md      # Optional
+    └── scripts/          # Optional
+        └── lint.sh
+<
+
+`SKILL.md` is a markdown file with a YAML frontmatter, as per the Claude Agent
+Skills
+<https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work>
+page:
+
+>markdown
+    ---
+    name: lua-developer
+    description: The Lua conventions for this project. Use when writing or reviewing Lua.
+    ---
+    
+    # Lua Developer
+    
+    Follow these conventions when writing Lua in this project:
+    
+    - Two space indent, 120 columns
+    - `snake_case` for functions, `PascalCase` for classes
+    
+    See [REFERENCE.md](REFERENCE.md) for worked examples.
+    
+    Run [scripts/lint.sh](scripts/lint.sh) before you report the work as finished.
+<
+
+The instructions (the main body of the skill) should contain the information
+the LLM needs to follow the skill. However, a vague description may mean the
+LLM never calls the skill.
+
+Link to other files in the skill using paths relative to `SKILL.md`. The LLM is
+given the full path to `SKILL.md`, so it finds them wherever you started Neovim
+from.
+
+
+REMOVING A SKILL ~
+
+A skill can be removed by deleting the skill's line from the `Context`
+blockquote in the chat buffer.
+
+
 SLASH COMMANDS                            *codecompanion-usage-slash-commands*
 
 Slash Commands enable you to quickly add context to the chat buffer. They are
@@ -5734,6 +5970,12 @@ comprised of values present in the `interactions.chat.slash_commands` table
 alongside the `prompt_library` table where individual prompts have
 `opts.is_slash_cmd = true`.
 
+
+  [!NOTE] Every command on this page is CodeCompanion's own and is triggered with
+  `/`. An |codecompanion-configuration-adapters-acp| agent such as Claude Code
+  also exposes its own commands, which the plugin discovers from the agent at
+  runtime. Those are triggered with `\` to keep the two apart - see
+  |codecompanion-usage-chat-buffer--completion|.
 
 /ACP_SESSION_OPTIONS ~
 
@@ -5977,6 +6219,20 @@ that you set a token in your configuration with permission to create gists:
       },
     })
 <
+
+
+/SKILLS ~
+
+The `skills` slash command adds |codecompanion-usage-chat-buffer-skills| to the
+chat buffer. Multiple skills can be selected at once, depending on the picker
+you've configured.
+
+
+/SKILLS-GROUP ~
+
+The `skills-group` slash command adds a
+|codecompanion-configuration-skills-groups| of skills in one go. It's hidden if
+you haven't configured any groups.
 
 
 /SYMBOLS ~

--- a/doc/configuration/skills.md
+++ b/doc/configuration/skills.md
@@ -1,0 +1,171 @@
+---
+description: "Configure agent skills in CodeCompanion — SKILL.md directories that give your LLM domain-specific knowledge, loaded on demand, in Neovim."
+---
+
+# Configuring Skills
+
+Skills are reusable, filesystem-based resources that give LLMs domain-specific expertise ([source](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)). In CodeCompanion, skills are folders of repeatable instructions that your LLM reads when it needs them.
+
+At initialisation, the LLM only receives the skills name and description. During a conversation, if the LLM deduces that the skill is required, then it reads the skill fully. This is known as progressive disclosure and it's what allows many skills to be present in the chat without consuming significant context.
+
+CodeCompanion uses the same `SKILL.md` [format as Claude](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work).
+
+## Enabling and Disabling Skills
+
+Skills are enabled by default. To disable them:
+
+```lua
+require("codecompanion").setup({
+  skills = {
+    opts = {
+      chat = {
+        enabled = false,
+      },
+    },
+  },
+})
+```
+
+## Directories
+
+By passing in a list of directories, CodeCompanion will search for skills in each of them. They can be customised with:
+
+```lua
+require("codecompanion").setup({
+  skills = {
+    dirs = {
+      "~/.config/codecompanion/skills", -- Personal skills
+      ".codecompanion/skills",          -- Project skills
+      "~/.claude/skills",               -- Claude Code's personal skills
+      ".claude/skills",                 -- Claude Code's project skills
+    },
+  },
+})
+```
+
+The directories are searched in order and skills are keyed on the `name` in their frontmatter. This results in a directory further down the list taking precedence if skills of the same name clash. This also means that if you symlink one skills directory to another and list both, you get one entry per skill rather than two.
+
+CodeCompanion never caches skills so they can be added throughout the Neovim session without restarting.
+
+## Groups
+
+Groups allow you to group collective skills together under a single name for use in the chat buffer. They can be customised with:
+
+```lua
+require("codecompanion").setup({
+  skills = {
+    ["Senior Engineer"] = {
+      description = "How I want code written and reviewed",
+      skills = { "lua-developer", "code-review", "tdd" },
+    },
+    ["Technical Writer"] = {
+      description = "How I want the docs written",
+      skills = { "docs-voice", "changelog" },
+    },
+  },
+})
+```
+
+The skills in a group must reference the name of the skill as per its frontmatter and not the path to the skill. This means that the skill must exist in one of the directories listed in `dirs`.
+
+## Autoload
+
+Skills and groups can be autoloaded into the chat buffer on startup. This is configured with:
+
+::: code-group
+
+```lua{5} [Static]
+require("codecompanion").setup({
+  skills = {
+    opts = {
+      chat = {
+        autoload = { "Senior Engineer", "lua-developer" },
+      },
+    },
+  },
+})
+```
+
+```lua{6-11} [Conditional]
+require("codecompanion").setup({
+  skills = {
+    opts = {
+      chat = {
+        ---@return string[]
+        autoload = function()
+          if vim.fn.getcwd():find("my_project", 1, true) then
+            return { "Senior Engineer" }
+          end
+          return {}
+        end,
+      },
+    },
+  },
+})
+```
+
+:::
+
+## Prompt Library
+
+Skills can also be referenced in [prompt library](/configuration/prompt-library) items, ensuring that they are loaded in the chat buffer when the prompt is used.
+
+> [!NOTE]
+> The prompt library skills takes priority over `autoload`
+
+::: code-group
+
+```markdown [Markdown]
+---
+name: Review this PR
+interaction: chat
+description: Review the changes on this branch
+skills:
+  - code-review
+---
+```
+
+```lua [Lua]
+require("codecompanion").setup({
+  prompt_library = {
+    ["Review this PR"] = {
+      strategy = "chat",
+      skills = { "code-review" },
+      prompts = {
+        -- Omitted for brevity
+      },
+    },
+  },
+})
+```
+
+:::
+
+Set skills to `none` to start a prompt with no skills at all, overriding `autoload`:
+
+::: code-group
+
+```markdown [Markdown]
+---
+name: No skills prompt
+interaction: chat
+description: A prompt that loads no skills
+skills: none
+---
+```
+
+```lua [Lua]
+require("codecompanion").setup({
+  prompt_library = {
+    ["No skills prompt"] = {
+      strategy = "chat",
+      skills = "none",
+      prompts = {
+        -- Omitted for brevity
+      },
+    },
+  },
+})
+```
+
+:::

--- a/doc/configuration/skills.md
+++ b/doc/configuration/skills.md
@@ -142,30 +142,3 @@ require("codecompanion").setup({
 :::
 
 Set skills to `none` to start a prompt with no skills at all, overriding `autoload`:
-
-::: code-group
-
-```markdown [Markdown]
----
-name: No skills prompt
-interaction: chat
-description: A prompt that loads no skills
-skills: none
----
-```
-
-```lua [Lua]
-require("codecompanion").setup({
-  prompt_library = {
-    ["No skills prompt"] = {
-      strategy = "chat",
-      skills = "none",
-      prompts = {
-        -- Omitted for brevity
-      },
-    },
-  },
-})
-```
-
-:::

--- a/doc/usage/chat-buffer/skills.md
+++ b/doc/usage/chat-buffer/skills.md
@@ -1,0 +1,93 @@
+---
+description: "Write and use agent skills in the CodeCompanion chat buffer — SKILL.md folders your LLM reads on demand, compatible with Claude Code skills."
+---
+
+# Using Skills
+
+> [!IMPORTANT]
+> Skills are only available for [http](/configuration/adapters-http) adapters. [ACP](/configuration/adapters-acp) agents *may* have skills implemented which can be accessed via the `\` trigger. See [Skills on ACP Adapters](/usage/chat-buffer/skills#acp-adapters) for more information.
+
+Ensure that you have read the [Skills Configuration](/configuration/skills) section to understand how to configure skill directories and groups.
+
+## What Your LLM Sees
+
+Adding a skill to a chat buffer shares the skill's metadata (the YAML frontmatter in `SKILL.md`) with the LLM:
+
+```
+The `lua-developer` skill is available: The Lua conventions for this project. Use when writing or reviewing Lua.
+Read `/Users/Oli/.config/codecompanion/skills/lua-developer/SKILL.md` when the skill applies and follow its instructions.
+```
+
+By only loading the metadata, the context in the chat buffer is kept small.
+
+To read the skill in full, CodeCompanion attaches the `read_file` and `run_command` [tools](/usage/chat-buffer/agents-tools) to the chat. As a result, you'll need to use an LLM which has function calling capability.
+
+## Adding Skills
+
+The [/skills](/usage/chat-buffer/slash-commands#skills) slash command lists every skill found in the [skill directories](/configuration/skills#directories). Multiple skills can be added at once depending on the picker you've defined in the config.
+
+The [/skills-group](/usage/chat-buffer/slash-commands#skills-group) slash command lists your configured [groups](/configuration/skills#groups) and adds all of their skills to the chat buffer.
+
+Both commands use whichever picker you've set for them. The `default` provider is `vim.ui.select`, which only selects one item at a time:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      slash_commands = {
+        ["skills"] = {
+          opts = {
+            provider = "snacks", -- Can be "default", "telescope", "fzf_lua", "mini_pick" or "snacks"
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+## ACP Adapters
+
+Everything above applies to [http](/configuration/adapters-http) adapters. On an [ACP](/configuration/adapters-acp) adapter such as Claude Code, the agent runs its own skills, so `/skills` and `/skills-group` are hidden.
+
+Reach the agent's skills with the `\` trigger instead, which lists the [ACP commands](/usage/chat-buffer/#completion) the agent has discovered for itself. A skill in `~/.claude/skills` is therefore available either way: through `/skills` when you're on an http adapter, and through `\` when Claude Code is driving.
+
+## Creating a Skill
+
+A skill is a directory containing a `SKILL.md`, in one of your configured [skill directories](/configuration/skills#directories):
+
+```
+lua-developer/
+├── SKILL.md          # Required
+├── REFERENCE.md      # Optional
+└── scripts/          # Optional
+    └── lint.sh
+```
+
+`SKILL.md` is a markdown file with a YAML frontmatter, as per the Claude [Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview#how-skills-work) page:
+
+```markdown
+---
+name: lua-developer
+description: The Lua conventions for this project. Use when writing or reviewing Lua.
+---
+
+# Lua Developer
+
+Follow these conventions when writing Lua in this project:
+
+- Two space indent, 120 columns
+- `snake_case` for functions, `PascalCase` for classes
+
+See [REFERENCE.md](REFERENCE.md) for worked examples.
+
+Run [scripts/lint.sh](scripts/lint.sh) before you report the work as finished.
+```
+
+The instructions (the main body of the skill) should contain the information the LLM needs to follow the skill. However, a vague description may mean the LLM never calls the skill.
+
+Link to other files in the skill using paths relative to `SKILL.md`. The LLM is given the full path to `SKILL.md`, so it finds them wherever you started Neovim from.
+
+## Removing a Skill
+
+A skill can be removed by deleting the skill's line from the _Context_ blockquote in the chat buffer.

--- a/doc/usage/chat-buffer/skills.md
+++ b/doc/usage/chat-buffer/skills.md
@@ -28,7 +28,9 @@ The [/skills](/usage/chat-buffer/slash-commands#skills) slash command lists ever
 
 The [/skills-group](/usage/chat-buffer/slash-commands#skills-group) slash command lists your configured [groups](/configuration/skills#groups) and adds all of their skills to the chat buffer.
 
-Both commands use whichever picker you've set for them. The `default` provider is `vim.ui.select`, which only selects one item at a time:
+CodeCompanion detects whether you have [telescope](https://github.com/nvim-telescope/telescope.nvim), [fzf_lua](https://github.com/ibhagwan/fzf-lua), [mini_pick](https://github.com/echasnovski/mini.pick) or [snacks.nvim](https://github.com/folke/snacks.nvim) installed and picks one for you. Failing that, it falls back to the `default` provider, `vim.ui.select`, which is the only one that can't select more than one skill at a time.
+
+Each command is configured separately:
 
 ```lua
 require("codecompanion").setup({
@@ -38,6 +40,11 @@ require("codecompanion").setup({
         ["skills"] = {
           opts = {
             provider = "snacks", -- Can be "default", "telescope", "fzf_lua", "mini_pick" or "snacks"
+          },
+        },
+        ["skills-group"] = {
+          opts = {
+            provider = "snacks",
           },
         },
       },

--- a/doc/usage/chat-buffer/slash-commands.md
+++ b/doc/usage/chat-buffer/slash-commands.md
@@ -10,6 +10,9 @@ description: "Reference for all CodeCompanion slash commands — fetch URLs, add
 
 Slash Commands enable you to quickly add context to the chat buffer. They are comprised of values present in the `interactions.chat.slash_commands` table alongside the `prompt_library` table where individual prompts have `opts.is_slash_cmd = true`.
 
+> [!NOTE]
+> Every command on this page is CodeCompanion's own and is triggered with `/`. An [ACP](/configuration/adapters-acp) agent such as Claude Code also exposes its own commands, which the plugin discovers from the agent at runtime. Those are triggered with `\` to keep the two apart - see [ACP Commands](/usage/chat-buffer/#completion).
+
 ## /acp_session_options
 
 > [!NOTE]
@@ -172,6 +175,14 @@ require("codecompanion").setup({
   },
 })
 ```
+
+## /skills
+
+The _skills_ slash command adds [skills](/usage/chat-buffer/skills) to the chat buffer. Multiple skills can be selected at once, depending on the picker you've configured.
+
+## /skills-group
+
+The _skills-group_ slash command adds a [group](/configuration/skills#groups) of skills in one go. It's hidden if you haven't configured any groups.
 
 ## /symbols
 

--- a/lua/codecompanion/config.lua
+++ b/lua/codecompanion/config.lua
@@ -560,6 +560,33 @@ If you are providing code changes, use the insert_edit_into_file tool (if availa
             interactions = { "chat", "cli" },
           },
         },
+        ["skills"] = {
+          path = "interactions.chat.slash_commands.builtin.skills",
+          description = "Add a skill to the chat",
+          ---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
+          ---@return boolean
+          enabled = function(opts)
+            return require("codecompanion.skills").available_for(opts)
+          end,
+          opts = {
+            contains_code = false,
+            provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
+          },
+        },
+        ["skills-group"] = {
+          path = "interactions.chat.slash_commands.builtin.skills_group",
+          description = "Add a group of skills to the chat",
+          ---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
+          ---@return boolean
+          enabled = function(opts)
+            local skills = require("codecompanion.skills")
+            return skills.available_for(opts) and not vim.tbl_isempty(skills.groups())
+          end,
+          opts = {
+            contains_code = false,
+            provider = providers.pickers, -- telescope|fzf_lua|mini_pick|snacks|default
+          },
+        },
         ["save"] = {
           path = "interactions.chat.slash_commands.builtin.save",
           description = "Save the chat as a persistent session",
@@ -1227,6 +1254,25 @@ The user is working on a %s machine. Please respond with system specific command
       },
 
       show_presets = true, -- Show the preset rules files?
+    },
+  },
+  -- SKILLS --------------------------------------------------------------------
+  skills = {
+    ---@type string[]
+    dirs = {
+      "~/.config/codecompanion/skills",
+      ".codecompanion/skills",
+      "~/.claude/skills",
+      ".claude/skills",
+    },
+    opts = {
+      chat = {
+        enabled = true, -- When false, skills are unavailable and their slash commands are hidden
+
+        ---Group or skill names to add to every chat
+        ---@type string[]|fun(): string[]
+        autoload = {},
+      },
     },
   },
   -- DISPLAY OPTIONS ----------------------------------------------------------

--- a/lua/codecompanion/interactions/chat/init.lua
+++ b/lua/codecompanion/interactions/chat/init.lua
@@ -56,6 +56,7 @@
 ---@field mcp_servers? table<string> List of MCP server names to start and load into the chat buffer
 ---@field messages? CodeCompanion.Chat.Messages The messages to display in the chat buffer
 ---@field settings? table The settings that are used in the adapter of the chat buffer
+---@field skills? string[]|"none" Skill or skill group names to preload in the chat buffer
 ---@field status? string The status of any running jobs in the chat buffe
 ---@field stop_context_insertion? boolean Stop any visual selection from being automatically inserted into the chat buffer
 ---@field title? string The title of the chat buffer
@@ -519,6 +520,17 @@ local function load_tools(chat, args)
   end
 end
 
+---@param chat CodeCompanion.Chat
+---@param args CodeCompanion.ChatArgs
+---@return nil
+local function load_skills(chat, args)
+  if args.skills == "none" then
+    return
+  end
+
+  require("codecompanion.skills").autoload(chat, args.skills)
+end
+
 ---Start any MCP servers requested for this chat
 ---@param chat CodeCompanion.Chat
 ---@param args CodeCompanion.ChatArgs
@@ -674,6 +686,7 @@ function Chat.new(args)
   end
 
   load_tools(self, args)
+  load_skills(self, args)
   start_mcp_for_chat(self, args)
   register_callbacks(self, args)
 

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/skills.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/skills.lua
@@ -1,0 +1,54 @@
+local picker = require("codecompanion.skills.picker")
+local skills = require("codecompanion.skills")
+
+local CONSTANTS = {
+  NAME = "Skills",
+  PROMPT = "Select a skill",
+}
+
+local providers = picker.build({
+  prompt = CONSTANTS.PROMPT,
+  empty_message = "No skills found",
+  preview = true,
+  items = function()
+    return vim.tbl_map(function(skill)
+      return {
+        name = skill.name,
+        description = skill.description,
+        skills = { skill.name },
+        path = skill.path,
+      }
+    end, skills.list())
+  end,
+})
+
+---@class CodeCompanion.SlashCommand.Skills: CodeCompanion.SlashCommand
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommandArgs
+function SlashCommand.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+
+  return self
+end
+
+---@param SlashCommands CodeCompanion.SlashCommands
+---@return nil
+function SlashCommand:execute(SlashCommands)
+  return SlashCommands:set_provider(self, providers)
+end
+
+---@param selected { skills: string[] }
+---@return nil
+function SlashCommand:output(selected)
+  if not selected then
+    return
+  end
+  skills.add_to_chat(self.Chat, skills.resolve(selected.skills))
+end
+
+return SlashCommand

--- a/lua/codecompanion/interactions/chat/slash_commands/builtin/skills_group.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/builtin/skills_group.lua
@@ -1,0 +1,55 @@
+local picker = require("codecompanion.skills.picker")
+local skills = require("codecompanion.skills")
+
+local fmt = string.format
+
+local CONSTANTS = {
+  NAME = "Skills Group",
+  PROMPT = "Select a group of skills",
+}
+
+local providers = picker.build({
+  prompt = CONSTANTS.PROMPT,
+  empty_message = "No skill groups found",
+  preview = false,
+  items = function()
+    return vim.tbl_map(function(group)
+      return {
+        name = fmt("%s (%d)", group.name, #group.skills),
+        description = group.description,
+        skills = group.skills,
+      }
+    end, skills.groups())
+  end,
+})
+
+---@class CodeCompanion.SlashCommand.SkillsGroup: CodeCompanion.SlashCommand
+local SlashCommand = {}
+
+---@param args CodeCompanion.SlashCommandArgs
+function SlashCommand.new(args)
+  local self = setmetatable({
+    Chat = args.Chat,
+    config = args.config,
+    context = args.context,
+  }, { __index = SlashCommand })
+
+  return self
+end
+
+---@param SlashCommands CodeCompanion.SlashCommands
+---@return nil
+function SlashCommand:execute(SlashCommands)
+  return SlashCommands:set_provider(self, providers)
+end
+
+---@param selected { skills: string[] }
+---@return nil
+function SlashCommand:output(selected)
+  if not selected then
+    return
+  end
+  skills.add_to_chat(self.Chat, skills.resolve(selected.skills))
+end
+
+return SlashCommand

--- a/lua/codecompanion/interactions/chat/slash_commands/init.lua
+++ b/lua/codecompanion/interactions/chat/slash_commands/init.lua
@@ -22,6 +22,19 @@ local function add_prompt_tools(chat, prompt_config)
   end)
 end
 
+---Add prompt-declared skills to the current chat
+---@param chat CodeCompanion.Chat
+---@param prompt_config table
+local function add_prompt_skills(chat, prompt_config)
+  local prompt_skills = prompt_config.skills
+  if not prompt_skills or prompt_skills == "none" then
+    return
+  end
+
+  local skills = require("codecompanion.skills")
+  skills.add_to_chat(chat, skills.resolve(prompt_skills))
+end
+
 ---Resolve a path to the correct module
 ---@param path string The module or file path
 ---@return table|nil
@@ -171,6 +184,7 @@ end
 function SlashCommands.run(selected, chat)
   if selected.from_prompt_library then
     add_prompt_tools(chat, selected.config)
+    add_prompt_skills(chat, selected.config)
 
     local context = selected.config.context
     if context then

--- a/lua/codecompanion/interactions/init.lua
+++ b/lua/codecompanion/interactions/init.lua
@@ -26,6 +26,13 @@ local function get_tools(selected)
   return selected.tools
 end
 
+---Extract skills from the selected prompt
+---@param selected table
+---@return table<string>|nil
+local function get_skills(selected)
+  return selected.skills
+end
+
 ---Extract MCP servers from the selected prompt
 ---@param selected table
 ---@return table<string>|nil
@@ -172,6 +179,7 @@ function Interactions:chat()
       intro_message = (opts and opts.intro_message) or nil,
       mcp_servers = get_mcp_servers(self.selected),
       messages = messages,
+      skills = get_skills(self.selected),
       stop_context_insertion = (opts and self.selected.opts.stop_context_insertion) or false,
       tools = get_tools(self.selected),
     })
@@ -250,6 +258,7 @@ function Interactions:workflow()
     callbacks = get_callbacks(self.selected),
     mcp_servers = get_mcp_servers(self.selected),
     messages = messages,
+    skills = get_skills(self.selected),
     tools = get_tools(self.selected),
   })
   if not chat then

--- a/lua/codecompanion/interactions/shared/tags.lua
+++ b/lua/codecompanion/interactions/shared/tags.lua
@@ -14,6 +14,7 @@ local M = {
   QUICKFIX = "quickfix",
   RULES = "rules",
   SELECTION = "selection",
+  SKILLS = "skills",
   SYSTEM_PROMPT_FROM_CONFIG = "system_prompt_from_config",
   TERMINAL = "terminal",
   TOOL = "tool",

--- a/lua/codecompanion/prompt_library/init.lua
+++ b/lua/codecompanion/prompt_library/init.lua
@@ -55,6 +55,7 @@ function M.resolve(context, config)
       picker = prompt.picker,
       prompts = prompt.prompts,
       rules = prompt.rules,
+      skills = prompt.skills,
       tools = prompt.tools,
     })
 

--- a/lua/codecompanion/prompt_library/markdown.lua
+++ b/lua/codecompanion/prompt_library/markdown.lua
@@ -68,6 +68,7 @@ function M.parse_file(path, context)
     path = path,
     prompts = prompts,
     rules = frontmatter.rules,
+    skills = frontmatter.skills,
     tools = frontmatter.tools,
   }
 end

--- a/lua/codecompanion/skills/init.lua
+++ b/lua/codecompanion/skills/init.lua
@@ -1,0 +1,217 @@
+local chat_helpers = require("codecompanion.interactions.chat.helpers")
+local config = require("codecompanion.config")
+local files = require("codecompanion.utils.files")
+local log = require("codecompanion.utils.log")
+local tags = require("codecompanion.interactions.shared.tags")
+local yaml = require("codecompanion.utils.yaml")
+
+local fmt = string.format
+
+local SKILL_FILE = "SKILL.md"
+local RESERVED_KEYS = { dirs = true, opts = true }
+
+---@class CodeCompanion.Skill
+---@field name string
+---@field description string
+---@field path string Absolute path to the skill's SKILL.md
+
+---@class CodeCompanion.Skills.Group
+---@field name string
+---@field description? string
+---@field skills string[] Names of the skills in the group
+
+local M = {}
+
+---@return boolean
+local function has_yaml_parser()
+  return pcall(vim.treesitter.language.add, "yaml")
+end
+
+---@param path string
+---@return CodeCompanion.Skill|nil
+local function parse_skill(path)
+  local content = files.read(path)
+  if not content then
+    return log:warn("[Skills] Could not read `%s`", path)
+  end
+
+  local frontmatter = files.normalize_content(content):match("^%-%-%-\n(.-)\n%-%-%-")
+  if not frontmatter then
+    return log:warn("[Skills] `%s` has no frontmatter", path)
+  end
+
+  local ok, parsed = pcall(yaml.decode, frontmatter)
+  if not ok or type(parsed) ~= "table" then
+    return log:warn("[Skills] Could not parse the frontmatter in `%s`", path)
+  end
+  if not parsed.name or not parsed.description then
+    return log:warn("[Skills] `%s` needs both a `name` and a `description` in its frontmatter", path)
+  end
+
+  return { name = parsed.name, description = parsed.description, path = path }
+end
+
+---Scan the configured dirs for skills, sorted by name
+---@return CodeCompanion.Skill[]
+function M.list()
+  if not has_yaml_parser() then
+    log:warn("[Skills] Install the yaml parser with `:TSInstall yaml` and try again")
+    return {}
+  end
+
+  -- Later dirs take precedence, so a project skill overrides a personal one of the same name
+  local by_name = {}
+  for _, configured_dir in ipairs(config.skills.dirs or {}) do
+    local dir = vim.fs.abspath(vim.fs.normalize(configured_dir))
+    if files.is_dir(dir) then
+      for entry in vim.fs.dir(dir) do
+        local skill_file = vim.fs.joinpath(dir, entry, SKILL_FILE)
+        if files.exists(skill_file) then
+          local skill = parse_skill(skill_file)
+          if skill then
+            by_name[skill.name] = skill
+          end
+        end
+      end
+    end
+  end
+
+  local skills = vim.tbl_values(by_name)
+  table.sort(skills, function(a, b)
+    return a.name < b.name
+  end)
+
+  return skills
+end
+
+---The skill groups defined in the config, sorted by name
+---@return CodeCompanion.Skills.Group[]
+function M.groups()
+  local groups = {}
+  for name, group in pairs(config.skills or {}) do
+    if not RESERVED_KEYS[name] and type(group) == "table" then
+      table.insert(groups, { name = name, description = group.description, skills = group.skills or {} })
+    end
+  end
+
+  table.sort(groups, function(a, b)
+    return a.name < b.name
+  end)
+
+  return groups
+end
+
+---Resolve group names and skill names into the skills they refer to
+---@param names string[]
+---@return CodeCompanion.Skill[]
+function M.resolve(names)
+  local discovered = {}
+  for _, skill in ipairs(M.list()) do
+    discovered[skill.name] = skill
+  end
+
+  local groups = {}
+  for _, group in ipairs(M.groups()) do
+    groups[group.name] = group
+  end
+
+  local resolved = {}
+  local seen = {}
+
+  local function add(name)
+    local skill = discovered[name]
+    if not skill then
+      return log:warn("[Skills] Could not find a skill named `%s`", name)
+    end
+    if not seen[name] then
+      seen[name] = true
+      table.insert(resolved, skill)
+    end
+  end
+
+  for _, name in ipairs(names) do
+    local group = groups[name]
+    if group then
+      vim.iter(group.skills):each(add)
+    else
+      add(name)
+    end
+  end
+
+  return resolved
+end
+
+---Skills need a function calling model, so they're limited to HTTP adapters
+---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
+---@return boolean
+function M.available_for(opts)
+  if config.skills.opts.chat.enabled == false then
+    return false
+  end
+
+  local adapter = opts.adapter
+  return adapter ~= nil and adapter.type == "http" and adapter.opts.tools ~= false
+end
+
+---@param skill CodeCompanion.Skill
+---@return string
+local function skill_id(skill)
+  return "<skill>" .. skill.name .. "</skill>"
+end
+
+---Tell the chat a skill exists and give it the tools to load it on demand
+---@param chat CodeCompanion.Chat
+---@param skill CodeCompanion.Skill
+---@return nil
+local function add_skill(chat, skill)
+  local id = skill_id(skill)
+  if chat_helpers.has_context(id, chat.messages) then
+    return
+  end
+
+  chat.tool_registry:add_single_tool("read_file")
+  chat.tool_registry:add_single_tool("run_command")
+
+  local content = fmt(
+    "The `%s` skill is available: %s\nRead `%s` when the skill applies and follow its instructions.",
+    skill.name,
+    skill.description,
+    skill.path
+  )
+
+  chat:add_context({ role = config.constants.SYSTEM_ROLE, content = content }, "skills", id, {
+    path = skill.path,
+    tag = tags.SKILLS,
+  })
+end
+
+---@param chat CodeCompanion.Chat
+---@param skills CodeCompanion.Skill[]
+---@return nil
+function M.add_to_chat(chat, skills)
+  if not M.available_for(chat) then
+    return
+  end
+
+  vim.iter(skills):each(function(skill)
+    add_skill(chat, skill)
+  end)
+end
+
+---Add the skills a new chat asked for, falling back to the configured autoload
+---@param chat CodeCompanion.Chat
+---@param names? string[]|fun(): string[] Group or skill names
+---@return nil
+function M.autoload(chat, names)
+  names = names or config.skills.opts.chat.autoload
+  if type(names) == "function" then
+    names = names()
+  end
+  if not names or vim.tbl_isempty(names) then
+    return
+  end
+
+  M.add_to_chat(chat, M.resolve(names))
+end
+
+return M

--- a/lua/codecompanion/skills/init.lua
+++ b/lua/codecompanion/skills/init.lua
@@ -141,7 +141,6 @@ function M.resolve(names)
   return resolved
 end
 
----Skills need a function calling model, so they're limited to HTTP adapters
 ---@param opts { adapter: CodeCompanion.HTTPAdapter|CodeCompanion.ACPAdapter }
 ---@return boolean
 function M.available_for(opts)
@@ -155,7 +154,7 @@ end
 
 ---@param skill CodeCompanion.Skill
 ---@return string
-local function skill_id(skill)
+local function get_skill_id(skill)
   return "<skill>" .. skill.name .. "</skill>"
 end
 
@@ -164,7 +163,7 @@ end
 ---@param skill CodeCompanion.Skill
 ---@return nil
 local function add_skill(chat, skill)
-  local id = skill_id(skill)
+  local id = get_skill_id(skill)
   if chat_helpers.has_context(id, chat.messages) then
     return
   end

--- a/lua/codecompanion/skills/init.lua
+++ b/lua/codecompanion/skills/init.lua
@@ -30,8 +30,8 @@ end
 ---@param path string
 ---@return CodeCompanion.Skill|nil
 local function parse_skill(path)
-  local content = files.read(path)
-  if not content then
+  local ok, content = pcall(files.read, path)
+  if not ok or not content then
     return log:warn("[Skills] Could not read `%s`", path)
   end
 
@@ -40,11 +40,12 @@ local function parse_skill(path)
     return log:warn("[Skills] `%s` has no frontmatter", path)
   end
 
-  local ok, parsed = pcall(yaml.decode, frontmatter)
+  local parsed
+  ok, parsed = pcall(yaml.decode, frontmatter)
   if not ok or type(parsed) ~= "table" then
     return log:warn("[Skills] Could not parse the frontmatter in `%s`", path)
   end
-  if not parsed.name or not parsed.description then
+  if type(parsed.name) ~= "string" or type(parsed.description) ~= "string" then
     return log:warn("[Skills] `%s` needs both a `name` and a `description` in its frontmatter", path)
   end
 
@@ -168,8 +169,15 @@ local function add_skill(chat, skill)
     return
   end
 
-  chat.tool_registry:add_single_tool("read_file")
-  chat.tool_registry:add_single_tool("run_command")
+  local tools_config = chat.tools.tools_config
+  if not tools_config.read_file then
+    return log:warn("[Skills] The `%s` skill needs the `read_file` tool, which is disabled", skill.name)
+  end
+
+  chat.tool_registry:add_single_tool("read_file", { config = tools_config.read_file })
+  if tools_config.run_command then
+    chat.tool_registry:add_single_tool("run_command", { config = tools_config.run_command })
+  end
 
   local content = fmt(
     "The `%s` skill is available: %s\nRead `%s` when the skill applies and follow its instructions.",

--- a/lua/codecompanion/skills/picker.lua
+++ b/lua/codecompanion/skills/picker.lua
@@ -1,0 +1,231 @@
+local utils = require("codecompanion.utils")
+
+---@class CodeCompanion.Skills.PickerItem
+---@field name string
+---@field description? string
+---@field skills string[] The skill names the selection resolves to
+---@field path? string Absolute path to the skill's SKILL.md, when it can be previewed
+
+local M = {}
+
+local MAX_NAME_COLUMN = 34
+
+---@param name string
+---@param width number
+---@return string
+local function pad(name, width)
+  return name .. string.rep(" ", math.max(width - vim.api.nvim_strwidth(name), 0))
+end
+
+---Map a picker's chosen display string back to its item
+---@param items table[]
+---@param display string
+---@return table|nil
+local function find_by_display(items, display)
+  return vim.iter(items):find(function(item)
+    return item.display == display
+  end)
+end
+
+---@param items table[]
+---@return number
+local function name_column(items)
+  local width = 0
+  for _, item in ipairs(items) do
+    width = math.max(width, vim.api.nvim_strwidth(item.name))
+  end
+  return math.min(width, MAX_NAME_COLUMN)
+end
+
+---Build the pickers for a list of selectable skills or groups
+---@param opts { prompt: string, empty_message: string, preview: boolean, items: fun(): CodeCompanion.Skills.PickerItem[] }
+---@return table<string, fun(SlashCommand: CodeCompanion.SlashCommand)>
+function M.build(opts)
+  ---@return table[]|nil, number
+  local function get_items()
+    local items = opts.items()
+    if vim.tbl_isempty(items) then
+      utils.notify(opts.empty_message, vim.log.levels.WARN)
+      return nil, 0
+    end
+
+    local width = name_column(items)
+    for _, item in ipairs(items) do
+      item.display = pad(item.name, width) .. "  " .. (item.description or "")
+      item.text = item.display
+      item.file = item.path
+    end
+
+    return items, width
+  end
+
+  return {
+    ---The default provider
+    ---@param SlashCommand CodeCompanion.SlashCommand
+    ---@return nil
+    default = function(SlashCommand)
+      local items = get_items()
+      if not items then
+        return
+      end
+
+      vim.ui.select(items, {
+        kind = "codecompanion.nvim",
+        prompt = opts.prompt,
+        format_item = function(item)
+          return item.display
+        end,
+      }, function(selected)
+        if not selected then
+          return
+        end
+        return SlashCommand:output(selected)
+      end)
+    end,
+
+    ---The Snacks.nvim provider
+    ---@param SlashCommand CodeCompanion.SlashCommand
+    ---@return nil
+    snacks = function(SlashCommand)
+      local items, width = get_items()
+      if not items then
+        return
+      end
+
+      local snacks = require("codecompanion.providers.slash_commands.snacks")
+      snacks = snacks.new({
+        title = opts.prompt .. ": ",
+        output = function(selection)
+          return SlashCommand:output(selection)
+        end,
+      })
+
+      local align = snacks.provider.picker.util.align
+
+      snacks.provider.picker.pick({
+        title = opts.prompt,
+        items = items,
+        prompt = snacks.title,
+        format = function(item, _)
+          return {
+            { align(item.name, width, { truncate = true }), "SnacksPickerLabel" },
+            { "  " },
+            { item.description or "", "SnacksPickerComment" },
+          }
+        end,
+        preview = opts.preview and "file" or "none",
+        confirm = snacks:display(),
+        main = { file = false, float = true },
+      })
+    end,
+
+    ---The Telescope provider
+    ---@param SlashCommand CodeCompanion.SlashCommand
+    ---@return nil
+    telescope = function(SlashCommand)
+      local items = get_items()
+      if not items then
+        return
+      end
+
+      local telescope = require("codecompanion.providers.slash_commands.telescope")
+      telescope = telescope.new({
+        title = opts.prompt,
+        output = function(selection)
+          return SlashCommand:output(selection.value)
+        end,
+      })
+
+      local values = require("telescope.config").values
+
+      require("telescope.pickers")
+        .new({}, {
+          prompt_title = telescope.title,
+          finder = require("telescope.finders").new_table({
+            results = items,
+            entry_maker = function(item)
+              return { value = item, display = item.display, ordinal = item.display, path = item.path }
+            end,
+          }),
+          sorter = values.generic_sorter({}),
+          previewer = opts.preview and values.file_previewer({}) or nil,
+          attach_mappings = telescope:display(),
+        })
+        :find()
+    end,
+
+    ---The Mini.Pick provider
+    ---@param SlashCommand CodeCompanion.SlashCommand
+    ---@return nil
+    mini_pick = function(SlashCommand)
+      local items = get_items()
+      if not items then
+        return
+      end
+
+      local mini_pick = require("codecompanion.providers.slash_commands.mini_pick")
+      mini_pick = mini_pick.new({
+        title = opts.prompt,
+        output = function(selected)
+          return SlashCommand:output(selected)
+        end,
+      })
+
+      local source = mini_pick:display(function(selected)
+        return find_by_display(items, selected)
+      end)
+      source.source.items = vim.tbl_map(function(item)
+        return item.display
+      end, items)
+
+      if opts.preview then
+        source.source.preview = function(buf_id, display)
+          local item = find_by_display(items, display)
+          return mini_pick.provider.default_preview(buf_id, item.path)
+        end
+      end
+
+      mini_pick.provider.start(source)
+    end,
+
+    ---The fzf-lua provider
+    ---@param SlashCommand CodeCompanion.SlashCommand
+    ---@return nil
+    fzf_lua = function(SlashCommand)
+      local items = get_items()
+      if not items then
+        return
+      end
+
+      local fzf = require("codecompanion.providers.slash_commands.fzf_lua")
+      fzf = fzf.new({
+        title = opts.prompt,
+        output = function(selected)
+          return SlashCommand:output(selected)
+        end,
+      })
+
+      local display = fzf:display(function(selected)
+        return find_by_display(items, selected)
+      end)
+
+      if opts.preview then
+        local previewer = require("fzf-lua.previewer.builtin").buffer_or_file:extend()
+        function previewer:parse_entry(entry)
+          local item = find_by_display(items, entry)
+          return { path = item and item.path }
+        end
+        display.previewer = previewer
+      end
+
+      fzf.provider.fzf_exec(
+        vim.tbl_map(function(item)
+          return item.display
+        end, items),
+        display
+      )
+    end,
+  }
+end
+
+return M

--- a/scripts/vimdoc.md
+++ b/scripts/vimdoc.md
@@ -20,6 +20,7 @@ doc/configuration/code-review.md
 doc/configuration/inline.md
 doc/configuration/mcp.md
 doc/configuration/rules.md
+doc/configuration/skills.md
 doc/configuration/prompt-library.md
 doc/configuration/system-prompt.md
 doc/configuration/extensions.md
@@ -34,6 +35,7 @@ doc/usage/chat-buffer/index.md
 doc/usage/chat-buffer/agents-tools.md
 doc/usage/chat-buffer/editor-context.md
 doc/usage/chat-buffer/rules.md
+doc/usage/chat-buffer/skills.md
 doc/usage/chat-buffer/slash-commands.md
 doc/usage/cli.md
 doc/usage/code-review.md

--- a/tests/skills/test_skills.lua
+++ b/tests/skills/test_skills.lua
@@ -1,0 +1,145 @@
+local new_set = MiniTest.new_set
+local h = require("tests.helpers")
+
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+  hooks = {
+    post_once = child.stop,
+  },
+})
+
+T["Skills"] = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+    end,
+  },
+})
+
+---@param dirs string[]
+local function list_skills(dirs)
+  return child.lua(string.format(
+    [[
+      package.loaded["codecompanion.config"] = { skills = { dirs = %s } }
+      return require("codecompanion.skills").list()
+    ]],
+    vim.inspect(dirs)
+  ))
+end
+
+T["Skills"]["discovers only the skills with a name and a description"] = function()
+  local skills = list_skills({ "tests/stubs/skills/personal" })
+
+  h.eq(2, #skills)
+  h.eq("house-style", skills[1].name)
+  h.eq("Lua conventions for this project", skills[1].description)
+  h.eq("pdf-forms", skills[2].name)
+  h.eq("Fill and inspect PDF forms", skills[2].description)
+  h.expect_match(skills[2].path, "tests/stubs/skills/personal/pdf%-forms/SKILL%.md$")
+end
+
+T["Skills"]["a later dir overrides a skill with the same name"] = function()
+  local skills = list_skills({ "tests/stubs/skills/personal", "tests/stubs/skills/project" })
+
+  h.eq(2, #skills)
+  h.eq("house-style", skills[1].name)
+  h.eq("Lua conventions from the project directory", skills[1].description)
+end
+
+T["Skills"]["keeps discovering when a configured dir doesn't exist"] = function()
+  local skills = list_skills({ "tests/stubs/skills/does-not-exist", "tests/stubs/skills/personal" })
+
+  h.eq(2, #skills)
+end
+
+T["Skills in a chat"] = new_set({
+  hooks = {
+    pre_case = function()
+      h.child_start(child)
+      child.lua([[
+        h = require("tests.helpers")
+        _G.chat = h.setup_chat_buffer()
+
+        local config = require("codecompanion.config")
+        config.skills.dirs = { "tests/stubs/skills/personal" }
+        config.skills["Senior Engineer"] = {
+          description = "Skills for a senior engineer",
+          skills = { "house-style", "pdf-forms" },
+        }
+
+        _G.skills = require("codecompanion.skills")
+      ]])
+    end,
+    post_case = function()
+      child.lua([[h.teardown_chat_buffer()]])
+    end,
+  },
+})
+
+T["Skills in a chat"]["names the skill and points at its SKILL.md"] = function()
+  child.lua([[_G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))]])
+
+  local content = child.lua_get([[_G.chat.messages[#_G.chat.messages].content]])
+  h.expect_contains("pdf-forms", content)
+  h.expect_contains("Fill and inspect PDF forms", content)
+  h.expect_match(content, "tests/stubs/skills/personal/pdf%-forms/SKILL%.md")
+end
+
+T["Skills in a chat"]["attaches the tools the model needs to load a skill"] = function()
+  child.lua([[_G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))]])
+
+  h.eq(true, child.lua_get([[_G.chat.tool_registry.in_use.read_file]]))
+  h.eq(true, child.lua_get([[_G.chat.tool_registry.in_use.run_command]]))
+end
+
+T["Skills in a chat"]["a group adds every skill it names"] = function()
+  child.lua([[_G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "Senior Engineer" }))]])
+
+  local ids = child.lua_get([[
+    vim.tbl_map(function(item) return item.id end, _G.chat.context_items)
+  ]])
+  h.eq(true, vim.tbl_contains(ids, "<skill>house-style</skill>"))
+  h.eq(true, vim.tbl_contains(ids, "<skill>pdf-forms</skill>"))
+end
+
+T["Skills in a chat"]["adding the same skill twice adds it once"] = function()
+  child.lua([[
+    _G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))
+    _G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))
+  ]])
+
+  local count = child.lua_get([[
+    #vim.tbl_filter(function(item)
+      return item.id == "<skill>pdf-forms</skill>"
+    end, _G.chat.context_items)
+  ]])
+  h.eq(1, count)
+end
+
+T["Skills in a chat"]["DOES NOT add skills when the adapter has no tool support"] = function()
+  child.lua([[
+    _G.chat.adapter.opts.tools = false
+    _G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))
+  ]])
+
+  h.eq(0, child.lua_get([[#_G.chat.context_items]]))
+end
+
+T["Skills in a chat"]["autoload adds the configured skills to a new chat"] = function()
+  local ids = child.lua([[
+    local config = require("codecompanion.config")
+    config.skills.opts.chat.autoload = { "Senior Engineer" }
+
+    local chat = require("codecompanion.interactions.chat").new({
+      buffer_context = { bufnr = 1, filetype = "lua" },
+      adapter = "test_adapter",
+    })
+    return vim.tbl_map(function(item) return item.id end, chat.context_items)
+  ]])
+
+  h.eq(true, vim.tbl_contains(ids, "<skill>house-style</skill>"))
+  h.eq(true, vim.tbl_contains(ids, "<skill>pdf-forms</skill>"))
+end
+
+return T

--- a/tests/skills/test_skills.lua
+++ b/tests/skills/test_skills.lua
@@ -39,6 +39,16 @@ T["Skills"]["discovers only the skills with a name and a description"] = functio
   h.expect_match(skills[2].path, "tests/stubs/skills/personal/pdf%-forms/SKILL%.md$")
 end
 
+T["Skills"]["skips a skill whose name is not a string"] = function()
+  local skills = list_skills({ "tests/stubs/skills/personal" })
+
+  local names = vim.tbl_map(function(skill)
+    return skill.name
+  end, skills)
+  h.eq(false, vim.tbl_contains(names, true))
+  h.eq(2, #skills)
+end
+
 T["Skills"]["a later dir overrides a skill with the same name"] = function()
   local skills = list_skills({ "tests/stubs/skills/personal", "tests/stubs/skills/project" })
 
@@ -91,6 +101,26 @@ T["Skills in a chat"]["attaches the tools the model needs to load a skill"] = fu
 
   h.eq(true, child.lua_get([[_G.chat.tool_registry.in_use.read_file]]))
   h.eq(true, child.lua_get([[_G.chat.tool_registry.in_use.run_command]]))
+end
+
+T["Skills in a chat"]["DOES NOT add a skill when `read_file` is disabled"] = function()
+  child.lua([[
+    _G.chat.tools.tools_config.read_file = nil
+    _G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))
+  ]])
+
+  h.eq(0, child.lua_get([[#_G.chat.context_items]]))
+  h.eq(vim.NIL, child.lua_get([[_G.chat.tool_registry.in_use.read_file]]))
+end
+
+T["Skills in a chat"]["adds a skill without `run_command` when it is disabled"] = function()
+  child.lua([[
+    _G.chat.tools.tools_config.run_command = nil
+    _G.skills.add_to_chat(_G.chat, _G.skills.resolve({ "pdf-forms" }))
+  ]])
+
+  h.eq(true, child.lua_get([[_G.chat.tool_registry.in_use.read_file]]))
+  h.eq(vim.NIL, child.lua_get([[_G.chat.tool_registry.in_use.run_command]]))
 end
 
 T["Skills in a chat"]["a group adds every skill it names"] = function()

--- a/tests/stubs/skills/personal/house-style/SKILL.md
+++ b/tests/stubs/skills/personal/house-style/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: house-style
+description: Lua conventions for this project
+---
+
+# House Style
+
+Two space indent.

--- a/tests/stubs/skills/personal/name-not-a-string/SKILL.md
+++ b/tests/stubs/skills/personal/name-not-a-string/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: true
+description: A name that YAML reads as a boolean rather than a string
+---
+
+# Name Not A String

--- a/tests/stubs/skills/personal/no-description/SKILL.md
+++ b/tests/stubs/skills/personal/no-description/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: no-description
+---
+
+# No Description

--- a/tests/stubs/skills/personal/not-a-skill/README.md
+++ b/tests/stubs/skills/personal/not-a-skill/README.md
@@ -1,0 +1,1 @@
+Not a skill, there is no SKILL.md here.

--- a/tests/stubs/skills/personal/pdf-forms/SKILL.md
+++ b/tests/stubs/skills/personal/pdf-forms/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: pdf-forms
+description: Fill and inspect PDF forms
+---
+
+# PDF Forms
+
+Read `REFERENCE.md` for the field mapping.

--- a/tests/stubs/skills/project/house-style/SKILL.md
+++ b/tests/stubs/skills/project/house-style/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: house-style
+description: Lua conventions from the project directory
+---
+
+# House Style
+
+The project's own take.


### PR DESCRIPTION
<!-- Please do not alter the structure of this PR template -->

## Description

Something I've had in testing for a while that I'm now comfortable to release.

Skills in CodeCompanion allow a user to point to a collection of directories that contain a `SKILL.md` file. They can be loaded into a chat manually with the `/skill` slash command or even autoloaded as part of groups.

The docs have this covered in more detail.

## Supporting Documentation

https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview

## AI Usage

Claude Code + Opus 5

## Related Issue(s)

#2674
#2716

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change -->

## Checklist

- [x] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [x] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
