### PR TITLE
Enforce ordering of system messages and tool calls.

### DIFF
--- a/lua/codecompanion/adapters/http/openai.lua
+++ b/lua/codecompanion/adapters/http/openai.lua
@@ -192,6 +192,25 @@ return {
         end)
         :totable()
 
+      -- Reorder messages: system messages must come first (required for models like Qwen3)
+      -- This must happen after all message processing to handle both initial messages and tool responses
+      local system_messages = {}
+      local tool_messages = {}
+      local other_messages = {}
+
+      for _, msg in ipairs(messages) do
+        if msg and msg.role == "system" then
+          table.insert(system_messages, msg)
+        elseif msg and msg.role == "tool" then
+          -- Keep tool responses in their original position relative to other non-system messages
+          table.insert(tool_messages, msg)
+        elseif msg then
+          table.insert(other_messages, msg)
+        end
+      end
+
+      messages = vim.list_extend(vim.list_extend(system_messages, other_messages), tool_messages)
+
       return { messages = messages }
     end,
 


### PR DESCRIPTION
## Recent changes to Qwen3 and derivative models enforce ordering of system messages and tool calls.  This fixes it in my testing, but I would suggest others test this more robustly.  Quick hacks via Claude-Haiku.

Loop over all messages in the post to the model and reorder them such that they start with a system message or a tool message before any other messages.  This is a strict failure for Qwen3 models after recent updates.

## Supporting Documentation
Similar fixes:  https://github.com/anomalyco/opencode/issues/42909

## AI Usage
Quick hacks via Claude-Haiku.

## Related Issue(s)
I was a bit too lazy to open an Issue, but I can if you guys want one for tracking

## Screenshots
None.

Failure Log from Noice:
`
Error  09:05:04 AM notify.error CodeCompanion [ERROR] 2026-09-12 09:05:04
Error: {"error":{"message":"litellm.BadRequestError: OpenAIException - System message must be at the beginning.. Received Model Group=nrp/qwen3\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
Error  09:05:04 AM notify.error CodeCompanion [ERROR] 2026-09-12 09:05:04
[chat::_submit_http] Error: {
body = '{"error":{"message":"litellm.BadRequestError: OpenAIException - System message must be at the beginning.. Received Model Group=nrp/qwen3\\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}',exit = 0,
headers = { "date: Sat, 12 Sep 2026 15:05:04 GMT", "content-type: application/json", "content-length: 215", "x-litellm-call-id: 7315108b-d122-4d99-a26e-febd98d46131", "x-litellm-response-cost: 0", "x-litellm-key-spend: 0.0", "x-litellm-timeout: 1200", "x-frame-options: DENY", "content-security-policy: frame-ancestors 'none'", "x-content-type-options: nosniff", "strict-transport-security: max-age=31536000; includeSubDomains" },status = 400}
 `

## Checklist

- [X ] I've read the [contributing](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X ] I confirm that this PR has been majority created by me, and not AI (unless stated in the "AI Usage" section above)
- [ X] I've run `make all` to ensure docs are generated, tests pass and [StyLua](https://github.com/JohnnyMorganz/StyLua) has formatted the code
- [ ] _(optional)_ I've added [test](https://github.com/olimorris/codecompanion.nvim/blob/main/CONTRIBUTING.md#testing) coverage for this fix/feature
- [ ] _(optional)_ I've updated the README and/or relevant docs pages
